### PR TITLE
Add coroutine awaitable interfaces to the gateway network layer

### DIFF
--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -256,7 +256,11 @@ uint32_t GatewayConfig::maxSendDataSize() const
 
 void GatewayConfig::setMaxSendDataSize(uint32_t _maxSendDataSize)
 {
-    m_maxSendDataSize = _maxSendDataSize;
+    // Single enforcement point for the send-batch byte budget (shared with initP2PConfig's
+    // parse path): 0 would make Session::tryPopSomeEncodedMsgs never pop and silently stall
+    // every outbound write on the session, so clamp to a working minimum wherever the value
+    // comes from.
+    m_maxSendDataSize = std::max<uint32_t>(_maxSendDataSize, 1);
 }
 
 uint32_t GatewayConfig::maxMsgCountSendOneTime() const
@@ -625,7 +629,7 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     m_maxReadDataSize = _pt.get<uint32_t>("p2p.session_max_read_data_size", defaultMaxReadDataSize);
 
     constexpr static uint32_t defaultMaxSendDataSize = 1024 * 1024;
-    m_maxSendDataSize = _pt.get<uint32_t>("p2p.session_max_send_data_size", defaultMaxSendDataSize);
+    auto maxSendDataSize = _pt.get<uint32_t>("p2p.session_max_send_data_size", defaultMaxSendDataSize);
 
     constexpr static uint32_t defaultMaxSendMsgCount = 10;
     m_maxSendMsgCount = _pt.get<uint32_t>("p2p.session_max_send_msg_count", defaultMaxSendMsgCount);
@@ -634,7 +638,9 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     // Session::tryPopSomeEncodedMsgs enforces on every write loop iteration. Unlike
     // p2p.max_connections_per_second above, 0 does NOT mean "unlimited" here: with the byte
     // budget at 0 the batch loop never pops, every write loop exits on its first iteration, and
-    // all outbound traffic on the session stalls silently. Clamp to a working minimum instead.
+    // all outbound traffic on the session stalls silently. Warn here so the operator sees the
+    // config problem, then route through the setter — the single clamp enforcement point shared
+    // with every other writer of this value.
     //
     // p2p.session_max_send_msg_count is parsed for config-file compatibility only and is
     // deliberately NOT enforced anywhere — the base had the message-count condition commented
@@ -644,12 +650,12 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     // see the behaviour-change note in the PR description. No clamp here: nothing reads this
     // value, so warning the operator to "fix" a 0 would invite a config change that changes
     // nothing.
-    if (m_maxSendDataSize == 0)
+    if (maxSendDataSize == 0)
     {
         GATEWAY_CONFIG_LOG(WARNING)
             << LOG_DESC("p2p.session_max_send_data_size must be positive, clamped to 1");
-        m_maxSendDataSize = 1;
     }
+    setMaxSendDataSize(maxSendDataSize);
 
     m_smSSL = smSSL;
     m_listenIP = listenIP;

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -636,24 +636,19 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     // budget at 0 the batch loop never pops, every write loop exits on its first iteration, and
     // all outbound traffic on the session stalls silently. Clamp to a working minimum instead.
     //
-    // p2p.session_max_send_msg_count is retained for config-file compatibility but is
-    // deliberately NOT enforced by the batch loop — the base had the message-count condition
-    // commented out and drained the whole queue into a single scatter-gather write, and
-    // re-enabling it capped every async_write at the (default 10) message budget, costing
-    // ceil(N/10) post + async_write round-trips under broadcast fan-out. The byte budget alone
-    // is the sole cap; see the behaviour-change note in the PR description. The clamp below is
-    // kept so a historical 0 in a config file cannot silently mean something else.
+    // p2p.session_max_send_msg_count is parsed for config-file compatibility only and is
+    // deliberately NOT enforced anywhere — the base had the message-count condition commented
+    // out and drained the whole queue into a single scatter-gather write, and re-enabling it
+    // capped every async_write at the (default 10) message budget, costing ceil(N/10) post +
+    // async_write round-trips under broadcast fan-out. The byte budget alone is the sole cap;
+    // see the behaviour-change note in the PR description. No clamp here: nothing reads this
+    // value, so warning the operator to "fix" a 0 would invite a config change that changes
+    // nothing.
     if (m_maxSendDataSize == 0)
     {
         GATEWAY_CONFIG_LOG(WARNING)
             << LOG_DESC("p2p.session_max_send_data_size must be positive, clamped to 1");
         m_maxSendDataSize = 1;
-    }
-    if (m_maxSendMsgCount == 0)
-    {
-        GATEWAY_CONFIG_LOG(WARNING)
-            << LOG_DESC("p2p.session_max_send_msg_count must be positive, clamped to 1");
-        m_maxSendMsgCount = 1;
     }
 
     m_smSSL = smSSL;

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -630,11 +630,19 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     constexpr static uint32_t defaultMaxSendMsgCount = 10;
     m_maxSendMsgCount = _pt.get<uint32_t>("p2p.session_max_send_msg_count", defaultMaxSendMsgCount);
 
-    // session_max_send_data_size / session_max_send_msg_count bound the send-batch budget that
+    // p2p.session_max_send_data_size bounds the send-batch budget that
     // Session::tryPopSomeEncodedMsgs enforces on every write loop iteration. Unlike
-    // p2p.max_connections_per_second above, 0 does NOT mean "unlimited" here: with either budget
-    // at 0 the batch loop never pops, every write loop exits on its first iteration, and all
-    // outbound traffic on the session stalls silently. Clamp to a working minimum instead.
+    // p2p.max_connections_per_second above, 0 does NOT mean "unlimited" here: with the byte
+    // budget at 0 the batch loop never pops, every write loop exits on its first iteration, and
+    // all outbound traffic on the session stalls silently. Clamp to a working minimum instead.
+    //
+    // p2p.session_max_send_msg_count is retained for config-file compatibility but is
+    // deliberately NOT enforced by the batch loop — the base had the message-count condition
+    // commented out and drained the whole queue into a single scatter-gather write, and
+    // re-enabling it capped every async_write at the (default 10) message budget, costing
+    // ceil(N/10) post + async_write round-trips under broadcast fan-out. The byte budget alone
+    // is the sole cap; see the behaviour-change note in the PR description. The clamp below is
+    // kept so a historical 0 in a config file cannot silently mean something else.
     if (m_maxSendDataSize == 0)
     {
         GATEWAY_CONFIG_LOG(WARNING)

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -630,6 +630,24 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     constexpr static uint32_t defaultMaxSendMsgCount = 10;
     m_maxSendMsgCount = _pt.get<uint32_t>("p2p.session_max_send_msg_count", defaultMaxSendMsgCount);
 
+    // session_max_send_data_size / session_max_send_msg_count bound the send-batch budget that
+    // Session::tryPopSomeEncodedMsgs enforces on every write loop iteration. Unlike
+    // p2p.max_connections_per_second above, 0 does NOT mean "unlimited" here: with either budget
+    // at 0 the batch loop never pops, every write loop exits on its first iteration, and all
+    // outbound traffic on the session stalls silently. Clamp to a working minimum instead.
+    if (m_maxSendDataSize == 0)
+    {
+        GATEWAY_CONFIG_LOG(WARNING)
+            << LOG_DESC("p2p.session_max_send_data_size must be positive, clamped to 1");
+        m_maxSendDataSize = 1;
+    }
+    if (m_maxSendMsgCount == 0)
+    {
+        GATEWAY_CONFIG_LOG(WARNING)
+            << LOG_DESC("p2p.session_max_send_msg_count must be positive, clamped to 1");
+        m_maxSendMsgCount = 1;
+    }
+
     m_smSSL = smSSL;
     m_listenIP = listenIP;
     m_listenPort = (uint16_t)listenPort;

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -629,9 +629,20 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     m_maxReadDataSize = _pt.get<uint32_t>("p2p.session_max_read_data_size", defaultMaxReadDataSize);
 
     constexpr static uint32_t defaultMaxSendDataSize = 1024 * 1024;
-    auto maxSendDataSize = _pt.get<uint32_t>("p2p.session_max_send_data_size", defaultMaxSendDataSize);
+    auto maxSendDataSize =
+        _pt.get<uint32_t>("p2p.session_max_send_data_size", defaultMaxSendDataSize);
 
     constexpr static uint32_t defaultMaxSendMsgCount = 10;
+    // p2p.session_max_send_msg_count is parsed for config-file compatibility only and is
+    // deliberately NOT enforced anywhere (see the comment below). If the operator has explicitly
+    // tuned it, say so at startup — a value that is accepted and echoed back but has no effect
+    // would otherwise be silent and indistinguishable from a working setting.
+    if (_pt.get_optional<uint32_t>("p2p.session_max_send_msg_count"))
+    {
+        GATEWAY_CONFIG_LOG(WARNING) << LOG_DESC(
+            "p2p.session_max_send_msg_count is no longer enforced; the send-batch "
+            "is capped by p2p.session_max_send_data_size only");
+    }
     m_maxSendMsgCount = _pt.get<uint32_t>("p2p.session_max_send_msg_count", defaultMaxSendMsgCount);
 
     // p2p.session_max_send_data_size bounds the send-batch budget that
@@ -648,8 +659,9 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     // capped every async_write at the (default 10) message budget, costing ceil(N/10) post +
     // async_write round-trips under broadcast fan-out. The byte budget alone is the sole cap;
     // see the behaviour-change note in the PR description. No clamp here: nothing reads this
-    // value, so warning the operator to "fix" a 0 would invite a config change that changes
-    // nothing.
+    // value, so "fixing" a 0 would change nothing; an explicitly-configured value is instead
+    // flagged with a deprecation warning above so a tuned-but-ignored setting is visible at
+    // startup.
     if (maxSendDataSize == 0)
     {
         GATEWAY_CONFIG_LOG(WARNING)

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -633,7 +633,7 @@ std::shared_ptr<Service> GatewayFactory::buildService(const GatewayConfig::Ptr& 
     // Session Factory
     auto sessionFactory = std::make_shared<SessionFactory>(selfInfo,
         _config->sessionRecvBufferSize(), _config->allowMaxMsgSize(), _config->maxReadDataSize(),
-        _config->maxSendDataSize(), _config->maxMsgCountSendOneTime(), _config->enableCompress());
+        _config->maxSendDataSize(), _config->enableCompress());
     // KeyFactory
     auto keyFactory = std::make_shared<bcos::crypto::KeyFactoryImpl>();
     // Session Callback manager

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -124,6 +124,12 @@ boost::asio::steady_timer ASIOInterface::newTimer(uint32_t timeout)
         *(m_ioServicePool->getIOService()), std::chrono::milliseconds(timeout));
 }
 
+boost::asio::steady_timer ASIOInterface::newAcceptorTimer(uint32_t timeout)
+{
+    return boost::asio::steady_timer(
+        m_acceptor.get_executor(), std::chrono::milliseconds(timeout));
+}
+
 std::shared_ptr<SocketFace> ASIOInterface::newSocket(bool _server, NodeIPEndpoint nodeIPEndpoint)
 {
     std::shared_ptr<SocketFace> socket = std::make_shared<Socket>(m_ioServicePool->getIOService(),

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -100,19 +100,9 @@ void ASIOInterface::setType(int type)
     m_type = type;
 }
 
-void ASIOInterface::setIOServicePool(IOServicePool::Ptr _ioServicePool)
-{
-    m_ioServicePool = std::move(_ioServicePool);
-}
-
 ba::ssl::context* ASIOInterface::srvContext()
 {
     return m_srvContext.has_value() ? &*m_srvContext : nullptr;
-}
-
-ba::ssl::context* ASIOInterface::clientContext()
-{
-    return m_clientContext.has_value() ? &*m_clientContext : nullptr;
 }
 
 void ASIOInterface::setSrvContext(ba::ssl::context _srvContext)
@@ -143,30 +133,6 @@ bi::tcp::acceptor* ASIOInterface::acceptor()
     return &m_acceptor;
 }
 
-void ASIOInterface::asyncAccept(
-    const std::shared_ptr<SocketFace>& socket, Handler_Type handler, boost::system::error_code)
-{
-    m_acceptor.async_accept(socket->ref(), std::move(handler));
-}
-
-void ASIOInterface::asyncRead(const std::shared_ptr<SocketFace>& socket,
-    boost::asio::mutable_buffer buffers, ReadWriteHandler handler)
-{
-    switch (m_type)
-    {
-    case TCP_ONLY:
-    {
-        ba::async_read(socket->ref(), buffers, std::move(handler));
-        break;
-    }
-    case SSL:
-    {
-        ba::async_read(socket->sslref(), buffers, std::move(handler));
-        break;
-    }
-    }
-}
-
 void ASIOInterface::asyncReadSome(const std::shared_ptr<SocketFace>& socket,
     boost::asio::mutable_buffer buffers, ReadWriteHandler handler)
 {
@@ -182,39 +148,40 @@ void ASIOInterface::asyncReadSome(const std::shared_ptr<SocketFace>& socket,
         socket->sslref().async_read_some(buffers, std::move(handler));
         break;
     }
+    default:
+        break;
     }
 }
 
-void ASIOInterface::asyncHandshake(const std::shared_ptr<SocketFace>& socket,
-    ba::ssl::stream_base::handshake_type type, Handler_Type handler)
-{
-    socket->sslref().async_handshake(type, std::move(handler));
-}
-
 void ASIOInterface::setVerifyCallback(
-    const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool)
+    const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool /*unused*/)
 {
     socket->sslref().set_verify_callback(std::move(callback));
 }
 
-void ASIOInterface::asyncResolveConnect(
-    const std::shared_ptr<SocketFace>& socket, Handler_Type handler)
+void ASIOInterface::resolveConnect(const std::shared_ptr<SocketFace>& socket,
+    std::function<void(boost::system::error_code)> handler)
 {
     auto protocol = socket->nodeIPEndpoint().isIPv6() ? bi::tcp::tcp::v6() : bi::tcp::tcp::v4();
     m_resolver.async_resolve(protocol, socket->nodeIPEndpoint().address(),
         to_string(socket->nodeIPEndpoint().port()),
-        [=](const boost::system::error_code& ec, bi::tcp::resolver::results_type results) {
+        [socket, handler = std::move(handler)](const boost::system::error_code& ec,
+            const bi::tcp::resolver::results_type& results) mutable {
             if (ec || results.empty())
             {
                 ASIO_LOG(WARNING) << LOG_DESC("asyncResolve failed")
                                   << LOG_KV("host", socket->nodeIPEndpoint().address())
                                   << LOG_KV("port", socket->nodeIPEndpoint().port());
+                // Total completion: the client coroutine co_awaits this operation, so the
+                // handler must fire on resolve failure too — the old callback version silently
+                // dropped it, which would pin the awaiting coroutine forever.
+                handler(ec ? ec : boost::asio::error::host_not_found);
                 return;
             }
 
             // results is a iterator, but only use first endpoint.
             auto it = results.begin();
-            socket->ref().async_connect(it->endpoint(), handler);
+            socket->ref().async_connect(it->endpoint(), std::move(handler));
             ASIO_LOG(INFO) << LOG_DESC("asyncResolveConnect") << LOG_KV("endpoint", it->endpoint());
         });
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -133,30 +133,27 @@ bi::tcp::acceptor* ASIOInterface::acceptor()
     return &m_acceptor;
 }
 
-void ASIOInterface::asyncReadSome(const std::shared_ptr<SocketFace>& socket,
-    boost::asio::mutable_buffer buffers, ReadWriteHandler handler)
+task::Task<std::tuple<boost::system::error_code, std::size_t>> ASIOInterface::awaitableReadSome(
+    std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers)
 {
     switch (m_type)
     {
     case TCP_ONLY:
-    {
-        socket->ref().async_read_some(buffers, std::move(handler));
-        break;
-    }
+        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [socket = std::move(socket), buffers](auto handler) {
+                socket->ref().async_read_some(buffers, std::move(handler));
+            });
     case SSL:
-    {
-        socket->sslref().async_read_some(buffers, std::move(handler));
-        break;
-    }
+        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [socket = std::move(socket), buffers](auto handler) {
+                socket->sslref().async_read_some(buffers, std::move(handler));
+            });
     default:
         // total completion: an unexpected type must still answer the read, or the awaiting
-        // read-loop coroutine pins forever. Posted, never invoked inline — this function runs on
-        // the initiator's stack (inside the awaitable's await_suspend), and inline invocation
-        // would resume that coroutine from within its own await_suspend.
-        m_ioServicePool->post([handler = std::move(handler)]() mutable {
-            handler(boost::asio::error::operation_not_supported, 0);
-        });
-        break;
+        // read-loop coroutine pins forever
+        co_return std::make_tuple(
+            boost::system::error_code(boost::asio::error::operation_not_supported),
+            std::size_t{0});
     }
 }
 
@@ -164,31 +161,4 @@ void ASIOInterface::setVerifyCallback(
     const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool /*unused*/)
 {
     socket->sslref().set_verify_callback(std::move(callback));
-}
-
-void ASIOInterface::resolveConnect(const std::shared_ptr<SocketFace>& socket,
-    std::function<void(boost::system::error_code)> handler)
-{
-    auto protocol = socket->nodeIPEndpoint().isIPv6() ? bi::tcp::tcp::v6() : bi::tcp::tcp::v4();
-    m_resolver.async_resolve(protocol, socket->nodeIPEndpoint().address(),
-        to_string(socket->nodeIPEndpoint().port()),
-        [socket, handler = std::move(handler)](const boost::system::error_code& ec,
-            const bi::tcp::resolver::results_type& results) mutable {
-            if (ec || results.empty())
-            {
-                ASIO_LOG(WARNING) << LOG_DESC("asyncResolve failed")
-                                  << LOG_KV("host", socket->nodeIPEndpoint().address())
-                                  << LOG_KV("port", socket->nodeIPEndpoint().port());
-                // Total completion: the client coroutine co_awaits this operation, so the
-                // handler must fire on resolve failure too — the old callback version silently
-                // dropped it, which would pin the awaiting coroutine forever.
-                handler(ec ? ec : boost::asio::error::host_not_found);
-                return;
-            }
-
-            // results is a iterator, but only use first endpoint.
-            auto it = results.begin();
-            socket->ref().async_connect(it->endpoint(), std::move(handler));
-            ASIO_LOG(INFO) << LOG_DESC("asyncResolveConnect") << LOG_KV("endpoint", it->endpoint());
-        });
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -91,8 +91,9 @@ ASIOInterface::ASIOInterface(
 {
     boost::asio::socket_base::reuse_address optionReuseAddress(true);
     m_acceptor.set_option(optionReuseAddress);
-    // The read path needs no runtime seam: awaitableReadSome compiles against the default
-    // policy (DefaultReadPolicy), whose invoke() calls the inline initiateReadSome below.
+    // The read path needs no runtime seam: awaitableReadSome compiles against the default policy
+    // (DefaultReadPolicy), whose invoke() directly dispatches async_read_some on the socket
+    // (TCP vs SSL by m_type) — see ASIOInterface.h.
 }
 
 ASIOInterface::~ASIOInterface() = default;

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -91,6 +91,12 @@ ASIOInterface::ASIOInterface(
 {
     boost::asio::socket_base::reuse_address optionReuseAddress(true);
     m_acceptor.set_option(optionReuseAddress);
+    // default read initiation: the real async_read_some dispatch (see the seam contract on
+    // setReadSomeInitiate in ASIOInterface.h)
+    m_readSomeInitiate = [this](const std::shared_ptr<SocketFace>& socket,
+                              boost::asio::mutable_buffer buffers, ReadSomeHandler completion) {
+        initiateReadSome(socket, buffers, std::move(completion));
+    };
 }
 
 ASIOInterface::~ASIOInterface() = default;
@@ -134,8 +140,7 @@ bi::tcp::acceptor* ASIOInterface::acceptor()
 }
 
 void ASIOInterface::initiateReadSome(const std::shared_ptr<SocketFace>& socket,
-    boost::asio::mutable_buffer buffers,
-    detail::AsioCompletion<boost::system::error_code, std::size_t> completion)
+    boost::asio::mutable_buffer buffers, ReadSomeHandler completion)
 {
     switch (m_type)
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -133,27 +133,28 @@ bi::tcp::acceptor* ASIOInterface::acceptor()
     return &m_acceptor;
 }
 
-task::Task<std::tuple<boost::system::error_code, std::size_t>> ASIOInterface::awaitableReadSome(
-    std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers)
+void ASIOInterface::initiateReadSome(const std::shared_ptr<SocketFace>& socket,
+    boost::asio::mutable_buffer buffers,
+    detail::AsioCompletion<boost::system::error_code, std::size_t> completion)
 {
     switch (m_type)
     {
     case TCP_ONLY:
-        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
-            [socket = std::move(socket), buffers](auto handler) {
-                socket->ref().async_read_some(buffers, std::move(handler));
-            });
+        socket->ref().async_read_some(buffers, std::move(completion));
+        break;
     case SSL:
-        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
-            [socket = std::move(socket), buffers](auto handler) {
-                socket->sslref().async_read_some(buffers, std::move(handler));
-            });
+        socket->sslref().async_read_some(buffers, std::move(completion));
+        break;
     default:
         // total completion: an unexpected type must still answer the read, or the awaiting
-        // read-loop coroutine pins forever
-        co_return std::make_tuple(
-            boost::system::error_code(boost::asio::error::operation_not_supported),
-            std::size_t{0});
+        // read-loop coroutine pins forever. POST the completion rather than invoking it
+        // inline — initiateReadSome runs on the initiator's stack inside await_suspend, and
+        // an inline invocation would resume the coroutine from within its own await_suspend.
+        boost::asio::post(socket->ioService(),
+            [completion = std::move(completion)]() mutable {
+                completion(boost::asio::error::operation_not_supported, std::size_t{0});
+            });
+        break;
     }
 }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -149,6 +149,13 @@ void ASIOInterface::asyncReadSome(const std::shared_ptr<SocketFace>& socket,
         break;
     }
     default:
+        // total completion: an unexpected type must still answer the read, or the awaiting
+        // read-loop coroutine pins forever. Posted, never invoked inline — this function runs on
+        // the initiator's stack (inside the awaitable's await_suspend), and inline invocation
+        // would resume that coroutine from within its own await_suspend.
+        m_ioServicePool->post([handler = std::move(handler)]() mutable {
+            handler(boost::asio::error::operation_not_supported, 0);
+        });
         break;
     }
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -91,12 +91,8 @@ ASIOInterface::ASIOInterface(
 {
     boost::asio::socket_base::reuse_address optionReuseAddress(true);
     m_acceptor.set_option(optionReuseAddress);
-    // default read initiation: the real async_read_some dispatch (see the seam contract on
-    // setReadSomeInitiate in ASIOInterface.h)
-    m_readSomeInitiate = [this](const std::shared_ptr<SocketFace>& socket,
-                              boost::asio::mutable_buffer buffers, ReadSomeHandler completion) {
-        initiateReadSome(socket, buffers, std::move(completion));
-    };
+    // The read path needs no runtime seam: awaitableReadSome compiles against the default
+    // policy (DefaultReadPolicy), whose invoke() calls the inline initiateReadSome below.
 }
 
 ASIOInterface::~ASIOInterface() = default;
@@ -137,30 +133,6 @@ std::shared_ptr<SocketFace> ASIOInterface::newSocket(bool _server, NodeIPEndpoin
 bi::tcp::acceptor* ASIOInterface::acceptor()
 {
     return &m_acceptor;
-}
-
-void ASIOInterface::initiateReadSome(const std::shared_ptr<SocketFace>& socket,
-    boost::asio::mutable_buffer buffers, ReadSomeHandler completion)
-{
-    switch (m_type)
-    {
-    case TCP_ONLY:
-        socket->ref().async_read_some(buffers, std::move(completion));
-        break;
-    case SSL:
-        socket->sslref().async_read_some(buffers, std::move(completion));
-        break;
-    default:
-        // total completion: an unexpected type must still answer the read, or the awaiting
-        // read-loop coroutine pins forever. POST the completion rather than invoking it
-        // inline — initiateReadSome runs on the initiator's stack inside await_suspend, and
-        // an inline invocation would resume the coroutine from within its own await_suspend.
-        boost::asio::post(socket->ioService(),
-            [completion = std::move(completion)]() mutable {
-                completion(boost::asio::error::operation_not_supported, std::size_t{0});
-            });
-        break;
-    }
 }
 
 void ASIOInterface::setVerifyCallback(

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -32,7 +32,7 @@ public:
         SSL = 1
     };
 
-    /// read handler
+    /// verify callback
     using VerifyCallback = std::function<bool(bool, boost::asio::ssl::verify_context&)>;
 
     ASIOInterface(IOServicePool::Ptr _ioServicePool, std::string listenHost, uint16_t listenPort);
@@ -51,8 +51,6 @@ public:
 
     virtual bi::tcp::acceptor* acceptor();
 
-    // Kept as the unit-test mock point for the read path: every read-loop test fake overrides
-    // this virtual, and awaitableReadSome below dispatches through it.
     virtual void setVerifyCallback(
         const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool /*unused*/ = true);
 
@@ -61,15 +59,29 @@ public:
     // for the threading / exception / lifetime contract). Each operation guarantees total
     // completion: the awaiting coroutine is resumed exactly once, on success and on failure
     // alike — a silently dropped completion would pin the suspended coroutine (and everything
-    // its frame holds) forever.
+    // its frame holds) forever. The awaitables live in the calling coroutine's own frame — no
+    // bridge frame, and no per-operation allocation — and are obtained from the non-virtual
+    // awaitable* helpers below, which dispatch through a single overridable initiation hook.
     //
-    // awaitableReadSome is the unit-test mock point for the read path. It is a virtual
-    // COROUTINE (a virtual cannot return an AsioAwaitable, whose type depends on the call
-    // site's lambda): the production implementation bridges to async_read_some through
-    // AsioAwaitable, and test fakes override it with their own coroutine. The other
-    // operations are non-virtual and initiate the asio operation directly.
-    virtual task::Task<std::tuple<boost::system::error_code, std::size_t>> awaitableReadSome(
-        std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers);
+    // The read mock point is the initiateReadSome VIRTUAL below: every read-loop test fake
+    // overrides it, and awaitableReadSome dispatches through it. CONTRACT for overrides (and
+    // for every initiate call in this header): the completion must be handed to a deferred
+    // executor (asio, or a post to some io_context) — it must be neither invoked nor dropped
+    // synchronously. A synchronous invocation / drop is neutralized by the arm/cancel handshake
+    // in AsioAwaitable (see AsioAwaitable.h) rather than corrupting the running coroutine, but
+    // the awaitable's total-completion guarantee is clearest when every override defers.
+    virtual void initiateReadSome(const std::shared_ptr<SocketFace>& socket,
+        boost::asio::mutable_buffer buffers,
+        detail::AsioCompletion<boost::system::error_code, std::size_t> completion);
+
+    auto awaitableReadSome(
+        const std::shared_ptr<SocketFace>& socket, boost::asio::mutable_buffer buffers)
+    {
+        return makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [this, socket, buffers](auto handler) {
+                initiateReadSome(socket, buffers, std::move(handler));
+            });
+    }
 
     auto awaitableAccept(const std::shared_ptr<SocketFace>& socket)
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -45,6 +45,11 @@ public:
     virtual void setClientContext(ba::ssl::context _clientContext);
 
     virtual boost::asio::steady_timer newTimer(uint32_t timeout);
+    // Unlike newTimer (round-robin pool context), this timer is bound to the acceptor's own
+    // executor, so awaiting it resumes the caller on the acceptor's single io_context thread.
+    // The accept retry loop relies on that thread to serialize its m_run re-check and its
+    // async_accept re-arm against the cancelAcceptor() that Host::stop() posts there.
+    virtual boost::asio::steady_timer newAcceptorTimer(uint32_t timeout);
 
     virtual std::shared_ptr<SocketFace> newSocket(
         bool _server, NodeIPEndpoint nodeIPEndpoint = NodeIPEndpoint());

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -8,12 +8,14 @@
 #pragma once
 #include "bcos-gateway/libnetwork/AsioAwaitable.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
+#include "bcos-task/Task.h"
 #include "bcos-utilities/IOServicePool.h"
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 
 namespace ba = boost::asio;
@@ -31,7 +33,6 @@ public:
     };
 
     /// read handler
-    using ReadWriteHandler = std::function<void(const boost::system::error_code, std::size_t)>;
     using VerifyCallback = std::function<bool(bool, boost::asio::ssl::verify_context&)>;
 
     ASIOInterface(IOServicePool::Ptr _ioServicePool, std::string listenHost, uint16_t listenPort);
@@ -52,9 +53,6 @@ public:
 
     // Kept as the unit-test mock point for the read path: every read-loop test fake overrides
     // this virtual, and awaitableReadSome below dispatches through it.
-    virtual void asyncReadSome(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers, ReadWriteHandler handler);
-
     virtual void setVerifyCallback(
         const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool /*unused*/ = true);
 
@@ -63,8 +61,16 @@ public:
     // for the threading / exception / lifetime contract). Each operation guarantees total
     // completion: the awaiting coroutine is resumed exactly once, on success and on failure
     // alike — a silently dropped completion would pin the suspended coroutine (and everything
-    // its frame holds) forever. awaitableReadSome dispatches through the asyncReadSome virtual
-    // so unit-test fakes keep intercepting it; the others initiate the asio operation directly.
+    // its frame holds) forever.
+    //
+    // awaitableReadSome is the unit-test mock point for the read path. It is a virtual
+    // COROUTINE (a virtual cannot return an AsioAwaitable, whose type depends on the call
+    // site's lambda): the production implementation bridges to async_read_some through
+    // AsioAwaitable, and test fakes override it with their own coroutine. The other
+    // operations are non-virtual and initiate the asio operation directly.
+    virtual task::Task<std::tuple<boost::system::error_code, std::size_t>> awaitableReadSome(
+        std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers);
+
     auto awaitableAccept(const std::shared_ptr<SocketFace>& socket)
     {
         return makeAsioAwaitable<boost::system::error_code>(
@@ -85,15 +91,6 @@ public:
         return makeAsioAwaitable<boost::system::error_code>(
             [socket, type](auto handler) {
                 socket->sslref().async_handshake(type, std::move(handler));
-            });
-    }
-
-    auto awaitableReadSome(
-        const std::shared_ptr<SocketFace>& socket, boost::asio::mutable_buffer buffers)
-    {
-        return makeAsioAwaitable<boost::system::error_code, std::size_t>(
-            [this, socket, buffers](auto handler) {
-                asyncReadSome(socket, buffers, std::move(handler));
             });
     }
 
@@ -158,9 +155,35 @@ public:
 
 private:
     // resolve + connect helper backing awaitableResolveConnect (total completion: the handler
-    // fires with an error when resolution fails — see the coroutine-interface comment above)
-    void resolveConnect(const std::shared_ptr<SocketFace>& socket,
-        std::function<void(boost::system::error_code)> handler);
+    // fires with an error when resolution fails — see the coroutine-interface comment above).
+    // Templated because the handler is the move-only AsioCompletion.
+    template <typename Handler>
+    void resolveConnect(const std::shared_ptr<SocketFace>& socket, Handler handler)
+    {
+        auto protocol = socket->nodeIPEndpoint().isIPv6() ? bi::tcp::tcp::v6() : bi::tcp::tcp::v4();
+        m_resolver.async_resolve(protocol, socket->nodeIPEndpoint().address(),
+            std::to_string(socket->nodeIPEndpoint().port()),
+            [socket, handler = std::move(handler)](const boost::system::error_code& ec,
+                const bi::tcp::resolver::results_type& results) mutable {
+                if (ec || results.empty())
+                {
+                    ASIO_LOG(WARNING) << LOG_DESC("asyncResolve failed")
+                                      << LOG_KV("host", socket->nodeIPEndpoint().address())
+                                      << LOG_KV("port", socket->nodeIPEndpoint().port());
+                    // Total completion: the client coroutine co_awaits this operation, so the
+                    // handler must fire on resolve failure too — the old callback version
+                    // silently dropped it, which would pin the awaiting coroutine forever.
+                    handler(ec ? ec : boost::asio::error::host_not_found);
+                    return;
+                }
+
+                // results is a iterator, but only use first endpoint.
+                auto it = results.begin();
+                socket->ref().async_connect(it->endpoint(), std::move(handler));
+                ASIO_LOG(INFO) << LOG_DESC("asyncResolveConnect")
+                               << LOG_KV("endpoint", it->endpoint());
+            });
+    }
 
     IOServicePool::Ptr m_ioServicePool;
     bi::tcp::acceptor m_acceptor;

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -6,6 +6,7 @@
  * @date 2018-09-13
  */
 #pragma once
+#include "bcos-gateway/libnetwork/AsioAwaitable.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
 #include "bcos-utilities/IOServicePool.h"
 #include <boost/asio.hpp>
@@ -29,11 +30,7 @@ public:
         SSL = 1
     };
 
-    /// CompletionHandler
-    using Base_Handler = std::function<void()>;
-    /// accept handler
-    using Handler_Type = std::function<void(const boost::system::error_code)>;
-    /// write handler
+    /// read handler
     using ReadWriteHandler = std::function<void(const boost::system::error_code, std::size_t)>;
     using VerifyCallback = std::function<bool(bool, boost::asio::ssl::verify_context&)>;
 
@@ -41,10 +38,7 @@ public:
     virtual ~ASIOInterface();
     virtual void setType(int type);
 
-    virtual void setIOServicePool(IOServicePool::Ptr _ioServicePool);
-
     virtual ba::ssl::context* srvContext();
-    virtual ba::ssl::context* clientContext();
 
     virtual void setSrvContext(ba::ssl::context _srvContext);
     virtual void setClientContext(ba::ssl::context _clientContext);
@@ -56,53 +50,98 @@ public:
 
     virtual bi::tcp::acceptor* acceptor();
 
-    virtual void asyncAccept(const std::shared_ptr<SocketFace>& socket, Handler_Type handler,
-        boost::system::error_code /*unused*/ = boost::system::error_code());
-
-    virtual void asyncResolveConnect(
-        const std::shared_ptr<SocketFace>& socket, Handler_Type handler);
-
-    void asyncWrite(const std::shared_ptr<SocketFace>& socket, auto buffers, auto handler)
-    {
-        auto type = m_type;
-        if (socket->isConnected())
-        {
-            auto& ioService = socket->ioService();
-            boost::asio::post(ioService, [type, socket, buffers = std::move(buffers),
-                                             handler = std::move(handler)]() mutable {
-                switch (type)
-                {
-                case TCP_ONLY:
-                {
-                    ba::async_write(socket->ref(), buffers, std::move(handler));
-                    break;
-                }
-                case SSL:
-                {
-                    ba::async_write(socket->sslref(), buffers, std::move(handler));
-                    break;
-                }
-                }
-            });
-        }
-    }
-
-    virtual void asyncRead(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers, ReadWriteHandler handler);
-
+    // Kept as the unit-test mock point for the read path: every read-loop test fake overrides
+    // this virtual, and awaitableReadSome below dispatches through it.
     virtual void asyncReadSome(const std::shared_ptr<SocketFace>& socket,
         boost::asio::mutable_buffer buffers, ReadWriteHandler handler);
-
-    virtual void asyncHandshake(const std::shared_ptr<SocketFace>& socket,
-        ba::ssl::stream_base::handshake_type type, Handler_Type handler);
 
     virtual void setVerifyCallback(
         const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool /*unused*/ = true);
 
-    template <class Task>
-    void dispatch(Task&& task)
+    // ----- coroutine-facing interface -----------------------------------------
+    // Awaitable network operations, for use inside task::Task coroutines (see AsioAwaitable.h
+    // for the threading / exception / lifetime contract). Each operation guarantees total
+    // completion: the awaiting coroutine is resumed exactly once, on success and on failure
+    // alike — a silently dropped completion would pin the suspended coroutine (and everything
+    // its frame holds) forever. awaitableReadSome dispatches through the asyncReadSome virtual
+    // so unit-test fakes keep intercepting it; the others initiate the asio operation directly.
+    auto awaitableAccept(const std::shared_ptr<SocketFace>& socket)
     {
-        m_ioServicePool->dispatch(std::forward<Task>(task));
+        return makeAsioAwaitable<boost::system::error_code>(
+            [this, socket](auto handler) {
+                m_acceptor.async_accept(socket->ref(), std::move(handler));
+            });
+    }
+
+    auto awaitableResolveConnect(const std::shared_ptr<SocketFace>& socket)
+    {
+        return makeAsioAwaitable<boost::system::error_code>(
+            [this, socket](auto handler) { resolveConnect(socket, std::move(handler)); });
+    }
+
+    static auto awaitableHandshake(const std::shared_ptr<SocketFace>& socket,
+        ba::ssl::stream_base::handshake_type type)
+    {
+        return makeAsioAwaitable<boost::system::error_code>(
+            [socket, type](auto handler) {
+                socket->sslref().async_handshake(type, std::move(handler));
+            });
+    }
+
+    auto awaitableReadSome(
+        const std::shared_ptr<SocketFace>& socket, boost::asio::mutable_buffer buffers)
+    {
+        return makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [this, socket, buffers](auto handler) {
+                asyncReadSome(socket, buffers, std::move(handler));
+            });
+    }
+
+    auto awaitableWrite(const std::shared_ptr<SocketFace>& socket, auto buffers)
+    {
+        return makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [this, socket, buffers = std::move(buffers)](auto handler) mutable {
+                auto type = m_type;
+                auto& ioService = socket->ioService();
+                if (socket->isConnected())
+                {
+                    boost::asio::post(ioService, [type, socket, buffers = std::move(buffers),
+                                                     handler = std::move(handler)]() mutable {
+                        switch (type)
+                        {
+                        case TCP_ONLY:
+                        {
+                            ba::async_write(socket->ref(), buffers, std::move(handler));
+                            break;
+                        }
+                        case SSL:
+                        {
+                            ba::async_write(socket->sslref(), buffers, std::move(handler));
+                            break;
+                        }
+                        default:
+                            break;
+                        }
+                    });
+                }
+                else
+                {
+                    // total completion, see the class comment above
+                    boost::asio::post(ioService, [handler = std::move(handler)]() mutable {
+                        handler(boost::asio::error::not_connected, 0);
+                    });
+                }
+            });
+    }
+
+    // Cancel any pending async_accept so the accept loop (Host::acceptLoop) completes with
+    // operation_aborted and can exit, releasing the strong Host reference its coroutine frame
+    // holds. Must run on the acceptor's io_context thread — post it there, e.g. from Host::stop().
+    void cancelAcceptor()
+    {
+        boost::system::error_code ec;
+        // NOLINTNEXTLINE(bugprone-unused-return-value) error is delivered via the ec out-param
+        m_acceptor.cancel(ec);
     }
 
     template <class Task>
@@ -112,6 +151,11 @@ public:
     }
 
 private:
+    // resolve + connect helper backing awaitableResolveConnect (total completion: the handler
+    // fires with an error when resolution fails — see the coroutine-interface comment above)
+    void resolveConnect(const std::shared_ptr<SocketFace>& socket,
+        std::function<void(boost::system::error_code)> handler);
+
     IOServicePool::Ptr m_ioServicePool;
     bi::tcp::acceptor m_acceptor;
     bi::tcp::resolver m_resolver;

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -120,6 +120,12 @@ public:
                             break;
                         }
                         default:
+                            // total completion: an unexpected type must still answer the
+                            // awaiting coroutine — dropping the handler would pin its frame
+                            // forever. (The completion-or-cancel guard in AsioAwaitable would
+                            // eventually release the frame, but failing loudly here keeps the
+                            // error explicit.)
+                            handler(boost::asio::error::operation_not_supported, 0);
                             break;
                         }
                     });

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -61,25 +61,32 @@ public:
     // alike — a silently dropped completion would pin the suspended coroutine (and everything
     // its frame holds) forever. The awaitables live in the calling coroutine's own frame — no
     // bridge frame, and no per-operation allocation — and are obtained from the non-virtual
-    // awaitable* helpers below, which dispatch through a single overridable initiation hook.
+    // awaitable* helpers below.
     //
-    // The read mock point is the initiateReadSome VIRTUAL below: every read-loop test fake
-    // overrides it, and awaitableReadSome dispatches through it. CONTRACT for overrides (and
-    // for every initiate call in this header): the completion must be handed to a deferred
-    // executor (asio, or a post to some io_context) — it must be neither invoked nor dropped
-    // synchronously. A synchronous invocation / drop is neutralized by the arm/cancel handshake
-    // in AsioAwaitable (see AsioAwaitable.h) rather than corrupting the running coroutine, but
-    // the awaitable's total-completion guarantee is clearest when every override defers.
-    virtual void initiateReadSome(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers,
-        detail::AsioCompletion<boost::system::error_code, std::size_t> completion);
+    // The read mock point is the injectable read-initiation hook (setReadSomeInitiate):
+    // production uses the default target (the real async_read_some dispatch, see the private
+    // initiateReadSome); read-loop test fakes replace it to park / control read completions
+    // deterministically. CONTRACT (for injected fakes and for every initiate call in this
+    // header): the completion must be handed to a deferred executor (asio, or a post to some
+    // io_context) — it must be neither invoked nor dropped synchronously. A synchronous
+    // invocation / drop is neutralized by the arm/cancel handshake in AsioAwaitable (see
+    // AsioAwaitable.h) rather than corrupting the running coroutine, but the awaitable's
+    // total-completion guarantee is clearest when every initiation defers.
+    using ReadSomeHandler = detail::AsioCompletion<boost::system::error_code, std::size_t>;
+    using ReadSomeInitiate = std::function<void(const std::shared_ptr<SocketFace>& socket,
+        boost::asio::mutable_buffer buffers, ReadSomeHandler completion)>;
+    // unit-test seam for the read path (see the contract above); set before reads are armed
+    void setReadSomeInitiate(ReadSomeInitiate initiate)
+    {
+        m_readSomeInitiate = std::move(initiate);
+    }
 
     auto awaitableReadSome(
         const std::shared_ptr<SocketFace>& socket, boost::asio::mutable_buffer buffers)
     {
         return makeAsioAwaitable<boost::system::error_code, std::size_t>(
             [this, socket, buffers](auto handler) {
-                initiateReadSome(socket, buffers, std::move(handler));
+                m_readSomeInitiate(socket, buffers, std::move(handler));
             });
     }
 
@@ -166,6 +173,12 @@ public:
     }
 
 private:
+    // Real read initiation: async_read_some dispatch on m_type (TCP vs SSL, with the unexpected-
+    // type default completing via operation_not_supported). This is the default target of
+    // m_readSomeInitiate (see the seam contract on setReadSomeInitiate).
+    void initiateReadSome(const std::shared_ptr<SocketFace>& socket,
+        boost::asio::mutable_buffer buffers, ReadSomeHandler completion);
+
     // resolve + connect helper backing awaitableResolveConnect (total completion: the handler
     // fires with an error when resolution fails — see the coroutine-interface comment above).
     // Templated because the handler is the move-only AsioCompletion.
@@ -204,5 +217,8 @@ private:
     std::optional<ba::ssl::context> m_srvContext;
     std::optional<ba::ssl::context> m_clientContext;
     int m_type = 0;
+    // The read-initiation seam (see setReadSomeInitiate): defaults to initiateReadSome; read
+    // fakes replace it before reads are armed.
+    ReadSomeInitiate m_readSomeInitiate;
 };
 }  // namespace bcos::gateway

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -63,30 +63,57 @@ public:
     // bridge frame, and no per-operation allocation — and are obtained from the non-virtual
     // awaitable* helpers below.
     //
-    // The read mock point is the injectable read-initiation hook (setReadSomeInitiate):
-    // production uses the default target (the real async_read_some dispatch, see the private
-    // initiateReadSome); read-loop test fakes replace it to park / control read completions
-    // deterministically. CONTRACT (for injected fakes and for every initiate call in this
-    // header): the completion must be handed to a deferred executor (asio, or a post to some
-    // io_context) — it must be neither invoked nor dropped synchronously. A synchronous
-    // invocation / drop is neutralized by the arm/cancel handshake in AsioAwaitable (see
-    // AsioAwaitable.h) rather than corrupting the running coroutine, but the awaitable's
+    // The read path is a COMPILE-TIME policy (the template parameter of awaitableReadSome):
+    // production uses DefaultReadPolicy, whose invoke() directly dispatches async_read_some on
+    // the socket (TCP vs SSL, see DefaultReadPolicy below) — no std::function, no virtual call,
+    // fully inlined. Read-loop test fakes substitute their own policy type to park / control
+    // read completions deterministically. CONTRACT (for custom policies and for every initiate
+    // call in this header): the completion must be handed to a deferred executor (asio, or a
+    // post to some io_context) — it must be neither invoked nor dropped synchronously. A
+    // synchronous invocation / drop is neutralized by the arm/cancel handshake in AsioAwaitable
+    // (see AsioAwaitable.h) rather than corrupting the running coroutine, but the awaitable's
     // total-completion guarantee is clearest when every initiation defers.
     using ReadSomeHandler = detail::AsioCompletion<boost::system::error_code, std::size_t>;
-    using ReadSomeInitiate = std::function<void(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers, ReadSomeHandler completion)>;
-    // unit-test seam for the read path (see the contract above); set before reads are armed
-    void setReadSomeInitiate(ReadSomeInitiate initiate)
-    {
-        m_readSomeInitiate = std::move(initiate);
-    }
 
+    // Production read-initiation policy: directly dispatches async_read_some on the socket
+    // (TCP vs SSL, with the unexpected-type default completing via operation_not_supported).
+    // Nested in ASIOInterface so it can read the private m_type; tests provide their own policy
+    // with the same invoke() signature.
+    struct DefaultReadPolicy
+    {
+        static void invoke(ASIOInterface* self, const std::shared_ptr<SocketFace>& socket,
+            boost::asio::mutable_buffer buffers, ReadSomeHandler completion)
+        {
+            switch (self->m_type)
+            {
+            case TCP_ONLY:
+                socket->ref().async_read_some(buffers, std::move(completion));
+                break;
+            case SSL:
+                socket->sslref().async_read_some(buffers, std::move(completion));
+                break;
+            default:
+                // total completion: an unexpected type must still answer the read, or the
+                // awaiting read-loop coroutine pins forever. POST the completion rather than
+                // invoking it inline — this runs on the initiator's stack inside await_suspend,
+                // and an inline invocation would resume the coroutine from within its own
+                // await_suspend.
+                boost::asio::post(socket->ioService(),
+                    [completion = std::move(completion)]() mutable {
+                        completion(boost::asio::error::operation_not_supported, std::size_t{0});
+                    });
+                break;
+            }
+        }
+    };
+
+    template <typename ReadPolicy = DefaultReadPolicy>
     auto awaitableReadSome(
         const std::shared_ptr<SocketFace>& socket, boost::asio::mutable_buffer buffers)
     {
         return makeAsioAwaitable<boost::system::error_code, std::size_t>(
             [this, socket, buffers](auto handler) {
-                m_readSomeInitiate(socket, buffers, std::move(handler));
+                ReadPolicy::invoke(this, socket, buffers, std::move(handler));
             });
     }
 
@@ -173,12 +200,6 @@ public:
     }
 
 private:
-    // Real read initiation: async_read_some dispatch on m_type (TCP vs SSL, with the unexpected-
-    // type default completing via operation_not_supported). This is the default target of
-    // m_readSomeInitiate (see the seam contract on setReadSomeInitiate).
-    void initiateReadSome(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers, ReadSomeHandler completion);
-
     // resolve + connect helper backing awaitableResolveConnect (total completion: the handler
     // fires with an error when resolution fails — see the coroutine-interface comment above).
     // Templated because the handler is the move-only AsioCompletion.
@@ -217,8 +238,5 @@ private:
     std::optional<ba::ssl::context> m_srvContext;
     std::optional<ba::ssl::context> m_clientContext;
     int m_type = 0;
-    // The read-initiation seam (see setReadSomeInitiate): defaults to initiateReadSome; read
-    // fakes replace it before reads are armed.
-    ReadSomeInitiate m_readSomeInitiate;
 };
 }  // namespace bcos::gateway

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -20,6 +20,7 @@
 #include "bcos-gateway/libnetwork/Common.h"
 #include <boost/exception/diagnostic_information.hpp>
 #include <coroutine>
+#include <cstdint>
 #include <exception>
 #include <tuple>
 #include <type_traits>
@@ -52,19 +53,40 @@ namespace bcos::gateway
 // deliberately torn down, and this matches the base semantics, where destroying an uninvoked
 // handler simply released its captured shared_ptr without firing any logic.
 //
-// Arm/cancel handshake: the completion and await_suspend share three atomics so a completion
-// that resolves DURING initiation can never touch a frame that has not suspended yet (resuming
-// or destroying a still-running coroutine is undefined behaviour):
-//  - m_suspended is set by await_suspend only after initiate() returns, marking the coroutine
-//    as safely suspended. operator() resumes only when it observes this flag; the destructor
-//    performs the frame-destroying rescue only when it observes it too.
-//  - a completion invoked before that point records m_completedBeforeSuspend and defers the
-//    resume; await_suspend observes it and resumes inline (returns false).
-//  - a completion DROPPED before that point (destroyed without invocation, outside stack
-//    unwinding) records m_droppedBeforeSuspend instead of destroying the running frame;
-//    await_suspend observes it and resumes inline with operation_aborted.
+// Arm/cancel handshake: the completion and await_suspend share ONE atomic state (see
+// detail::CompletionState below), and each side claims its transition with a single
+// compare_exchange_strong, so a completion that resolves DURING initiation can never touch a
+// frame that has not suspended yet, and exactly one side wins the transition:
+//  - await_suspend claims Init -> Suspended only after initiate() returns. On success the
+//    coroutine suspends and the completion owns the resume; on failure the observed state
+//    (Completed or Dropped) means the completion already settled synchronously inside
+//    initiate(), so await_suspend resumes inline (returns false) instead.
+//  - operator() writes the result, then claims Init -> Completed. On success await_suspend will
+//    observe it and resume inline — operator() must NOT resume the still-running frame; on
+//    failure the state is Suspended, so it resumes the suspended coroutine.
+//  - ~AsioCompletion claims Init -> Dropped when an armed completion is destroyed without
+//    invocation. On success await_suspend observes it and resumes inline with operation_aborted;
+//    on failure the state is Suspended, so the frame-destroying rescue runs.
+// The single-atomic claim removes the check-then-set window a multi-flag handshake has: a
+// cross-thread completion landing between a read and a later store can no longer be lost.
+//
+// Rescue scope: destroying the suspended frame releases the strong Session/Host reference, the
+// socket and the buffers — everything the coroutine body owns. One small frame is NOT
+// reclaimed: task::wait wraps these loop coroutines in an AsyncTask frame that is resumed only
+// through the inner coroutine's final_suspend, so destroying the inner handle directly orphans
+// the wrapper frame (a bounded, shutdown-scoped leak — one small AsyncTask per rescued
+// operation).
 namespace detail
 {
+// Handshake state shared by the completion and await_suspend (see the arm/cancel handshake
+// contract above). Each transition is claimed by exactly one side via compare_exchange_strong.
+enum class CompletionState : uint8_t
+{
+    Init = 0,   // no side has claimed the completion yet
+    Suspended,  // await_suspend has suspended the coroutine; the completion owns the resume
+    Completed,  // operator() ran (result written); await_suspend resumes inline
+    Dropped     // the armed completion was destroyed uninvoked; await_suspend fails inline
+};
 // Result tuple for the dropped-completion path: the first element (always boost::system::
 // error_code for every awaitable in this file) is operation_aborted, the remaining elements are
 // zero-initialized so the awaiting coroutine sees a well-formed error result.
@@ -86,16 +108,12 @@ class AsioCompletion
 {
 public:
     AsioCompletion(std::tuple<Results...>* result, std::coroutine_handle<> handle,
-        std::atomic<bool>* suspended, std::atomic<bool>* completedBeforeSuspend,
-        std::atomic<bool>* droppedBeforeSuspend)
-      : m_result(result), m_handle(handle), m_suspended(suspended),
-        m_completedBeforeSuspend(completedBeforeSuspend),
-        m_droppedBeforeSuspend(droppedBeforeSuspend)
+        std::atomic<CompletionState>* state)
+      : m_result(result), m_handle(handle), m_state(state)
     {}
     AsioCompletion(AsioCompletion&& other) noexcept
-      : m_result(other.m_result), m_handle(other.m_handle), m_suspended(other.m_suspended),
-        m_completedBeforeSuspend(other.m_completedBeforeSuspend),
-        m_droppedBeforeSuspend(other.m_droppedBeforeSuspend), m_armed(other.m_armed)
+      : m_result(other.m_result), m_handle(other.m_handle), m_state(other.m_state),
+        m_armed(other.m_armed)
     {
         // the moved-from instance no longer owns the completion duty
         other.m_armed = false;
@@ -114,19 +132,19 @@ public:
             // of unwinding; await_resume rethrows the initiation error instead.
             if (m_armed && std::uncaught_exceptions() == 0)
             {
-                if (m_suspended->load(std::memory_order_acquire))
+                auto expected = CompletionState::Init;
+                if (m_state->compare_exchange_strong(expected, CompletionState::Dropped,
+                        std::memory_order_acq_rel))
+                {
+                    // we claimed the drop: await_suspend has not suspended yet (state was
+                    // Init), so it will observe Dropped and resume inline with operation_aborted
+                    return;
+                }
+                if (expected == CompletionState::Suspended)
                 {
                     // the coroutine has suspended and no completion will ever come: release
                     // the frame (and everything it owns) — the completion-or-cancel rescue
                     m_handle.destroy();
-                }
-                else
-                {
-                    // the completion was dropped synchronously inside initiate() WITHOUT
-                    // throwing: the coroutine is still running on the initiator's stack, so
-                    // destroying it would be UB. Record the cancellation instead; await_suspend
-                    // observes it and resumes inline with operation_aborted.
-                    m_droppedBeforeSuspend->store(true, std::memory_order_release);
                 }
             }
         }
@@ -143,17 +161,19 @@ public:
         }
         m_armed = false;
         *m_result = std::make_tuple(std::move(results)...);
-        if (m_suspended->load(std::memory_order_acquire))
+        auto expected = CompletionState::Init;
+        if (m_state->compare_exchange_strong(
+                expected, CompletionState::Completed, std::memory_order_acq_rel))
+        {
+            // we claimed the completion: await_suspend has not suspended yet, so it will
+            // observe Completed and resume inline (return false) — resuming here would resume
+            // a still-running frame (UB)
+            return;
+        }
+        if (expected == CompletionState::Suspended)
         {
             // normal asynchronous completion: the coroutine has suspended, resume it
             resume();
-        }
-        else
-        {
-            // completed synchronously inside initiate(): the coroutine has not suspended yet,
-            // so resuming here would resume a running frame (UB). Record the result instead;
-            // await_suspend observes the flag and resumes inline by returning false.
-            m_completedBeforeSuspend->store(true, std::memory_order_release);
         }
     }
 
@@ -178,9 +198,7 @@ private:
 
     std::tuple<Results...>* m_result;
     std::coroutine_handle<> m_handle;
-    std::atomic<bool>* m_suspended;
-    std::atomic<bool>* m_completedBeforeSuspend;
-    std::atomic<bool>* m_droppedBeforeSuspend;
+    std::atomic<CompletionState>* m_state;
     bool m_armed = true;
 };
 }  // namespace detail
@@ -191,14 +209,11 @@ struct AsioAwaitable
     Initiate m_initiate;
     std::tuple<Results...> m_result{};
     std::exception_ptr m_error = nullptr;
-    // Arm/cancel handshake with the completion (see the detail::AsioCompletion contract above):
-    // m_suspended is set once await_suspend has passed initiate() back control, i.e. the
-    // coroutine is about to suspend; m_completedBeforeSuspend / m_droppedBeforeSuspend record a
-    // completion that fired / was dropped synchronously inside initiate(), which await_suspend
-    // turns into an inline resume instead of suspending.
-    std::atomic<bool> m_suspended{false};
-    std::atomic<bool> m_completedBeforeSuspend{false};
-    std::atomic<bool> m_droppedBeforeSuspend{false};
+    // Arm/cancel handshake with the completion (see the detail::CompletionState contract above):
+    // a single atomic state, claimed once by whichever side wins — await_suspend (Suspended),
+    // the completion (Completed), or its destructor (Dropped). A cross-thread completion landing
+    // between a read and a store of a multi-flag handshake can no longer be lost.
+    std::atomic<detail::CompletionState> m_state{detail::CompletionState::Init};
 
     constexpr bool await_ready() const noexcept { return false; }
     bool await_suspend(std::coroutine_handle<> handle)
@@ -207,21 +222,16 @@ struct AsioAwaitable
         // finish) this coroutine on another thread before initiate() returns — for the write
         // path the initiating thread is an arbitrary producer while completion runs on the
         // socket's io_context — destroying this frame while initiate() is still on the stack.
-        // Nothing member-owned may be touched after the call below.
         auto initiate = std::move(m_initiate);
         try
         {
             // The completion is moved into the operation: initiate must either hand it to a
             // deferred executor (asio) or invoke it before returning — never drop it. Both the
             // synchronous-invocation and the synchronous-drop cases are neutralized by the
-            // handshake (the completion observes m_suspended == false and defers to
-            // await_suspend instead of touching the running frame); the only sanctioned drop is
-            // initiation failure, which unwinds through this catch.
-            m_suspended.store(false, std::memory_order_relaxed);
-            m_completedBeforeSuspend.store(false, std::memory_order_relaxed);
-            m_droppedBeforeSuspend.store(false, std::memory_order_relaxed);
-            initiate(detail::AsioCompletion<Results...>(&m_result, handle, &m_suspended,
-                &m_completedBeforeSuspend, &m_droppedBeforeSuspend));
+            // handshake (the completion's CAS observes Init and defers to await_suspend instead
+            // of touching the running frame); the only sanctioned drop is initiation failure,
+            // which unwinds through this catch.
+            initiate(detail::AsioCompletion<Results...>(&m_result, handle, &m_state));
         }
         catch (...)
         {
@@ -232,22 +242,30 @@ struct AsioAwaitable
             m_error = std::current_exception();
             return false;
         }
-        if (m_completedBeforeSuspend.load(std::memory_order_acquire))
+        // After initiate() returns, touch only the single atomic state below — and only until
+        // the CAS decides: on success we return immediately (the completion owns the resume), so
+        // a cross-thread resume cannot catch us touching members; on failure the completion
+        // settled synchronously inside initiate() WITHOUT resuming (it observed Init and
+        // deferred to us), so the frame is still running and safe to read.
+        auto expected = detail::CompletionState::Init;
+        if (m_state.compare_exchange_strong(
+                expected, detail::CompletionState::Suspended, std::memory_order_acq_rel))
+        {
+            // we claimed the suspend: the coroutine is now parked and the completion (or its
+            // destructor) will resume / release it
+            return true;
+        }
+        if (expected == detail::CompletionState::Completed)
         {
             // the completion fired synchronously inside initiate(): the result is already in
             // m_result, so resume inline (return false) instead of suspending
             return false;
         }
-        if (m_droppedBeforeSuspend.load(std::memory_order_acquire))
-        {
-            // the completion was dropped synchronously inside initiate() without throwing: no
-            // completion will ever come. Resume inline with operation_aborted so the awaiting
-            // coroutine completes with an error instead of suspending forever.
-            m_result = detail::makeOperationAbortedResult<Results...>();
-            return false;
-        }
-        m_suspended.store(true, std::memory_order_release);
-        return true;
+        // Dropped: the completion was dropped synchronously inside initiate() without throwing.
+        // Resume inline with operation_aborted so the awaiting coroutine completes with an error
+        // instead of suspending forever.
+        m_result = detail::makeOperationAbortedResult<Results...>();
+        return false;
     }
     std::tuple<Results...> await_resume()
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -50,26 +50,52 @@ namespace bcos::gateway
 // suspended frame, releasing its references. Destroying — rather than resuming — the coroutine
 // runs no loop code: at that point the objects the loop body would touch may already be gone or
 // deliberately torn down, and this matches the base semantics, where destroying an uninvoked
-// handler simply released its captured shared_ptr without firing any logic. The rescue destroys
-// only the innermost frame of the co_await chain; production unwinding always comes through
-// normal completion (the frame pins the socket, which pins the io_context, so teardown cannot
-// destroy a pending handler out from under it), and test fakes must drain parked reads before
-// tearing down (see the FakeASIO stopReads() pattern in the unittests).
+// handler simply released its captured shared_ptr without firing any logic.
+//
+// Arm/cancel handshake: the completion and await_suspend share three atomics so a completion
+// that resolves DURING initiation can never touch a frame that has not suspended yet (resuming
+// or destroying a still-running coroutine is undefined behaviour):
+//  - m_suspended is set by await_suspend only after initiate() returns, marking the coroutine
+//    as safely suspended. operator() resumes only when it observes this flag; the destructor
+//    performs the frame-destroying rescue only when it observes it too.
+//  - a completion invoked before that point records m_completedBeforeSuspend and defers the
+//    resume; await_suspend observes it and resumes inline (returns false).
+//  - a completion DROPPED before that point (destroyed without invocation, outside stack
+//    unwinding) records m_droppedBeforeSuspend instead of destroying the running frame;
+//    await_suspend observes it and resumes inline with operation_aborted.
 namespace detail
 {
+// Result tuple for the dropped-completion path: the first element (always boost::system::
+// error_code for every awaitable in this file) is operation_aborted, the remaining elements are
+// zero-initialized so the awaiting coroutine sees a well-formed error result.
+template <typename First, typename... Rest>
+std::tuple<First, Rest...> makeOperationAbortedResult()
+{
+    return std::make_tuple(
+        boost::system::error_code(boost::asio::error::operation_aborted), Rest{}...);
+}
+
 // The completion handler handed to asio. Move-only: asio moves (never copies) the handler into
 // the operation, and a move transfers the completion duty to the new instance. Exactly one of
-// two exits happens: operator() runs the handler path, or the armed instance is destroyed first
-// and the rescue above fires.
+// three exits happens: operator() runs the handler path, the armed instance is destroyed while
+// the coroutine is suspended (the rescue above), or the armed instance is destroyed while the
+// coroutine is still running on the initiator's stack (a synchronous drop inside initiate()),
+// which is recorded as a cancellation for await_suspend to observe (see the handshake above).
 template <typename... Results>
 class AsioCompletion
 {
 public:
-    AsioCompletion(std::tuple<Results...>* result, std::coroutine_handle<> handle)
-      : m_result(result), m_handle(handle)
+    AsioCompletion(std::tuple<Results...>* result, std::coroutine_handle<> handle,
+        std::atomic<bool>* suspended, std::atomic<bool>* completedBeforeSuspend,
+        std::atomic<bool>* droppedBeforeSuspend)
+      : m_result(result), m_handle(handle), m_suspended(suspended),
+        m_completedBeforeSuspend(completedBeforeSuspend),
+        m_droppedBeforeSuspend(droppedBeforeSuspend)
     {}
     AsioCompletion(AsioCompletion&& other) noexcept
-      : m_result(other.m_result), m_handle(other.m_handle), m_armed(other.m_armed)
+      : m_result(other.m_result), m_handle(other.m_handle), m_suspended(other.m_suspended),
+        m_completedBeforeSuspend(other.m_completedBeforeSuspend),
+        m_droppedBeforeSuspend(other.m_droppedBeforeSuspend), m_armed(other.m_armed)
     {
         // the moved-from instance no longer owns the completion duty
         other.m_armed = false;
@@ -88,7 +114,20 @@ public:
             // of unwinding; await_resume rethrows the initiation error instead.
             if (m_armed && std::uncaught_exceptions() == 0)
             {
-                m_handle.destroy();
+                if (m_suspended->load(std::memory_order_acquire))
+                {
+                    // the coroutine has suspended and no completion will ever come: release
+                    // the frame (and everything it owns) — the completion-or-cancel rescue
+                    m_handle.destroy();
+                }
+                else
+                {
+                    // the completion was dropped synchronously inside initiate() WITHOUT
+                    // throwing: the coroutine is still running on the initiator's stack, so
+                    // destroying it would be UB. Record the cancellation instead; await_suspend
+                    // observes it and resumes inline with operation_aborted.
+                    m_droppedBeforeSuspend->store(true, std::memory_order_release);
+                }
             }
         }
         catch (...)
@@ -104,7 +143,18 @@ public:
         }
         m_armed = false;
         *m_result = std::make_tuple(std::move(results)...);
-        resume();
+        if (m_suspended->load(std::memory_order_acquire))
+        {
+            // normal asynchronous completion: the coroutine has suspended, resume it
+            resume();
+        }
+        else
+        {
+            // completed synchronously inside initiate(): the coroutine has not suspended yet,
+            // so resuming here would resume a running frame (UB). Record the result instead;
+            // await_suspend observes the flag and resumes inline by returning false.
+            m_completedBeforeSuspend->store(true, std::memory_order_release);
+        }
     }
 
 private:
@@ -128,6 +178,9 @@ private:
 
     std::tuple<Results...>* m_result;
     std::coroutine_handle<> m_handle;
+    std::atomic<bool>* m_suspended;
+    std::atomic<bool>* m_completedBeforeSuspend;
+    std::atomic<bool>* m_droppedBeforeSuspend;
     bool m_armed = true;
 };
 }  // namespace detail
@@ -138,6 +191,14 @@ struct AsioAwaitable
     Initiate m_initiate;
     std::tuple<Results...> m_result{};
     std::exception_ptr m_error = nullptr;
+    // Arm/cancel handshake with the completion (see the detail::AsioCompletion contract above):
+    // m_suspended is set once await_suspend has passed initiate() back control, i.e. the
+    // coroutine is about to suspend; m_completedBeforeSuspend / m_droppedBeforeSuspend record a
+    // completion that fired / was dropped synchronously inside initiate(), which await_suspend
+    // turns into an inline resume instead of suspending.
+    std::atomic<bool> m_suspended{false};
+    std::atomic<bool> m_completedBeforeSuspend{false};
+    std::atomic<bool> m_droppedBeforeSuspend{false};
 
     constexpr bool await_ready() const noexcept { return false; }
     bool await_suspend(std::coroutine_handle<> handle)
@@ -151,11 +212,16 @@ struct AsioAwaitable
         try
         {
             // The completion is moved into the operation: initiate must either hand it to a
-            // deferred executor (asio) or invoke it before returning — never drop it. Dropping
-            // an armed completion outside stack unwinding destroys the RUNNING frame (see the
-            // destructor's rescue); the only sanctioned drop is initiation failure, which
-            // unwinds through this catch.
-            initiate(detail::AsioCompletion<Results...>(&m_result, handle));
+            // deferred executor (asio) or invoke it before returning — never drop it. Both the
+            // synchronous-invocation and the synchronous-drop cases are neutralized by the
+            // handshake (the completion observes m_suspended == false and defers to
+            // await_suspend instead of touching the running frame); the only sanctioned drop is
+            // initiation failure, which unwinds through this catch.
+            m_suspended.store(false, std::memory_order_relaxed);
+            m_completedBeforeSuspend.store(false, std::memory_order_relaxed);
+            m_droppedBeforeSuspend.store(false, std::memory_order_relaxed);
+            initiate(detail::AsioCompletion<Results...>(&m_result, handle, &m_suspended,
+                &m_completedBeforeSuspend, &m_droppedBeforeSuspend));
         }
         catch (...)
         {
@@ -166,6 +232,21 @@ struct AsioAwaitable
             m_error = std::current_exception();
             return false;
         }
+        if (m_completedBeforeSuspend.load(std::memory_order_acquire))
+        {
+            // the completion fired synchronously inside initiate(): the result is already in
+            // m_result, so resume inline (return false) instead of suspending
+            return false;
+        }
+        if (m_droppedBeforeSuspend.load(std::memory_order_acquire))
+        {
+            // the completion was dropped synchronously inside initiate() without throwing: no
+            // completion will ever come. Resume inline with operation_aborted so the awaiting
+            // coroutine completes with an error instead of suspending forever.
+            m_result = detail::makeOperationAbortedResult<Results...>();
+            return false;
+        }
+        m_suspended.store(true, std::memory_order_release);
         return true;
     }
     std::tuple<Results...> await_resume()

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Bridge the callback-style ASIOInterface operations into task::Task coroutines
+ * @file AsioAwaitable.h
+ */
+#pragma once
+#include "bcos-gateway/libnetwork/Common.h"
+#include <boost/exception/diagnostic_information.hpp>
+#include <coroutine>
+#include <tuple>
+#include <utility>
+
+namespace bcos::gateway
+{
+// Awaitable bridging one callback-style asio operation into a task::Task coroutine.
+//
+// Threading contract: the wrapped asio operation never invokes its completion handler inline
+// from the initiating call, so the suspended coroutine is always resumed on the io_context
+// thread that completes the operation — the same thread the old hand-written callback chain ran
+// on. resume() is wrapped in try/catch: an exception escaping the resumed coroutine must not
+// unwind the asio handler into io_context::run() (the same containment the hand-written
+// callbacks applied). The loop coroutines additionally catch everything internally, so this is
+// the second line of defence.
+//
+// Lifetime contract: the awaitable object lives inside the coroutine frame, and asio invokes
+// the completion handler exactly once before the frame can unwind, so the `this` capture is
+// valid for as long as the handler may run.
+template <typename Initiate, typename... Results>
+struct AsioAwaitable
+{
+    Initiate m_initiate;
+    std::tuple<Results...> m_result{};
+
+    constexpr bool await_ready() const noexcept { return false; }
+    void await_suspend(std::coroutine_handle<> handle)
+    {
+        m_initiate([this, handle](Results... results) mutable {
+            m_result = std::make_tuple(std::move(results)...);
+            try
+            {
+                handle.resume();
+            }
+            catch (std::exception const& e)
+            {
+                ASIO_LOG(WARNING) << LOG_DESC("asio awaitable resume exception")
+                                  << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        });
+    }
+    std::tuple<Results...> await_resume() { return std::move(m_result); }
+};
+
+template <typename... Results, typename Initiate>
+auto makeAsioAwaitable(Initiate&& initiate)
+{
+    return AsioAwaitable<std::decay_t<Initiate>, Results...>{
+        std::forward<Initiate>(initiate), {}};
+}
+}  // namespace bcos::gateway

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -122,8 +122,7 @@ private:
         catch (...)
         {
             ASIO_LOG(WARNING) << LOG_DESC("asio awaitable resume exception")
-                              << LOG_KV(
-                                     "what", boost::current_exception_diagnostic_information());
+                              << LOG_KV("what", boost::current_exception_diagnostic_information());
         }
     }
 
@@ -182,7 +181,6 @@ struct AsioAwaitable
 template <typename... Results, typename Initiate>
 auto makeAsioAwaitable(Initiate&& initiate)
 {
-    return AsioAwaitable<std::decay_t<Initiate>, Results...>{
-        std::forward<Initiate>(initiate), {}};
+    return AsioAwaitable<std::decay_t<Initiate>, Results...>{std::forward<Initiate>(initiate), {}};
 }
 }  // namespace bcos::gateway

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -19,11 +19,8 @@
 #pragma once
 #include "bcos-gateway/libnetwork/Common.h"
 #include <boost/exception/diagnostic_information.hpp>
-#include <boost/system/error_code.hpp>
-#include <atomic>
 #include <coroutine>
 #include <exception>
-#include <memory>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -48,22 +45,22 @@ namespace bcos::gateway
 // only while the io_context keeps running — a handler destroyed WITHOUT being invoked (an
 // io_context torn down with the operation still pending, or a test fake that drops the handler)
 // would otherwise pin the suspended coroutine frame forever, leaking everything the frame owns
-// (the strong Session/Host reference, socket, buffers). Every asio-side copy of the handler
-// shares one AsioCompletion; when the last copy is destroyed without the handler ever having
-// run, the completion DESTROYS the suspended frame, releasing its references. Destroying —
-// rather than resuming — the coroutine runs no loop code: at this point the objects the loop
-// body would touch may already be gone or deliberately torn down, and this matches the base
-// semantics, where destroying an uninvoked handler simply released its captured shared_ptr
-// without firing any logic.
+// (the strong Session/Host reference, socket, buffers). The completion therefore watches its
+// own destruction: an armed completion that is destroyed without having run DESTROYS the
+// suspended frame, releasing its references. Destroying — rather than resuming — the coroutine
+// runs no loop code: at that point the objects the loop body would touch may already be gone or
+// deliberately torn down, and this matches the base semantics, where destroying an uninvoked
+// handler simply released its captured shared_ptr without firing any logic. The rescue destroys
+// only the innermost frame of the co_await chain; production unwinding always comes through
+// normal completion (the frame pins the socket, which pins the io_context, so teardown cannot
+// destroy a pending handler out from under it), and test fakes must drain parked reads before
+// tearing down (see the FakeASIO stopReads() pattern in the unittests).
 namespace detail
 {
-// Completion state shared by every copy asio makes of an operation's handler (asio handlers
-// must be copyable for some call sites — e.g. they are type-erased into the std::function of
-// ASIOInterface::asyncReadSome — so the single ownership has to live one indirection away).
-// Exactly one of two exits happens: complete() runs the handler path, or the last shared owner
-// is destroyed first and the destructor destroys the suspended frame. m_completed also
-// serialises the two against each other: the destructor can only run once asio has released
-// every copy, i.e. after complete() ran on one of them.
+// The completion handler handed to asio. Move-only: asio moves (never copies) the handler into
+// the operation, and a move transfers the completion duty to the new instance. Exactly one of
+// two exits happens: operator() runs the handler path, or the armed instance is destroyed first
+// and the rescue above fires.
 template <typename... Results>
 class AsioCompletion
 {
@@ -71,44 +68,44 @@ public:
     AsioCompletion(std::tuple<Results...>* result, std::coroutine_handle<> handle)
       : m_result(result), m_handle(handle)
     {}
+    AsioCompletion(AsioCompletion&& other) noexcept
+      : m_result(other.m_result), m_handle(other.m_handle), m_armed(other.m_armed)
+    {
+        // the moved-from instance no longer owns the completion duty
+        other.m_armed = false;
+    }
     AsioCompletion(const AsioCompletion&) = delete;
     AsioCompletion& operator=(const AsioCompletion&) = delete;
+    AsioCompletion& operator=(AsioCompletion&&) = delete;
 
     ~AsioCompletion() noexcept
     {
         try
         {
-            if (m_completed.exchange(true))
+            // std::uncaught_exceptions(): destruction during stack unwinding means initiation
+            // threw (see await_suspend) and the coroutine is still RUNNING on that stack —
+            // destroying a non-suspended frame is undefined behaviour, so the rescue stays out
+            // of unwinding; await_resume rethrows the initiation error instead.
+            if (m_armed && std::uncaught_exceptions() == 0)
             {
-                return;
+                m_handle.destroy();
             }
-            // asio destroyed the handler without invoking it: destroy the suspended frame so
-            // its strong references unwind instead of leaking (see the header comment). No
-            // result is stored and no loop code runs — resuming here would execute arbitrary
-            // loop bodies (drop(), logging) in a context where the objects they touch may
-            // already be torn down.
-            m_handle.destroy();
         }
         catch (...)
         {}
     }
 
-    void complete(Results... results)
+    void operator()(Results... results)
     {
-        if (m_completed.exchange(true))
+        if (!m_armed)
         {
-            // asio guarantees exactly one invocation; this is only a defensive guard
+            // asio guarantees exactly one invocation; this also rejects a moved-from instance
             return;
         }
+        m_armed = false;
         *m_result = std::make_tuple(std::move(results)...);
         resume();
     }
-
-    // Initiation failed before the handler reached asio: nothing will ever invoke or destroy an
-    // asio-side copy, so the destructor must not fire either — the coroutine is still RUNNING on
-    // the initiator's stack at that point (we are inside its own await_suspend), and destroying
-    // a non-suspended frame is undefined behaviour.
-    void disarm() { m_completed.store(true); }
 
 private:
     void resume() noexcept
@@ -132,7 +129,7 @@ private:
 
     std::tuple<Results...>* m_result;
     std::coroutine_handle<> m_handle;
-    std::atomic<bool> m_completed{false};
+    bool m_armed = true;
 };
 }  // namespace detail
 
@@ -152,22 +149,21 @@ struct AsioAwaitable
         // socket's io_context — destroying this frame while initiate() is still on the stack.
         // Nothing member-owned may be touched after the call below.
         auto initiate = std::move(m_initiate);
-        auto completion =
-            std::make_shared<detail::AsioCompletion<Results...>>(&m_result, handle);
         try
         {
-            // copied, not moved: if initiate() throws, the catch below still needs the completion
-            initiate([completion](Results... results) mutable {
-                completion->complete(std::move(results)...);
-            });
+            // The completion is moved into the operation: initiate must either hand it to a
+            // deferred executor (asio) or invoke it before returning — never drop it. Dropping
+            // an armed completion outside stack unwinding destroys the RUNNING frame (see the
+            // destructor's rescue); the only sanctioned drop is initiation failure, which
+            // unwinds through this catch.
+            initiate(detail::AsioCompletion<Results...>(&m_result, handle));
         }
         catch (...)
         {
             // Initiation itself threw: no handler reached asio, so nothing will resume the
-            // coroutine. Disarm the completion, then resume immediately by NOT suspending;
-            // await_resume rethrows so the loop's own catch handles it, exactly as a synchronous
-            // throw from the old callback-style initiation did.
-            completion->disarm();
+            // coroutine. Resume immediately by NOT suspending; await_resume rethrows so the
+            // loop's own catch handles it, exactly as a synchronous throw from the old
+            // callback-style initiation did.
             m_error = std::current_exception();
             return false;
         }

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -133,19 +133,23 @@ public:
                 // moved-from, or the completion already ran: nothing to settle
                 return;
             }
-            // The std::uncaught_exceptions() guard applies only to the Init -> Dropped claim
-            // below: destruction during stack unwinding means initiation threw (see
-            // await_suspend) and the coroutine is still RUNNING on that stack — destroying a
-            // non-suspended frame is undefined behaviour, so the claim is skipped there and
-            // await_resume rethrows the initiation error instead. The guard must NOT gate the
-            // Suspended-state rescue below: Suspended is published by await_suspend's CAS only
-            // after initiate() returned normally, so a Suspended frame is structurally never
-            // the still-running case — gating it would strand a genuinely parked coroutine
-            // (and everything it owns) whenever the destroying thread happens to be unwinding
-            // for unrelated reasons.
+            // The Init -> Dropped claim is safe in EVERY destruction context, including stack
+            // unwinding: it only records the cancellation — it never touches the frame. When the
+            // destruction comes from an initiation failure unwinding through await_suspend, the
+            // claim succeeds harmlessly and await_suspend's catch resumes inline and rethrows
+            // the initiation error (the Dropped state is never consulted); any other Init-state
+            // destruction (a test fake dropping the handler, io_context teardown on a thread
+            // that happens to be unwinding) records Dropped so await_suspend resumes inline with
+            // operation_aborted instead of parking forever. This is why the claim must NOT be
+            // gated on std::uncaught_exceptions(): that thread-global counter keys on an
+            // unrelated property (is THIS thread unwinding right now), not on the fact that
+            // matters (did initiate() throw on this stack), and gating on it would strand a
+            // genuinely armed completion destroyed on an unwinding thread. The frame-destroying
+            // rescue below needs no such guard either: Suspended is published by await_suspend's
+            // CAS only after initiate() returned normally, so a Suspended frame is structurally
+            // never the still-running case.
             auto expected = CompletionState::Init;
-            if (std::uncaught_exceptions() == 0 &&
-                m_state->compare_exchange_strong(
+            if (m_state->compare_exchange_strong(
                     expected, CompletionState::Dropped, std::memory_order_acq_rel))
             {
                 // we claimed the drop: await_suspend has not suspended yet (state was Init),

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -19,8 +19,13 @@
 #pragma once
 #include "bcos-gateway/libnetwork/Common.h"
 #include <boost/exception/diagnostic_information.hpp>
+#include <boost/system/error_code.hpp>
+#include <atomic>
 #include <coroutine>
+#include <exception>
+#include <memory>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 namespace bcos::gateway
@@ -30,37 +35,152 @@ namespace bcos::gateway
 // Threading contract: the wrapped asio operation never invokes its completion handler inline
 // from the initiating call, so the suspended coroutine is always resumed on the io_context
 // thread that completes the operation — the same thread the old hand-written callback chain ran
-// on. resume() is wrapped in try/catch: an exception escaping the resumed coroutine must not
-// unwind the asio handler into io_context::run() (the same containment the hand-written
-// callbacks applied). The loop coroutines additionally catch everything internally, so this is
-// the second line of defence.
+// on. resume() is wrapped in try/catch (including catch(...)): an exception escaping the resumed
+// coroutine must not unwind the asio handler into io_context::run() (the same containment the
+// hand-written callbacks applied). The loop coroutines additionally catch everything internally,
+// so this is the second line of defence.
 //
-// Lifetime contract: the awaitable object lives inside the coroutine frame, and asio invokes
-// the completion handler exactly once before the frame can unwind, so the `this` capture is
-// valid for as long as the handler may run.
+// Lifetime contract: the awaitable object lives inside the coroutine frame, and the coroutine
+// can only unwind through the completion handler (or the cancellation path below), so the
+// `this` capture is valid for as long as the handler may run.
+//
+// Completion-or-cancel contract: asio normally invokes the completion handler exactly once, but
+// only while the io_context keeps running — a handler destroyed WITHOUT being invoked (an
+// io_context torn down with the operation still pending, or a test fake that drops the handler)
+// would otherwise pin the suspended coroutine frame forever, leaking everything the frame owns
+// (the strong Session/Host reference, socket, buffers). Every asio-side copy of the handler
+// shares one AsioCompletion; when the last copy is destroyed without the handler ever having
+// run, the completion DESTROYS the suspended frame, releasing its references. Destroying —
+// rather than resuming — the coroutine runs no loop code: at this point the objects the loop
+// body would touch may already be gone or deliberately torn down, and this matches the base
+// semantics, where destroying an uninvoked handler simply released its captured shared_ptr
+// without firing any logic.
+namespace detail
+{
+// Completion state shared by every copy asio makes of an operation's handler (asio handlers
+// must be copyable for some call sites — e.g. they are type-erased into the std::function of
+// ASIOInterface::asyncReadSome — so the single ownership has to live one indirection away).
+// Exactly one of two exits happens: complete() runs the handler path, or the last shared owner
+// is destroyed first and the destructor destroys the suspended frame. m_completed also
+// serialises the two against each other: the destructor can only run once asio has released
+// every copy, i.e. after complete() ran on one of them.
+template <typename... Results>
+class AsioCompletion
+{
+public:
+    AsioCompletion(std::tuple<Results...>* result, std::coroutine_handle<> handle)
+      : m_result(result), m_handle(handle)
+    {}
+    AsioCompletion(const AsioCompletion&) = delete;
+    AsioCompletion& operator=(const AsioCompletion&) = delete;
+
+    ~AsioCompletion() noexcept
+    {
+        try
+        {
+            if (m_completed.exchange(true))
+            {
+                return;
+            }
+            // asio destroyed the handler without invoking it: destroy the suspended frame so
+            // its strong references unwind instead of leaking (see the header comment). No
+            // result is stored and no loop code runs — resuming here would execute arbitrary
+            // loop bodies (drop(), logging) in a context where the objects they touch may
+            // already be torn down.
+            m_handle.destroy();
+        }
+        catch (...)
+        {}
+    }
+
+    void complete(Results... results)
+    {
+        if (m_completed.exchange(true))
+        {
+            // asio guarantees exactly one invocation; this is only a defensive guard
+            return;
+        }
+        *m_result = std::make_tuple(std::move(results)...);
+        resume();
+    }
+
+    // Initiation failed before the handler reached asio: nothing will ever invoke or destroy an
+    // asio-side copy, so the destructor must not fire either — the coroutine is still RUNNING on
+    // the initiator's stack at that point (we are inside its own await_suspend), and destroying
+    // a non-suspended frame is undefined behaviour.
+    void disarm() { m_completed.store(true); }
+
+private:
+    void resume() noexcept
+    {
+        try
+        {
+            m_handle.resume();
+        }
+        catch (std::exception const& e)
+        {
+            ASIO_LOG(WARNING) << LOG_DESC("asio awaitable resume exception")
+                              << LOG_KV("what", boost::diagnostic_information(e));
+        }
+        catch (...)
+        {
+            ASIO_LOG(WARNING) << LOG_DESC("asio awaitable resume exception")
+                              << LOG_KV(
+                                     "what", boost::current_exception_diagnostic_information());
+        }
+    }
+
+    std::tuple<Results...>* m_result;
+    std::coroutine_handle<> m_handle;
+    std::atomic<bool> m_completed{false};
+};
+}  // namespace detail
+
 template <typename Initiate, typename... Results>
 struct AsioAwaitable
 {
     Initiate m_initiate;
     std::tuple<Results...> m_result{};
+    std::exception_ptr m_error = nullptr;
 
     constexpr bool await_ready() const noexcept { return false; }
-    void await_suspend(std::coroutine_handle<> handle)
+    bool await_suspend(std::coroutine_handle<> handle)
     {
-        m_initiate([this, handle](Results... results) mutable {
-            m_result = std::make_tuple(std::move(results)...);
-            try
-            {
-                handle.resume();
-            }
-            catch (std::exception const& e)
-            {
-                ASIO_LOG(WARNING) << LOG_DESC("asio awaitable resume exception")
-                                  << LOG_KV("what", boost::diagnostic_information(e));
-            }
-        });
+        // Move the initiate function onto the stack: the completion it schedules may resume (and
+        // finish) this coroutine on another thread before initiate() returns — for the write
+        // path the initiating thread is an arbitrary producer while completion runs on the
+        // socket's io_context — destroying this frame while initiate() is still on the stack.
+        // Nothing member-owned may be touched after the call below.
+        auto initiate = std::move(m_initiate);
+        auto completion =
+            std::make_shared<detail::AsioCompletion<Results...>>(&m_result, handle);
+        try
+        {
+            // copied, not moved: if initiate() throws, the catch below still needs the completion
+            initiate([completion](Results... results) mutable {
+                completion->complete(std::move(results)...);
+            });
+        }
+        catch (...)
+        {
+            // Initiation itself threw: no handler reached asio, so nothing will resume the
+            // coroutine. Disarm the completion, then resume immediately by NOT suspending;
+            // await_resume rethrows so the loop's own catch handles it, exactly as a synchronous
+            // throw from the old callback-style initiation did.
+            completion->disarm();
+            m_error = std::current_exception();
+            return false;
+        }
+        return true;
     }
-    std::tuple<Results...> await_resume() { return std::move(m_result); }
+    std::tuple<Results...> await_resume()
+    {
+        if (m_error)
+        {
+            std::rethrow_exception(m_error);
+        }
+        return std::move(m_result);
+    }
 };
 
 template <typename... Results, typename Initiate>

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -30,10 +30,12 @@ namespace bcos::gateway
 {
 // Awaitable bridging one callback-style asio operation into a task::Task coroutine.
 //
-// Threading contract: the wrapped asio operation never invokes its completion handler inline
-// from the initiating call, so the suspended coroutine is always resumed on the io_context
-// thread that completes the operation — the same thread the old hand-written callback chain ran
-// on. resume() is wrapped in try/catch (including catch(...)): an exception escaping the resumed
+// Threading contract: initiations are expected to defer — the completion handler is handed to a
+// deferred executor (asio, or a post to some io_context) — so the suspended coroutine is resumed
+// on the io_context thread that completes the operation, the same thread the old hand-written
+// callback chain ran on. A synchronous invocation or drop from the initiating call does not
+// corrupt the running coroutine either: it is neutralized by the arm/cancel handshake below.
+// resume() is wrapped in try/catch (including catch(...)): an exception escaping the resumed
 // coroutine must not unwind the asio handler into io_context::run() (the same containment the
 // hand-written callbacks applied). The loop coroutines additionally catch everything internally,
 // so this is the second line of defence.

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -128,26 +128,36 @@ public:
     {
         try
         {
-            // std::uncaught_exceptions(): destruction during stack unwinding means initiation
-            // threw (see await_suspend) and the coroutine is still RUNNING on that stack —
-            // destroying a non-suspended frame is undefined behaviour, so the rescue stays out
-            // of unwinding; await_resume rethrows the initiation error instead.
-            if (m_armed && std::uncaught_exceptions() == 0)
+            if (!m_armed)
             {
-                auto expected = CompletionState::Init;
-                if (m_state->compare_exchange_strong(expected, CompletionState::Dropped,
-                        std::memory_order_acq_rel))
-                {
-                    // we claimed the drop: await_suspend has not suspended yet (state was
-                    // Init), so it will observe Dropped and resume inline with operation_aborted
-                    return;
-                }
-                if (expected == CompletionState::Suspended)
-                {
-                    // the coroutine has suspended and no completion will ever come: release
-                    // the frame (and everything it owns) — the completion-or-cancel rescue
-                    m_handle.destroy();
-                }
+                // moved-from, or the completion already ran: nothing to settle
+                return;
+            }
+            // The std::uncaught_exceptions() guard applies only to the Init -> Dropped claim
+            // below: destruction during stack unwinding means initiation threw (see
+            // await_suspend) and the coroutine is still RUNNING on that stack — destroying a
+            // non-suspended frame is undefined behaviour, so the claim is skipped there and
+            // await_resume rethrows the initiation error instead. The guard must NOT gate the
+            // Suspended-state rescue below: Suspended is published by await_suspend's CAS only
+            // after initiate() returned normally, so a Suspended frame is structurally never
+            // the still-running case — gating it would strand a genuinely parked coroutine
+            // (and everything it owns) whenever the destroying thread happens to be unwinding
+            // for unrelated reasons.
+            auto expected = CompletionState::Init;
+            if (std::uncaught_exceptions() == 0 &&
+                m_state->compare_exchange_strong(
+                    expected, CompletionState::Dropped, std::memory_order_acq_rel))
+            {
+                // we claimed the drop: await_suspend has not suspended yet (state was Init),
+                // so it will observe Dropped and resume inline with operation_aborted
+                return;
+            }
+            if (expected == CompletionState::Suspended ||
+                m_state->load(std::memory_order_acquire) == CompletionState::Suspended)
+            {
+                // the coroutine has suspended and no completion will ever come: release the
+                // frame (and everything it owns) — the completion-or-cancel rescue
+                m_handle.destroy();
             }
         }
         catch (...)

--- a/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/AsioAwaitable.h
@@ -18,7 +18,10 @@
  */
 #pragma once
 #include "bcos-gateway/libnetwork/Common.h"
+#include <boost/asio/error.hpp>
 #include <boost/exception/diagnostic_information.hpp>
+#include <boost/system/error_code.hpp>
+#include <atomic>
 #include <coroutine>
 #include <cstdint>
 #include <exception>

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -158,56 +158,60 @@ task::Task<void> Host::acceptLoop()
                     iterationFailed = true;
                 }
                 socket->close();
-                // re-arm accept (the old code recursed into startAccept here)
-                continue;
+                // NO continue here: a failed iteration must FALL THROUGH to the retry backoff
+                // below (an early continue would skip it and leave iterationFailed dead).
+                // Shutdown is unaffected — !m_run with no ec leaves iterationFailed false, so
+                // the while condition exits without the delay.
             }
-
-            /// if the connected peer over the limitation, drop socket
-            socket->setNodeIPEndpoint(endpoint);
-            // FIB-186: DEBUG, not INFO — under connection churn this fires on every accept and
-            // would flood the log, letting a low-trust peer fill the disk.
-            HOST_LOG(DEBUG) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
-            // FIB-186: bound admission of new connections BEFORE the CPU-heavy TLS handshake,
-            // so connection churn from a low-trust peer cannot flood the shared I/O pool with
-            // accept / handshake / teardown work and starve inter-validator PBFT reads (the
-            // FIB-184 session caps apply only AFTER the handshake completes). Reserve the
-            // in-flight-handshake slot first because it is the refundable check: if the
-            // accept-rate limiter below then rejects, the guard is destroyed and no rate token is
-            // spent. Checking the rate token first would instead waste a token whenever the
-            // handshake cap is already saturated, needlessly lowering the effective accept rate
-            // for legitimate peers arriving in that window. The guard is handed into
-            // serverHandshake, so the slot's acquire and release live in the same coroutine frame
-            // (see tryAcquireHandshakeSlotGuard).
-            std::string remoteAddress = socket->nodeIPEndpoint().address();
-            auto handshakeGuard = tryAcquireHandshakeSlotGuard(weak_from_this());
-            if (!handshakeGuard)
+            else
             {
-                HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
-                                << LOG_DESC("pending-handshake cap reached, reject connection")
-                                << LOG_KV("address", remoteAddress)
-                                << LOG_KV("pendingHandshakes", currentPendingHandshakes())
-                                << LOG_KV("maxPendingHandshakes", m_maxPendingHandshakes);
-                socket->close();
-                continue;
+                /// if the connected peer over the limitation, drop socket
+                socket->setNodeIPEndpoint(endpoint);
+                // FIB-186: DEBUG, not INFO — under connection churn this fires on every accept and
+                // would flood the log, letting a low-trust peer fill the disk.
+                HOST_LOG(DEBUG) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
+                // FIB-186: bound admission of new connections BEFORE the CPU-heavy TLS handshake,
+                // so connection churn from a low-trust peer cannot flood the shared I/O pool with
+                // accept / handshake / teardown work and starve inter-validator PBFT reads (the
+                // FIB-184 session caps apply only AFTER the handshake completes). Reserve the
+                // in-flight-handshake slot first because it is the refundable check: if the
+                // accept-rate limiter below then rejects, the guard is destroyed and no rate token
+                // is spent. Checking the rate token first would instead waste a token whenever the
+                // handshake cap is already saturated, needlessly lowering the effective accept rate
+                // for legitimate peers arriving in that window. The guard is handed into
+                // serverHandshake, so the slot's acquire and release live in the same coroutine
+                // frame (see tryAcquireHandshakeSlotGuard).
+                std::string remoteAddress = socket->nodeIPEndpoint().address();
+                auto handshakeGuard = tryAcquireHandshakeSlotGuard(weak_from_this());
+                if (!handshakeGuard)
+                {
+                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                    << LOG_DESC("pending-handshake cap reached, reject connection")
+                                    << LOG_KV("address", remoteAddress)
+                                    << LOG_KV("pendingHandshakes", currentPendingHandshakes())
+                                    << LOG_KV("maxPendingHandshakes", m_maxPendingHandshakes);
+                    socket->close();
+                    continue;
+                }
+                // Accept-rate token bucket: drops a churn flood cheaply (accept + close) before
+                // paying handshake CPU, which the concurrency cap alone does not. On rejection the
+                // handshake slot reserved just above is released by the guard going out of scope.
+                if (!tryAcquireConnectionToken())
+                {
+                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                    << LOG_DESC("connection accept-rate limit reached, reject")
+                                    << LOG_KV("address", remoteAddress)
+                                    << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
+                    socket->close();
+                    continue;
+                }
+                // Run the per-connection TLS handshake in its own coroutine and keep accepting:
+                // the old code re-armed accept right after arming the async handshake, and
+                // awaiting the handshake here would serialize accepts (one handshake at a time),
+                // defeating the concurrency-cap design. The handshake slot guard travels with the
+                // coroutine frame, so the slot is released exactly when that frame unwinds.
+                task::wait(serverHandshake(std::move(socket), std::move(handshakeGuard)));
             }
-            // Accept-rate token bucket: drops a churn flood cheaply (accept + close) before
-            // paying handshake CPU, which the concurrency cap alone does not. On rejection the
-            // handshake slot reserved just above is released by the guard going out of scope.
-            if (!tryAcquireConnectionToken())
-            {
-                HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
-                                << LOG_DESC("connection accept-rate limit reached, reject")
-                                << LOG_KV("address", remoteAddress)
-                                << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
-                socket->close();
-                continue;
-            }
-            // Run the per-connection TLS handshake in its own coroutine and keep accepting: the
-            // old code re-armed accept right after arming the async handshake, and awaiting the
-            // handshake here would serialize accepts (one handshake at a time), defeating the
-            // concurrency-cap design. The handshake slot guard travels with the coroutine frame,
-            // so the slot is released exactly when that frame unwinds.
-            task::wait(serverHandshake(std::move(socket), std::move(handshakeGuard)));
         }
         catch (...)
         {
@@ -858,12 +862,16 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
             HOST_LOG(ERROR) << LOG_DESC("TCP Connection refused by node")
                             << LOG_KV("endpoint", _nodeIPEndpoint)
                             << LOG_KV("message", ec.message());
-            socket->close();
-            connectTimer->cancel();
-
-            boost::asio::post(socket->ioService(), [callback = std::move(callback)]() mutable {
-                callback(NetworkException(ConnectError, "Connect failed"), {}, {});
-            });
+            // Settle on the SOCKET's io_context: on RESOLVE failure this coroutine resumed on
+            // the resolver's context (resolveConnect invokes the handler inline from the
+            // resolver completion), while connectTimer's async_wait handler runs on the
+            // socket's — close()/cancel() from here would race it ("Shared objects: Unsafe").
+            boost::asio::post(socket->ioService(),
+                [socket, connectTimer, callback = std::move(callback)]() mutable {
+                    socket->close();
+                    connectTimer->cancel();
+                    callback(NetworkException(ConnectError, "Connect failed"), {}, {});
+                });
             co_return;
         }
         insertPendingConns(_nodeIPEndpoint);
@@ -890,16 +898,20 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
         // setVerifyCallback, or an initiation failure rethrown by await_resume) would otherwise
         // leak the pending-connection entry — permanently blocking every future reconnect to
         // this peer — and orphan the caller's callback. Settle the operation exactly like the
-        // error paths do: erase the entry, close the socket and answer the callback. POSTED, not
-        // inline — this catch can run on a producer's stack inside an await_suspend.
+        // error paths do: erase the entry, close the socket and answer the callback. The
+        // socket teardown is POSTED to the socket's io_context — this catch is reachable on
+        // the resolver's thread (see the resolve-failure branch above) as well as on a
+        // producer's stack inside an await_suspend, and close() from here would race the
+        // connect timer's handler ("Shared objects: Unsafe").
         erasePendingConns(_nodeIPEndpoint);
-        socket->close();
-        if (callback)
-        {
-            boost::asio::post(socket->ioService(), [callback = std::move(callback)]() mutable {
-                callback(NetworkException(ConnectError, "Connect failed"), {}, {});
+        boost::asio::post(socket->ioService(),
+            [socket, callback = std::move(callback)]() mutable {
+                socket->close();
+                if (callback)
+                {
+                    callback(NetworkException(ConnectError, "Connect failed"), {}, {});
+                }
             });
-        }
     }
 }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -235,8 +235,8 @@ task::Task<void> Host::acceptLoop()
             catch (...)
             {
                 HOST_LOG(ERROR) << LOG_DESC("accept retry timer exception")
-                                << LOG_KV("what",
-                                       boost::current_exception_diagnostic_information());
+                                << LOG_KV(
+                                       "what", boost::current_exception_diagnostic_information());
             }
         }
     }
@@ -954,8 +954,7 @@ void Host::stop()
             // m_run == false and exit. With no inbound connection, a Host whose cancel was lost
             // here stays alive until stop() is retried.
             HOST_LOG(WARNING) << LOG_DESC("cancel acceptor on stop failed")
-                              << LOG_KV("what",
-                                     boost::current_exception_diagnostic_information());
+                              << LOG_KV("what", boost::current_exception_diagnostic_information());
         }
     }
     // FIB-186 (vector D): the dedicated teardown executor is deliberately NOT stopped here.

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -850,8 +850,12 @@ void Host::stop()
         }
         catch (...)
         {
-            // stop() also runs from ~Host, which must not throw; a lost cancel only delays the
-            // accept loop's exit (it still ends on the next accept or acceptor destruction)
+            // stop() also runs from ~Host, which must not throw. A lost cancel is NOT
+            // self-healing: the accept loop's coroutine frame holds this Host (and with it the
+            // ASIOInterface and the acceptor) alive, so "acceptor destruction" can never end the
+            // loop from the outside — only the NEXT completed accept lets the loop observe
+            // m_run == false and exit. With no inbound connection, a Host whose cancel was lost
+            // here stays alive until stop() is retried.
             HOST_LOG(WARNING) << LOG_DESC("cancel acceptor on stop failed")
                               << LOG_KV("what",
                                      boost::current_exception_diagnostic_information());
@@ -889,6 +893,14 @@ void bcos::gateway::Host::postTeardown(std::function<void()> f)
 }
 bcos::gateway::Host::~Host()
 {
+    // The accept loop's coroutine frame holds a strong Host reference, so reaching ~Host with
+    // m_run still set means the loop was never started — a started-but-never-stopped Host simply
+    // never gets here (see the stop() contract on the class comment). Flag the missing stop()
+    // rather than letting it pass silently.
+    if (m_run)
+    {
+        HOST_LOG(WARNING) << LOG_DESC("Host destroyed without stop()");
+    }
     stop();
 };
 uint16_t bcos::gateway::Host::listenPort() const

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -123,6 +123,7 @@ task::Task<void> Host::acceptLoop()
     // failed iteration must be survivable, so each one is guarded and the loop continues.
     while (m_run)
     {
+        bool iterationFailed = false;
         try
         {
             auto socket = m_asioInterface->newSocket(true, NodeIPEndpoint());
@@ -190,8 +191,23 @@ task::Task<void> Host::acceptLoop()
         {
             // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
             // a failed iteration must not kill the accept loop, so log and continue
+            iterationFailed = true;
             HOST_LOG(ERROR) << LOG_DESC("accept iteration exception")
                             << LOG_KV("what", boost::current_exception_diagnostic_information());
+        }
+        // Give a failed iteration a suspension point before retrying: when the throw came from
+        // newSocket() (the canonical failure is fd exhaustion), the iteration never reached the
+        // accept co_await, so falling straight through would spin synchronously and starve the
+        // acceptor's io_context thread — the shared resolver and the session sockets live on it.
+        // A short timer turns a persistent failure into a slow retry loop instead of a livelock.
+        // (co_await is not permitted inside a catch handler, so the delay lives after the
+        // try/catch, reached only on a failed iteration.)
+        if (iterationFailed)
+        {
+            auto retryTimer = m_asioInterface->newTimer(ACCEPT_RETRY_INTERVAL_MS);
+            co_await makeAsioAwaitable<boost::system::error_code>([&retryTimer](auto handler) {
+                retryTimer.async_wait(std::move(handler));
+            });
         }
     }
 }
@@ -808,6 +824,21 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
         HOST_LOG(ERROR) << LOG_DESC("client connect exception")
                         << LOG_KV("endpoint", _nodeIPEndpoint)
                         << LOG_KV("what", boost::current_exception_diagnostic_information());
+        // Total completion for the caller-facing callback: an exception between
+        // insertPendingConns() and handshakeClient() (bad_alloc on endpointPublicKey,
+        // setVerifyCallback, or an initiation failure rethrown by await_resume) would otherwise
+        // leak the pending-connection entry — permanently blocking every future reconnect to
+        // this peer — and orphan the caller's callback. Settle the operation exactly like the
+        // error paths do: erase the entry, close the socket and answer the callback. POSTED, not
+        // inline — this catch can run on a producer's stack inside an await_suspend.
+        erasePendingConns(_nodeIPEndpoint);
+        socket->close();
+        if (callback)
+        {
+            boost::asio::post(socket->ioService(), [callback = std::move(callback)]() mutable {
+                callback(NetworkException(ConnectError, "Connect failed"), {}, {});
+            });
+        }
     }
 }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -21,6 +21,7 @@
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
 #include "bcos-utilities/IOServicePool.h"
+#include <bcos-task/Wait.h>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -70,120 +71,144 @@ struct HandshakeSlotGuard
  * information)
  * @attention: this function is called repeatedly
  */
-void Host::startAccept(boost::system::error_code boost_error)
+void Host::startAccept(boost::system::error_code /*boost_error*/)
 {
     /// accept the connection
     if (m_run)
     {
         HOST_LOG(INFO) << LOG_DESC("P2P StartAccept") << LOG_KV("Host", m_listenHost) << ":"
                        << m_listenPort;
-        auto socket = m_asioInterface->newSocket(true, NodeIPEndpoint());
-        // get and set the accepted endpoint to socket(client endpoint)
-        /// define callback after accept connections
-        m_asioInterface->asyncAccept(
-            socket,
-            [this, socket](boost::system::error_code ec) {
-                /// get the endpoint information of remote client after accept the
-                /// connections
-                auto endpoint = socket->remoteEndpoint();
-                HOST_LOG(TRACE) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
-                /// network accept failed
-                if (ec || !m_run)
-                {
-                    HOST_LOG(ERROR) << "Error: " << ec;
-                    socket->close();
-                    startAccept();
+        // fire-and-forget: the detached task owns the coroutine chain; acceptLoop() exits when
+        // Host::stop() clears m_run and cancels the acceptor.
+        task::wait(acceptLoop());
+    }
+}
 
-                    return;
-                }
+task::Task<void> Host::acceptLoop()
+{
+    // The frame holds the Host alive for the whole accept loop. This deliberately extends the old
+    // lifetime (the accept handler held a raw this): the loop only exits after Host::stop()
+    // cancels the acceptor, so a pending async_accept can never fire on a destroyed Host.
+    auto self = shared_from_this();
+    try
+    {
+        while (m_run)
+        {
+            auto socket = m_asioInterface->newSocket(true, NodeIPEndpoint());
+            auto [ec] = co_await m_asioInterface->awaitableAccept(socket);
+            /// get the endpoint information of remote client after accept the connections
+            auto endpoint = socket->remoteEndpoint();
+            HOST_LOG(TRACE) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
+            /// network accept failed
+            if (ec || !m_run)
+            {
+                HOST_LOG(ERROR) << "Error: " << ec;
+                socket->close();
+                // re-arm accept (the old code recursed into startAccept here)
+                continue;
+            }
 
-                /// if the connected peer over the limitation, drop socket
-                socket->setNodeIPEndpoint(endpoint);
-                // FIB-186: DEBUG, not INFO — under connection churn this fires on every accept and
-                // would flood the log, letting a low-trust peer fill the disk.
-                HOST_LOG(DEBUG) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
-                // FIB-186: bound concurrent in-flight TLS handshakes (global cap) BEFORE starting
-                // the handshake. The FIB-184 session caps apply only after the handshake completes,
-                // so connection churn from a low-trust peer would otherwise flood the shared I/O
-                // thread-pool with accept / handshake / teardown work and starve inter-validator
-                // PBFT reads, halting consensus. Over the cap, drop the socket and re-arm accept
-                // without running the (CPU-heavy) TLS handshake.
-                std::string remoteAddress = socket->nodeIPEndpoint().address();
-                // FIB-186: bound admission of new connections BEFORE the CPU-heavy TLS handshake,
-                // so connection churn from a low-trust peer cannot flood the shared I/O pool with
-                // accept / handshake / teardown work and starve inter-validator PBFT reads (the
-                // FIB-184 session caps apply only AFTER the handshake completes). Reserve the
-                // in-flight-handshake slot first because it is the refundable check: if the
-                // accept-rate limiter below then rejects, we release the slot and no rate token is
-                // spent. Checking the rate token first would instead waste a token whenever the
-                // handshake cap is already saturated, needlessly lowering the effective accept rate
-                // for legitimate peers arriving in that window.
-                if (!tryAcquireHandshakeSlot())
-                {
-                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
-                                    << LOG_DESC("pending-handshake cap reached, reject connection")
-                                    << LOG_KV("address", remoteAddress)
-                                    << LOG_KV("pendingHandshakes", currentPendingHandshakes())
-                                    << LOG_KV("maxPendingHandshakes", m_maxPendingHandshakes);
-                    socket->close();
-                    startAccept();
-                    return;
-                }
-                // Accept-rate token bucket: drops a churn flood cheaply (accept + close) before
-                // paying handshake CPU, which the concurrency cap alone does not. On rejection the
-                // handshake slot reserved just above must be released so it is not leaked -- the
-                // HandshakeSlotGuard that normally releases it is only created once both checks
-                // pass.
-                if (!tryAcquireConnectionToken())
-                {
-                    releaseHandshakeSlot();
-                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
-                                    << LOG_DESC("connection accept-rate limit reached, reject")
-                                    << LOG_KV("address", remoteAddress)
-                                    << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
-                    socket->close();
-                    startAccept();
-                    return;
-                }
-                // Release the slot exactly once when the handshake completes (success, failure, or
-                // abort): the guard rides the completion handler and is destroyed with it.
-                auto handshakeGuard = std::make_shared<HandshakeSlotGuard>(weak_from_this());
-                // FIB-186: bound the handshake's lifetime. A stalled / slow TLS handshake would
-                // otherwise never complete, so its admission slot (above) would never be released
-                // and this Host (kept alive by the completion handler's shared_from_this) could
-                // never be destroyed. On timeout close the socket; that completes async_handshake
-                // with an error, so the completion handler runs, the guard is destroyed and the
-                // slot released. The timer and the handshake completion run on the socket's single
-                // io_context thread, so they are serialised (no race on close/cancel). Same pattern
-                // as the outbound connectTimer.
-                auto handshakeTimer = std::make_shared<boost::asio::steady_timer>(
-                    socket->ioService(), std::chrono::milliseconds(m_handshakeTimeout));
-                handshakeTimer->async_wait([socket](const boost::system::error_code& timerError) {
-                    if (timerError == boost::asio::error::operation_aborted)
-                    {
-                        return;
-                    }
-                    if (socket->isConnected())
-                    {
-                        HOST_LOG(WARNING) << LOG_BADGE("startAccept")
-                                          << LOG_DESC("in-flight handshake timed out, close socket")
-                                          << LOG_KV("endpoint", socket->nodeIPEndpoint());
-                        socket->close();
-                    }
-                });
-                /// register ssl callback to get the NodeID of peers
-                std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
-                m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
-                m_asioInterface->asyncHandshake(socket, ba::ssl::stream_base::server,
-                    [self = shared_from_this(), endpointPublicKey, socket, handshakeGuard,
-                        handshakeTimer](const boost::system::error_code& handshakeError) {
-                        handshakeTimer->cancel();
-                        self->handshakeServer(handshakeError, endpointPublicKey, socket);
-                    });
+            /// if the connected peer over the limitation, drop socket
+            socket->setNodeIPEndpoint(endpoint);
+            // FIB-186: DEBUG, not INFO — under connection churn this fires on every accept and
+            // would flood the log, letting a low-trust peer fill the disk.
+            HOST_LOG(DEBUG) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
+            // FIB-186: bound admission of new connections BEFORE the CPU-heavy TLS handshake,
+            // so connection churn from a low-trust peer cannot flood the shared I/O pool with
+            // accept / handshake / teardown work and starve inter-validator PBFT reads (the
+            // FIB-184 session caps apply only AFTER the handshake completes). Reserve the
+            // in-flight-handshake slot first because it is the refundable check: if the
+            // accept-rate limiter below then rejects, we release the slot and no rate token is
+            // spent. Checking the rate token first would instead waste a token whenever the
+            // handshake cap is already saturated, needlessly lowering the effective accept rate
+            // for legitimate peers arriving in that window.
+            std::string remoteAddress = socket->nodeIPEndpoint().address();
+            if (!tryAcquireHandshakeSlot())
+            {
+                HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                << LOG_DESC("pending-handshake cap reached, reject connection")
+                                << LOG_KV("address", remoteAddress)
+                                << LOG_KV("pendingHandshakes", currentPendingHandshakes())
+                                << LOG_KV("maxPendingHandshakes", m_maxPendingHandshakes);
+                socket->close();
+                continue;
+            }
+            // Accept-rate token bucket: drops a churn flood cheaply (accept + close) before
+            // paying handshake CPU, which the concurrency cap alone does not. On rejection the
+            // handshake slot reserved just above must be released so it is not leaked -- the
+            // HandshakeSlotGuard that normally releases it is only created once both checks
+            // pass.
+            if (!tryAcquireConnectionToken())
+            {
+                releaseHandshakeSlot();
+                HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                << LOG_DESC("connection accept-rate limit reached, reject")
+                                << LOG_KV("address", remoteAddress)
+                                << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
+                socket->close();
+                continue;
+            }
+            // Run the per-connection TLS handshake in its own coroutine and keep accepting: the
+            // old code re-armed accept right after arming the async handshake, and awaiting the
+            // handshake here would serialize accepts (one handshake at a time), defeating the
+            // concurrency-cap design.
+            task::wait(serverHandshake(std::move(socket)));
+        }
+    }
+    catch (...)
+    {
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h)
+        HOST_LOG(ERROR) << LOG_DESC("accept loop exception")
+                        << LOG_KV("what", boost::current_exception_diagnostic_information());
+    }
+}
 
-                startAccept();
-            },
-            boost_error);
+task::Task<void> Host::serverHandshake(std::shared_ptr<SocketFace> socket)
+{
+    auto self = shared_from_this();
+    // FIB-186: release the in-flight-handshake slot exactly once when this frame unwinds
+    // (handshake success, failure, abort, or an escaping exception). This replaces the guard
+    // riding the old completion handler with plain RAII on the coroutine frame.
+    HandshakeSlotGuard handshakeGuard(weak_from_this());
+    try
+    {
+        // FIB-186: bound the handshake's lifetime. A stalled / slow TLS handshake would
+        // otherwise never complete, so its admission slot would never be released and this Host
+        // (kept alive by the coroutine frame's shared_from_this) could never be destroyed. On
+        // timeout close the socket; that completes async_handshake with an error, so the
+        // coroutine resumes, the guard is destroyed and the slot released. The timer and the
+        // handshake completion run on the socket's single io_context thread, so they are
+        // serialised (no race on close/cancel). Same pattern as the outbound connectTimer.
+        auto handshakeTimer = std::make_shared<boost::asio::steady_timer>(
+            socket->ioService(), std::chrono::milliseconds(m_handshakeTimeout));
+        handshakeTimer->async_wait([socket](const boost::system::error_code& timerError) {
+            if (timerError == boost::asio::error::operation_aborted)
+            {
+                return;
+            }
+            if (socket->isConnected())
+            {
+                HOST_LOG(WARNING) << LOG_BADGE("startAccept")
+                                  << LOG_DESC("in-flight handshake timed out, close socket")
+                                  << LOG_KV("endpoint", socket->nodeIPEndpoint());
+                socket->close();
+            }
+        });
+        /// register ssl callback to get the NodeID of peers
+        std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
+        m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
+        auto [handshakeError] =
+            co_await m_asioInterface->awaitableHandshake(socket, ba::ssl::stream_base::server);
+        handshakeTimer->cancel();
+        handshakeServer(handshakeError, endpointPublicKey, socket);
+    }
+    catch (...)
+    {
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
+        // the HandshakeSlotGuard still releases the admission slot on unwind
+        HOST_LOG(ERROR) << LOG_DESC("server handshake exception")
+                        << LOG_KV("endpoint", socket->nodeIPEndpoint())
+                        << LOG_KV("what", boost::current_exception_diagnostic_information());
     }
 }
 
@@ -647,7 +672,7 @@ void Host::start()
     if (!haveNetwork())
     {
         m_run = true;
-        if (m_asioInterface->acceptor())
+        if (m_asioInterface->acceptor() != nullptr)
         {
             startAccept();
         }
@@ -678,62 +703,78 @@ void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
     }
 
     std::shared_ptr<SocketFace> socket = m_asioInterface->newSocket(false, _nodeIPEndpoint);
-    /// if async connect timeout, close the socket directly
-    auto connectTimer = std::make_shared<boost::asio::steady_timer>(
-        socket->ioService(), std::chrono::milliseconds(m_connectTimeThre));
-    connectTimer->async_wait(
-        [this, socket, _nodeIPEndpoint](const boost::system::error_code& error) {
-            /// return when cancel has been called
-            if (error == boost::asio::error::operation_aborted)
-            {
-                HOST_LOG(DEBUG) << LOG_DESC("AsyncConnect handshake handler revoke this operation");
-                return;
-            }
-            /// connection timer error
-            if (error && error != boost::asio::error::operation_aborted)
-            {
-                HOST_LOG(ERROR) << LOG_DESC("AsyncConnect timer failed")
-                                << LOG_KV("errorValue", error.value())
-                                << LOG_KV("message", error.message());
-            }
-            if (socket->isConnected())
-            {
-                HOST_LOG(WARNING) << LOG_DESC("AsyncConnect timeout erase")
-                                  << LOG_KV("endpoint", _nodeIPEndpoint);
-                erasePendingConns(_nodeIPEndpoint);
-                socket->close();
-            }
-        });
-    /// callback async connect
-    m_asioInterface->asyncResolveConnect(socket,
-        [this, callback = std::move(callback), _nodeIPEndpoint, socket,
-            connectTimer = std::move(connectTimer)](boost::system::error_code const& ec) mutable {
-            if (ec)
-            {
-                HOST_LOG(ERROR) << LOG_DESC("TCP Connection refused by node")
-                                << LOG_KV("endpoint", _nodeIPEndpoint)
-                                << LOG_KV("message", ec.message());
-                socket->close();
+    // fire-and-forget: the coroutine frame owns the connect/handshake chain (and the strong Host
+    // reference) until it completes — the old nested-lambda chain did the same via captures.
+    task::wait(clientConnect(std::move(socket), _nodeIPEndpoint, std::move(callback)));
+}
 
-                boost::asio::post(socket->ioService(), [callback = std::move(callback)]() mutable {
-                    callback(NetworkException(ConnectError, "Connect failed"), {}, {});
-                });
-                return;
-            }
-            insertPendingConns(_nodeIPEndpoint);
-            /// get the public key of the server during handshake
-            std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
-            m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
-            /// call handshakeClient after handshake succeed
-            m_asioInterface->asyncHandshake(socket, ba::ssl::stream_base::client,
-                [self = shared_from_this(), socket,
-                    endpointPublicKey = std::move(endpointPublicKey),
-                    callback = std::move(callback), nodeIPEndPoint = _nodeIPEndpoint,
-                    connectTimer = std::move(connectTimer)](auto error) mutable {
-                    self->handshakeClient(error, std::move(socket), endpointPublicKey,
-                        std::move(callback), nodeIPEndPoint, std::move(connectTimer));
-                });
-        });
+task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
+    NodeIPEndpoint _nodeIPEndpoint,
+    std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)> callback)
+{
+    auto self = shared_from_this();
+    try
+    {
+        /// if async connect timeout, close the socket directly
+        auto connectTimer = std::make_shared<boost::asio::steady_timer>(
+            socket->ioService(), std::chrono::milliseconds(m_connectTimeThre));
+        connectTimer->async_wait(
+            [this, socket, _nodeIPEndpoint](const boost::system::error_code& error) {
+                /// return when cancel has been called
+                if (error == boost::asio::error::operation_aborted)
+                {
+                    HOST_LOG(DEBUG)
+                        << LOG_DESC("AsyncConnect handshake handler revoke this operation");
+                    return;
+                }
+                /// connection timer error
+                if (error && error != boost::asio::error::operation_aborted)
+                {
+                    HOST_LOG(ERROR) << LOG_DESC("AsyncConnect timer failed")
+                                    << LOG_KV("errorValue", error.value())
+                                    << LOG_KV("message", error.message());
+                }
+                if (socket->isConnected())
+                {
+                    HOST_LOG(WARNING) << LOG_DESC("AsyncConnect timeout erase")
+                                      << LOG_KV("endpoint", _nodeIPEndpoint);
+                    erasePendingConns(_nodeIPEndpoint);
+                    socket->close();
+                }
+            });
+        /// callback async connect
+        auto [ec] = co_await m_asioInterface->awaitableResolveConnect(socket);
+        if (ec)
+        {
+            HOST_LOG(ERROR) << LOG_DESC("TCP Connection refused by node")
+                            << LOG_KV("endpoint", _nodeIPEndpoint)
+                            << LOG_KV("message", ec.message());
+            socket->close();
+            connectTimer->cancel();
+
+            boost::asio::post(socket->ioService(), [callback = std::move(callback)]() mutable {
+                callback(NetworkException(ConnectError, "Connect failed"), {}, {});
+            });
+            co_return;
+        }
+        insertPendingConns(_nodeIPEndpoint);
+        /// get the public key of the server during handshake
+        std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
+        m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
+        /// call handshakeClient after handshake succeed
+        auto [handshakeError] =
+            co_await m_asioInterface->awaitableHandshake(socket, ba::ssl::stream_base::client);
+        connectTimer->cancel();
+        handshakeClient(handshakeError, std::move(socket), endpointPublicKey,
+            std::move(callback), _nodeIPEndpoint);
+    }
+    catch (...)
+    {
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h)
+        HOST_LOG(ERROR) << LOG_DESC("client connect exception")
+                        << LOG_KV("endpoint", _nodeIPEndpoint)
+                        << LOG_KV("what", boost::current_exception_diagnostic_information());
+    }
 }
 
 /**
@@ -747,9 +788,8 @@ void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
 void Host::handshakeClient(const boost::system::error_code& error,
     std::shared_ptr<SocketFace> socket, std::shared_ptr<std::string> endpointPublicKey,
     std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)> callback,
-    NodeIPEndpoint _nodeIPEndpoint, std::shared_ptr<boost::asio::steady_timer> timerPtr)
+    NodeIPEndpoint _nodeIPEndpoint)
 {
-    timerPtr->cancel();
     erasePendingConns(_nodeIPEndpoint);
     if (error)
     {
@@ -792,6 +832,31 @@ void Host::stop()
     }
     // signal run() to prepare for shutdown and reset m_timer
     m_run = false;
+    // Cancel the acceptor so the accept loop's pending async_accept completes with
+    // operation_aborted: acceptLoop's coroutine frame holds a strong reference to this Host, and
+    // only the completed accept lets the loop observe m_run == false and exit, releasing it.
+    // Posted to the acceptor's io_context (asio objects are not thread-safe, and stop() runs off
+    // the pool thread); the ASIOInterface copy keeps the acceptor alive until the cancel runs.
+    if (auto asioInterface = m_asioInterface; asioInterface && asioInterface->acceptor() != nullptr)
+    {
+        try
+        {
+            // evaluate the executor BEFORE the move below: the evaluation order of post()'s
+            // arguments is unspecified, so moving asioInterface into the lambda first would leave
+            // a null shared_ptr for the acceptor() call
+            auto executor = asioInterface->acceptor()->get_executor();
+            boost::asio::post(executor,
+                [asioInterface = std::move(asioInterface)]() { asioInterface->cancelAcceptor(); });
+        }
+        catch (...)
+        {
+            // stop() also runs from ~Host, which must not throw; a lost cancel only delays the
+            // accept loop's exit (it still ends on the next accept or acceptor destruction)
+            HOST_LOG(WARNING) << LOG_DESC("cancel acceptor on stop failed")
+                              << LOG_KV("what",
+                                     boost::current_exception_diagnostic_information());
+        }
+    }
     // FIB-186 (vector D): the dedicated teardown executor is deliberately NOT stopped here.
     // Clearing m_run above is what stops work arriving: Session::drop() checks haveNetwork() and
     // runs the teardown notification inline once it is false, so nothing new is enqueued after this

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -41,9 +41,9 @@ using namespace bcos::crypto;
 namespace
 {
 // FIB-186: RAII guard bound to an in-flight TLS handshake. Constructed after a handshake slot is
-// acquired and moved into the handshake completion handler; its destructor releases the slot when
-// the handler runs (success / failure / abort) or is destroyed on shutdown. Held via weak_ptr so a
-// Host torn down before the handshake completes does not crash the guard.
+// acquired; its destructor releases the slot exactly once when the frame it rides in unwinds
+// (success / failure / abort) or is destroyed. Held via weak_ptr so a Host torn down before the
+// handshake completes does not crash the guard.
 struct HandshakeSlotGuard
 {
     std::weak_ptr<Host> host;
@@ -58,6 +58,32 @@ struct HandshakeSlotGuard
         }
     }
 };
+
+// FIB-186: reserve an in-flight-handshake slot and return an owning guard (nullptr when the cap
+// is reached). Combining the acquire with the guard construction closes the "throw between
+// acquire and guard" window — a throw after the acquire but before the guard existed would leak
+// the slot. Returned as shared_ptr<void> so the concrete guard type stays an implementation
+// detail; the guard is handed into the serverHandshake coroutine frame, so acquire and release
+// live in the same frame.
+std::shared_ptr<void> tryAcquireHandshakeSlotGuard(std::weak_ptr<Host> host)
+{
+    auto hostPtr = host.lock();
+    if (!hostPtr || !hostPtr->tryAcquireHandshakeSlot())
+    {
+        return nullptr;
+    }
+    try
+    {
+        return std::make_shared<HandshakeSlotGuard>(std::move(host));
+    }
+    catch (...)
+    {
+        // guard construction failed (allocation): release the just-acquired slot so it is not
+        // leaked, then rethrow so the accept-loop iteration is skipped
+        hostPtr->releaseHandshakeSlot();
+        throw;
+    }
+}
 }  // namespace
 
 /**
@@ -90,9 +116,14 @@ task::Task<void> Host::acceptLoop()
     // lifetime (the accept handler held a raw this): the loop only exits after Host::stop()
     // cancels the acceptor, so a pending async_accept can never fire on a destroyed Host.
     auto self = shared_from_this();
-    try
+    // The try/catch lives INSIDE the while loop: this loop is the only thing that re-arms
+    // async_accept, so an exception escaping it (newSocket allocation, remoteEndpoint, or the
+    // coroutine-frame allocation inside task::wait(serverHandshake(...))) would permanently stop
+    // inbound connection acceptance while the node keeps running and reports itself healthy. A
+    // failed iteration must be survivable, so each one is guarded and the loop continues.
+    while (m_run)
     {
-        while (m_run)
+        try
         {
             auto socket = m_asioInterface->newSocket(true, NodeIPEndpoint());
             auto [ec] = co_await m_asioInterface->awaitableAccept(socket);
@@ -118,12 +149,15 @@ task::Task<void> Host::acceptLoop()
             // accept / handshake / teardown work and starve inter-validator PBFT reads (the
             // FIB-184 session caps apply only AFTER the handshake completes). Reserve the
             // in-flight-handshake slot first because it is the refundable check: if the
-            // accept-rate limiter below then rejects, we release the slot and no rate token is
+            // accept-rate limiter below then rejects, the guard is destroyed and no rate token is
             // spent. Checking the rate token first would instead waste a token whenever the
             // handshake cap is already saturated, needlessly lowering the effective accept rate
-            // for legitimate peers arriving in that window.
+            // for legitimate peers arriving in that window. The guard is handed into
+            // serverHandshake, so the slot's acquire and release live in the same coroutine frame
+            // (see tryAcquireHandshakeSlotGuard).
             std::string remoteAddress = socket->nodeIPEndpoint().address();
-            if (!tryAcquireHandshakeSlot())
+            auto handshakeGuard = tryAcquireHandshakeSlotGuard(weak_from_this());
+            if (!handshakeGuard)
             {
                 HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
                                 << LOG_DESC("pending-handshake cap reached, reject connection")
@@ -135,12 +169,9 @@ task::Task<void> Host::acceptLoop()
             }
             // Accept-rate token bucket: drops a churn flood cheaply (accept + close) before
             // paying handshake CPU, which the concurrency cap alone does not. On rejection the
-            // handshake slot reserved just above must be released so it is not leaked -- the
-            // HandshakeSlotGuard that normally releases it is only created once both checks
-            // pass.
+            // handshake slot reserved just above is released by the guard going out of scope.
             if (!tryAcquireConnectionToken())
             {
-                releaseHandshakeSlot();
                 HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
                                 << LOG_DESC("connection accept-rate limit reached, reject")
                                 << LOG_KV("address", remoteAddress)
@@ -151,25 +182,28 @@ task::Task<void> Host::acceptLoop()
             // Run the per-connection TLS handshake in its own coroutine and keep accepting: the
             // old code re-armed accept right after arming the async handshake, and awaiting the
             // handshake here would serialize accepts (one handshake at a time), defeating the
-            // concurrency-cap design.
-            task::wait(serverHandshake(std::move(socket)));
+            // concurrency-cap design. The handshake slot guard travels with the coroutine frame,
+            // so the slot is released exactly when that frame unwinds.
+            task::wait(serverHandshake(std::move(socket), std::move(handshakeGuard)));
         }
-    }
-    catch (...)
-    {
-        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h)
-        HOST_LOG(ERROR) << LOG_DESC("accept loop exception")
-                        << LOG_KV("what", boost::current_exception_diagnostic_information());
+        catch (...)
+        {
+            // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
+            // a failed iteration must not kill the accept loop, so log and continue
+            HOST_LOG(ERROR) << LOG_DESC("accept iteration exception")
+                            << LOG_KV("what", boost::current_exception_diagnostic_information());
+        }
     }
 }
 
-task::Task<void> Host::serverHandshake(std::shared_ptr<SocketFace> socket)
+task::Task<void> Host::serverHandshake(
+    std::shared_ptr<SocketFace> socket, std::shared_ptr<void> handshakeGuard)
 {
     auto self = shared_from_this();
-    // FIB-186: release the in-flight-handshake slot exactly once when this frame unwinds
-    // (handshake success, failure, abort, or an escaping exception). This replaces the guard
-    // riding the old completion handler with plain RAII on the coroutine frame.
-    HandshakeSlotGuard handshakeGuard(weak_from_this());
+    // The handshakeGuard owns the reserved FIB-186 admission slot; it is destroyed exactly when
+    // this frame unwinds (handshake success, failure, abort, or the completion-or-cancel rescue
+    // destroying the frame), releasing the slot exactly once. Acquired in acceptLoop so the
+    // slot/token admission ordering is preserved (see acceptLoop).
     try
     {
         // FIB-186: bound the handshake's lifetime. A stalled / slow TLS handshake would

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -112,7 +112,9 @@ void Host::startAccept(boost::system::error_code /*boost_error*/)
         HOST_LOG(INFO) << LOG_DESC("P2P StartAccept") << LOG_KV("Host", m_listenHost) << ":"
                        << m_listenPort;
         // fire-and-forget: the detached task owns the coroutine chain; acceptLoop() exits when
-        // Host::stop() clears m_run and cancels the acceptor.
+        // Host::stop() clears m_run and cancels the acceptor. Arm the exit latch BEFORE launching
+        // so stop() can never miss a started loop (see Host::stop).
+        m_acceptLoopStarted.store(true, std::memory_order_release);
         task::wait(acceptLoop());
     }
 }
@@ -141,7 +143,20 @@ task::Task<void> Host::acceptLoop()
             /// network accept failed
             if (ec || !m_run)
             {
-                HOST_LOG(ERROR) << "Error: " << ec;
+                // A REAL accept error (EMFILE/ENFILE — fd exhaustion arrives here as an
+                // error_code, not as a throw) must take the same retry backoff as a thrown
+                // iteration below: the pending connection stays in the listen backlog, so the
+                // next async_accept fails identically and an un-delayed loop would spin on the
+                // acceptor's io_context thread, allocating a Socket + ssl::stream per turn and
+                // starving the sessions and the shared resolver on that context.
+                // operation_aborted (Host::stop()'s cancel) stays on the fast path so shutdown
+                // is not delayed — and never logged at ERROR.
+                if (ec && ec != boost::asio::error::operation_aborted)
+                {
+                    HOST_LOG(ERROR) << LOG_DESC("accept failed")
+                                    << LOG_KV("message", ec.message());
+                    iterationFailed = true;
+                }
                 socket->close();
                 // re-arm accept (the old code recursed into startAccept here)
                 continue;
@@ -202,13 +217,16 @@ task::Task<void> Host::acceptLoop()
             HOST_LOG(ERROR) << LOG_DESC("accept iteration exception")
                             << LOG_KV("what", boost::current_exception_diagnostic_information());
         }
-        // Give a failed iteration a suspension point before retrying: when the throw came from
-        // newSocket() (the canonical failure is fd exhaustion), the iteration never reached the
-        // accept co_await, so falling straight through would spin synchronously and starve the
-        // acceptor's io_context thread — the shared resolver and the session sockets live on it.
-        // A short timer turns a persistent failure into a slow retry loop instead of a livelock.
-        // (co_await is not permitted inside a catch handler, so the delay lives after the
-        // try/catch, reached only on a failed iteration.)
+        // Give a failed iteration a suspension point before retrying. Two failure shapes land
+        // here: a throw (newSocket() allocation — the canonical cause is fd exhaustion —,
+        // remoteEndpoint, or the frame allocation inside task::wait(serverHandshake(...))) never
+        // reached the accept co_await, so falling straight through would spin synchronously; and
+        // a real accept error_code (EMFILE/ENFILE, marked above) would re-fail identically on the
+        // next async_accept because the pending connection stays in the listen backlog. Both
+        // would starve the acceptor's io_context thread — the shared resolver and the session
+        // sockets live on it. A short timer turns a persistent failure into a slow retry loop
+        // instead of a livelock. (co_await is not permitted inside a catch handler, so the delay
+        // lives after the try/catch, reached only on a failed iteration.)
         // The timer MUST be armed on the acceptor's own executor (newAcceptorTimer), not on a
         // round-robin pool context: co_await resumes the loop on the timer's thread, and only
         // the acceptor's single io_context thread serializes the next while (m_run) re-check and
@@ -239,6 +257,17 @@ task::Task<void> Host::acceptLoop()
                                        "what", boost::current_exception_diagnostic_information());
             }
         }
+    }
+    // Satisfy the stop() exit latch (see Host::stop): the loop has returned, so its frame's
+    // strong Host reference is about to go away. The frame-destroy rescue path never reaches
+    // here — that is precisely the case stop()'s bounded wait exists to diagnose.
+    try
+    {
+        m_acceptLoopExit.set_value();
+    }
+    catch (...)
+    {
+        // a second acceptLoop after a Host restart finds the promise already satisfied
     }
 }
 
@@ -952,8 +981,35 @@ void Host::stop()
             // ASIOInterface and the acceptor) alive, so "acceptor destruction" can never end the
             // loop from the outside — only the NEXT completed accept lets the loop observe
             // m_run == false and exit. With no inbound connection, a Host whose cancel was lost
-            // here stays alive until stop() is retried.
+            // here stays alive until stop() is retried. The bounded wait below is what makes
+            // this diagnosable instead of silent.
             HOST_LOG(WARNING) << LOG_DESC("cancel acceptor on stop failed")
+                              << LOG_KV("what", boost::current_exception_diagnostic_information());
+        }
+    }
+    // Bounded wait for the accept loop to exit (see the latch contract in Host.h): the loop's
+    // frame holds a strong Host reference, so a lost cancel above — or an acceptor io_context
+    // that was already stopped/drained before the post — would otherwise leak the whole Host
+    // graph silently. After a successful cancel the loop exits within one event-loop turn (plus
+    // at most one ACCEPT_RETRY_INTERVAL_MS backoff), so 10s is generous; a timeout means the
+    // cancel never landed and this Host will outlive its teardown. Callers run stop() off the
+    // pool threads (Service::stop / ~Host on the shutdown path), so waiting here cannot block
+    // the acceptor's io_context thread the loop needs to exit.
+    if (m_acceptLoopStarted.load(std::memory_order_acquire))
+    {
+        try
+        {
+            if (m_acceptLoopExit.get_future().wait_for(std::chrono::seconds(10)) !=
+                std::future_status::ready)
+            {
+                HOST_LOG(ERROR) << LOG_DESC("accept loop did not exit within 10s of stop(); "
+                                            "the posted cancel was likely lost and this Host "
+                                            "(ASIOInterface, acceptor, teardown pool) may leak");
+            }
+        }
+        catch (...)
+        {
+            HOST_LOG(WARNING) << LOG_DESC("accept loop exit wait failed")
                               << LOG_KV("what", boost::current_exception_diagnostic_information());
         }
     }

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -202,9 +202,18 @@ task::Task<void> Host::acceptLoop()
         // A short timer turns a persistent failure into a slow retry loop instead of a livelock.
         // (co_await is not permitted inside a catch handler, so the delay lives after the
         // try/catch, reached only on a failed iteration.)
+        // The timer MUST be armed on the acceptor's own executor (newAcceptorTimer), not on a
+        // round-robin pool context: co_await resumes the loop on the timer's thread, and only
+        // the acceptor's single io_context thread serializes the next while (m_run) re-check and
+        // async_accept re-arm against the cancelAcceptor() that Host::stop() posts to that same
+        // context. Resuming on a foreign pool thread would reopen the check-then-act window —
+        // stop()'s cancel could land between the m_run read and the re-arm, be consumed by a
+        // acceptor with nothing pending, and leave a fresh async_accept that never completes,
+        // making the Host immortal (see the m_run contract in Host.h) — and would race the
+        // posted cancel() on the acceptor object itself ("Shared objects: Unsafe").
         if (iterationFailed)
         {
-            auto retryTimer = m_asioInterface->newTimer(ACCEPT_RETRY_INTERVAL_MS);
+            auto retryTimer = m_asioInterface->newAcceptorTimer(ACCEPT_RETRY_INTERVAL_MS);
             co_await makeAsioAwaitable<boost::system::error_code>([&retryTimer](auto handler) {
                 retryTimer.async_wait(std::move(handler));
             });

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -86,6 +86,13 @@ std::shared_ptr<void> tryAcquireHandshakeSlotGuard(std::weak_ptr<Host> host)
 }
 }  // namespace
 
+// FIB-186: member wrapper over the anonymous-namespace factory above, so acceptLoop and tests
+// drive the exact same acquire-and-guard path.
+std::shared_ptr<void> Host::acquireHandshakeSlotGuard()
+{
+    return tryAcquireHandshakeSlotGuard(weak_from_this());
+}
+
 /**
  * @brief: accept connection requests, maily include procedures:
  *         1. async_accept: accept connection requests
@@ -213,10 +220,24 @@ task::Task<void> Host::acceptLoop()
         // posted cancel() on the acceptor object itself ("Shared objects: Unsafe").
         if (iterationFailed)
         {
-            auto retryTimer = m_asioInterface->newAcceptorTimer(ACCEPT_RETRY_INTERVAL_MS);
-            co_await makeAsioAwaitable<boost::system::error_code>([&retryTimer](auto handler) {
-                retryTimer.async_wait(std::move(handler));
-            });
+            // Guard the retry itself: newAcceptorTimer / async_wait run OUTSIDE the iteration's
+            // try above, so a throw here (timer allocation, initiation failure rethrown by
+            // await_resume) would escape acceptLoop entirely and permanently stop inbound
+            // acceptance while m_run stays true. Log and let the while loop retry.
+            try
+            {
+                auto retryTimer = m_asioInterface->newAcceptorTimer(ACCEPT_RETRY_INTERVAL_MS);
+                co_await makeAsioAwaitable<boost::system::error_code>(
+                    [&retryTimer](auto handler) {
+                        retryTimer.async_wait(std::move(handler));
+                    });
+            }
+            catch (...)
+            {
+                HOST_LOG(ERROR) << LOG_DESC("accept retry timer exception")
+                                << LOG_KV("what",
+                                       boost::current_exception_diagnostic_information());
+            }
         }
     }
 }
@@ -612,8 +633,8 @@ bool Host::tryAcquireHandshakeSlot()
     return true;
 }
 
-// FIB-186: release a previously reserved handshake slot. Runs from the HandshakeSlotGuard bound to
-// the handshake completion handler, i.e. exactly once when the handshake finishes or is aborted.
+// FIB-186: release a previously reserved handshake slot. Runs from the HandshakeSlotGuard riding
+// the serverHandshake coroutine frame, i.e. exactly once when that frame unwinds.
 void Host::releaseHandshakeSlot()
 {
     std::lock_guard<std::mutex> lock(x_pendingHandshakes);
@@ -824,8 +845,10 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
         auto [handshakeError] =
             co_await m_asioInterface->awaitableHandshake(socket, ba::ssl::stream_base::client);
         connectTimer->cancel();
-        handshakeClient(handshakeError, std::move(socket), endpointPublicKey,
-            std::move(callback), _nodeIPEndpoint);
+        // Pass COPIES of socket/callback, not moves: if handshakeClient itself throws, the
+        // catch(...) below settles the operation through socket->close() and the callback —
+        // both would be moved-from (null) here had they been moved into the call.
+        handshakeClient(handshakeError, socket, endpointPublicKey, callback, _nodeIPEndpoint);
     }
     catch (...)
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -186,6 +186,10 @@ public:
     // frame unwinds (handshake success, failure, or abort).
     bool tryAcquireHandshakeSlot();
     void releaseHandshakeSlot();
+    // FIB-186: reserve a slot AND return the owning RAII guard in one step (nullptr when the cap
+    // is reached). The guard rides the caller's coroutine frame, so acquire and release live in
+    // the same frame — and the "throw between acquire and guard" window cannot leak a slot.
+    std::shared_ptr<void> acquireHandshakeSlotGuard();
 
     // FIB-186: rate-limit accepted new connections (not just their concurrency). The pending-
     // handshake cap above bounds how many handshakes run at once, but on a fast link a churn flood

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -10,6 +10,7 @@
 #include "bcos-gateway/libnetwork/Message.h"
 #include "bcos-gateway/libnetwork/PeerBlackWhitelistInterface.h"
 #include "bcos-gateway/libnetwork/SessionCallback.h"
+#include "bcos-task/Task.h"
 #include "bcos-utilities/Common.h"
 #include <openssl/x509.h>
 #include <boost/asio/ssl/stream_base.hpp>
@@ -244,11 +245,27 @@ protected:
         std::shared_ptr<std::string> endpointPublicKey,
         std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
             callback,
-        NodeIPEndpoint _nodeIPEndpoint, std::shared_ptr<boost::asio::steady_timer> timerPtr);
+        NodeIPEndpoint _nodeIPEndpoint);
 
     void erasePendingConns(NodeIPEndpoint const& nodeIPEndpoint);
 
     void insertPendingConns(NodeIPEndpoint const& nodeIPEndpoint);
+
+private:
+    // Coroutine bodies for the accept/connect paths, launched fire-and-forget (task::wait) from
+    // startAccept()/asyncConnect(). Each frame holds a strong Host reference for its whole
+    // lifetime — structurally replacing the per-operation shared_from_this() captures of the old
+    // completion handlers. acceptLoop additionally keeps the Host alive until Host::stop()
+    // cancels the acceptor, which completes the pending async_accept with operation_aborted and
+    // lets the loop exit.
+    task::Task<void> acceptLoop();
+    task::Task<void> serverHandshake(std::shared_ptr<SocketFace> socket);
+    task::Task<void> clientConnect(std::shared_ptr<SocketFace> socket,
+        NodeIPEndpoint _nodeIPEndpoint,
+        std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
+            callback);
+
+protected:
 
     // FIB-186 (vector D): dedicated single-thread executor for session-teardown notifications, kept
     // separate from the shared IOServicePool so a bulk-disconnect flood cannot starve

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -46,6 +46,13 @@ class ASIOInterface;
 
 using x509PubHandler = std::function<bool(X509* x509, std::string& pubHex)>;
 
+// Lifetime contract: a started Host must be stopped (stop()) BEFORE its last strong reference
+// is released. The acceptLoop coroutine frame holds a strong Host reference for its whole life
+// and exits only when stop() clears m_run and cancels the acceptor, so a Host that is started
+// but never stopped is never destroyed — it keeps the ASIOInterface, the acceptor and the
+// teardown executor alive with it. ~Host calls stop() defensively, but the destructor can only
+// run once every strong reference — including the accept loop's — is already gone, so it cannot
+// substitute for an explicit stop().
 class Host : public std::enable_shared_from_this<Host>
 {
 public:
@@ -266,7 +273,6 @@ private:
             callback);
 
 protected:
-
     // FIB-186 (vector D): dedicated single-thread executor for session-teardown notifications, kept
     // separate from the shared IOServicePool so a bulk-disconnect flood cannot starve
     // inbound-message delivery. See postTeardown.

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -18,6 +18,7 @@
 #include <boost/system/error_code.hpp>
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -329,6 +330,19 @@ protected:
     // reference, so a torn/stale read would re-arm async_accept after the cancel was consumed
     // and make the Host immortal.
     std::atomic<bool> m_run{false};
+
+    // Accept-loop exit latch (see Host::stop). The loop's frame holds a strong Host reference,
+    // forming a reference cycle (frame -> Host -> ASIOInterface -> IOServicePool -> io_context ->
+    // pending async_accept -> the frame) whose only cut point is the cancel Host::stop() posts
+    // to the acceptor's io_context — if that cancel is lost (the io_context was already stopped
+    // or drained, or the post threw), nothing else ends the loop and the whole graph leaks
+    // silently. stop() therefore waits on this latch with a bounded timeout and logs loudly on
+    // expiry, turning the silent permanent leak into a bounded wait plus a diagnosable line.
+    // m_acceptLoopStarted gates the wait (a Host whose loop never ran has nothing to wait for);
+    // the promise is satisfied when acceptLoop returns. The frame-destroy rescue path never
+    // satisfies it, which is exactly the case the timeout exists to diagnose.
+    std::atomic<bool> m_acceptLoopStarted{false};
+    std::promise<void> m_acceptLoopExit;
 
     P2PInfo m_p2pInfo;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -266,7 +266,12 @@ private:
     // cancels the acceptor, which completes the pending async_accept with operation_aborted and
     // lets the loop exit.
     task::Task<void> acceptLoop();
-    task::Task<void> serverHandshake(std::shared_ptr<SocketFace> socket);
+    // handshakeGuard owns the reserved FIB-186 in-flight-handshake admission slot (acquired in
+    // acceptLoop so the slot/token admission ordering is preserved); it is released exactly when
+    // this coroutine frame unwinds. Held as shared_ptr<void> to keep the concrete guard type an
+    // implementation detail of Host.cpp.
+    task::Task<void> serverHandshake(
+        std::shared_ptr<SocketFace> socket, std::shared_ptr<void> handshakeGuard);
     task::Task<void> clientConnect(std::shared_ptr<SocketFace> socket,
         NodeIPEndpoint _nodeIPEndpoint,
         std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
@@ -307,7 +312,13 @@ protected:
     std::function<bool(X509* x509, std::string& pubHex)> m_sslContextPubHandler;
     std::function<bool(X509* x509, std::string& pubHex)> m_sslContextPubHandlerWithoutExtInfo;
 
-    bool m_run = false;
+    // Network run flag. Written by start()/stop() from the caller's thread, read as the accept
+    // loop's condition on the acceptor's io_context thread (Host::acceptLoop) and by
+    // haveNetwork() from every session thread. Must be atomic: the new Host contract makes
+    // observing m_run == false the only mechanism that releases the accept loop's strong Host
+    // reference, so a torn/stale read would re-arm async_accept after the cancel was consumed
+    // and make the Host immortal.
+    std::atomic<bool> m_run{false};
 
     P2PInfo m_p2pInfo;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -164,10 +164,10 @@ public:
     constexpr static std::size_t DEFAULT_MAX_PENDING_HANDSHAKES = 64;
     // FIB-186: default inbound TLS handshake timeout (ms). Without a timeout a stalled / slow
     // handshake never completes, so its admission slot is never released and (because the
-    // completion handler holds shared_from_this) this Host can never be destroyed. Bounding it lets
-    // a slow-loris peer hold at most this long before its slot is reclaimed. GatewayFactory plumbs
-    // the configured value (p2p.handshake_timeout_ms); this constant is the default when the config
-    // omits it.
+    // serverHandshake coroutine frame holds shared_from_this) this Host can never be destroyed.
+    // Bounding it lets a slow-loris peer hold at most this long before its slot is reclaimed.
+    // GatewayFactory plumbs the configured value (p2p.handshake_timeout_ms); this constant is
+    // the default when the config omits it.
     constexpr static int DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000;
 
     std::size_t maxPendingHandshakes() const { return m_maxPendingHandshakes; }
@@ -182,8 +182,8 @@ public:
 
     // FIB-186: reserve / release an in-flight-handshake slot. tryAcquire returns false (caller must
     // close the socket and re-arm accept) when the global cap is reached. release runs from the
-    // HandshakeSlotGuard bound to the handshake completion handler, i.e. exactly once when the
-    // handshake finishes (success, failure, or abort).
+    // HandshakeSlotGuard riding the serverHandshake coroutine frame, i.e. exactly once when that
+    // frame unwinds (handshake success, failure, or abort).
     bool tryAcquireHandshakeSlot();
     void releaseHandshakeSlot();
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -222,6 +222,12 @@ public:
     }
     bool tryAcquireConnectionToken();
 
+    // Retry delay after a failed accept-loop iteration (ms): the per-iteration catch in
+    // acceptLoop re-arms a short timer before retrying, so a persistently failing newSocket()
+    // (e.g. fd exhaustion) degrades to a slow retry loop instead of spinning the acceptor's
+    // io_context thread at 100% CPU.
+    constexpr static uint32_t ACCEPT_RETRY_INTERVAL_MS = 200;
+
 protected:
     /// obtain the common name from the subject:
     /// the subject format is: /CN=xx/O=xxx/OU=xxx/ commonly

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -51,8 +51,8 @@ Session::Session(
     // createSession passes the config-validated session_recv_buffer_size, which is forced to
     // 2 * allow_max_msg_size = 64MB; allocating that per session up front let authenticated TLS
     // connect/close churn exhaust the heap (SIGSEGV inside malloc during Session construction).
-    // Allocate only INITIAL_SESSION_RECV_BUFFER_SIZE (16KB) initially and let doRead grow the
-    // buffer up to m_maxRecvBufferSize on demand, so only sessions that actually carry large
+    // Allocate only INITIAL_SESSION_RECV_BUFFER_SIZE (16KB) initially and let the read loop grow
+    // the buffer up to m_maxRecvBufferSize on demand, so only sessions that actually carry large
     // messages pay for a large buffer. _forceSize keeps the exact size for tests that assert a
     // specific small buffer.
     m_recvBuffer(_forceSize ? _recvBufferSize :
@@ -302,6 +302,41 @@ task::Task<void> Session::writeLoop()
         void release() { released = true; }
     } writeLoopGuard{this, payloads};
 
+    // Fails the in-flight batch: the payloads have already been moved out of m_writeQueue and no
+    // completion handler exists for them, so their callbacks would never fire (drop() only drains
+    // m_writeQueue). Invoked from every exception exit so the batch is settled exactly once — a
+    // batch destroyed with its callbacks unfired would pin every awaiting sender forever.
+    // Posted rather than inline when the network is still up, for the same reason as drop()'s
+    // drain: this code runs on the caller's stack, which may still be inside an await_suspend.
+    auto failBatch = [this](std::vector<Payload>& batch) {
+        for (auto& payload : batch)
+        {
+            if (payload.m_callback)
+            {
+                auto callback = std::move(payload.m_callback);
+                if (m_server.get().haveNetwork())
+                {
+                    m_server.get().asioInterface()->post([callback = std::move(callback)]() {
+                        callback(boost::asio::error::operation_aborted);
+                    });
+                }
+                else
+                {
+                    try
+                    {
+                        callback(boost::asio::error::operation_aborted);
+                    }
+                    catch (std::exception const& e2)
+                    {
+                        SESSION_LOG(WARNING) << LOG_DESC("write callback exception")
+                                             << LOG_KV("what", boost::diagnostic_information(e2));
+                    }
+                }
+            }
+        }
+        batch.clear();
+    };
+
     try
     {
         while (true)
@@ -386,38 +421,17 @@ task::Task<void> Session::writeLoop()
         // never fire (drop() only drains m_writeQueue). Fail them here — posted rather than
         // inline, for the same reason as drop()'s drain: this catch runs on the caller's stack,
         // which may still be inside an await_suspend.
-        for (auto& payload : payloads)
-        {
-            if (payload.m_callback)
-            {
-                auto callback = std::move(payload.m_callback);
-                if (m_server.get().haveNetwork())
-                {
-                    m_server.get().asioInterface()->post([callback = std::move(callback)]() {
-                        callback(boost::asio::error::operation_aborted);
-                    });
-                }
-                else
-                {
-                    try
-                    {
-                        callback(boost::asio::error::operation_aborted);
-                    }
-                    catch (std::exception const& e2)
-                    {
-                        SESSION_LOG(WARNING) << LOG_DESC("write callback exception")
-                                             << LOG_KV("what", boost::diagnostic_information(e2));
-                    }
-                }
-            }
-        }
+        failBatch(payloads);
         drop(TCPError);
     }
     catch (...)
     {
-        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h)
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
+        // fail the in-flight batch here too — the catch(std::exception&) arm above does it, and a
+        // batch destroyed with its callbacks unfired would pin every awaiting sender forever
         SESSION_LOG(ERROR) << LOG_DESC("write error") << LOG_KV("endpoint", nodeIPEndpoint())
                            << LOG_KV("what", boost::current_exception_diagnostic_information());
+        failBatch(payloads);
         drop(TCPError);
     }
 
@@ -775,22 +789,6 @@ void Session::start()
     // that want to park reads call the templated startWithPolicy<FakePolicy>() instead (see
     // SessionReadLoop.h).
     startWithPolicy<ASIOInterface::DefaultReadPolicy>();
-}
-
-void Session::doRead()
-{
-    if (m_active && m_server.get().haveNetwork())
-    {
-        // fire-and-forget: the detached task owns the coroutine chain; readLoop() holds the
-        // session alive in its frame (FIB-184) and exits on error, drop or shutdown.
-        task::wait(readLoop<ASIOInterface::DefaultReadPolicy>());
-    }
-    else
-    {
-        SESSION_LOG(ERROR) << LOG_DESC("callback doRead failed for session inactive")
-                           << LOG_KV("active", m_active.load())
-                           << LOG_KV("haveNetwork", m_server.get().haveNetwork());
-    }
 }
 
 bool Session::checkRead(boost::system::error_code _ec)
@@ -1268,7 +1266,7 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     // The pre-send checks run in the same order as the removed asyncSendMessage path (active →
     // allowMaxMsgSize → beforeMessageHandler), but the size limit is judged on the COMPRESSED wire
     // bytes (totalLength, computed above after compression) rather than the pre-compression
-    // estimate the old path used: the peer's read side (Session::doRead) rejects frames by the
+    // estimate the old path used: the peer's read side (the read loop) rejects frames by the
     // on-the-wire length too, so a message that only fits after compression is accepted here and
     // decodes on the peer — this is an intentional, documented divergence from asyncSendMessage.
     // The outgoing rate-limit handler receives the ACTUAL wire bytes (totalLength including the
@@ -1456,14 +1454,6 @@ void bcos::gateway::Session::setMaxSendDataSize(uint32_t _maxSendDataSize)
 {
     m_maxSendDataSize = _maxSendDataSize;
 }
-uint32_t bcos::gateway::Session::maxSendMsgCountS() const
-{
-    return m_maxSendMsgCount;
-}
-void bcos::gateway::Session::setMaxSendMsgCountS(uint32_t _maxSendMsgCountS)
-{
-    m_maxSendMsgCount = _maxSendMsgCountS;
-}
 uint32_t bcos::gateway::Session::allowMaxMsgSize() const
 {
     return m_allowMaxMsgSize;
@@ -1500,14 +1490,12 @@ std::shared_ptr<SessionFace> bcos::gateway::SessionFactory::createSession(Host& 
     session->setAllowMaxMsgSize(m_allowMaxMsgSize);
     session->setMaxReadDataSize(m_maxReadDataSize);
     session->setMaxSendDataSize(m_maxSendDataSize);
-    session->setMaxSendMsgCountS(m_maxSendMsgCountS);
     session->setEnableCompress(m_enableCompress);
     BCOS_LOG(INFO) << LOG_BADGE("SessionFactory") << LOG_DESC("create new session")
                    << LOG_KV("sessionRecvBufferSize", m_sessionRecvBufferSize)
                    << LOG_KV("allowMaxMsgSize", m_allowMaxMsgSize)
                    << LOG_KV("maxReadDataSize", m_maxReadDataSize)
                    << LOG_KV("maxSendDataSize", m_maxSendDataSize)
-                   << LOG_KV("maxSendMsgCountS", m_maxSendMsgCountS)
                    << LOG_KV("enableCompress", m_enableCompress);
     return session;
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -19,6 +19,7 @@
 #include "bcos-utilities/Overloaded.h"
 #include "bcos-utilities/ZstdCompress.h"
 #include <bcos-framework/protocol/Protocol.h>  // for MessageExtFieldFlag
+#include <bcos-task/Wait.h>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/throw_exception.hpp>
@@ -58,8 +59,7 @@ Session::Session(
     m_server(server),
     m_socket(std::move(socket)),
     m_idleCheckTimer(
-        std::make_shared<Timer>(m_socket->ioService(), m_idleTimeInterval, "idleChecker")),
-    m_writings(std::make_shared<Writings>())
+        std::make_shared<Timer>(m_socket->ioService(), m_idleTimeInterval, "idleChecker"))
 {
     SESSION_LOG(INFO) << "[Session::Session] this=" << this
                       << LOG_KV("recvBufferSize", m_maxRecvBufferSize);
@@ -184,46 +184,21 @@ std::size_t Session::writeQueueSize()
     return static_cast<std::size_t>(!m_writeQueue.empty());
 }
 
-void Session::onWrite(boost::system::error_code ec, std::size_t /*unused*/)
-{
-    if (!active())
-    {
-        return;
-    }
-
-    try
-    {
-        m_lastWriteTime.store(utcSteadyTime());
-        if (ec)
-        {
-            SESSION_LOG(WARNING) << LOG_DESC("onWrite error sending")
-                                 << LOG_KV("message", ec.message())
-                                 << LOG_KV("endpoint", nodeIPEndpoint());
-            drop(TCPError);
-            return;
-        }
-        write();
-    }
-    catch (std::exception& e)
-    {
-        SESSION_LOG(ERROR) << LOG_DESC("onWrite error") << LOG_KV("endpoint", nodeIPEndpoint())
-                           << LOG_KV("what", boost::diagnostic_information(e));
-        drop(TCPError);
-        return;
-    }
-}
-
 bool Session::tryPopSomeEncodedMsgs(
     std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize, size_t _maxSendMsgCount)  // NOLINT
 {
     // Desc: Try to send multi packets one time to improve the efficiency of sending
-    // data
+    // data. Stop batching once the configured byte (session_max_send_data_size) or message-count
+    // (session_max_send_msg_count) budget is exhausted; the remainder stays queued for the next
+    // loop iteration.
     size_t totalDataSize = 0;
+    size_t msgCount = 0;
     Payload payload;
-    // while (totalDataSize < _maxSendDataSize && m_writeQueue.try_pop(payload))
-    while (m_writeQueue.try_pop(payload))
+    while (totalDataSize < _maxSendDataSize && msgCount < _maxSendMsgCount &&
+           m_writeQueue.try_pop(payload))
     {
         totalDataSize += payload.size();
+        ++msgCount;
         encodedMsgs.emplace_back(std::move(payload));
     }
 
@@ -232,115 +207,166 @@ bool Session::tryPopSomeEncodedMsgs(
 
 void Session::write()
 {
-    std::unique_lock lock(m_writingQueueMutex, std::try_to_lock);
-    if (!lock.owns_lock())
+    if (m_writingInFlight.exchange(true))
     {
+        // a write loop is already in flight; it drains the queue
         return;
     }
-    if (!m_server.get().haveNetwork())
-    {
-        SESSION_LOG(WARNING) << "Host has gone";
-        drop(TCPError);
-        return;
-    }
-    if (!m_socket->isConnected())
-    {
-        SESSION_LOG(WARNING) << "Error sending ssl socket is close!"
-                             << LOG_KV("endpoint", nodeIPEndpoint());
-        drop(TCPError);
-        return;
-    }
+    task::wait(writeLoop());
+}
+
+task::Task<void> Session::writeLoop()
+{
+    // FIB-184: the coroutine frame holds a strong reference to the session for the whole write
+    // loop. async_write operates on m_socket and reads from the batch buffers below; the frame
+    // keeps the session (socket, SSL stream, batch buffers) alive until each write completes, so
+    // a concurrent teardown on another thread cannot free them mid-write.
+    auto self = shared_from_this();
+
+    // Batch scratch owned by this frame for the whole loop (was the m_writings member; the frame
+    // is the lifetime owner now, so no shared_ptr indirection is needed).
+    std::vector<Payload> payloads;
+    std::vector<boost::asio::const_buffer> buffers;
 
     try
     {
-        if (!tryPopSomeEncodedMsgs(m_writings->payloads, m_maxSendDataSize, m_maxSendMsgCount))
+        while (true)
         {
-            return;
-        }
+            if (!m_server.get().haveNetwork())
+            {
+                SESSION_LOG(WARNING) << "Host has gone";
+                drop(TCPError);
+                break;
+            }
+            if (!m_socket->isConnected())
+            {
+                SESSION_LOG(WARNING)
+                    << "Error sending ssl socket is close!" << LOG_KV("endpoint", nodeIPEndpoint());
+                drop(TCPError);
+                break;
+            }
 
-        auto outputIt = std::back_inserter(m_writings->buffers);
-        for (auto& payload : m_writings->payloads)
-        {
-            payload.toConstBuffer(outputIt);
-        }
-        m_server.get().asioInterface()->asyncWrite(m_socket, m_writings->buffers,
-            // FIB-184: hold a strong reference to the session for the duration of the async write.
-            // async_write operates on this->m_socket and reads from buffers owned via m_writings;
-            // a strong ref keeps the socket/SSL stream (and m_writings, which backs the buffers
-            // asyncWrite captures by reference) alive until the write completes, so a concurrent
-            // teardown on another thread cannot free them mid-write.
-            [session = shared_from_this(), m_lock = std::move(lock)](
-                const boost::system::error_code _error, std::size_t _size) mutable {
+            if (!tryPopSomeEncodedMsgs(payloads, m_maxSendDataSize, m_maxSendMsgCount))
+            {
+                // queue drained; fall through to the single exit below
+                break;
+            }
+
+            auto outputIt = std::back_inserter(buffers);
+            for (auto& payload : payloads)
+            {
+                payload.toConstBuffer(outputIt);
+            }
+            auto [error, size] =
+                co_await m_server.get().asioInterface()->awaitableWrite(m_socket, buffers);
+
+            buffers.clear();
+            for (auto& payload : payloads)
+            {
+                if (payload.m_callback)
                 {
-                    session->m_writings->buffers.clear();
-                    for (auto& payload : session->m_writings->payloads)
-                    {
-                        if (payload.m_callback)
-                        {
-                            session->m_server.get().asioInterface()->post(
-                                [callback = std::move(payload.m_callback), error = _error]() {
-                                    // The callback resumes a coroutine whose await_resume may throw
-                                    // (fastSendMessageWithoutResponse throws NetworkException on
-                                    // write failure). Catch so it cannot escape io_context::run().
-                                    try
-                                    {
-                                        callback(error);
-                                    }
-                                    catch (std::exception const& e)
-                                    {
-                                        SESSION_LOG(WARNING)
-                                            << LOG_DESC("write callback exception")
-                                            << LOG_KV("what", boost::diagnostic_information(e));
-                                    }
-                                });
-                        }
-                    }
-                    session->m_writings->payloads.clear();
-                    session->onWrite(_error, _size);
+                    m_server.get().asioInterface()->post(
+                        [callback = std::move(payload.m_callback), error]() {
+                            // The callback resumes a coroutine whose await_resume may throw
+                            // (fastSendMessageWithoutResponse throws NetworkException on
+                            // write failure). Catch so it cannot escape io_context::run().
+                            try
+                            {
+                                callback(error);
+                            }
+                            catch (std::exception const& e)
+                            {
+                                SESSION_LOG(WARNING)
+                                    << LOG_DESC("write callback exception")
+                                    << LOG_KV("what", boost::diagnostic_information(e));
+                            }
+                        });
                 }
-            });
+            }
+            payloads.clear();
+
+            if (!active())
+            {
+                break;
+            }
+            m_lastWriteTime.store(utcSteadyTime());
+            if (error)
+            {
+                SESSION_LOG(WARNING)
+                    << LOG_DESC("onWrite error sending") << LOG_KV("message", error.message())
+                    << LOG_KV("endpoint", nodeIPEndpoint());
+                drop(TCPError);
+                break;
+            }
+            // loop back and drain the next batch
+        }
     }
     catch (std::exception& e)
     {
         SESSION_LOG(ERROR) << LOG_DESC("write error") << LOG_KV("endpoint", nodeIPEndpoint())
                            << LOG_KV("what", boost::diagnostic_information(e));
-        // FIB-185 (review): when asyncWrite throws, the payloads have already been moved into
-        // m_writings->payloads and the completion handler was never registered, so their callbacks
-        // would never fire (drop() only drains m_writeQueue, and this catch runs before any
-        // completion handler exists). Fail them here — posted rather than inline, for the same
-        // reason as drop()'s drain: this catch runs on the caller's stack, which may still be
-        // inside an await_suspend.
-        for (auto& p : m_writings->payloads)
+        // FIB-185 (review): when the write path throws, the payloads have already been moved into
+        // the local batch and no completion handler exists for them, so their callbacks would
+        // never fire (drop() only drains m_writeQueue). Fail them here — posted rather than
+        // inline, for the same reason as drop()'s drain: this catch runs on the caller's stack,
+        // which may still be inside an await_suspend.
+        for (auto& payload : payloads)
         {
-            if (p.m_callback)
+            if (payload.m_callback)
             {
-                auto cb = std::move(p.m_callback);
+                auto callback = std::move(payload.m_callback);
                 if (m_server.get().haveNetwork())
                 {
-                    m_server.get().asioInterface()->post(
-                        [callback = std::move(cb)]() {
-                            callback(boost::asio::error::operation_aborted);
-                        });
+                    m_server.get().asioInterface()->post([callback = std::move(callback)]() {
+                        callback(boost::asio::error::operation_aborted);
+                    });
                 }
                 else
                 {
                     try
                     {
-                        cb(boost::asio::error::operation_aborted);
+                        callback(boost::asio::error::operation_aborted);
                     }
                     catch (std::exception const& e2)
                     {
-                        SESSION_LOG(WARNING)
-                            << LOG_DESC("write callback exception")
-                            << LOG_KV("what", boost::diagnostic_information(e2));
+                        SESSION_LOG(WARNING) << LOG_DESC("write callback exception")
+                                             << LOG_KV("what", boost::diagnostic_information(e2));
                     }
                 }
             }
         }
-        m_writings->payloads.clear();
         drop(TCPError);
-        return;
     }
+    catch (...)
+    {
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h)
+        SESSION_LOG(ERROR) << LOG_DESC("write error") << LOG_KV("endpoint", nodeIPEndpoint())
+                           << LOG_KV("what", boost::current_exception_diagnostic_information());
+        drop(TCPError);
+    }
+
+    // Single exit: clear the single-flight flag and, if the queue was refilled while this loop
+    // was draining, hand the writer role to a fresh loop. Runs after every exit path (normal
+    // drain, drop, exception). No wakeup is ever lost: a producer that pushed after the last
+    // drain either wins the CAS in its own write() (flag already cleared) or this tail finds the
+    // queue non-empty and re-arms. The re-arm (write()) drives the next loop only to its first
+    // suspension (task::wait is fire-and-forget), so recursion is bounded to depth one. Gated on
+    // active(): after a drop the queue is drained by drop() (and late producers fail via send()'s
+    // re-check), so re-arming there would just spin a fresh loop into the same teardown.
+    m_writingInFlight.store(false);
+    if (active() && !m_writeQueue.empty())
+    {
+        try
+        {
+            write();
+        }
+        catch (std::exception const& e)
+        {
+            SESSION_LOG(WARNING) << LOG_DESC("write re-arm exception")
+                                 << LOG_KV("what", boost::diagnostic_information(e));
+        }
+    }
+    co_return;
 }
 
 void Session::drop(DisconnectReason _reason)
@@ -366,8 +392,9 @@ void Session::drop(DisconnectReason _reason)
     // chains (fastSendMessageWithoutResponse). Without this, a session that disappears before the
     // write completes would leak the whole task::wait chain — including the strong refs to the
     // session/socket/service it captured (a broadcast fan-out multiplies this by the peer count).
-    // In-flight writes (m_writings) are covered by the asyncWrite completion handler, which
-    // already invokes their callbacks with the error when the socket close cancels the write.
+    // In-flight writes (the write loop's current batch) are covered by the write loop
+    // (Session::writeLoop), which invokes their callbacks with the error when the socket close
+    // cancels the write.
     // Also covers Session::write()'s early returns: they call drop(TCPError) right after the
     // payload has been pushed into m_writeQueue.
     //
@@ -385,10 +412,9 @@ void Session::drop(DisconnectReason _reason)
         {
             if (m_server.get().haveNetwork())
             {
-                m_server.get().asioInterface()->post(
-                    [callback = std::move(payload.m_callback)]() {
-                        callback(boost::asio::error::operation_aborted);
-                    });
+                m_server.get().asioInterface()->post([callback = std::move(payload.m_callback)]() {
+                    callback(boost::asio::error::operation_aborted);
+                });
             }
             else
             {
@@ -442,25 +468,22 @@ void Session::drop(DisconnectReason _reason)
             }
             if (m_server.get().haveNetwork())
             {
-                m_server.get().asioInterface()->post(
-                    [callback = std::move(callback)]() mutable {
-                        // the callback resumes a coroutine whose await_resume may rethrow; keep
-                        // the exception out of io_context::run() (same containment as onMessage /
-                        // onTimeout / the write-completion post)
-                        try
-                        {
-                            callback->callback(
-                                NetworkException(
-                                    P2PExceptionType::NetworkTimeout, "NetworkTimeout"),
-                                Message::Ptr());
-                        }
-                        catch (std::exception const& e)
-                        {
-                            SESSION_LOG(WARNING)
-                                << LOG_DESC("response callback exception during drop")
-                                << LOG_KV("what", boost::diagnostic_information(e));
-                        }
-                    });
+                m_server.get().asioInterface()->post([callback = std::move(callback)]() mutable {
+                    // the callback resumes a coroutine whose await_resume may rethrow; keep
+                    // the exception out of io_context::run() (same containment as onMessage /
+                    // onTimeout / the write-completion post)
+                    try
+                    {
+                        callback->callback(
+                            NetworkException(P2PExceptionType::NetworkTimeout, "NetworkTimeout"),
+                            Message::Ptr());
+                    }
+                    catch (std::exception const& e)
+                    {
+                        SESSION_LOG(WARNING) << LOG_DESC("response callback exception during drop")
+                                             << LOG_KV("what", boost::diagnostic_information(e));
+                    }
+                });
             }
             else
             {
@@ -472,9 +495,8 @@ void Session::drop(DisconnectReason _reason)
                 }
                 catch (std::exception const& e)
                 {
-                    SESSION_LOG(WARNING)
-                        << LOG_DESC("response callback exception during drop")
-                        << LOG_KV("what", boost::diagnostic_information(e));
+                    SESSION_LOG(WARNING) << LOG_DESC("response callback exception during drop")
+                                         << LOG_KV("what", boost::diagnostic_information(e));
                 }
             }
         }
@@ -693,163 +715,182 @@ void Session::doRead()
 {
     if (m_active && m_server.get().haveNetwork())
     {
-        // FIB-184: capture a strong reference (shared_from_this) instead of a weak_ptr. The
-        // buffer handed to asyncReadSome below points into this->m_recvBuffer and the stream is
-        // this->m_socket — both owned by the session. Holding a strong ref keeps the session, and
-        // therefore the recv buffer and the socket, alive until this handler completes, so a
-        // concurrent teardown on another thread can free them only after the read finishes. This
-        // supersedes the FIB-97 socket-only capture, which kept the SSL stream alive but not the
-        // recv buffer that async_read_some writes into — the actual use-after-free.
-        auto asyncRead = [session = shared_from_this()](
-                             const boost::system::error_code& ec, std::size_t bytesTransferred) {
-            {
-                if (ec)
-                {
-                    SESSION_LOG(INFO) << LOG_DESC("doRead failed")
-                                      << LOG_KV("endpoint", session->nodeIPEndpoint())
-                                      << LOG_KV("message", ec.message());
-                    session->drop(TCPError);
-                    return;
-                }
-
-                session->m_lastReadTime.store(utcSteadyTime());
-
-                auto& recvBuffer = session->recvBuffer();
-                // FIB-184 (review): onWrite advances the write position and returns false if the
-                // just-read bytes would overrun the recv buffer. With the lazy-initial / grow-on-
-                // demand buffer the read size is bounded by the write-buffer span, so this should
-                // not happen; but if it ever did the bytes would be silently dropped and the stream
-                // desynchronized. Treat it as a transport error and drop the session instead.
-                if (!recvBuffer.onWrite(bytesTransferred))
-                {
-                    SESSION_LOG(ERROR)
-                        << LOG_BADGE("doRead") << LOG_DESC("recv buffer overflow on write, drop")
-                        << LOG_KV("bytesTransferred", bytesTransferred)
-                        << LOG_KV("recvBufferSize", recvBuffer.recvBufferSize());
-                    session->drop(TCPError);
-                    return;
-                }
-
-                while (true)
-                {
-                    Message::Ptr message = session->m_messageFactory->buildMessage();
-                    try
-                    {
-                        auto writeBuffer = recvBuffer.asWriteBuffer();
-                        auto readBuffer = recvBuffer.asReadBuffer();
-                        // Note: the decode function may throw exception
-                        ssize_t result = message->decode(readBuffer);
-                        if (result > 0)
-                        {
-                            NetworkException e(P2PExceptionType::Success, "Success");
-                            session->onMessage(e, message);
-                            recvBuffer.onRead(result);
-                        }
-                        else if (result == 0)
-                        {
-                            auto length = message->lengthDirect();
-                            if (length > session->allowMaxMsgSize())
-                            {
-                                SESSION_LOG(ERROR)
-                                    << LOG_BADGE("doRead")
-                                    << LOG_DESC("the message size exceeded the allow maximum value")
-                                    << LOG_KV("msgSize", message->length())
-                                    << LOG_KV("allowMaxMsgSize", session->allowMaxMsgSize());
-
-                                session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                                       "ProtocolError(msg overflow)"),
-                                    message);
-                                session->drop(UserReason);
-                                break;
-                            }
-
-                            if ((length > recvBuffer.recvBufferSize()) ||
-                                (length > writeBuffer.size()) ||
-                                session->maxReadDataSize() > writeBuffer.size())
-                            {
-                                recvBuffer.moveToHeader();
-
-                                // the write buffer is not enough, move the left data to recv
-                                // buffer header for waiting for the next read
-                                if (length >= recvBuffer.recvBufferSize())
-                                {
-                                    auto resizeRecvBufferSize = 2 * length;
-                                    resizeRecvBufferSize = std::min<std::size_t>(
-                                        resizeRecvBufferSize, session->m_maxRecvBufferSize);
-                                    recvBuffer.resizeBuffer(resizeRecvBufferSize);
-
-                                    SESSION_LOG(INFO)
-                                        << LOG_BADGE("doRead")
-                                        << LOG_DESC(
-                                               "the current recv buffer size is not enough for "
-                                               "the "
-                                               "next message, resize the recv buffer")
-                                        << LOG_KV("msgSize", length)
-                                        << LOG_KV("resizeRecvBufferSize", resizeRecvBufferSize)
-                                        << LOG_KV("allowMaxMsgSize", session->allowMaxMsgSize());
-                                }
-                            }
-
-                            session->doRead();
-                            break;
-                        }
-                        else
-                        {
-                            SESSION_LOG(ERROR)
-                                << LOG_BADGE("doRead") << LOG_DESC("decode message error")
-                                << LOG_KV("result", result);
-                            session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                                   "ProtocolError(decode msg error)"),
-                                message);
-                            session->drop(UserReason);
-                            break;
-                        }
-                    }
-                    catch (std::exception const& e)
-                    {
-                        SESSION_LOG(ERROR) << LOG_DESC("Decode message exception")
-                                           << LOG_KV("message", boost::diagnostic_information(e));
-                        session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                               "ProtocolError(decode msg exception)"),
-                            message);
-                        session->drop(UserReason);
-                        break;
-                    }
-                    catch (...)
-                    {
-                        SESSION_LOG(ERROR)
-                            << LOG_DESC("Decode message exception")
-                            << LOG_KV("message", boost::current_exception_diagnostic_information());
-                        session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                               "ProtocolError(decode msg exception)"),
-                            message);
-                        session->drop(UserReason);
-                        break;
-                    }
-                }
-            }
-        };
-
-        if (m_socket->isConnected())
-        {
-            auto writeBuffer = m_recvBuffer.asWriteBuffer();
-            std::size_t readSize =
-                (writeBuffer.size() > m_maxReadDataSize ? m_maxReadDataSize : writeBuffer.size());
-            m_server.get().asioInterface()->asyncReadSome(
-                m_socket, boost::asio::buffer((void*)writeBuffer.data(), readSize), asyncRead);
-        }
-        else
-        {
-            SESSION_LOG(WARNING) << LOG_DESC("Error Reading ssl socket is close!");
-            drop(TCPError);
-            return;
-        }
+        // fire-and-forget: the detached task owns the coroutine chain; readLoop() holds the
+        // session alive in its frame (FIB-184) and exits on error, drop or shutdown.
+        task::wait(readLoop());
     }
     else
     {
         SESSION_LOG(ERROR) << LOG_DESC("callback doRead failed for session inactive")
                            << LOG_KV("active", m_active.load())
                            << LOG_KV("haveNetwork", m_server.get().haveNetwork());
+    }
+}
+
+task::Task<void> Session::readLoop()
+{
+    // FIB-184: the coroutine frame holds a strong reference to the session for the whole read
+    // loop. While the loop is suspended at the co_await below, the buffer handed to
+    // async_read_some points into this->m_recvBuffer and the stream is this->m_socket — the frame
+    // keeps both alive until the read completes, so a concurrent teardown on another thread can
+    // free them only after the read finishes. This supersedes the FIB-97/FIB-184 completion-
+    // handler captures with a structural guarantee.
+    auto self = shared_from_this();
+    try
+    {
+        while (m_active && m_server.get().haveNetwork())
+        {
+            if (!m_socket->isConnected())
+            {
+                SESSION_LOG(WARNING) << LOG_DESC("Error Reading ssl socket is close!");
+                drop(TCPError);
+                co_return;
+            }
+
+            auto writeBuffer = m_recvBuffer.asWriteBuffer();
+            std::size_t readSize =
+                (writeBuffer.size() > m_maxReadDataSize ? m_maxReadDataSize : writeBuffer.size());
+            auto [ec, bytesTransferred] =
+                co_await m_server.get().asioInterface()->awaitableReadSome(
+                    m_socket, boost::asio::buffer((void*)writeBuffer.data(), readSize));
+
+            if (ec)
+            {
+                SESSION_LOG(INFO) << LOG_DESC("doRead failed")
+                                  << LOG_KV("endpoint", nodeIPEndpoint())
+                                  << LOG_KV("message", ec.message());
+                drop(TCPError);
+                co_return;
+            }
+
+            m_lastReadTime.store(utcSteadyTime());
+
+            auto& recvBuffer = this->recvBuffer();
+            // FIB-184 (review): onWrite advances the write position and returns false if the
+            // just-read bytes would overrun the recv buffer. With the lazy-initial / grow-on-
+            // demand buffer the read size is bounded by the write-buffer span, so this should
+            // not happen; but if it ever did the bytes would be silently dropped and the stream
+            // desynchronized. Treat it as a transport error and drop the session instead.
+            if (!recvBuffer.onWrite(bytesTransferred))
+            {
+                SESSION_LOG(ERROR)
+                    << LOG_BADGE("doRead") << LOG_DESC("recv buffer overflow on write, drop")
+                    << LOG_KV("bytesTransferred", bytesTransferred)
+                    << LOG_KV("recvBufferSize", recvBuffer.recvBufferSize());
+                drop(TCPError);
+                co_return;
+            }
+
+            // decode every complete message already in the buffer, then loop back for more
+            while (true)
+            {
+                Message::Ptr message = m_messageFactory->buildMessage();
+                try
+                {
+                    auto bufferForWrite = recvBuffer.asWriteBuffer();
+                    auto readBuffer = recvBuffer.asReadBuffer();
+                    // Note: the decode function may throw exception
+                    ssize_t result = message->decode(readBuffer);
+                    if (result > 0)
+                    {
+                        NetworkException e(P2PExceptionType::Success, "Success");
+                        onMessage(e, message);
+                        recvBuffer.onRead(result);
+                    }
+                    else if (result == 0)
+                    {
+                        auto length = message->lengthDirect();
+                        if (length > allowMaxMsgSize())
+                        {
+                            SESSION_LOG(ERROR)
+                                << LOG_BADGE("doRead")
+                                << LOG_DESC("the message size exceeded the allow maximum value")
+                                << LOG_KV("msgSize", message->length())
+                                << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
+
+                            onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                          "ProtocolError(msg overflow)"),
+                                message);
+                            drop(UserReason);
+                            co_return;
+                        }
+
+                        if ((length > recvBuffer.recvBufferSize()) ||
+                            (length > bufferForWrite.size()) ||
+                            maxReadDataSize() > bufferForWrite.size())
+                        {
+                            recvBuffer.moveToHeader();
+
+                            // the write buffer is not enough, move the left data to recv
+                            // buffer header for waiting for the next read
+                            if (length >= recvBuffer.recvBufferSize())
+                            {
+                                auto resizeRecvBufferSize = 2 * length;
+                                resizeRecvBufferSize = std::min<std::size_t>(
+                                    resizeRecvBufferSize, m_maxRecvBufferSize);
+                                recvBuffer.resizeBuffer(resizeRecvBufferSize);
+
+                                SESSION_LOG(INFO)
+                                    << LOG_BADGE("doRead")
+                                    << LOG_DESC(
+                                           "the current recv buffer size is not enough for "
+                                           "the "
+                                           "next message, resize the recv buffer")
+                                    << LOG_KV("msgSize", length)
+                                    << LOG_KV("resizeRecvBufferSize", resizeRecvBufferSize)
+                                    << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
+                            }
+                        }
+
+                        // need more data: continue the outer loop and arm the next read
+                        // (replaces the session->doRead() recursion of the callback version)
+                        break;
+                    }
+                    else
+                    {
+                        SESSION_LOG(ERROR)
+                            << LOG_BADGE("doRead") << LOG_DESC("decode message error")
+                            << LOG_KV("result", result);
+                        onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                      "ProtocolError(decode msg error)"),
+                            message);
+                        drop(UserReason);
+                        co_return;
+                    }
+                }
+                catch (std::exception const& e)
+                {
+                    SESSION_LOG(ERROR) << LOG_DESC("Decode message exception")
+                                       << LOG_KV("message", boost::diagnostic_information(e));
+                    onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                  "ProtocolError(decode msg exception)"),
+                        message);
+                    drop(UserReason);
+                    co_return;
+                }
+                catch (...)
+                {
+                    SESSION_LOG(ERROR)
+                        << LOG_DESC("Decode message exception")
+                        << LOG_KV("message", boost::current_exception_diagnostic_information());
+                    onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                  "ProtocolError(decode msg exception)"),
+                        message);
+                    drop(UserReason);
+                    co_return;
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
+        // a session whose read loop died without a drop would zombie until the idle timer
+        SESSION_LOG(ERROR) << LOG_DESC("read loop exception")
+                           << LOG_KV("endpoint", nodeIPEndpoint())
+                           << LOG_KV("what", boost::current_exception_diagnostic_information());
+        drop(TCPError);
+        co_return;
     }
 }
 
@@ -1283,8 +1324,7 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     bcos::bytes compressedPayload;
     ::ranges::any_view<bytesConstRef, ::ranges::category::forward> wirePayloads =
         ::ranges::views::all(payloadRefs);
-    if (m_enableCompress &&
-        message.version() >= (uint16_t)bcos::protocol::ProtocolVersion::V2)
+    if (m_enableCompress && message.version() >= (uint16_t)bcos::protocol::ProtocolVersion::V2)
     {
         uint32_t payloadSize = 0;
         for (auto const& ref : payloadRefs)
@@ -1307,8 +1347,7 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
                     message.ext() | bcos::protocol::MessageExtFieldFlag::COMPRESS);
                 *(uint16_t*)(headerBuffer.data() + c_p2pHeaderExtOffset) =
                     boost::asio::detail::socket_ops::host_to_network_short(compressedExt);
-                wirePayloads =
-                    ::ranges::views::single(bcos::ref(std::as_const(compressedPayload)));
+                wirePayloads = ::ranges::views::single(bcos::ref(std::as_const(compressedPayload)));
             }
             else
             {
@@ -1348,9 +1387,9 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
     // silently bypass outgoing bandwidth/QPS limiting. A rejection surfaces as a thrown
     // NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine retry loops can stop.
-    if (auto result = (m_beforeMessageHandler ?
-                           m_beforeMessageHandler(*this, message, totalLength) :
-                           std::nullopt))
+    if (auto result =
+            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message, totalLength) :
+                                      std::nullopt))
     {
         const auto& error = result.value();
         BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
@@ -1381,8 +1420,8 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
 
 size_t bcos::gateway::Payload::size() const
 {
-    return ::ranges::accumulate(m_data, size_t(0),
-        [](size_t sum, const bytesConstRef& ref) { return sum + ref.size(); });
+    return ::ranges::accumulate(
+        m_data, size_t(0), [](size_t sum, const bytesConstRef& ref) { return sum + ref.size(); });
 }
 std::size_t bcos::gateway::SessionRecvBuffer::readPos() const
 {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -317,7 +317,19 @@ task::Task<void> Session::writeLoop()
                 if (m_server.get().haveNetwork())
                 {
                     m_server.get().asioInterface()->post([callback = std::move(callback)]() {
-                        callback(boost::asio::error::operation_aborted);
+                        // Same containment as the success-path write completion below: the
+                        // callback resumes a waiter whose await_resume may throw, and this
+                        // lambda runs inside io_context::run(), so nothing may escape it.
+                        try
+                        {
+                            callback(boost::asio::error::operation_aborted);
+                        }
+                        catch (std::exception const& e2)
+                        {
+                            SESSION_LOG(WARNING)
+                                << LOG_DESC("write callback exception")
+                                << LOG_KV("what", boost::diagnostic_information(e2));
+                        }
                     });
                 }
                 else
@@ -369,7 +381,8 @@ task::Task<void> Session::writeLoop()
             // `size` is unused: the loop re-derives the batch layout from `payloads` on each
             // iteration, and a short/failed write is handled through `error` alone
             [[maybe_unused]] auto [error, size] =
-                co_await m_server.get().asioInterface()->awaitableWrite(m_socket, buffers);
+                co_await m_server.get().asioInterface()->awaitableWrite(
+                    m_socket, std::move(buffers));
 
             buffers.clear();
             for (auto& payload : payloads)

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -212,7 +212,20 @@ void Session::write()
         // a write loop is already in flight; it drains the queue
         return;
     }
-    task::wait(writeLoop());
+    // Release-on-unwind, matching the old std::unique_lock(try_to_lock) writer flag: if the
+    // launch throws (coroutine-frame allocation failure, or an exception from the prologue of
+    // writeLoop — e.g. bad_weak_ptr from shared_from_this() — propagating back out through
+    // task::wait), the flag must not stay set, or every later write() would early-return at the
+    // CAS above and the queue would never drain again.
+    try
+    {
+        task::wait(writeLoop());
+    }
+    catch (...)
+    {
+        m_writingInFlight.store(false);
+        throw;
+    }
 }
 
 task::Task<void> Session::writeLoop()
@@ -257,7 +270,9 @@ task::Task<void> Session::writeLoop()
             {
                 payload.toConstBuffer(outputIt);
             }
-            auto [error, size] =
+            // `size` is unused: the loop re-derives the batch layout from `payloads` on each
+            // iteration, and a short/failed write is handled through `error` alone
+            [[maybe_unused]] auto [error, size] =
                 co_await m_server.get().asioInterface()->awaitableWrite(m_socket, buffers);
 
             buffers.clear();

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -185,20 +185,21 @@ std::size_t Session::writeQueueSize()
 }
 
 bool Session::tryPopSomeEncodedMsgs(
-    std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize, size_t _maxSendMsgCount)  // NOLINT
+    std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize)  // NOLINT
 {
-    // Desc: Try to send multi packets one time to improve the efficiency of sending
-    // data. Stop batching once the configured byte (session_max_send_data_size) or message-count
-    // (session_max_send_msg_count) budget is exhausted; the remainder stays queued for the next
-    // loop iteration.
+    // Desc: Try to send multi packets one time to improve the efficiency of sending data. Stop
+    // batching once the configured byte budget (p2p.session_max_send_data_size) is exhausted;
+    // the remainder stays queued for the next loop iteration. The message-count budget
+    // (p2p.session_max_send_msg_count) is deliberately NOT enforced here — the base had that
+    // condition commented out and drained the whole queue into a single scatter-gather write,
+    // and re-enabling it capped every async_write at 10 messages, costing ceil(N/10) post +
+    // async_write round-trips under broadcast fan-out. The byte budget alone bounds a single
+    // write's memory footprint; see the behaviour-change note in the PR description.
     size_t totalDataSize = 0;
-    size_t msgCount = 0;
     Payload payload;
-    while (totalDataSize < _maxSendDataSize && msgCount < _maxSendMsgCount &&
-           m_writeQueue.try_pop(payload))
+    while (totalDataSize < _maxSendDataSize && m_writeQueue.try_pop(payload))
     {
         totalDataSize += payload.size();
-        ++msgCount;
         encodedMsgs.emplace_back(std::move(payload));
     }
 
@@ -217,6 +218,15 @@ void Session::write()
     // writeLoop — e.g. bad_weak_ptr from shared_from_this() — propagating back out through
     // task::wait), the flag must not stay set, or every later write() would early-return at the
     // CAS above and the queue would never drain again.
+    //
+    // The exception is NOT propagated to the caller: write() is reached only from a sender's
+    // await_suspend (fastSendMessageWith/WithoutResponse), and by then the Payload carrying the
+    // completion callback is already queued. An exception escaping await_suspend resumes the
+    // sender and is immediately rethrown, unwinding the sender's frame while the queued
+    // callback still captures the (now destroyed) awaitable — whoever popped the payload next
+    // would write through a dangling `this`. Match the base instead: swallow, log and drop,
+    // which drains m_writeQueue and posts every queued callback (the sender is still suspended,
+    // so its frame is alive when the callback runs).
     try
     {
         task::wait(writeLoop());
@@ -224,7 +234,9 @@ void Session::write()
     catch (...)
     {
         m_writingInFlight.store(false);
-        throw;
+        SESSION_LOG(ERROR) << LOG_DESC("write loop launch failed")
+                           << LOG_KV("what", boost::current_exception_diagnostic_information());
+        drop(TCPError);
     }
 }
 
@@ -240,6 +252,54 @@ task::Task<void> Session::writeLoop()
     // is the lifetime owner now, so no shared_ptr indirection is needed).
     std::vector<Payload> payloads;
     std::vector<boost::asio::const_buffer> buffers;
+
+    // Frame-local RAII guard for the single-flight write flag. The completion-or-cancel rescue
+    // (detail::AsioCompletion in AsioAwaitable.h) can DESTROY this frame without running the
+    // loop body or its catch blocks (an armed write completion destroyed without invocation).
+    // Frame destruction runs frame-local destructors only, so without this guard m_writingInFlight
+    // — a Session member — would stay claimed forever (every later write() returns at the CAS and
+    // the queue never drains again), and the batch already moved into `payloads` would be
+    // destroyed with its m_callbacks never fired (the awaiting senders leak). Declared AFTER
+    // payloads so the guard's destructor — which runs FIRST on frame destruction — still sees the
+    // batch to fail. release() is called on every normal exit path (the loop tail), so the guard
+    // fires only on the destroy path.
+    struct WriteLoopGuard
+    {
+        Session* session;
+        std::vector<Payload>& payloads;
+        bool released = false;
+        ~WriteLoopGuard()
+        {
+            if (released)
+            {
+                return;
+            }
+            session->m_writingInFlight.store(false);
+            // fail the batch callbacks inline (not posted): on the destroy path there is no
+            // guaranteed-live executor to post to, and the senders awaiting them are suspended
+            // (their frames are alive), so a synchronous resume is safe here — the destroy path
+            // never runs on a sender's own stack.
+            for (auto& payload : payloads)
+            {
+                if (payload.m_callback)
+                {
+                    auto callback = std::move(payload.m_callback);
+                    try
+                    {
+                        callback(boost::asio::error::operation_aborted);
+                    }
+                    catch (std::exception const& e)
+                    {
+                        SESSION_LOG(WARNING)
+                            << LOG_DESC("write batch callback failed on frame destroy")
+                            << LOG_KV("what", boost::diagnostic_information(e));
+                    }
+                }
+            }
+            payloads.clear();
+        }
+        void release() { released = true; }
+    } writeLoopGuard{this, payloads};
 
     try
     {
@@ -259,7 +319,7 @@ task::Task<void> Session::writeLoop()
                 break;
             }
 
-            if (!tryPopSomeEncodedMsgs(payloads, m_maxSendDataSize, m_maxSendMsgCount))
+            if (!tryPopSomeEncodedMsgs(payloads, m_maxSendDataSize))
             {
                 // queue drained; fall through to the single exit below
                 break;
@@ -368,6 +428,11 @@ task::Task<void> Session::writeLoop()
     // suspension (task::wait is fire-and-forget), so recursion is bounded to depth one. Gated on
     // active(): after a drop the queue is drained by drop() (and late producers fail via send()'s
     // re-check), so re-arming there would just spin a fresh loop into the same teardown.
+    //
+    // The guard is released BEFORE the explicit store so its destructor never fires on this path
+    // (it must not clear the flag that a re-armed write() has just claimed). The destroy path
+    // (completion-or-cancel rescue) never reaches this tail, so the guard fires there instead.
+    writeLoopGuard.release();
     m_writingInFlight.store(false);
     if (active() && !m_writeQueue.empty())
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -13,6 +13,7 @@
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Message.h"
 #include "bcos-gateway/libnetwork/SessionFace.h"
+#include "bcos-gateway/libnetwork/SessionReadLoop.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
 #include "bcos-gateway/libp2p/Common.h"  // for c_compressThreshold / c_zstdCompressLevel
 #include "bcos-utilities/BoostLog.h"
@@ -769,26 +770,11 @@ void Session::disconnect(DisconnectReason _reason)
 
 void Session::start()
 {
-    SESSION_LOG(INFO) << "[Session::start] this=" << this;
-    if (!m_active && m_server.get().haveNetwork())
-    {
-        m_active = true;
-        m_lastWriteTime.store(utcSteadyTime());
-        m_lastReadTime.store(utcSteadyTime());
-        doRead();
-    }
-
-    auto self = weak_from_this();
-    m_idleCheckTimer->registerTimeoutHandler([self]() {
-        auto session = self.lock();
-        if (session)
-        {
-            session->checkNetworkStatus();
-        }
-    });
-    m_idleCheckTimer->start();
-
-    SESSION_LOG(INFO) << "[start] start session " << LOG_KV("this", this);
+    // Production read policy (default): the read loop compiles against
+    // ASIOInterface::DefaultReadPolicy — a direct async_read_some call. Read-loop test fakes
+    // that want to park reads call the templated startWithPolicy<FakePolicy>() instead (see
+    // SessionReadLoop.h).
+    startWithPolicy<ASIOInterface::DefaultReadPolicy>();
 }
 
 void Session::doRead()
@@ -797,180 +783,13 @@ void Session::doRead()
     {
         // fire-and-forget: the detached task owns the coroutine chain; readLoop() holds the
         // session alive in its frame (FIB-184) and exits on error, drop or shutdown.
-        task::wait(readLoop());
+        task::wait(readLoop<ASIOInterface::DefaultReadPolicy>());
     }
     else
     {
         SESSION_LOG(ERROR) << LOG_DESC("callback doRead failed for session inactive")
                            << LOG_KV("active", m_active.load())
                            << LOG_KV("haveNetwork", m_server.get().haveNetwork());
-    }
-}
-
-task::Task<void> Session::readLoop()
-{
-    // FIB-184: the coroutine frame holds a strong reference to the session for the whole read
-    // loop. While the loop is suspended at the co_await below, the buffer handed to
-    // async_read_some points into this->m_recvBuffer and the stream is this->m_socket — the frame
-    // keeps both alive until the read completes, so a concurrent teardown on another thread can
-    // free them only after the read finishes. This supersedes the FIB-97/FIB-184 completion-
-    // handler captures with a structural guarantee.
-    auto self = shared_from_this();
-    try
-    {
-        while (m_active && m_server.get().haveNetwork())
-        {
-            if (!m_socket->isConnected())
-            {
-                SESSION_LOG(WARNING) << LOG_DESC("Error Reading ssl socket is close!");
-                drop(TCPError);
-                co_return;
-            }
-
-            auto writeBuffer = m_recvBuffer.asWriteBuffer();
-            std::size_t readSize =
-                (writeBuffer.size() > m_maxReadDataSize ? m_maxReadDataSize : writeBuffer.size());
-            auto [ec, bytesTransferred] =
-                co_await m_server.get().asioInterface()->awaitableReadSome(
-                    m_socket, boost::asio::buffer((void*)writeBuffer.data(), readSize));
-
-            if (ec)
-            {
-                SESSION_LOG(INFO) << LOG_DESC("doRead failed")
-                                  << LOG_KV("endpoint", nodeIPEndpoint())
-                                  << LOG_KV("message", ec.message());
-                drop(TCPError);
-                co_return;
-            }
-
-            m_lastReadTime.store(utcSteadyTime());
-
-            auto& recvBuffer = this->recvBuffer();
-            // FIB-184 (review): onWrite advances the write position and returns false if the
-            // just-read bytes would overrun the recv buffer. With the lazy-initial / grow-on-
-            // demand buffer the read size is bounded by the write-buffer span, so this should
-            // not happen; but if it ever did the bytes would be silently dropped and the stream
-            // desynchronized. Treat it as a transport error and drop the session instead.
-            if (!recvBuffer.onWrite(bytesTransferred))
-            {
-                SESSION_LOG(ERROR)
-                    << LOG_BADGE("doRead") << LOG_DESC("recv buffer overflow on write, drop")
-                    << LOG_KV("bytesTransferred", bytesTransferred)
-                    << LOG_KV("recvBufferSize", recvBuffer.recvBufferSize());
-                drop(TCPError);
-                co_return;
-            }
-
-            // decode every complete message already in the buffer, then loop back for more
-            while (true)
-            {
-                Message::Ptr message = m_messageFactory->buildMessage();
-                try
-                {
-                    auto bufferForWrite = recvBuffer.asWriteBuffer();
-                    auto readBuffer = recvBuffer.asReadBuffer();
-                    // Note: the decode function may throw exception
-                    ssize_t result = message->decode(readBuffer);
-                    if (result > 0)
-                    {
-                        NetworkException e(P2PExceptionType::Success, "Success");
-                        onMessage(e, message);
-                        recvBuffer.onRead(result);
-                    }
-                    else if (result == 0)
-                    {
-                        auto length = message->lengthDirect();
-                        if (length > allowMaxMsgSize())
-                        {
-                            SESSION_LOG(ERROR)
-                                << LOG_BADGE("doRead")
-                                << LOG_DESC("the message size exceeded the allow maximum value")
-                                << LOG_KV("msgSize", message->length())
-                                << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
-
-                            onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                          "ProtocolError(msg overflow)"),
-                                message);
-                            drop(UserReason);
-                            co_return;
-                        }
-
-                        if ((length > recvBuffer.recvBufferSize()) ||
-                            (length > bufferForWrite.size()) ||
-                            maxReadDataSize() > bufferForWrite.size())
-                        {
-                            recvBuffer.moveToHeader();
-
-                            // the write buffer is not enough, move the left data to recv
-                            // buffer header for waiting for the next read
-                            if (length >= recvBuffer.recvBufferSize())
-                            {
-                                auto resizeRecvBufferSize = 2 * length;
-                                resizeRecvBufferSize = std::min<std::size_t>(
-                                    resizeRecvBufferSize, m_maxRecvBufferSize);
-                                recvBuffer.resizeBuffer(resizeRecvBufferSize);
-
-                                SESSION_LOG(INFO)
-                                    << LOG_BADGE("doRead")
-                                    << LOG_DESC(
-                                           "the current recv buffer size is not enough for "
-                                           "the "
-                                           "next message, resize the recv buffer")
-                                    << LOG_KV("msgSize", length)
-                                    << LOG_KV("resizeRecvBufferSize", resizeRecvBufferSize)
-                                    << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
-                            }
-                        }
-
-                        // need more data: continue the outer loop and arm the next read
-                        // (replaces the session->doRead() recursion of the callback version)
-                        break;
-                    }
-                    else
-                    {
-                        SESSION_LOG(ERROR)
-                            << LOG_BADGE("doRead") << LOG_DESC("decode message error")
-                            << LOG_KV("result", result);
-                        onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                      "ProtocolError(decode msg error)"),
-                            message);
-                        drop(UserReason);
-                        co_return;
-                    }
-                }
-                catch (std::exception const& e)
-                {
-                    SESSION_LOG(ERROR) << LOG_DESC("Decode message exception")
-                                       << LOG_KV("message", boost::diagnostic_information(e));
-                    onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                  "ProtocolError(decode msg exception)"),
-                        message);
-                    drop(UserReason);
-                    co_return;
-                }
-                catch (...)
-                {
-                    SESSION_LOG(ERROR)
-                        << LOG_DESC("Decode message exception")
-                        << LOG_KV("message", boost::current_exception_diagnostic_information());
-                    onMessage(NetworkException(P2PExceptionType::ProtocolError,
-                                  "ProtocolError(decode msg exception)"),
-                        message);
-                    drop(UserReason);
-                    co_return;
-                }
-            }
-        }
-    }
-    catch (...)
-    {
-        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
-        // a session whose read loop died without a drop would zombie until the idle timer
-        SESSION_LOG(ERROR) << LOG_DESC("read loop exception")
-                           << LOG_KV("endpoint", nodeIPEndpoint())
-                           << LOG_KV("what", boost::current_exception_diagnostic_information());
-        drop(TCPError);
-        co_return;
     }
 }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -444,11 +444,16 @@ task::Task<void> Session::writeLoop()
     // active(): after a drop the queue is drained by drop() (and late producers fail via send()'s
     // re-check), so re-arming there would just spin a fresh loop into the same teardown.
     //
-    // The guard is released BEFORE the explicit store so its destructor never fires on this path
+    // The guard is released BEFORE the flag is cleared so its destructor never fires on this path
     // (it must not clear the flag that a re-armed write() has just claimed). The destroy path
     // (completion-or-cancel rescue) never reaches this tail, so the guard fires there instead.
+    // The flag is cleared with exchange, not store: the tail never otherwise READS the flag, and
+    // a plain store is release-only, so the queue re-check below would have no happens-before
+    // edge from a producer's push (push, then exchange(true) observing the flag set). The seq_cst
+    // exchange reads from the release sequence headed by that producer's exchange(true), giving
+    // every such producer's push a happens-before edge to the re-check.
     writeLoopGuard.release();
-    m_writingInFlight.store(false);
+    m_writingInFlight.exchange(false);
     if (active() && !m_writeQueue.empty())
     {
         try

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -198,7 +198,13 @@ bool Session::tryPopSomeEncodedMsgs(
     // write's memory footprint; see the behaviour-change note in the PR description.
     size_t totalDataSize = 0;
     Payload payload;
-    while (totalDataSize < _maxSendDataSize && m_writeQueue.try_pop(payload))
+    // Floor the budget at 1 here — the point where the invariant "the byte budget is never 0"
+    // is actually needed. The GatewayConfig clamp warns the operator, but Session::
+    // setMaxSendDataSize stores whatever it is given, and a 0 budget makes the while below
+    // never enter: tryPop returns false, writeLoop breaks on its first iteration and every
+    // outbound write on the session stalls silently and permanently.
+    size_t budget = std::max<size_t>(_maxSendDataSize, 1);
+    while (totalDataSize < budget && m_writeQueue.try_pop(payload))
     {
         totalDataSize += payload.size();
         encodedMsgs.emplace_back(std::move(payload));
@@ -214,23 +220,50 @@ void Session::write()
         // a write loop is already in flight; it drains the queue
         return;
     }
-    // Release-on-unwind, matching the old std::unique_lock(try_to_lock) writer flag: if the
-    // launch throws (coroutine-frame allocation failure, or an exception from the prologue of
-    // writeLoop — e.g. bad_weak_ptr from shared_from_this() — propagating back out through
-    // task::wait), the flag must not stay set, or every later write() would early-return at the
-    // CAS above and the queue would never drain again.
+    // Launch the loop on the socket's own io thread, NOT synchronously on the caller's stack.
+    // write() is reached from a sender's await_suspend (fastSendMessageWith/WithoutResponse via
+    // send()): running writeLoop's first iteration there would let a shutdown race (Host::stop()
+    // clearing m_run between send()'s active() re-check and writeLoop's haveNetwork() check) call
+    // drop(TCPError) on that stack, and drop()'s inline drain would invoke the just-queued
+    // payload's callback — resuming the very coroutine whose await_suspend is still running
+    // (undefined behaviour; await_resume's throw could even destroy the frame await_suspend is
+    // standing on). With the launch posted, every settlement inside writeLoop — including the
+    // drop() it may trigger and failBatch's inline branch — runs on an io thread, so no callback
+    // can land on a sender's own stack. Cost is one post per write-loop start; the loop already
+    // suspends into awaitableWrite, so steady-state cost is unchanged.
     //
-    // The exception is NOT propagated to the caller: write() is reached only from a sender's
-    // await_suspend (fastSendMessageWith/WithoutResponse), and by then the Payload carrying the
-    // completion callback is already queued. An exception escaping await_suspend resumes the
-    // sender and is immediately rethrown, unwinding the sender's frame while the queued
-    // callback still captures the (now destroyed) awaitable — whoever popped the payload next
-    // would write through a dangling `this`. Match the base instead: swallow, log and drop,
-    // which drains m_writeQueue and posts every queued callback (the sender is still suspended,
-    // so its frame is alive when the callback runs).
+    // Release-on-unwind, matching the old std::unique_lock(try_to_lock) writer flag: if the
+    // launch itself throws (post allocation failure, or bad_weak_ptr from shared_from_this()),
+    // the flag must not stay set, or every later write() would early-return at the CAS above and
+    // the queue would never drain again. The exception is NOT propagated to the caller (see
+    // above: the caller may be a sender's await_suspend with the payload already queued);
+    // swallow, log and drop, which drains m_writeQueue and completes every queued callback.
+    auto socket = m_socket;
+    if (!socket)
+    {
+        // inactive session (setSocket(nullptr) raced the active() checks): the queue is
+        // settled by send()'s post-push re-check or by drop(), so just release the flag
+        m_writingInFlight.store(false);
+        return;
+    }
     try
     {
-        task::wait(writeLoop());
+        boost::asio::post(socket->ioService(), [self = shared_from_this()]() {
+            try
+            {
+                task::wait(self->writeLoop());
+            }
+            catch (...)
+            {
+                // the loop's own catches make this unreachable in practice; if the frame
+                // allocation itself threw, release the flag and settle the queue
+                self->m_writingInFlight.store(false);
+                SESSION_LOG(ERROR) << LOG_DESC("write loop launch failed")
+                                   << LOG_KV("what",
+                                          boost::current_exception_diagnostic_information());
+                self->drop(TCPError);
+            }
+        });
     }
     catch (...)
     {
@@ -461,10 +494,10 @@ task::Task<void> Session::writeLoop()
     // was draining, hand the writer role to a fresh loop. Runs after every exit path (normal
     // drain, drop, exception). No wakeup is ever lost: a producer that pushed after the last
     // drain either wins the CAS in its own write() (flag already cleared) or this tail finds the
-    // queue non-empty and re-arms. The re-arm (write()) drives the next loop only to its first
-    // suspension (task::wait is fire-and-forget), so recursion is bounded to depth one. Gated on
-    // active(): after a drop the queue is drained by drop() (and late producers fail via send()'s
-    // re-check), so re-arming there would just spin a fresh loop into the same teardown.
+    // queue non-empty and re-arms. The re-arm (write()) posts the next loop's launch to the
+    // socket's io thread, so it never extends this stack. Gated on active(): after a drop the
+    // queue is drained by drop() (and late producers fail via send()'s re-check), so re-arming
+    // there would just spin a fresh loop into the same teardown.
     //
     // The guard is released BEFORE the flag is cleared so its destructor never fires on this path
     // (it must not clear the flag that a re-armed write() has just claimed). The destroy path
@@ -520,13 +553,14 @@ void Session::drop(DisconnectReason _reason)
     // Also covers Session::write()'s early returns: they call drop(TCPError) right after the
     // payload has been pushed into m_writeQueue.
     //
-    // FIB-185 (review): complete these callbacks OFF the caller's stack. drop() is reachable from
-    // Session::write()'s early-return path, which runs on the stack of a sender that is still
-    // inside its own await_suspend — calling the callback inline there would resume that coroutine
-    // from inside its own await_suspend (the exact hazard send()'s early-return branch avoids by
-    // posting). Post to the shared pool; when the host is already gone there is no live executor
-    // to hand it to, so fall back to inline — the same shape as the notifyDisconnect / closeSocket
-    // branches below.
+    // FIB-185 (review): complete these callbacks OFF the caller's stack whenever an executor is
+    // available. writeLoop never runs on a sender's stack anymore (Session::write() posts its
+    // launch), but drop() remains reachable from arbitrary caller stacks — including write()'s
+    // launch-failure catch, which can still sit inside a sender's await_suspend — so calling the
+    // callback inline here could resume a coroutine from inside its own await_suspend (the exact
+    // hazard send()'s early-return branch avoids by posting). Post to the shared pool; when the
+    // host is already gone there is no live executor to hand it to, so fall back to inline —
+    // the same shape as the notifyDisconnect / closeSocket branches below.
     Payload payload;
     while (m_writeQueue.try_pop(payload))
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -295,6 +295,15 @@ task::Task<void> Session::writeLoop()
                             << LOG_DESC("write batch callback failed on frame destroy")
                             << LOG_KV("what", boost::diagnostic_information(e));
                     }
+                    catch (...)
+                    {
+                        // the guard's destructor is implicitly noexcept: a foreign exception
+                        // (not derived from std::exception) escaping here would call
+                        // std::terminate, so catch everything and log
+                        SESSION_LOG(WARNING)
+                            << LOG_DESC("write batch callback failed on frame destroy")
+                            << LOG_KV("what", boost::current_exception_diagnostic_information());
+                    }
                 }
             }
             payloads.clear();
@@ -526,7 +535,19 @@ void Session::drop(DisconnectReason _reason)
             if (m_server.get().haveNetwork())
             {
                 m_server.get().asioInterface()->post([callback = std::move(payload.m_callback)]() {
-                    callback(boost::asio::error::operation_aborted);
+                    // The callback resumes a coroutine whose await_resume may throw
+                    // (fastSendMessageWithoutResponse throws NetworkException on write failure),
+                    // and this lambda runs inside io_context::run() — contain it exactly as
+                    // failBatch and the response-waiter flush below do.
+                    try
+                    {
+                        callback(boost::asio::error::operation_aborted);
+                    }
+                    catch (std::exception const& e)
+                    {
+                        SESSION_LOG(WARNING) << LOG_DESC("write callback exception during drop")
+                                             << LOG_KV("what", boost::diagnostic_information(e));
+                    }
                 });
             }
             else

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -195,8 +195,7 @@ public:
      * @param _maxSendDataSize
      * @return bool
      */
-    bool tryPopSomeEncodedMsgs(
-        std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize);
+    bool tryPopSomeEncodedMsgs(std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize);
 
     virtual void checkNetworkStatus();
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -91,12 +91,13 @@ struct Payload
 class Session : public SessionFace, public std::enable_shared_from_this<Session>
 {
 public:
-    // Grow ceiling: the recv buffer never grows beyond this (see Session::doRead grow path).
+    // Grow ceiling: the recv buffer never grows beyond this (see the read-loop grow path).
     constexpr static const std::size_t MIN_SESSION_RECV_BUFFER_SIZE = 512 * 1024UL;
     // FIB-184: initial recv-buffer size for a freshly created session. Previously every
     // session unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) up front, so a
     // flood of unauthenticated/short-lived sessions caused heap exhaustion. Start small and
-    // rely on the existing grow path (doRead grows up to m_maxRecvBufferSize) to expand only
+    // rely on the existing grow path (the read loop grows up to m_maxRecvBufferSize) to expand
+    // only
     // for sessions that actually carry large messages. Must stay well above the message
     // header length so the first read can always make forward progress.
     constexpr static const std::size_t INITIAL_SESSION_RECV_BUFFER_SIZE = 16 * 1024UL;
@@ -175,9 +176,6 @@ public:
     uint32_t maxSendDataSize() const;
     void setMaxSendDataSize(uint32_t _maxSendDataSize);
 
-    uint32_t maxSendMsgCountS() const;
-    void setMaxSendMsgCountS(uint32_t _maxSendMsgCountS);
-
     uint32_t allowMaxMsgSize() const;
     void setAllowMaxMsgSize(uint32_t _allowMaxMsgSize);
 
@@ -203,11 +201,6 @@ public:
 
     virtual void checkNetworkStatus();
 
-    // Launch the read loop with the production read-initiation policy (a direct async_read_some,
-    // see ASIOInterface::awaitableReadSome). Test fakes that want to park reads use
-    // startWithPolicy<FakePolicy>() instead.
-    void doRead();
-
     // FIB-184 (review): keep the grow ceiling private so it can only be read via
     // maxRecvBufferSize() and never widened from outside. Declared before m_recvBuffer to preserve
     // member init order.
@@ -222,8 +215,6 @@ public:
     uint32_t m_maxReadDataSize = 40 * 1024;
     // Maximum amount of data to be sent one time, default: 1M
     uint32_t m_maxSendDataSize = 1024 * 1024;
-    // Maximum number of packets to be sent one time, default: 10
-    uint32_t m_maxSendMsgCount = 10;
     //  Maximum size of message that is allowed to send or receive, default: 32M
     uint32_t m_allowMaxMsgSize = 32 * 1024 * 1024;
     //
@@ -234,8 +225,8 @@ public:
     void drop(DisconnectReason _reason);
 
 private:
-    // Coroutine body backing doRead(), launched fire-and-forget via task::wait. Each frame
-    // holds a strong reference to the session for the whole loop, so an in-flight read keeps
+    // Read-loop coroutine, launched fire-and-forget via task::wait from startWithPolicy. Each
+    // frame holds a strong reference to the session for the whole loop, so an in-flight read keeps
     // the session, its recv buffer and its socket alive — the FIB-184 lifetime invariant, made
     // structural instead of relying on completion-handler captures. ReadPolicy is the
     // compile-time read-initiation policy (see ASIOInterface::awaitableReadSome): production
@@ -269,7 +260,7 @@ public:
     /// single exit) to drain the queue.
     void write();
 
-    /// call by doRead() to deal with message
+    /// called by the read loop to deal with a decoded message
     void onMessage(NetworkException const& e, Message::Ptr message);
 
     std::reference_wrapper<Host> m_server;  ///< The host that owns us. Never null.
@@ -283,9 +274,9 @@ public:
     // it never blocks, so no lock is ever held across a co_await.
     std::atomic<bool> m_writingInFlight{false};
     // FIB-184 (review): atomic so the active flag is read/written without a data race between the
-    // network worker (set/clear in start/drop) and readers in active()/doRead(). Note active() is
-    // still a composite read (also m_socket / haveNetwork()), so this narrows but does not by
-    // itself make the whole liveness check atomic.
+    // network worker (set/clear in start/drop) and readers in active(). Note active() is still a
+    // composite read (also m_socket / haveNetwork()), so this narrows but does not by itself make
+    // the whole liveness check atomic.
     std::atomic<bool> m_active{false};
 
     SessionCallbackManagerInterface::Ptr m_sessionCallbackManager;
@@ -336,13 +327,12 @@ class SessionFactory
 public:
     SessionFactory(P2PInfo _hostInfo, uint32_t _sessionRecvBufferSize,  // NOLINT
         uint32_t _allowMaxMsgSize, uint32_t _maxReadDataSize, uint32_t _maxSendDataSize,
-        uint32_t _maxSendMsgCountS, bool _enableCompress)
+        bool _enableCompress)
       : m_hostInfo(std::move(_hostInfo)),
         m_sessionRecvBufferSize(_sessionRecvBufferSize),
         m_allowMaxMsgSize(_allowMaxMsgSize),
         m_maxReadDataSize(_maxReadDataSize),
         m_maxSendDataSize(_maxSendDataSize),
-        m_maxSendMsgCountS(_maxSendMsgCountS),
         m_enableCompress(_enableCompress)
     {}
     SessionFactory(const SessionFactory&) = delete;
@@ -361,7 +351,6 @@ private:
     uint32_t m_allowMaxMsgSize{0};
     uint32_t m_maxReadDataSize{0};
     uint32_t m_maxSendDataSize{0};
-    uint32_t m_maxSendMsgCountS{0};
     bool m_enableCompress = true;
 };
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -188,11 +188,10 @@ public:
      *
      * @param encodedMsgs
      * @param _maxSendDataSize
-     * @param _maxSendMsgCount
      * @return bool
      */
     bool tryPopSomeEncodedMsgs(
-        std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize, size_t _maxSendMsgCount);
+        std::vector<Payload>& encodedMsgs, size_t _maxSendDataSize);
 
     virtual void checkNetworkStatus();
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -97,8 +97,7 @@ public:
     // session unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) up front, so a
     // flood of unauthenticated/short-lived sessions caused heap exhaustion. Start small and
     // rely on the existing grow path (the read loop grows up to m_maxRecvBufferSize) to expand
-    // only
-    // for sessions that actually carry large messages. Must stay well above the message
+    // only for sessions that actually carry large messages. Must stay well above the message
     // header length so the first read can always make forward progress.
     constexpr static const std::size_t INITIAL_SESSION_RECV_BUFFER_SIZE = 16 * 1024UL;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -113,6 +113,14 @@ public:
     using Ptr = std::shared_ptr<Session>;
 
     void start() override;
+
+    // Read-policy seam (compile-time): identical lifecycle to start(), but the read loop is
+    // compiled against an explicit ReadPolicy so read-loop test fakes can inject a policy that
+    // parks / controls read completions (see ASIOInterface::awaitableReadSome). Production call
+    // sites use the virtual start() (the default policy) — this template costs nothing there.
+    // Definition lives in SessionReadLoop.h.
+    template <typename ReadPolicy>
+    void startWithPolicy();
     void disconnect(DisconnectReason _reason) override;
 
     task::Task<Message::Ptr> fastSendMessage(const Message& message,
@@ -195,6 +203,9 @@ public:
 
     virtual void checkNetworkStatus();
 
+    // Launch the read loop with the production read-initiation policy (a direct async_read_some,
+    // see ASIOInterface::awaitableReadSome). Test fakes that want to park reads use
+    // startWithPolicy<FakePolicy>() instead.
     void doRead();
 
     // FIB-184 (review): keep the grow ceiling private so it can only be read via
@@ -223,10 +234,14 @@ public:
     void drop(DisconnectReason _reason);
 
 private:
-    // Coroutine bodies backing doRead()/write(), launched fire-and-forget via task::wait. Each
-    // frame holds a strong reference to the session for the whole loop, so an in-flight
-    // read/write keeps the session, its recv buffer and its socket alive — the FIB-184 lifetime
-    // invariant, made structural instead of relying on completion-handler captures.
+    // Coroutine body backing doRead(), launched fire-and-forget via task::wait. Each frame
+    // holds a strong reference to the session for the whole loop, so an in-flight read keeps
+    // the session, its recv buffer and its socket alive — the FIB-184 lifetime invariant, made
+    // structural instead of relying on completion-handler captures. ReadPolicy is the
+    // compile-time read-initiation policy (see ASIOInterface::awaitableReadSome): production
+    // instantiates ASIOInterface::DefaultReadPolicy, test fakes their own. Definition in
+    // SessionReadLoop.h.
+    template <typename ReadPolicy>
     task::Task<void> readLoop();
     // Single-writer write loop (see write()): drains m_writeQueue in batches and serializes every
     // async_write through the single in-flight loop. The frame holds a strong reference to the

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -224,6 +224,17 @@ public:
     void drop(DisconnectReason _reason);
 
 private:
+    // Coroutine bodies backing doRead()/write(), launched fire-and-forget via task::wait. Each
+    // frame holds a strong reference to the session for the whole loop, so an in-flight
+    // read/write keeps the session, its recv buffer and its socket alive — the FIB-184 lifetime
+    // invariant, made structural instead of relying on completion-handler captures.
+    task::Task<void> readLoop();
+    // Single-writer write loop (see write()): drains m_writeQueue in batches and serializes every
+    // async_write through the single in-flight loop. The frame holds a strong reference to the
+    // session for the whole loop (see the body), keeping the socket and the batch buffers alive
+    // across each co_await.
+    task::Task<void> writeLoop();
+
     // FIB-184: perform the actual SSL/socket teardown (close + graceful async_shutdown). It has a
     // strict threading contract — it must run on the socket's io_context (or, on the shutdown path,
     // with the io_context threads already joined) so it never touches the ssl::stream concurrently
@@ -238,9 +249,10 @@ public:
 
     void onTimeout(const boost::system::error_code& error, uint32_t seq);
 
-    /// Perform a single round of the write operation. This could end up calling
-    /// itself asynchronously.
-    void onWrite(boost::system::error_code ec, std::size_t length);
+    /// Launch the write loop (writeLoop) if no write is currently in flight. Safe to call from
+    /// any thread: the first caller wins the m_writingInFlight CAS and becomes the single writer;
+    /// concurrent callers return immediately and rely on the in-flight writer (or writeLoop's
+    /// single exit) to drain the queue.
     void write();
 
     /// call by doRead() to deal with message
@@ -251,7 +263,11 @@ public:
 
     MessageFactory::Ptr m_messageFactory;
     tbb::concurrent_queue<Payload> m_writeQueue;
-    std::mutex m_writingQueueMutex;
+    // Single-flight flag guarding the write path: write() CASes it to true to claim the writer
+    // role (exactly one writeLoop runs at a time); writeLoop's exit guard clears it and re-arms
+    // write() when the queue is non-empty at exit. Replaces the old try_lock-as-flag std::mutex —
+    // it never blocks, so no lock is ever held across a co_await.
+    std::atomic<bool> m_writingInFlight{false};
     // FIB-184 (review): atomic so the active flag is read/written without a data race between the
     // network worker (set/clear in start/drop) and readers in active()/doRead(). Note active() is
     // still a composite read (also m_socket / haveNetwork()), so this narrows but does not by
@@ -296,13 +312,6 @@ public:
     // FIB-184: opaque guard whose destructor releases the Host session-cap slot. Destroyed with
     // the session, so the slot is freed exactly once on session teardown.
     std::shared_ptr<void> m_lifetimeGuard;
-
-    struct Writings
-    {
-        std::vector<Payload> payloads;
-        std::vector<boost::asio::const_buffer> buffers;
-    };
-    std::shared_ptr<Writings> m_writings;
 
     std::mutex x_pendingResponseSeqs;
     std::unordered_set<uint32_t> m_pendingResponseSeqs;

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionReadLoop.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionReadLoop.h
@@ -1,0 +1,219 @@
+/**
+ * @brief Template definitions of Session::readLoop / doRead / startWithPolicy — the read path
+ *        is a compile-time policy (see ASIOInterface::awaitableReadSome), so production compiles
+ *        against the default policy (a direct, inlined async_read_some) while read-loop test
+ *        fakes instantiate the same code with their own parking policy. The bodies live in this
+ *        separate header (included by Session.cpp and by the mock-using test TUs) to keep
+ *        Session.h a pure class declaration.
+ * @file SessionReadLoop.h
+ */
+#pragma once
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Common.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include <bcos-task/Wait.h>
+#include <boost/exception/diagnostic_information.hpp>
+
+namespace bcos::gateway
+{
+// Read-policy seam (compile-time): identical lifecycle to start(), but the read loop is compiled
+// against an explicit ReadPolicy so read-loop test fakes can inject a policy that parks/controls
+// read completions (see ASIOInterface::awaitableReadSome). Production call sites use the virtual
+// start() (the default policy), which delegates here with ASIOInterface::DefaultReadPolicy — this
+// template adds no runtime cost in production. Tests instantiate it with a fake policy, e.g.
+// session->startWithPolicy<FakeASIO::ReadPolicy>().
+template <typename ReadPolicy>
+void Session::startWithPolicy()
+{
+    SESSION_LOG(INFO) << "[Session::start] this=" << this;
+    if (!m_active && m_server.get().haveNetwork())
+    {
+        m_active = true;
+        m_lastWriteTime.store(utcSteadyTime());
+        m_lastReadTime.store(utcSteadyTime());
+        // fire-and-forget: the detached task owns the coroutine chain; readLoop() holds the
+        // session alive in its frame (FIB-184) and exits on error, drop or shutdown.
+        task::wait(readLoop<ReadPolicy>());
+    }
+
+    auto self = weak_from_this();
+    m_idleCheckTimer->registerTimeoutHandler([self]() {
+        auto session = self.lock();
+        if (session)
+        {
+            session->checkNetworkStatus();
+        }
+    });
+    m_idleCheckTimer->start();
+}
+
+template <typename ReadPolicy>
+task::Task<void> Session::readLoop()
+{
+    // FIB-184: the coroutine frame holds a strong reference to the session for the whole read
+    // loop. While the loop is suspended at the co_await below, the buffer handed to
+    // async_read_some points into this->m_recvBuffer and the stream is this->m_socket — the frame
+    // keeps both alive until the read completes, so a concurrent teardown on another thread can
+    // free them only after the read finishes. This supersedes the FIB-97/FIB-184 completion-
+    // handler captures with a structural guarantee.
+    auto self = shared_from_this();
+    try
+    {
+        while (m_active && m_server.get().haveNetwork())
+        {
+            if (!m_socket->isConnected())
+            {
+                SESSION_LOG(WARNING) << LOG_DESC("Error Reading ssl socket is close!");
+                drop(TCPError);
+                co_return;
+            }
+
+            auto writeBuffer = m_recvBuffer.asWriteBuffer();
+            std::size_t readSize =
+                (writeBuffer.size() > m_maxReadDataSize ? m_maxReadDataSize : writeBuffer.size());
+            auto [ec, bytesTransferred] =
+                co_await m_server.get().asioInterface()
+                    ->template awaitableReadSome<ReadPolicy>(
+                        m_socket, boost::asio::buffer((void*)writeBuffer.data(), readSize));
+
+            if (ec)
+            {
+                SESSION_LOG(INFO) << LOG_DESC("doRead failed")
+                                  << LOG_KV("endpoint", nodeIPEndpoint())
+                                  << LOG_KV("message", ec.message());
+                drop(TCPError);
+                co_return;
+            }
+
+            m_lastReadTime.store(utcSteadyTime());
+
+            auto& recvBuffer = this->recvBuffer();
+            // FIB-184 (review): onWrite advances the write position and returns false if the
+            // just-read bytes would overrun the recv buffer. With the lazy-initial / grow-on-
+            // demand buffer the read size is bounded by the write-buffer span, so this should
+            // not happen; but if it ever did the bytes would be silently dropped and the stream
+            // desynchronized. Treat it as a transport error and drop the session instead.
+            if (!recvBuffer.onWrite(bytesTransferred))
+            {
+                SESSION_LOG(ERROR)
+                    << LOG_BADGE("doRead") << LOG_DESC("recv buffer overflow on write, drop")
+                    << LOG_KV("bytesTransferred", bytesTransferred)
+                    << LOG_KV("recvBufferSize", recvBuffer.recvBufferSize());
+                drop(TCPError);
+                co_return;
+            }
+
+            // decode every complete message already in the buffer, then loop back for more
+            while (true)
+            {
+                Message::Ptr message = m_messageFactory->buildMessage();
+                try
+                {
+                    auto bufferForWrite = recvBuffer.asWriteBuffer();
+                    auto readBuffer = recvBuffer.asReadBuffer();
+                    // Note: the decode function may throw exception
+                    ssize_t result = message->decode(readBuffer);
+                    if (result > 0)
+                    {
+                        NetworkException e(P2PExceptionType::Success, "Success");
+                        onMessage(e, message);
+                        recvBuffer.onRead(result);
+                    }
+                    else if (result == 0)
+                    {
+                        auto length = message->lengthDirect();
+                        if (length > allowMaxMsgSize())
+                        {
+                            SESSION_LOG(ERROR)
+                                << LOG_BADGE("doRead")
+                                << LOG_DESC("the message size exceeded the allow maximum value")
+                                << LOG_KV("msgSize", message->length())
+                                << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
+
+                            onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                          "ProtocolError(msg overflow)"),
+                                message);
+                            drop(UserReason);
+                            co_return;
+                        }
+
+                        if ((length > recvBuffer.recvBufferSize()) ||
+                            (length > bufferForWrite.size()) ||
+                            maxReadDataSize() > bufferForWrite.size())
+                        {
+                            recvBuffer.moveToHeader();
+
+                            // the write buffer is not enough, move the left data to recv
+                            // buffer header for waiting for the next read
+                            if (length >= recvBuffer.recvBufferSize())
+                            {
+                                auto resizeRecvBufferSize = 2 * length;
+                                resizeRecvBufferSize = std::min<std::size_t>(
+                                    resizeRecvBufferSize, m_maxRecvBufferSize);
+                                recvBuffer.resizeBuffer(resizeRecvBufferSize);
+
+                                SESSION_LOG(INFO)
+                                    << LOG_BADGE("doRead")
+                                    << LOG_DESC(
+                                           "the current recv buffer size is not enough for "
+                                           "the "
+                                           "next message, resize the recv buffer")
+                                    << LOG_KV("msgSize", length)
+                                    << LOG_KV("resizeRecvBufferSize", resizeRecvBufferSize)
+                                    << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
+                            }
+                        }
+
+                        // need more data: continue the outer loop and arm the next read
+                        // (replaces the session->doRead() recursion of the callback version)
+                        break;
+                    }
+                    else
+                    {
+                        SESSION_LOG(ERROR)
+                            << LOG_BADGE("doRead") << LOG_DESC("decode message error")
+                            << LOG_KV("result", result);
+                        onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                      "ProtocolError(decode msg error)"),
+                            message);
+                        drop(UserReason);
+                        co_return;
+                    }
+                }
+                catch (std::exception const& e)
+                {
+                    SESSION_LOG(ERROR) << LOG_DESC("Decode message exception")
+                                       << LOG_KV("message", boost::diagnostic_information(e));
+                    onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                  "ProtocolError(decode msg exception)"),
+                        message);
+                    drop(UserReason);
+                    co_return;
+                }
+                catch (...)
+                {
+                    SESSION_LOG(ERROR)
+                        << LOG_DESC("Decode message exception")
+                        << LOG_KV("message", boost::current_exception_diagnostic_information());
+                    onMessage(NetworkException(P2PExceptionType::ProtocolError,
+                                  "ProtocolError(decode msg exception)"),
+                        message);
+                    drop(UserReason);
+                    co_return;
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        // never let an exception escape into the resuming asio handler (see AsioAwaitable.h);
+        // a session whose read loop died without a drop would zombie until the idle timer
+        SESSION_LOG(ERROR) << LOG_DESC("read loop exception")
+                           << LOG_KV("endpoint", nodeIPEndpoint())
+                           << LOG_KV("what", boost::current_exception_diagnostic_information());
+        drop(TCPError);
+        co_return;
+    }
+}
+}  // namespace bcos::gateway

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionReadLoop.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionReadLoop.h
@@ -79,7 +79,7 @@ task::Task<void> Session::readLoop()
 
             if (ec)
             {
-                SESSION_LOG(INFO) << LOG_DESC("doRead failed")
+                SESSION_LOG(INFO) << LOG_DESC("readLoop failed")
                                   << LOG_KV("endpoint", nodeIPEndpoint())
                                   << LOG_KV("message", ec.message());
                 drop(TCPError);
@@ -97,7 +97,7 @@ task::Task<void> Session::readLoop()
             if (!recvBuffer.onWrite(bytesTransferred))
             {
                 SESSION_LOG(ERROR)
-                    << LOG_BADGE("doRead") << LOG_DESC("recv buffer overflow on write, drop")
+                    << LOG_BADGE("readLoop") << LOG_DESC("recv buffer overflow on write, drop")
                     << LOG_KV("bytesTransferred", bytesTransferred)
                     << LOG_KV("recvBufferSize", recvBuffer.recvBufferSize());
                 drop(TCPError);
@@ -126,7 +126,7 @@ task::Task<void> Session::readLoop()
                         if (length > allowMaxMsgSize())
                         {
                             SESSION_LOG(ERROR)
-                                << LOG_BADGE("doRead")
+                                << LOG_BADGE("readLoop")
                                 << LOG_DESC("the message size exceeded the allow maximum value")
                                 << LOG_KV("msgSize", message->length())
                                 << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
@@ -154,7 +154,7 @@ task::Task<void> Session::readLoop()
                                 recvBuffer.resizeBuffer(resizeRecvBufferSize);
 
                                 SESSION_LOG(INFO)
-                                    << LOG_BADGE("doRead")
+                                    << LOG_BADGE("readLoop")
                                     << LOG_DESC(
                                            "the current recv buffer size is not enough for "
                                            "the "
@@ -172,7 +172,7 @@ task::Task<void> Session::readLoop()
                     else
                     {
                         SESSION_LOG(ERROR)
-                            << LOG_BADGE("doRead") << LOG_DESC("decode message error")
+                            << LOG_BADGE("readLoop") << LOG_DESC("decode message error")
                             << LOG_KV("result", result);
                         onMessage(NetworkException(P2PExceptionType::ProtocolError,
                                       "ProtocolError(decode msg error)"),

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionReadLoop.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionReadLoop.h
@@ -1,5 +1,5 @@
 /**
- * @brief Template definitions of Session::readLoop / doRead / startWithPolicy — the read path
+ * @brief Template definitions of Session::readLoop / startWithPolicy — the read path
  *        is a compile-time policy (see ASIOInterface::awaitableReadSome), so production compiles
  *        against the default policy (a direct, inlined async_read_some) while read-loop test
  *        fakes instantiate the same code with their own parking policy. The bodies live in this
@@ -166,7 +166,7 @@ task::Task<void> Session::readLoop()
                         }
 
                         // need more data: continue the outer loop and arm the next read
-                        // (replaces the session->doRead() recursion of the callback version)
+                        // (replaces the doRead() recursion of the old callback version)
                         break;
                     }
                     else

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -64,16 +64,16 @@ public:
 
     FakeASIO_Lifetime()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_Lifetime"), "0.0.0.0", 0)
-    {}
-    ~FakeASIO_Lifetime() noexcept override = default;
-
-    // Initiation mock point for the read path: park the read's completion in a manually-fired
-    // slot so a test can hold a read "in flight" and complete it deterministically.
-    void initiateReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
-        ba::mutable_buffer /*buffers*/, ReadCompletion completion) override
     {
-        m_readHandler.emplace(std::move(completion));
+        // Initiation mock point for the read path (see the seam contract on
+        // ASIOInterface::setReadSomeInitiate): park the read's completion in a manually-fired
+        // slot so a test can hold a read "in flight" and complete it deterministically.
+        setReadSomeInitiate([this](const std::shared_ptr<SocketFace>& /*socket*/,
+                                 ba::mutable_buffer /*buffers*/, ReadCompletion completion) {
+            m_readHandler.emplace(std::move(completion));
+        });
     }
+    ~FakeASIO_Lifetime() noexcept override = default;
 
     bool hasReadHandler() const { return m_readHandler.has_value(); }
 

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -42,6 +42,8 @@
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <future>
+#include <optional>
+#include <tuple>
 using namespace bcos;
 using namespace bcos::gateway;
 using namespace bcos::test;
@@ -52,43 +54,44 @@ namespace bi = boost::asio::ip;
 
 BOOST_FIXTURE_TEST_SUITE(FIB184_SessionAsyncLifetimeTest, TestPromptFixture)
 
-// A fake ASIO that captures — but does not invoke — the async read handler, so a test can hold a
-// read "in flight" and fire it deterministically.
+// A fake ASIO that parks the read-loop's coroutine at a manually-fired completion, so a test can
+// hold a read "in flight" and complete it deterministically.
 class FakeASIO_Lifetime : public bcos::gateway::ASIOInterface
 {
 public:
+    using ReadResult = std::tuple<boost::system::error_code, std::size_t>;
+
     FakeASIO_Lifetime()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_Lifetime"), "0.0.0.0", 0)
     {}
     ~FakeASIO_Lifetime() noexcept override = default;
 
-    void asyncReadSome(
-        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler handler) override
+    task::Task<ReadResult> awaitableReadSome(
+        std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer /*buffers*/) override
     {
-        m_readHandler = std::move(handler);
+        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [this](auto handler) { m_readHandler.emplace(std::move(handler)); });
     }
 
-    bool hasReadHandler() const { return static_cast<bool>(m_readHandler); }
+    bool hasReadHandler() const { return m_readHandler.has_value(); }
 
-    // Complete the outstanding read, releasing the reference it holds on the session. The slot is
-    // cleared EXPLICITLY rather than relying on move-from leaving it empty: a moved-from
-    // std::function is only "valid but unspecified", and libc++ leaves a small-object-optimised
-    // target still engaged, so the moved-from slot kept the handler -- and with it a
-    // shared_ptr<Session> -- alive forever. Real ASIO destroys the handler after invoking it; this
-    // clear is what makes the fake match that. Clearing before the call also means a re-armed read
-    // lands in a fresh slot instead of being overwritten.
+    // Complete the outstanding read, unwinding the read loop suspended on it. The slot is
+    // cleared EXPLICITLY before firing: firing resumes the read loop, which re-arms the next
+    // read into a fresh slot, and the moved-from optional would otherwise be destroyed only
+    // after the new completion was already parked in it.
     void fireReadHandler(boost::system::error_code error, std::size_t bytes)
     {
         auto handler = std::move(m_readHandler);
-        m_readHandler = ReadWriteHandler();
+        m_readHandler.reset();
         if (handler)
         {
-            handler(error, bytes);
+            (*handler)(error, bytes);
         }
     }
 
 private:
-    ReadWriteHandler m_readHandler;
+    std::optional<bcos::gateway::detail::AsioCompletion<boost::system::error_code, std::size_t>>
+        m_readHandler;
 };
 
 class FakeHost_Lifetime : public bcos::gateway::Host

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -59,18 +59,20 @@ BOOST_FIXTURE_TEST_SUITE(FIB184_SessionAsyncLifetimeTest, TestPromptFixture)
 class FakeASIO_Lifetime : public bcos::gateway::ASIOInterface
 {
 public:
-    using ReadResult = std::tuple<boost::system::error_code, std::size_t>;
+    using ReadCompletion =
+        bcos::gateway::detail::AsioCompletion<boost::system::error_code, std::size_t>;
 
     FakeASIO_Lifetime()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_Lifetime"), "0.0.0.0", 0)
     {}
     ~FakeASIO_Lifetime() noexcept override = default;
 
-    task::Task<ReadResult> awaitableReadSome(
-        std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer /*buffers*/) override
+    // Initiation mock point for the read path: park the read's completion in a manually-fired
+    // slot so a test can hold a read "in flight" and complete it deterministically.
+    void initiateReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
+        ba::mutable_buffer /*buffers*/, ReadCompletion completion) override
     {
-        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
-            [this](auto handler) { m_readHandler.emplace(std::move(handler)); });
+        m_readHandler.emplace(std::move(completion));
     }
 
     bool hasReadHandler() const { return m_readHandler.has_value(); }

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -175,13 +175,12 @@ BOOST_AUTO_TEST_CASE(InFlightReadKeepsSessionAlive)
         session->setMessageHandler([](NetworkException, SessionFace::Ptr, Message::Ptr) {});
         weakSession = session;
 
-        // startWithPolicy() calls doRead() directly now (it used to defer the first read
-        // through ASIOInterface::strandPost, which no longer exists), so the read handler is
-        // armed synchronously here.
+        // startWithPolicy() arms the first read synchronously (the old code used to defer the
+        // first read through ASIOInterface::strandPost, which no longer exists).
         session->startWithPolicy<FakeASIO_Lifetime::ReadPolicy>();
 
         BOOST_REQUIRE_MESSAGE(fakeAsio->hasReadHandler(),
-            "Session::start()/doRead() must arm exactly one async read");
+            "Session::startWithPolicy() must arm exactly one async read");
         // `session` goes out of scope here: the in-flight read is now the only owner.
     }
 

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -34,6 +34,7 @@
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/SessionReadLoop.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
@@ -64,16 +65,27 @@ public:
 
     FakeASIO_Lifetime()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_Lifetime"), "0.0.0.0", 0)
-    {
-        // Initiation mock point for the read path (see the seam contract on
-        // ASIOInterface::setReadSomeInitiate): park the read's completion in a manually-fired
-        // slot so a test can hold a read "in flight" and complete it deterministically.
-        setReadSomeInitiate([this](const std::shared_ptr<SocketFace>& /*socket*/,
-                                 ba::mutable_buffer /*buffers*/, ReadCompletion completion) {
-            m_readHandler.emplace(std::move(completion));
-        });
-    }
+    {}
     ~FakeASIO_Lifetime() noexcept override = default;
+
+    // Compile-time read-initiation policy (see ASIOInterface::awaitableReadSome): the read loop
+    // is launched with this policy (startWithPolicy<FakeASIO_Lifetime::ReadPolicy>) so every
+    // read parks its completion in a manually-fired slot.
+    struct ReadPolicy
+    {
+        static void invoke(ASIOInterface* asio, const std::shared_ptr<SocketFace>& /*socket*/,
+            ba::mutable_buffer /*buffers*/, ReadCompletion completion)
+        {
+            dynamic_cast<FakeASIO_Lifetime*>(asio)->parkRead(std::move(completion));
+        }
+    };
+
+    // Read-policy target (see FakeASIO_Lifetime::ReadPolicy): park the read's completion in a
+    // manually-fired slot so a test can hold a read "in flight" and complete it deterministically.
+    void parkRead(ReadCompletion completion)
+    {
+        m_readHandler.emplace(std::move(completion));
+    }
 
     bool hasReadHandler() const { return m_readHandler.has_value(); }
 
@@ -163,10 +175,10 @@ BOOST_AUTO_TEST_CASE(InFlightReadKeepsSessionAlive)
         session->setMessageHandler([](NetworkException, SessionFace::Ptr, Message::Ptr) {});
         weakSession = session;
 
-        // start() calls doRead() directly now (it used to defer the first read through
-        // ASIOInterface::strandPost, which no longer exists), so the read handler is armed
-        // synchronously here.
-        session->start();
+        // startWithPolicy() calls doRead() directly now (it used to defer the first read
+        // through ASIOInterface::strandPost, which no longer exists), so the read handler is
+        // armed synchronously here.
+        session->startWithPolicy<FakeASIO_Lifetime::ReadPolicy>();
 
         BOOST_REQUIRE_MESSAGE(fakeAsio->hasReadHandler(),
             "Session::start()/doRead() must arm exactly one async read");

--- a/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
@@ -45,9 +45,6 @@ public:
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB184"), "0.0.0.0", 0)
     {}
     ~FakeASIO_FIB184() noexcept override {}
-    void asyncReadSome(
-        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
-    {}
 };
 
 class FakeSocket_FIB184 : public SocketFace

--- a/bcos-gateway/test/unittests/FIB186_BulkDisconnectReactorTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BulkDisconnectReactorTest.cpp
@@ -20,7 +20,7 @@
  * @date 2026-07-14
  *
  * Root cause (from code): every inbound P2P message delivery is
- *   Session::doRead -> Session::onMessage -> asioInterface()->post(...)  (Session.cpp: onMessage)
+ *   Session readLoop -> Session::onMessage -> asioInterface()->post(...)  (Session.cpp: onMessage)
  * and, before the fix, every session teardown notification went to that SAME reactor. So message
  * delivery and teardown shared ONE pool. A bulk-disconnect of a large established session pool
  * floods that reactor with teardown work (each drop drives onDisconnect -> onRemoveNodeIDs ->

--- a/bcos-gateway/test/unittests/FIB186_BulkDisconnectReactorTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BulkDisconnectReactorTest.cpp
@@ -78,9 +78,6 @@ public:
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(2, "FIB186Reactor"), "0.0.0.0", 0)
     {}
     ~FakeASIO_Reactor() noexcept override = default;
-    void asyncReadSome(
-        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
-    {}
 };
 
 // Host subclass with the network marked up, so Session::drop() takes the "hand the teardown

--- a/bcos-gateway/test/unittests/FIB186_HandshakeAdmissionTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_HandshakeAdmissionTest.cpp
@@ -58,6 +58,7 @@ public:
     }
     bool callTryAcquireHandshakeSlot() { return tryAcquireHandshakeSlot(); }
     void callReleaseHandshakeSlot() { releaseHandshakeSlot(); }
+    std::shared_ptr<void> callAcquireHandshakeSlotGuard() { return acquireHandshakeSlotGuard(); }
 };
 
 // FIB-186: the global concurrent-handshake cap rejects once the total limit is hit. It is global,
@@ -82,35 +83,35 @@ BOOST_AUTO_TEST_CASE(GlobalHandshakeCapIsEnforced)
     BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 2u);
 }
 
-// FIB-186: the RAII HandshakeSlotGuard pattern releases the slot exactly once when the handshake
-// path unwinds (success, failure, or abort). Mirrors how Host::serverHandshake binds the guard
-// into its coroutine frame.
+// FIB-186: the REAL HandshakeSlotGuard the accept loop hands into serverHandshake releases the
+// slot exactly once when the frame unwinds (success, failure, or abort — all three are the same
+// frame destruction, which is what this drives).
 BOOST_AUTO_TEST_CASE(GuardReleasesSlotExactlyOnce)
 {
     auto hashImpl = std::make_shared<Keccak256>();
     auto fakeAsio = std::make_shared<FakeASIO_FIB186>();
     auto fakeHost = std::make_shared<FakeHost_FIB186>(hashImpl, fakeAsio);
 
-    BOOST_CHECK(fakeHost->callTryAcquireHandshakeSlot());
-    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 1u);
-
     {
-        // A shared_ptr with a release-on-destroy deleter models the HandshakeSlotGuard riding the
-        // completion handler; when the last copy is destroyed the slot is released once.
-        std::weak_ptr<Host> weakHost = fakeHost;
-        auto guard = std::shared_ptr<void>(nullptr, [weakHost](void*) {
-            if (auto h = weakHost.lock())
-            {
-                std::static_pointer_cast<FakeHost_FIB186>(h)->callReleaseHandshakeSlot();
-            }
-        });
-        // Copying the handler (as asio may) must not double-release: release happens on final
-        // destruction of the shared guard, not per copy.
+        // Acquiring through the real factory reserves the slot and binds it to the guard.
+        auto guard = fakeHost->callAcquireHandshakeSlotGuard();
+        BOOST_REQUIRE(guard);
+        BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 1u);
+        // Copying the guard (the coroutine frame may hold several references to it) must not
+        // double-release: the slot is released on final destruction, not per copy.
         auto guardCopy = guard;
         BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 1u);
     }
-    // After the guard (and its copy) is destroyed, the slot is released exactly once.
+    // After the last copy is destroyed — i.e. the serverHandshake frame unwound — the slot is
+    // released exactly once.
     BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 0u);
+
+    // Cap reached: the real factory returns nullptr and reserves nothing.
+    fakeHost->setMaxPendingHandshakes(1);
+    auto guard = fakeHost->callAcquireHandshakeSlotGuard();
+    BOOST_REQUIRE(guard);
+    BOOST_CHECK(!fakeHost->callAcquireHandshakeSlotGuard());
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 1u);
 }
 
 // FIB-186: releasing an unknown / already-drained address never underflows the global counter.

--- a/bcos-gateway/test/unittests/FIB186_HandshakeAdmissionTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_HandshakeAdmissionTest.cpp
@@ -44,9 +44,6 @@ public:
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB186"), "0.0.0.0", 0)
     {}
     ~FakeASIO_FIB186() noexcept override {}
-    void asyncReadSome(
-        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
-    {}
 };
 
 // Exposes the protected handshake-admission helpers for direct testing, mirroring the FIB-184
@@ -86,8 +83,8 @@ BOOST_AUTO_TEST_CASE(GlobalHandshakeCapIsEnforced)
 }
 
 // FIB-186: the RAII HandshakeSlotGuard pattern releases the slot exactly once when the handshake
-// completion handler is destroyed (success, failure, or abort). Mirrors how startAccept binds the
-// guard into the asyncHandshake completion handler.
+// path unwinds (success, failure, or abort). Mirrors how Host::serverHandshake binds the guard
+// into its coroutine frame.
 BOOST_AUTO_TEST_CASE(GuardReleasesSlotExactlyOnce)
 {
     auto hashImpl = std::make_shared<Keccak256>();

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -93,7 +93,6 @@ public:
         });
     }
 
-    void strandPost(Base_Handler handler) { m_handler = handler; }
     void stop() { m_threadPool.reset(); }
 
     void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
@@ -101,18 +100,8 @@ public:
     {
         m_threadPool->post([this, packet]() { appendRecvPacket(packet); });
     }
-    void triggerRead()
-    {
-        m_threadPool->post([this]() {
-            if (m_handler)
-            {
-                m_handler();
-            }
-        });
-    }
 
 protected:
-    Base_Handler m_handler;
     std::queue<Packet> m_recvPackets;
     bcos::IOServicePool::Ptr m_threadPool;
 };
@@ -245,7 +234,6 @@ BOOST_AUTO_TEST_CASE(DecodeErrorTriggersSessionDrop)
             [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
 
         session->start();
-        fakeAsio->triggerRead();
 
         // Send a packet that will trigger a decode error (MESSAGE_ERROR)
         auto badPacket = std::make_shared<std::vector<uint8_t>>(10, 0xAB);
@@ -289,7 +277,6 @@ BOOST_AUTO_TEST_CASE(DecodeExceptionTriggersSessionDrop)
             [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
 
         session->start();
-        fakeAsio->triggerRead();
 
         // Send a packet that will trigger a decode exception
         auto badPacket = std::make_shared<std::vector<uint8_t>>(10, 0xCD);
@@ -420,8 +407,9 @@ BOOST_AUTO_TEST_CASE(DropFlushesOnlyOwnPendingResponseCallbacks)
 }
 
 // The with-response send must fail exactly once when the async write itself fails, claiming the
-// response callback back (the claimOnWriteError branch) or via the teardown flush — onWrite()
-// drops the session on a write error, so the drop flush legitimately races the write callback
+// response callback back (the claimOnWriteError branch) or via the teardown flush — the write
+// loop drops the session on a write error, so the drop flush legitimately races the write
+// callback
 // and either the raw asio write error or NetworkTimeout is a valid outcome; what must hold is
 // exactly-once completion, no leftover callback, and no hang. The fake socket's SSL stream sits
 // on a TCP pair whose peer closed at construction, so the write (and its implicit handshake)

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -54,23 +54,23 @@ public:
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"), "0.0.0.0", 0),
         m_threadPool(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"))
     {
-    }
-    ~FakeASIO_FIB() noexcept override {}
-
-    // Initiation mock point for the read path: park the read's completion and feed it buffered
-    // packets from the fake's own pool thread. The park is posted onto the pool thread so EVERY
-    // access to m_pendingReads happens on the single pool thread — the first arm happens on the
-    // caller's thread (Session::start() -> readLoop), and without the post it would race the pool
-    // thread's delivery in multi-session tests that share this fake (see deliverIfPossible).
-    void initiateReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
-        ba::mutable_buffer buffers, ReadCompletion completion) override
-    {
-        ++m_readsInFlight;
-        m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
-            m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
-            deliverIfPossible();
+        // Initiation mock point for the read path (see the seam contract on
+        // ASIOInterface::setReadSomeInitiate): park the read's completion and feed it buffered
+        // packets from the fake's own pool thread. The park is posted onto the pool thread so
+        // EVERY access to m_pendingReads happens on the single pool thread — the first arm
+        // happens on the caller's thread (Session::start() -> readLoop), and without the post it
+        // would race the pool thread's delivery in multi-session tests that share this fake (see
+        // deliverIfPossible).
+        setReadSomeInitiate([this](const std::shared_ptr<SocketFace>& /*socket*/,
+                                 ba::mutable_buffer buffers, ReadCompletion completion) {
+            ++m_readsInFlight;
+            m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
+                m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
+                deliverIfPossible();
+            });
         });
     }
+    ~FakeASIO_FIB() noexcept override {}
 
     // Test teardown: complete every parked read with operation_aborted so the read loops — and
     // the sessions their frames keep alive — unwind BEFORE the test nulls the socket or

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -47,7 +47,6 @@ class FakeASIO_FIB : public bcos::gateway::ASIOInterface
 {
 public:
     using Packet = std::shared_ptr<std::vector<uint8_t>>;
-    using ReadResult = std::tuple<boost::system::error_code, std::size_t>;
     using ReadCompletion =
         bcos::gateway::detail::AsioCompletion<boost::system::error_code, std::size_t>;
 
@@ -58,17 +57,19 @@ public:
     }
     ~FakeASIO_FIB() noexcept override {}
 
-    // Coroutine mock point for the read path: park the read's completion and feed it buffered
-    // packets from the fake's own pool thread.
-    task::Task<ReadResult> awaitableReadSome(
-        std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer buffers) override
+    // Initiation mock point for the read path: park the read's completion and feed it buffered
+    // packets from the fake's own pool thread. The park is posted onto the pool thread so EVERY
+    // access to m_pendingReads happens on the single pool thread — the first arm happens on the
+    // caller's thread (Session::start() -> readLoop), and without the post it would race the pool
+    // thread's delivery in multi-session tests that share this fake (see deliverIfPossible).
+    void initiateReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
+        ba::mutable_buffer buffers, ReadCompletion completion) override
     {
         ++m_readsInFlight;
-        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
-            [this, buffers](auto handler) {
-                m_pendingReads.push_back(PendingRead{buffers, std::move(handler)});
-                kickDelivery();
-            });
+        m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
+            m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
+            deliverIfPossible();
+        });
     }
 
     // Test teardown: complete every parked read with operation_aborted so the read loops — and
@@ -128,12 +129,10 @@ protected:
         return bytesTransferred;
     }
 
-    // Everything below runs on the pool thread only: the first read is armed on the caller's
-    // thread but publishes the parked completion through kickDelivery's post, and every later
-    // arm happens inside fireRead's resume, which runs on the pool thread. Multiple sessions may
-    // share this fake, so parked reads form a FIFO list rather than a single slot.
-    void kickDelivery() { m_threadPool->post([this] { deliverIfPossible(); }); }
-
+    // Everything below runs on the pool thread only: every read arm (including the first, via
+    // initiateReadSome's post) and every delivery are posted onto the single pool thread, so
+    // m_pendingReads is never touched from another thread. Multiple sessions may share this
+    // fake, so parked reads form a FIFO list rather than a single slot.
     void deliverIfPossible()
     {
         if (m_pendingReads.empty() || m_recvPackets.empty())

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -142,7 +142,7 @@ protected:
     }
 
     // Everything below runs on the pool thread only: every read arm (including the first, via
-    // initiateReadSome's post) and every delivery are posted onto the single pool thread, so
+    // parkRead's post) and every delivery are posted onto the single pool thread, so
     // m_pendingReads is never touched from another thread. Multiple sessions may share this
     // fake, so parked reads form a FIFO list rather than a single slot.
     void deliverIfPossible()

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -22,6 +22,7 @@
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/SessionReadLoop.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/IOServicePool.h>
@@ -53,24 +54,35 @@ public:
     FakeASIO_FIB()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"), "0.0.0.0", 0),
         m_threadPool(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"))
+    {}
+    ~FakeASIO_FIB() noexcept override {}
+
+    // Compile-time read-initiation policy (see ASIOInterface::awaitableReadSome): the read loop
+    // is launched with this policy (startWithPolicy<FakeASIO_FIB::ReadPolicy>) so every read
+    // parks its completion here instead of arming the real async_read_some.
+    struct ReadPolicy
     {
-        // Initiation mock point for the read path (see the seam contract on
-        // ASIOInterface::setReadSomeInitiate): park the read's completion and feed it buffered
-        // packets from the fake's own pool thread. The park is posted onto the pool thread so
-        // EVERY access to m_pendingReads happens on the single pool thread — the first arm
-        // happens on the caller's thread (Session::start() -> readLoop), and without the post it
-        // would race the pool thread's delivery in multi-session tests that share this fake (see
-        // deliverIfPossible).
-        setReadSomeInitiate([this](const std::shared_ptr<SocketFace>& /*socket*/,
-                                 ba::mutable_buffer buffers, ReadCompletion completion) {
-            ++m_readsInFlight;
-            m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
-                m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
-                deliverIfPossible();
-            });
+        static void invoke(ASIOInterface* asio, const std::shared_ptr<SocketFace>& /*socket*/,
+            ba::mutable_buffer buffers, ReadCompletion completion)
+        {
+            dynamic_cast<FakeASIO_FIB*>(asio)->parkRead(buffers, std::move(completion));
+        }
+    };
+
+    // Read-policy target (see FakeASIO_FIB::ReadPolicy): park the read's completion and feed it
+    // buffered packets from the fake's own pool thread. The park is posted onto the pool thread
+    // so EVERY access to m_pendingReads happens on the single pool thread — the first arm
+    // happens on the caller's thread (Session::startWithPolicy -> readLoop), and without the
+    // post it would race the pool thread's delivery in multi-session tests that share this fake
+    // (see deliverIfPossible).
+    void parkRead(ba::mutable_buffer buffers, ReadCompletion completion)
+    {
+        ++m_readsInFlight;
+        m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
+            m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
+            deliverIfPossible();
         });
     }
-    ~FakeASIO_FIB() noexcept override {}
 
     // Test teardown: complete every parked read with operation_aborted so the read loops — and
     // the sessions their frames keep alive — unwind BEFORE the test nulls the socket or
@@ -294,7 +306,7 @@ BOOST_AUTO_TEST_CASE(DecodeErrorTriggersSessionDrop)
         session->setMessageHandler(
             [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
 
-        session->start();
+        session->startWithPolicy<FakeASIO_FIB::ReadPolicy>();
 
         // Send a packet that will trigger a decode error (MESSAGE_ERROR)
         auto badPacket = std::make_shared<std::vector<uint8_t>>(10, 0xAB);
@@ -337,7 +349,7 @@ BOOST_AUTO_TEST_CASE(DecodeExceptionTriggersSessionDrop)
         session->setMessageHandler(
             [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
 
-        session->start();
+        session->startWithPolicy<FakeASIO_FIB::ReadPolicy>();
 
         // Send a packet that will trigger a decode exception
         auto badPacket = std::make_shared<std::vector<uint8_t>>(10, 0xCD);
@@ -494,7 +506,7 @@ BOOST_AUTO_TEST_CASE(WriteFailureFailsWithResponseWaiterExactlyOnce)
         session->setSessionCallbackManager(callbackManager);
         session->setMessageHandler(
             [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
-        session->start();
+        session->startWithPolicy<FakeASIO_FIB::ReadPolicy>();
 
         // the socket's io_context is never run by the fixture: drive it so the posted
         // async_write actually executes (and fails against the closed peer)

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -28,6 +28,10 @@
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <queue>
 #include <thread>
+#include <atomic>
+#include <optional>
+#include <tuple>
+#include <list>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -43,6 +47,10 @@ class FakeASIO_FIB : public bcos::gateway::ASIOInterface
 {
 public:
     using Packet = std::shared_ptr<std::vector<uint8_t>>;
+    using ReadResult = std::tuple<boost::system::error_code, std::size_t>;
+    using ReadCompletion =
+        bcos::gateway::detail::AsioCompletion<boost::system::error_code, std::size_t>;
+
     FakeASIO_FIB()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"), "0.0.0.0", 0),
         m_threadPool(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"))
@@ -50,8 +58,50 @@ public:
     }
     ~FakeASIO_FIB() noexcept override {}
 
-    void readSome(std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers,
-        ReadWriteHandler handler)
+    // Coroutine mock point for the read path: park the read's completion and feed it buffered
+    // packets from the fake's own pool thread.
+    task::Task<ReadResult> awaitableReadSome(
+        std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer buffers) override
+    {
+        ++m_readsInFlight;
+        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [this, buffers](auto handler) {
+                m_pendingReads.push_back(PendingRead{buffers, std::move(handler)});
+                kickDelivery();
+            });
+    }
+
+    // Test teardown: complete every parked read with operation_aborted so the read loops — and
+    // the sessions their frames keep alive — unwind BEFORE the test nulls the socket or
+    // destroys this fake. Poll readsInFlight() until 0 afterwards: the counter is decremented
+    // only after the fired completion has synchronously unwound the whole read loop, so 0 means
+    // the unwind is done and no coroutine touches the session any more.
+    void stopReads()
+    {
+        m_threadPool->post([this] {
+            while (!m_pendingReads.empty())
+            {
+                auto pending = std::move(m_pendingReads.front());
+                m_pendingReads.pop_front();
+                fireRead(std::move(pending.completion), boost::asio::error::operation_aborted, 0);
+            }
+        });
+    }
+    std::size_t readsInFlight() const { return m_readsInFlight.load(); }
+
+    void stop() { m_threadPool.reset(); }
+
+    void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
+    void asyncAppendRecvPacket(Packet packet)
+    {
+        m_threadPool->post([this, packet]() {
+            m_recvPackets.push(std::move(packet));
+            deliverIfPossible();
+        });
+    }
+
+protected:
+    std::size_t drainPackets(ba::mutable_buffer buffers)
     {
         std::size_t bytesTransferred = 0;
         auto limit = buffers.size();
@@ -75,34 +125,46 @@ public:
                 bytesTransferred += packet->size();
             }
         }
-
-        handler(boost::system::error_code(), bytesTransferred);
+        return bytesTransferred;
     }
 
-    void asyncReadSome(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers, ReadWriteHandler handler) override
+    // Everything below runs on the pool thread only: the first read is armed on the caller's
+    // thread but publishes the parked completion through kickDelivery's post, and every later
+    // arm happens inside fireRead's resume, which runs on the pool thread. Multiple sessions may
+    // share this fake, so parked reads form a FIFO list rather than a single slot.
+    void kickDelivery() { m_threadPool->post([this] { deliverIfPossible(); }); }
+
+    void deliverIfPossible()
     {
-        m_threadPool->post([this, socket, buffers, handler]() {
-            if (m_recvPackets.empty())
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                asyncReadSome(socket, buffers, handler);
-                return;
-            }
-            readSome(socket, buffers, handler);
-        });
+        if (m_pendingReads.empty() || m_recvPackets.empty())
+        {
+            return;
+        }
+        auto pending = std::move(m_pendingReads.front());
+        m_pendingReads.pop_front();
+        fireRead(std::move(pending.completion), boost::system::error_code(),
+            drainPackets(pending.buffers));
     }
 
-    void stop() { m_threadPool.reset(); }
-
-    void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
-    void asyncAppendRecvPacket(Packet packet)
+    // Fire a parked completion. The fire resumes the read loop SYNCHRONOUSLY on this (pool)
+    // thread — on success the loop processes the messages and re-arms a fresh read (parking a
+    // new completion and re-incrementing the counter), on error it unwinds completely — so the
+    // counter is decremented only after the loop has settled.
+    void fireRead(ReadCompletion completion, boost::system::error_code ec, std::size_t bytes)
     {
-        m_threadPool->post([this, packet]() { appendRecvPacket(packet); });
+        completion(ec, bytes);
+        --m_readsInFlight;
     }
 
-protected:
+    struct PendingRead
+    {
+        ba::mutable_buffer buffers;
+        ReadCompletion completion;
+    };
+
     std::queue<Packet> m_recvPackets;
+    std::list<PendingRead> m_pendingReads;
+    std::atomic<std::size_t> m_readsInFlight{0};
     bcos::IOServicePool::Ptr m_threadPool;
 };
 
@@ -476,6 +538,15 @@ BOOST_AUTO_TEST_CASE(WriteFailureFailsWithResponseWaiterExactlyOnce)
         BOOST_CHECK(errorCode.load() != 0);
         BOOST_CHECK(callbackManager->getCallback(seq, false) == nullptr);
 
+        // drain the parked read so the read loop unwinds before the socket is nulled
+        fakeAsio->stopReads();
+        size_t drainRetry = 0;
+        while (fakeAsio->readsInFlight() != 0 && drainRetry < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            drainRetry++;
+        }
+        BOOST_REQUIRE_EQUAL(fakeAsio->readsInFlight(), 0);
         session->setSocket(nullptr);
     }
 

--- a/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
+++ b/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
@@ -49,14 +49,6 @@ public:
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB97new"), "0.0.0.0", 0)
     {}
     ~FakeASIO_FIB97new() noexcept override = default;
-
-    // Never issues actual async reads — tests that call drop() don't need reads.
-    void asyncReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
-        boost::asio::mutable_buffer /*buffers*/, ReadWriteHandler /*handler*/) override
-    {}
-
-    void strandPost(Base_Handler /*handler*/) {}
-    void stop() {}
 };
 
 class FakeSocket_FIB97new : public SocketFace

--- a/bcos-gateway/test/unittests/GatewayConfigSettersTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigSettersTest.cpp
@@ -58,6 +58,11 @@ BOOST_AUTO_TEST_CASE(settersAndGetters)
     BOOST_CHECK_EQUAL(config->maxSendDataSize(), 48U * 1024U);
     BOOST_CHECK_EQUAL(config->maxMsgCountSendOneTime(), 20U);
 
+    // The setter shares initP2PConfig's clamp: a 0 byte budget would stall every outbound write
+    // (the batch loop never pops), so it can never be stored through any path.
+    config->setMaxSendDataSize(0U);
+    BOOST_CHECK_EQUAL(config->maxSendDataSize(), 1U);
+
     // read-only getters should not throw on a freshly constructed config
     BOOST_CHECK_NO_THROW(config->listenIP());
     BOOST_CHECK_NO_THROW(config->listenPort());

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -493,7 +493,8 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
     // session (the batch loop never pops) — unlike max_connections_per_second, 0 is NOT
     // "unlimited" here, so the byte budget is clamped to a working minimum at load time.
     // session_max_send_msg_count is parsed for compatibility but not enforced anywhere, so a 0
-    // is accepted as-is (no clamp, no warning — nothing reads the value).
+    // is accepted as-is (no clamp); an explicitly-present value now triggers a startup
+    // deprecation warning instead.
     {
         auto config = std::make_shared<GatewayConfig>();
         boost::property_tree::ptree pt;

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -489,6 +489,18 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxConnectionsPerSecond(), 0U);
     }
+    // Round-1 review: 0 for the send-batch budgets would stall every outbound write on the
+    // session (the batch loop never pops) — unlike max_connections_per_second, 0 is NOT
+    // "unlimited" here, so both keys are clamped to a working minimum at load time.
+    {
+        auto config = std::make_shared<GatewayConfig>();
+        boost::property_tree::ptree pt;
+        pt.put("p2p.session_max_send_data_size", 0);
+        pt.put("p2p.session_max_send_msg_count", 0);
+        config->initP2PConfig(pt, false);
+        BOOST_CHECK_EQUAL(config->maxSendDataSize(), 1U);
+        BOOST_CHECK_EQUAL(config->maxMsgCountSendOneTime(), 1U);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -489,9 +489,11 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxConnectionsPerSecond(), 0U);
     }
-    // Round-1 review: 0 for the send-batch budgets would stall every outbound write on the
+    // Round-1 review: 0 for the send-batch byte budget would stall every outbound write on the
     // session (the batch loop never pops) — unlike max_connections_per_second, 0 is NOT
-    // "unlimited" here, so both keys are clamped to a working minimum at load time.
+    // "unlimited" here, so the byte budget is clamped to a working minimum at load time.
+    // session_max_send_msg_count is parsed for compatibility but not enforced anywhere, so a 0
+    // is accepted as-is (no clamp, no warning — nothing reads the value).
     {
         auto config = std::make_shared<GatewayConfig>();
         boost::property_tree::ptree pt;
@@ -499,7 +501,7 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         pt.put("p2p.session_max_send_msg_count", 0);
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxSendDataSize(), 1U);
-        BOOST_CHECK_EQUAL(config->maxMsgCountSendOneTime(), 1U);
+        BOOST_CHECK_EQUAL(config->maxMsgCountSendOneTime(), 0U);
     }
 }
 

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -66,23 +66,24 @@ public:
     FakeASIO()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO"), "0.0.0.0", 0),
         m_threadPool(std::make_shared<bcos::IOServicePool>(1, "FakeASIO"))
-    {};
-    virtual ~FakeASIO() noexcept override {};
-
-    // Initiation mock point for the read path: park the read's completion and feed it buffered
-    // packets from the fake's own pool thread. The park is posted onto the pool thread so EVERY
-    // access to m_pendingReads happens on the single pool thread — the first arm happens on the
-    // caller's thread (Session::start() -> readLoop), and without the post it would race the pool
-    // thread's delivery in multi-session tests that share this fake (see deliverIfPossible).
-    void initiateReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
-        ba::mutable_buffer buffers, ReadCompletion completion) override
     {
-        ++m_readsInFlight;
-        m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
-            m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
-            deliverIfPossible();
+        // Initiation mock point for the read path (see the seam contract on
+        // ASIOInterface::setReadSomeInitiate): park the read's completion and feed it buffered
+        // packets from the fake's own pool thread. The park is posted onto the pool thread so
+        // EVERY access to m_pendingReads happens on the single pool thread — the first arm
+        // happens on the caller's thread (Session::start() -> readLoop), and without the post it
+        // would race the pool thread's delivery in multi-session tests that share this fake (see
+        // deliverIfPossible).
+        setReadSomeInitiate([this](const std::shared_ptr<SocketFace>& /*socket*/,
+                                 ba::mutable_buffer buffers, ReadCompletion completion) {
+            ++m_readsInFlight;
+            m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
+                m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
+                deliverIfPossible();
+            });
         });
-    }
+    };
+    virtual ~FakeASIO() noexcept override {};
 
     // Synchronous helper for fakeClassTest (no session involved).
     template <typename Handler>

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -165,7 +165,7 @@ protected:
     }
 
     // Everything below runs on the pool thread only: every read arm (including the first, via
-    // initiateReadSome's post) and every delivery are posted onto the single pool thread, so
+    // parkRead's post) and every delivery are posted onto the single pool thread, so
     // m_pendingReads is never touched from another thread. Multiple sessions may share this
     // fake, so parked reads form a FIFO list rather than a single slot.
     void deliverIfPossible()
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(doReadTest)
         session->setMessageHandler(
             [&recvPacketCnt, &recvBufferSize, &lastReadTime](
                 NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {
-                // doRead() call this function after reading a message
+                // the read loop calls this function after reading a message
                 lastReadTime = utcSteadyTime();
                 if (e.errorCode() != P2PExceptionType::Success)
                 {

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -23,6 +23,7 @@
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/SessionReadLoop.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-gateway/libp2p/P2PMessageV2.h"
 #include "bcos-gateway/libp2p/P2PSession.h"
@@ -66,24 +67,35 @@ public:
     FakeASIO()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO"), "0.0.0.0", 0),
         m_threadPool(std::make_shared<bcos::IOServicePool>(1, "FakeASIO"))
-    {
-        // Initiation mock point for the read path (see the seam contract on
-        // ASIOInterface::setReadSomeInitiate): park the read's completion and feed it buffered
-        // packets from the fake's own pool thread. The park is posted onto the pool thread so
-        // EVERY access to m_pendingReads happens on the single pool thread — the first arm
-        // happens on the caller's thread (Session::start() -> readLoop), and without the post it
-        // would race the pool thread's delivery in multi-session tests that share this fake (see
-        // deliverIfPossible).
-        setReadSomeInitiate([this](const std::shared_ptr<SocketFace>& /*socket*/,
-                                 ba::mutable_buffer buffers, ReadCompletion completion) {
-            ++m_readsInFlight;
-            m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
-                m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
-                deliverIfPossible();
-            });
-        });
-    };
+    {}
     virtual ~FakeASIO() noexcept override {};
+
+    // Compile-time read-initiation policy (see ASIOInterface::awaitableReadSome): the read loop
+    // is launched with this policy (startWithPolicy<FakeASIO::ReadPolicy>) so every read parks
+    // its completion here instead of arming the real async_read_some.
+    struct ReadPolicy
+    {
+        static void invoke(ASIOInterface* asio, const std::shared_ptr<SocketFace>& /*socket*/,
+            ba::mutable_buffer buffers, ReadCompletion completion)
+        {
+            dynamic_cast<FakeASIO*>(asio)->parkRead(buffers, std::move(completion));
+        }
+    };
+
+    // Read-policy target (see FakeASIO::ReadPolicy): park the read's completion and feed it
+    // buffered packets from the fake's own pool thread. The park is posted onto the pool thread
+    // so EVERY access to m_pendingReads happens on the single pool thread — the first arm
+    // happens on the caller's thread (Session::startWithPolicy -> readLoop), and without the
+    // post it would race the pool thread's delivery in multi-session tests that share this fake
+    // (see deliverIfPossible).
+    void parkRead(ba::mutable_buffer buffers, ReadCompletion completion)
+    {
+        ++m_readsInFlight;
+        m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
+            m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
+            deliverIfPossible();
+        });
+    }
 
     // Synchronous helper for fakeClassTest (no session involved).
     template <typename Handler>
@@ -443,7 +455,7 @@ BOOST_AUTO_TEST_CASE(doReadTest)
                 recvPacketCnt++;
             });
 
-        session->start();
+        session->startWithPolicy<FakeASIO::ReadPolicy>();
 
         // send packets
         while (auto packet = messageBuilder.nextPacket())
@@ -502,7 +514,7 @@ BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
                 return bcos::Error::buildError(
                     "", P2PExceptionType::OutBWOverflow, "outgoing bandwidth overflow");
             });
-        session->start();
+        session->startWithPolicy<FakeASIO::ReadPolicy>();
 
         P2PMessage message;
         message.setSeq(1);
@@ -626,7 +638,7 @@ BOOST_AUTO_TEST_CASE(fastSendMessageCompression)
         auto sessionSocket = std::make_shared<RealLoopbackSocket>(io, std::move(client));
         auto session = std::make_shared<Session>(sessionSocket, *fakeHost, 2, true);
         session->setMessageFactory(fakeHost->messageFactory());
-        session->start();
+        session->startWithPolicy<FakeASIO::ReadPolicy>();
 
         // V2 wire format + payload well above the 1KB compress threshold -> compression must run
         P2PMessage message;
@@ -785,7 +797,7 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
         auto session = std::make_shared<Session>(
             std::make_shared<RealLoopbackSocket>(io, std::move(_client)), *host, 2, true);
         session->setMessageFactory(fakeMessageFactory);
-        session->start();
+        session->startWithPolicy<FakeASIO::ReadPolicy>();
         sessions.push_back(session);
 
         auto p2pSession = std::make_shared<P2PSession>();
@@ -941,7 +953,7 @@ BOOST_AUTO_TEST_CASE(fastSendConcurrentWriteOrder)
         auto sessionSocket = std::make_shared<RealLoopbackSocket>(io, std::move(client));
         auto session = std::make_shared<Session>(sessionSocket, *fakeHost, 2, true);
         session->setMessageFactory(fakeHost->messageFactory());
-        session->start();
+        session->startWithPolicy<FakeASIO::ReadPolicy>();
 
         std::vector<std::thread> senders;
         senders.reserve(threadCount);

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -60,7 +60,6 @@ class FakeASIO : public bcos::gateway::ASIOInterface
 {
 public:
     using Packet = std::shared_ptr<std::vector<uint8_t>>;
-    using ReadResult = std::tuple<boost::system::error_code, std::size_t>;
     using ReadCompletion =
         bcos::gateway::detail::AsioCompletion<boost::system::error_code, std::size_t>;
 
@@ -70,17 +69,19 @@ public:
     {};
     virtual ~FakeASIO() noexcept override {};
 
-    // Coroutine mock point for the read path: park the read's completion and feed it buffered
-    // packets from the fake's own pool thread.
-    task::Task<ReadResult> awaitableReadSome(
-        std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer buffers) override
+    // Initiation mock point for the read path: park the read's completion and feed it buffered
+    // packets from the fake's own pool thread. The park is posted onto the pool thread so EVERY
+    // access to m_pendingReads happens on the single pool thread — the first arm happens on the
+    // caller's thread (Session::start() -> readLoop), and without the post it would race the pool
+    // thread's delivery in multi-session tests that share this fake (see deliverIfPossible).
+    void initiateReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
+        ba::mutable_buffer buffers, ReadCompletion completion) override
     {
         ++m_readsInFlight;
-        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
-            [this, buffers](auto handler) {
-                m_pendingReads.push_back(PendingRead{buffers, std::move(handler)});
-                kickDelivery();
-            });
+        m_threadPool->post([this, buffers, completion = std::move(completion)]() mutable {
+            m_pendingReads.push_back(PendingRead{buffers, std::move(completion)});
+            deliverIfPossible();
+        });
     }
 
     // Synchronous helper for fakeClassTest (no session involved).
@@ -150,12 +151,10 @@ protected:
         return bytesTransferred;
     }
 
-    // Everything below runs on the pool thread only: the first read is armed on the caller's
-    // thread but publishes the parked completion through kickDelivery's post, and every later
-    // arm happens inside fireRead's resume, which runs on the pool thread. Multiple sessions may
-    // share this fake, so parked reads form a FIFO list rather than a single slot.
-    void kickDelivery() { m_threadPool->post([this] { deliverIfPossible(); }); }
-
+    // Everything below runs on the pool thread only: every read arm (including the first, via
+    // initiateReadSome's post) and every delivery are posted onto the single pool thread, so
+    // m_pendingReads is never touched from another thread. Multiple sessions may share this
+    // fake, so parked reads form a FIFO list rather than a single slot.
     void deliverIfPossible()
     {
         if (m_pendingReads.empty() || m_recvPackets.empty())
@@ -1056,6 +1055,42 @@ BOOST_AUTO_TEST_CASE(fastSendConcurrentWriteOrder)
 
     BOOST_CHECK_EQUAL(seqs.size(), totalMsgs);
     BOOST_CHECK_EQUAL(seenSeqs.size(), totalMsgs);
+}
+
+BOOST_AUTO_TEST_CASE(asioCompletionHandshakeSynchronousInvocation)
+{
+    // Arm/cancel handshake regression: an initiate that INVOKES the completion synchronously
+    // (before returning) must not resume the coroutine from inside its own await_suspend
+    // (resuming a not-yet-suspended frame is UB). AsioCompletion observes m_suspended == false,
+    // records the completion, and await_suspend resumes inline by returning false — the result
+    // is delivered exactly once.
+    auto task = []() -> task::Task<boost::system::error_code> {
+        auto [ec] = co_await makeAsioAwaitable<boost::system::error_code>(
+            [](auto handler) { handler(boost::system::error_code()); });
+        co_return ec;
+    }();
+    auto ec = task::syncWait(std::move(task));
+    BOOST_CHECK(!ec);
+}
+
+BOOST_AUTO_TEST_CASE(asioCompletionHandshakeSynchronousDrop)
+{
+    // Arm/cancel handshake regression: an initiate that DROPS the completion synchronously
+    // (destroys it without invocation, no exception) must not destroy the still-running frame
+    // from inside its own await_suspend. The destructor records the cancellation instead, and
+    // await_suspend resumes inline with operation_aborted so the awaiting coroutine completes
+    // with an error rather than suspending forever.
+    auto task = []() -> task::Task<boost::system::error_code> {
+        auto [ec] = co_await makeAsioAwaitable<boost::system::error_code>(
+            [](auto handler) {
+                // destroy the armed completion without invoking it: the by-value parameter is
+                // destroyed at scope exit
+                (void)handler;
+            });
+        co_return ec;
+    }();
+    auto ec = task::syncWait(std::move(task));
+    BOOST_CHECK_EQUAL(ec, boost::asio::error::operation_aborted);
 }
 
 BOOST_AUTO_TEST_CASE(SessionRecvBufferTest)

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -496,6 +496,46 @@ BOOST_AUTO_TEST_CASE(doReadTest)
     fakeSocket->close();
 }
 
+BOOST_AUTO_TEST_CASE(startUsesDefaultReadPolicy)
+{
+    // Coverage for the production read entry point: Session::start() is the only instantiation
+    // of readLoop<ASIOInterface::DefaultReadPolicy> (every other test enters via
+    // startWithPolicy<FakePolicy>). Drive DefaultReadPolicy down its deterministic
+    // unexpected-type branch — an m_type that is neither TCP_ONLY nor SSL completes the read
+    // with a posted operation_not_supported — and assert the read loop drops the session.
+    // (m_type defaults to TCP_ONLY, so "unset" would arm a real async_read_some on the fake's
+    // connected socket pair instead; the invalid type is what makes the branch deterministic.)
+    auto fakeMessageFactory = std::make_shared<FakeMessageFactory>();
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket>();
+    auto fakeAsio = std::make_shared<FakeASIO>();
+    fakeAsio->setType(2);
+    {
+        auto fakeHost =
+            std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory);
+
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        // Tolerant handler: the read error drops the session, and the drop notifies.
+        session->setMessageHandler([](NetworkException, SessionFace::Ptr, Message::Ptr) {});
+
+        session->start();  // virtual production entry — NOT startWithPolicy<>
+
+        size_t retryTimes = 0;
+        while (session->active() && retryTimes < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            retryTimes++;
+        }
+        BOOST_CHECK(!session->active());
+        // drop() captured the socket into a local shared_ptr before clearing m_active, so the
+        // socket can be nulled as soon as the session is inactive (same teardown as doReadTest).
+        session->setSocket(nullptr);
+    }
+
+    fakeSocket->close();
+}
+
 BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
 {
     // The fast path must honour the same pre-send (outgoing rate-limit) check the removed callback

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -873,6 +873,24 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
     task::syncWait(service->broadcastMessageToNeighbors(
         message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
 
+    // Session::write() posts the write-loop launch to the socket's io thread, so the broadcast
+    // returning only means each per-peer payload is QUEUED (the fan-out tasks are fire-and-
+    // forget). Wait (bounded) until both peers have actually received their frame before
+    // disconnecting below — otherwise the disconnect races the posted launch and drop() fails
+    // the queued payload instead of writing it. A genuinely lost frame still fails the size
+    // assertions at the end; the bound only keeps the peer reads from hanging forever first.
+    for (size_t frameRetry = 0; frameRetry < 500; ++frameRetry)
+    {
+        {
+            std::lock_guard<std::mutex> lock(recvMutex);
+            if (!receivedV2.empty() && !receivedV0.empty())
+            {
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
     // Round-7 review: disconnect the sessions BEFORE joining the peer threads. Each peer thread
     // blocks on a synchronous asio read; if a broadcast regression ever skipped a peer, that
     // thread would block forever and a disconnect placed after join() would never run — surfacing

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -39,9 +39,12 @@
 #include <chrono>
 #include <cstdint>
 #include <mutex>
+#include <optional>
 #include <queue>
+#include <list>
 #include <range/v3/view/single.hpp>
 #include <thread>
+#include <tuple>
 #include <unordered_set>
 #include <vector>
 
@@ -57,14 +60,70 @@ class FakeASIO : public bcos::gateway::ASIOInterface
 {
 public:
     using Packet = std::shared_ptr<std::vector<uint8_t>>;
+    using ReadResult = std::tuple<boost::system::error_code, std::size_t>;
+    using ReadCompletion =
+        bcos::gateway::detail::AsioCompletion<boost::system::error_code, std::size_t>;
+
     FakeASIO()
       : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO"), "0.0.0.0", 0),
         m_threadPool(std::make_shared<bcos::IOServicePool>(1, "FakeASIO"))
     {};
     virtual ~FakeASIO() noexcept override {};
 
-    void readSome(std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers,
-        ReadWriteHandler handler)
+    // Coroutine mock point for the read path: park the read's completion and feed it buffered
+    // packets from the fake's own pool thread.
+    task::Task<ReadResult> awaitableReadSome(
+        std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer buffers) override
+    {
+        ++m_readsInFlight;
+        co_return co_await makeAsioAwaitable<boost::system::error_code, std::size_t>(
+            [this, buffers](auto handler) {
+                m_pendingReads.push_back(PendingRead{buffers, std::move(handler)});
+                kickDelivery();
+            });
+    }
+
+    // Synchronous helper for fakeClassTest (no session involved).
+    template <typename Handler>
+    void readSome(std::shared_ptr<SocketFace> /*socket*/, ba::mutable_buffer buffers,
+        Handler&& handler)
+    {
+        handler(boost::system::error_code(), drainPackets(buffers));
+    }
+
+    // Test teardown: complete every parked read with operation_aborted so the read loops — and
+    // the sessions their frames keep alive — unwind BEFORE the test nulls the socket or
+    // destroys this fake. Poll readsInFlight() until 0 afterwards: the counter is decremented
+    // only after the fired completion has synchronously unwound the whole read loop, so 0 means
+    // the unwind is done and no coroutine touches the session any more.
+    void stopReads()
+    {
+        m_threadPool->post([this] {
+            while (!m_pendingReads.empty())
+            {
+                auto pending = std::move(m_pendingReads.front());
+                m_pendingReads.pop_front();
+                fireRead(std::move(pending.completion), boost::asio::error::operation_aborted, 0);
+            }
+        });
+    }
+    std::size_t readsInFlight() const { return m_readsInFlight.load(); }
+
+    void stop() { m_threadPool.reset(); }
+
+public:  // for testing
+    void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
+
+    void asyncAppendRecvPacket(Packet packet)
+    {
+        m_threadPool->post([this, packet]() {
+            m_recvPackets.push(std::move(packet));
+            deliverIfPossible();
+        });
+    }
+
+protected:
+    std::size_t drainPackets(ba::mutable_buffer buffers)
     {
         std::size_t bytesTransferred = 0;
         auto limit = buffers.size();
@@ -88,35 +147,46 @@ public:
                 bytesTransferred += packet->size();
             }
         }
-
-        handler(boost::system::error_code(), bytesTransferred);
+        return bytesTransferred;
     }
 
-    void asyncReadSome(const std::shared_ptr<SocketFace>& socket,
-        boost::asio::mutable_buffer buffers, ReadWriteHandler handler) override
+    // Everything below runs on the pool thread only: the first read is armed on the caller's
+    // thread but publishes the parked completion through kickDelivery's post, and every later
+    // arm happens inside fireRead's resume, which runs on the pool thread. Multiple sessions may
+    // share this fake, so parked reads form a FIFO list rather than a single slot.
+    void kickDelivery() { m_threadPool->post([this] { deliverIfPossible(); }); }
+
+    void deliverIfPossible()
     {
-        m_threadPool->post([this, socket, buffers, handler]() {
-            if (m_recvPackets.empty())
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                asyncReadSome(socket, buffers, handler);
-                return;
-            }
-            readSome(socket, buffers, handler);
-        });
+        if (m_pendingReads.empty() || m_recvPackets.empty())
+        {
+            return;
+        }
+        auto pending = std::move(m_pendingReads.front());
+        m_pendingReads.pop_front();
+        fireRead(std::move(pending.completion), boost::system::error_code(),
+            drainPackets(pending.buffers));
     }
-    void stop() { m_threadPool.reset(); }
 
-public:  // for testing
-    void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
-
-    void asyncAppendRecvPacket(Packet packet)
+    // Fire a parked completion. The fire resumes the read loop SYNCHRONOUSLY on this (pool)
+    // thread — on success the loop processes the messages and re-arms a fresh read (parking a
+    // new completion and re-incrementing the counter), on error it unwinds completely — so the
+    // counter is decremented only after the loop has settled.
+    void fireRead(ReadCompletion completion, boost::system::error_code ec, std::size_t bytes)
     {
-        m_threadPool->post([this, packet]() { appendRecvPacket(packet); });
+        completion(ec, bytes);
+        --m_readsInFlight;
     }
 
-protected:
+    struct PendingRead
+    {
+        ba::mutable_buffer buffers;
+        ReadCompletion completion;
+    };
+
     std::queue<Packet> m_recvPackets;
+    std::list<PendingRead> m_pendingReads;
+    std::atomic<std::size_t> m_readsInFlight{0};
     bcos::IOServicePool::Ptr m_threadPool;
 };
 
@@ -254,8 +324,23 @@ public:
 class FakeSocket : public SocketFace
 {
 public:
-    FakeSocket() : SocketFace(), m_workGuard(boost::asio::make_work_guard(m_ioService))
+    FakeSocket()
+      : SocketFace(),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_workGuard(boost::asio::make_work_guard(m_ioService))
     {
+        // A connected TCP pair backs the SSL stream so drop()/closeSocket() can call
+        // sslref().async_shutdown() safely (mirrors FakeSocket_FIB): the acceptor-side socket
+        // closes when it goes out of scope, so the shutdown completes with an error instead of
+        // dereferencing an unconnected stream.
+        bi::tcp::acceptor acceptor(m_ioService, bi::tcp::endpoint(bi::tcp::v4(), 0));
+        auto endpoint = acceptor.local_endpoint();
+        bi::tcp::socket clientSocket(m_ioService);
+        clientSocket.connect(endpoint);
+        bi::tcp::socket serverSocket(m_ioService);
+        acceptor.accept(serverSocket);
+        m_sslSocket = std::make_shared<ba::ssl::stream<bi::tcp::socket>>(
+            std::move(clientSocket), m_sslContext);
         m_worker = std::thread([this]() { m_ioService.run(); });
     };
     ~FakeSocket() override
@@ -267,8 +352,8 @@ public:
             m_worker.join();
         }
     }
-    bool isConnected() const override { return true; }
-    void close() override {}
+    bool isConnected() const override { return m_connected; }
+    void close() override { m_connected = false; }
     boost::asio::ip::tcp::endpoint remoteEndpoint(boost::system::error_code ec) override
     {
         return {};
@@ -284,11 +369,15 @@ public:
     ba::io_context& ioService() override { return m_ioService; }
 
 private:
-    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    // Declaration order matters: members are destroyed in reverse, so the io_context must
+    // outlive the SSL stream that deregisters from it in its destructor.
     ba::io_context m_ioService;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
     boost::asio::executor_work_guard<ba::io_context::executor_type> m_workGuard;
     std::thread m_worker;
     NodeIPEndpoint m_nodeIPEndpoint;
+    bool m_connected{true};
 };
 
 BOOST_AUTO_TEST_CASE(fakeClassTest)
@@ -374,6 +463,21 @@ BOOST_AUTO_TEST_CASE(doReadTest)
 
         BOOST_CHECK_EQUAL(recvPacketCnt, totalPacketNum);
         BOOST_CHECK_EQUAL(recvBufferSize, messageBuilder.sendBufferSize());
+
+        // Teardown: a read is still parked in the fake. Swap in a tolerant message handler
+        // first — failing the parked read drops the session, and the teardown notification
+        // would otherwise reach the strict handler above with a Disconnect error — then let the
+        // fake fail the read and wait for the read loop to unwind completely before nulling
+        // the socket.
+        session->setMessageHandler([](NetworkException, SessionFace::Ptr, Message::Ptr) {});
+        fakeAsio->stopReads();
+        size_t drainRetry = 0;
+        while (fakeAsio->readsInFlight() != 0 && drainRetry < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            drainRetry++;
+        }
+        BOOST_REQUIRE_EQUAL(fakeAsio->readsInFlight(), 0);
         session->setSocket(nullptr);
     }
 
@@ -408,6 +512,15 @@ BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
                 message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{})),
             NetworkException);
 
+        // drain the parked read so the read loop unwinds before the socket is nulled
+        fakeAsio->stopReads();
+        size_t drainRetry = 0;
+        while (fakeAsio->readsInFlight() != 0 && drainRetry < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            drainRetry++;
+        }
+        BOOST_REQUIRE_EQUAL(fakeAsio->readsInFlight(), 0);
         session->setSocket(nullptr);
     }
     fakeSocket->close();
@@ -533,6 +646,18 @@ BOOST_AUTO_TEST_CASE(fastSendMessageCompression)
         // socket while the io thread may still run the session's idle timer (checkNetworkStatus
         // would dereference a null m_socket).
         session->disconnect(DisconnectReason::DisconnectRequested);
+
+        // The session's read is parked in the fake ASIO (not on the real socket), so the
+        // disconnect does not unwind it — fail it explicitly and wait for the read loop to
+        // finish before the fake is destroyed.
+        fakeAsio->stopReads();
+        size_t drainRetry = 0;
+        while (fakeAsio->readsInFlight() != 0 && drainRetry < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            drainRetry++;
+        }
+        BOOST_REQUIRE_EQUAL(fakeAsio->readsInFlight(), 0);
     }
 
     peerThread.join();
@@ -706,6 +831,18 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
         session->disconnect(DisconnectReason::DisconnectRequested);
     }
 
+    // The sessions' reads are parked in the fake ASIO (not on the real sockets), so the
+    // disconnects do not unwind them — fail them explicitly and wait for the read loops to
+    // finish before the fake is destroyed.
+    fakeAsio->stopReads();
+    size_t drainRetry = 0;
+    while (fakeAsio->readsInFlight() != 0 && drainRetry < 200)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        drainRetry++;
+    }
+    BOOST_REQUIRE_EQUAL(fakeAsio->readsInFlight(), 0);
+
     peerV2.join();
     peerV0.join();
 
@@ -861,6 +998,18 @@ BOOST_AUTO_TEST_CASE(fastSendConcurrentWriteOrder)
         peerDone = true;
         // Unblock the peer thread's read (same teardown shape as fastSendMessageCompression).
         session->disconnect(DisconnectReason::DisconnectRequested);
+
+        // The session's read is parked in the fake ASIO (not on the real socket), so the
+        // disconnect does not unwind it — fail it explicitly and wait for the read loop to
+        // finish before the fake is destroyed.
+        fakeAsio->stopReads();
+        size_t drainRetry = 0;
+        while (fakeAsio->readsInFlight() != 0 && drainRetry < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            drainRetry++;
+        }
+        BOOST_REQUIRE_EQUAL(fakeAsio->readsInFlight(), 0);
     }
 
     peerThread.join();

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -1114,9 +1114,10 @@ BOOST_AUTO_TEST_CASE(asioCompletionHandshakeSynchronousInvocation)
 {
     // Arm/cancel handshake regression: an initiate that INVOKES the completion synchronously
     // (before returning) must not resume the coroutine from inside its own await_suspend
-    // (resuming a not-yet-suspended frame is UB). AsioCompletion observes m_suspended == false,
-    // records the completion, and await_suspend resumes inline by returning false — the result
-    // is delivered exactly once.
+    // (resuming a not-yet-suspended frame is UB). The completion's operator() claims
+    // Init -> Completed and deliberately does not resume; await_suspend observes Completed on
+    // its failed CAS and resumes inline by returning false — the result is delivered exactly
+    // once.
     auto task = []() -> task::Task<boost::system::error_code> {
         auto [ec] = co_await makeAsioAwaitable<boost::system::error_code>(
             [](auto handler) { handler(boost::system::error_code()); });

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -35,11 +35,15 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <mutex>
 #include <queue>
 #include <range/v3/view/single.hpp>
 #include <thread>
+#include <unordered_set>
+#include <vector>
 
 using namespace bcos;
 using namespace gateway;
@@ -409,9 +413,9 @@ BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
     fakeSocket->close();
 }
 
-// A SocketFace backed by a real connected TCP socket so the (non-virtual)
-// ASIOInterface::asyncWrite path actually completes on the wire — the FakeSocket above cannot
-// reach the compression branch because its write path is inert.
+// A SocketFace backed by a real connected TCP socket so the ASIOInterface::awaitableWrite path
+// actually completes on the wire — the FakeSocket above cannot reach the compression branch
+// because its write path is inert.
 class RealLoopbackSocket : public SocketFace
 {
 public:
@@ -732,6 +736,177 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
     BOOST_CHECK_EQUAL(decodedV2.srcP2PNodeID(), "srcNodeID");
     BOOST_CHECK_EQUAL(decodedV2.dstP2PNodeID(), "dstNodeID");
     BOOST_CHECK_EQUAL(decodedV2.ttl(), 10);
+}
+
+BOOST_AUTO_TEST_CASE(fastSendConcurrentWriteOrder)
+{
+    // Regression for the per-session write ordering guarantee: the write path must serialize
+    // concurrent producers. N threads call fastSendMessage concurrently and the single-writer
+    // write loop (Session::writeLoop, guarded by the m_writingInFlight single-flight flag) must
+    // put a complete, non-interleaved frame for every message on the wire — if the serialization
+    // were ever broken, frames would be torn or interleaved. Uses a real loopback socket
+    // (RealLoopbackSocket) so the full awaitableWrite -> async_write path runs, then parses the
+    // accumulated byte stream into frames by their length prefix.
+    constexpr size_t threadCount = 8;
+    constexpr size_t msgPerThread = 50;
+    constexpr size_t totalMsgs = threadCount * msgPerThread;
+
+    auto fakeMessageFactory = std::make_shared<FakeMessageFactory>();
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO>();
+
+    auto io = std::make_shared<ba::io_context>();
+    boost::asio::executor_work_guard<ba::io_context::executor_type> workGuard(io->get_executor());
+    std::thread ioThread([io] { io->run(); });
+
+    ba::ip::tcp::acceptor acceptor(*io, ba::ip::tcp::endpoint(ba::ip::tcp::v4(), 0));
+    auto listenEndpoint = acceptor.local_endpoint();
+
+    std::mutex recvMutex;
+    std::vector<uint8_t> received;
+    std::atomic<bool> peerDone{false};
+    std::thread peerThread([&] {
+        ba::ip::tcp::socket peer(*io);
+        boost::system::error_code ec;
+        acceptor.accept(peer, ec);
+        if (ec)
+        {
+            return;
+        }
+        std::array<uint8_t, 4096> buf;
+        while (!peerDone.load(std::memory_order_relaxed))
+        {
+            std::size_t n = peer.read_some(ba::buffer(buf), ec);
+            if (ec)
+            {
+                break;
+            }
+            if (n > 0)
+            {
+                std::lock_guard<std::mutex> lock(recvMutex);
+                received.insert(received.end(), buf.begin(), buf.begin() + n);
+            }
+        }
+    });
+
+    ba::ip::tcp::socket client(*io);
+    boost::system::error_code connectError;
+    client.connect(listenEndpoint, connectError);
+    BOOST_REQUIRE(!connectError);
+
+    // Each frame is the fixed 14-byte base header plus the 64-byte payload (payload is far below
+    // the compress threshold, so no compression runs even at V2).
+    const size_t frameSize = P2PMessage::MESSAGE_HEADER_LENGTH + 64;
+    const size_t expectedBytes = frameSize * totalMsgs;
+
+    {
+        auto fakeHost = std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory);
+        auto sessionSocket = std::make_shared<RealLoopbackSocket>(io, std::move(client));
+        auto session = std::make_shared<Session>(sessionSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        session->start();
+
+        std::vector<std::thread> senders;
+        senders.reserve(threadCount);
+        for (size_t t = 0; t < threadCount; ++t)
+        {
+            senders.emplace_back([t, session] {
+                for (size_t i = 0; i < msgPerThread; ++i)
+                {
+                    P2PMessage message;
+                    message.setVersion((uint16_t)bcos::protocol::ProtocolVersion::V2);
+                    message.setSeq(static_cast<uint32_t>(t * msgPerThread + i));
+                    bytes payload(64, static_cast<uint8_t>('a' + t));
+                    try
+                    {
+                        task::syncWait(session->fastSendMessage(message,
+                            ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
+                    }
+                    catch (std::exception const&)
+                    {
+                        // no write failure is expected on a healthy loopback; a torn/aborted write
+                        // would show up as a missing/corrupt frame in the wire assertions below
+                    }
+                }
+            });
+        }
+        for (auto& th : senders)
+        {
+            th.join();
+        }
+
+        // Every syncWait has returned, but the last async_write may still be completing on the io
+        // thread, so poll until the peer has the full byte count.
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+        while (true)
+        {
+            size_t got = 0;
+            {
+                std::lock_guard<std::mutex> lock(recvMutex);
+                got = received.size();
+            }
+            if (got >= expectedBytes)
+            {
+                break;
+            }
+            BOOST_CHECK_MESSAGE(std::chrono::steady_clock::now() < deadline,
+                "peer did not receive all " << expectedBytes << " bytes, got " << got);
+            if (std::chrono::steady_clock::now() >= deadline)
+            {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        peerDone = true;
+        // Unblock the peer thread's read (same teardown shape as fastSendMessageCompression).
+        session->disconnect(DisconnectReason::DisconnectRequested);
+    }
+
+    peerThread.join();
+    workGuard.reset();
+    {
+        boost::system::error_code ec;
+        acceptor.close(ec);
+    }
+    io->stop();
+    ioThread.join();
+
+    // Parse the accumulated stream into frames by the 4-byte length prefix. Header layout:
+    // [length:4][version:2][packetType:2][seq:4][ext:2] (P2PMessage::MESSAGE_HEADER_LENGTH = 14);
+    // seq sits at bytes [8..12) in network byte order.
+    std::vector<uint32_t> seqs;
+    std::unordered_set<uint32_t> seenSeqs;
+    {
+        std::lock_guard<std::mutex> lock(recvMutex);
+        BOOST_CHECK_EQUAL(received.size(), expectedBytes);
+        size_t pos = 0;
+        while (pos < received.size())
+        {
+            BOOST_REQUIRE(pos + 4 <= received.size());
+            uint32_t frameLen = (uint32_t(received[pos]) << 24) |
+                                (uint32_t(received[pos + 1]) << 16) |
+                                (uint32_t(received[pos + 2]) << 8) | received[pos + 3];
+            // a torn/interleaved frame would fail this exact-size assertion
+            BOOST_REQUIRE(frameLen == frameSize);
+            BOOST_REQUIRE(pos + frameLen <= received.size());
+            uint32_t seq = (uint32_t(received[pos + 8]) << 24) |
+                           (uint32_t(received[pos + 9]) << 16) |
+                           (uint32_t(received[pos + 10]) << 8) | received[pos + 11];
+            // payload integrity: each thread sent 64 bytes of ('a' + threadIdx)
+            uint8_t expect = static_cast<uint8_t>('a' + seq / msgPerThread);
+            for (size_t k = P2PMessage::MESSAGE_HEADER_LENGTH; k < frameLen; ++k)
+            {
+                BOOST_CHECK_EQUAL(received[pos + k], expect);
+            }
+            seqs.push_back(seq);
+            seenSeqs.insert(seq);
+            pos += frameLen;
+        }
+    }
+
+    BOOST_CHECK_EQUAL(seqs.size(), totalMsgs);
+    BOOST_CHECK_EQUAL(seenSeqs.size(), totalMsgs);
 }
 
 BOOST_AUTO_TEST_CASE(SessionRecvBufferTest)


### PR DESCRIPTION
## 概述

将网关网络层（`bcos-gateway/libnetwork`）中手写的回调链式异步逻辑重构为基于 `task::Task` 协程的 awaitable 接口，使 accept / connect / handshake / read / write 等关键路径均可直接 `co_await`，消除显式 `shared_from_this()` 捕获与回调嵌套，让会话与 Host 的生命周期约束从"依赖回调捕获"变为"结构上由协程帧持有"。

## 主要改动

- **新增 `AsioAwaitable.h`**：通用 awaitable 模板 `AsioAwaitable` / `makeAsioAwaitable`，将回调式 asio 操作桥接为协程。约定：asio 操作不会在发起调用处内联回调，协程始终在 io_context 线程上恢复；`resume()` 包裹 try/catch（含 `catch(...)`），异常不会逃逸进 `io_context::run()`。完成处理器是 move-only 的 `detail::AsioCompletion`（无堆分配），并带 **arm/cancel 握手**（详见下节）。
- **`ASIOInterface`**：
  - 新增协程接口 `awaitableAccept` / `awaitableResolveConnect` / `awaitableHandshake` / `awaitableReadSome` / `awaitableWrite`，并保证"总完成"（成功与失败都会恰好恢复一次等待中的协程，失败时也不会悬挂协程帧）。所有 awaitable 都直接返回 `AsioAwaitable`（非协程、非虚），在调用方协程帧内构造——读路径不再有桥接协程帧，也消除了每次 `async_read_some` 一个协程帧堆分配的额外开销。
  - 移除旧的回调接口 `asyncAccept` / `asyncResolveConnect` / `asyncHandshake` / `asyncReadSome` 及 `setIOServicePool` / `clientContext` / `dispatch`。
  - **读路径是编译期策略**（`awaitableReadSome<ReadPolicy = DefaultReadPolicy>`）：生产使用默认策略 `DefaultReadPolicy`，其 `invoke()` 直接在策略内联派发 `async_read_some`（按 `m_type` 区分 TCP / SSL，无 `std::function`、无虚调用、完全内联）。读路径测试 fake 提供自己的策略类型（与 `DefaultReadPolicy` 同签名的 `static invoke`），并通过 `Session::startWithPolicy<FakePolicy>()` 让读循环按该策略编译，实现 park-and-fire 拦截。策略契约：completion 必须交给延迟执行器（asio 或 post 到某个 io_context），既不能同步调用也不能同步丢弃（同步情形由 arm/cancel 握手在内部化解，但契约要求延迟）。
  - 新增 `cancelAcceptor()`：取消挂起的 `async_accept`，使 accept 循环以 `operation_aborted` 结束并退出、释放协程帧持有的强引用。
- **`Host`**：accept / connect 路径改为协程（`acceptLoop` / `serverHandshake` / `clientConnect`），以 `task::wait` 启动。协程帧在整个生命周期内持有 Host 强引用，结构化替代旧回调中的逐操作 `shared_from_this()` 捕获。
  - `acceptLoop` 的 try/catch 移入 `while` 循环内部：单次迭代异常（`newSocket` 分配、`remoteEndpoint`、`task::wait(serverHandshake(...))` 的协程帧分配）不再永久终止入站连接接收，而是记日志后继续下一次 accept。
  - FIB-186 握手槽位的 acquire 与 guard 构造合并为 `tryAcquireHandshakeSlotGuard`（返回 `shared_ptr<void>` 守卫），并随 `serverHandshake` 协程帧传递——acquire 与 release 同帧，消除"acquire 后、guard 构造前抛异常导致槽位泄漏"的窗口；同时保留"先槽位后限速令牌"的准入顺序。
- **`Session`**：读写路径改为协程（`readLoop` / `writeLoop`）。
  - 读侧：协程帧持有会话强引用，保证 FIB-184 生命周期不变量（会话、接收缓冲与 socket 存活）从"依赖完成回调捕获"变为结构保证。
  - 写侧：单写者写循环，批量排空 `m_writeQueue`，所有 `async_write` 串行经过同一个在途循环；用原子标志 `m_writingInFlight`（CAS）取代旧的 try_lock 式 `std::mutex` 作为写者标志，任何锁都不会跨越 `co_await`。
  - `writeLoop` 帧内新增 `WriteLoopGuard`（帧局部 RAII）：当完成-或-取消救援（armed completion 未调用即被析构 → `m_handle.destroy()`）直接销毁 `writeLoop` 帧、跳过循环体和 catch 时，guard 负责清掉 `m_writingInFlight` 并 fail 掉仍在批量中的回调——否则写者角色永久被占用、队列不再排空、等待的 `fastSendMessage` 协程泄漏。
  - `write()` 启动 `writeLoop` 失败时**不再把异常抛给调用方**（调用方处于 sender 的 `await_suspend` 内，异常逃逸会使已入队回调指向已析构的帧）：改为清标志、记 ERROR 日志并 `drop(TCPError)`，由 drop 排空队列并 post 回调。
  - **行为变化（非纯重构，已按评审披露）**：发送批量预算的取舍。基线把 `session_max_send_msg_count` 条件注释掉、一次 `async_write` 排空整个队列；本 PR 第 1 轮重新启用"字节+条数"双预算，导致每条 `async_write` 被默认 10 条上限截断，广播扇出下产生 `ceil(N/10)` 次 post + async_write 往返。第 5 轮决定**去掉条数预算、仅保留字节预算**（`session_max_send_data_size`）作为唯一上限——字节预算已能约束单次写的内存占用，且与基线吞吐语义一致；`p2p.session_max_send_msg_count` 配置保留读取（配置兼容），但批量循环不再执行它。仅 `p2p.session_max_send_data_size` 在 `GatewayConfig::initP2PConfig` 做下限校验：为 0 时告警并钳制为 1（0 并不等于"无限制"，字节预算为 0 会导致批量循环永不取包、出站流量静默停滞）；`p2p.session_max_send_msg_count` 保留读取（配置兼容）但不做钳制——该值已无消费者，钳制只会误导运营商去"修正"一个无效值；若配置中显式出现该 key，启动时会打印弃用警告，提示发送批量上限仅由字节预算约束。
- **测试**：适配既有 FIB184 / FIB186 / FIB70 / FIB97 相关单测，并在 `SessionTest.cpp` 中新增协程路径的测试覆盖。三个读路径 fake（`SessionTest` / `FIB70_FIB97` / `FIB184_SessionAsyncLifetime`）各自提供嵌套的 `ReadPolicy` 策略类型（park-and-fire：挂起读的 completion 由 fake 持有、确定性触发；多会话共享 fake 时挂起读构成 FIFO 队列），并调用 `session->startWithPolicy<FakeASIO::ReadPolicy>()` 启动读循环。`SessionTest` 与 `FIB70_FIB97` 的 fake 把 park 动作 post 到 fake 自己的单线程池，使 `m_pendingReads` 的所有访问都发生在池线程上（消除首读在测试线程 push 与池线程遍历之间的数据竞争）。新增回归用例：`asioCompletionHandshakeSynchronousInvocation`（initiate 内同步调用 completion → 内联恢复且结果恰好交付一次）、`asioCompletionHandshakeSynchronousDrop`（initiate 内同步丢弃 completion → 以 `operation_aborted` 内联恢复而非销毁运行中的帧）、以及 `GatewayConfigTest` 中"0 被钳制为 1"的用例。

## arm/cancel 握手（`detail::AsioCompletion` 与 `await_suspend` 共享单个原子状态机）

握手状态是单个 `std::atomic<detail::CompletionState>`（`Init` / `Suspended` / `Completed` / `Dropped`），每一侧用一次 `compare_exchange_strong` 抢占状态转移，恰好一方胜出——消除了多标志 check-then-set 的竞态窗口（跨线程 completion 落在“读标志”与“置位”之间不再丢失）：

- `await_suspend`：`initiate()` 返回后 CAS `Init -> Suspended`；成功则挂起（由 completion 或析构接管恢复），失败则按观察到的 `Completed` / `Dropped` 内联恢复（`return false`）。
- `initiate()` 内部**同步调用** completion：`operator()` 写结果后 CAS `Init -> Completed`；成功则不 resume（在 `await_suspend` 内恢复尚未挂起的帧是 UB），`await_suspend` 观察后内联恢复，结果恰好交付一次。
- `initiate()` 内部**同步丢弃** completion（未调用即析构、且未抛异常）：析构 CAS `Init -> Dropped`；成功则不销毁运行中的帧（销毁未挂起帧是 UB），`await_suspend` 观察后以 `operation_aborted` 内联恢复。
- 协程**已挂起**后 armed completion 未调用即被析构（io_context 拆除、测试 fake 丢弃）：析构 CAS 失败（状态为 `Suspended`），执行完成-或-取消救援——`m_handle.destroy()` 释放挂起帧及其强引用（与基线中未调用 handler 析构时释放其 `shared_ptr<Session>` 语义一致）。救援不运行任何循环代码；外层 `task::wait` 的 `AsyncTask` 包装帧不会被回收（有界、shutdown 范围的小泄漏，已在代码注释中记录）。

## 设计说明

- 线程契约：恢复协程的线程与旧手写回调链所在的线程一致（io_context 完成线程），不改变现有线程模型。
- 生命周期契约：awaitable 对象位于协程帧内，asio 在帧析构前恰好调用一次完成处理器，因此 `this` 捕获在处理器可能运行的整个期间均有效。
- `Host::m_run` 改为 `std::atomic<bool>`：`stop()` 从调用线程写、`acceptLoop` 在 acceptor 的 io_context 线程读、`haveNetwork()` 从所有会话线程读。新 Host 契约使"在 io 线程观察到 `m_run == false`"成为释放 accept 循环强引用的唯一机制，必须原子化（陈旧读会导致 accept 取消被消费后循环重新 arm、Host 永不析构）。



