### PR TITLE
feat(opstack): split C — Eth/Engine RPC query surface

### DIFF
--- a/bcos-framework/bcos-framework/engine/RawTransactionDispatch.h
+++ b/bcos-framework/bcos-framework/engine/RawTransactionDispatch.h
@@ -44,6 +44,11 @@ enum class RawTransactionKind : std::uint8_t
 ///
 /// Note: 0x00 is NOT a valid EIP-2718 type. Bytes in [0x05, 0x7d] and [0x7f, 0xbf] are
 /// reserved/unknown and classify as Unsupported.
+///
+/// Per-kind admission POLICY is enforced at the entry gates, not here: FISCO's OP policy
+/// rejects blob (type-3) where op-geth's decodeTyped accepts it — a deliberate acceptance
+/// divergence, not an op-geth check — and a single blob or unsupported transaction
+/// invalidates a whole engine payload rather than being dropped individually.
 inline RawTransactionKind dispatchRawTransaction(bcos::bytesConstRef raw)
 {
     if (raw.empty())
@@ -66,15 +71,6 @@ inline RawTransactionKind dispatchRawTransaction(bcos::bytesConstRef raw)
         // 0xc0..0xff: RLP list header => legacy transaction.
         return raw[0] >= 0xc0 ? RawTransactionKind::Legacy : RawTransactionKind::Unsupported;
     }
-}
-
-/// Whether a transaction of this kind may appear inside an Engine execution payload.
-/// FISCO's OP policy rejects blob (type-3) txs at the gate — op-geth's decodeTyped accepts
-/// them, so this is a deliberate acceptance divergence, not an op-geth check. A single blob or
-/// unsupported transaction invalidates the whole payload, it is not dropped individually.
-inline bool isRawTransactionPayloadAdmissible(RawTransactionKind kind)
-{
-    return kind != RawTransactionKind::Blob && kind != RawTransactionKind::Unsupported;
 }
 
 }  // namespace bcos::engine

--- a/bcos-rpc/CMakeLists.txt
+++ b/bcos-rpc/CMakeLists.txt
@@ -31,7 +31,9 @@ find_package(tarscpp REQUIRED)
 add_library(rpc ${SRCS} ${HEADERS})
 target_include_directories(rpc PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_link_libraries(rpc PUBLIC bcos-boostssl ledger codec bcos-crypto rlp-protocol protocol-tars mempool jsoncpp_static jwt-cpp::jwt-cpp tarscpp::tarsservant tarscpp::tarsutil)
+# bcos-framework is a direct include owner (OpBaseFee.h, LedgerTypeDef.h, engine Types);
+# declare it explicitly rather than relying on transitive PUBLIC props from ledger/etc.
+target_link_libraries(rpc PUBLIC bcos-framework bcos-boostssl ledger codec bcos-crypto rlp-protocol protocol-tars mempool jsoncpp_static jwt-cpp::jwt-cpp tarscpp::tarsservant tarscpp::tarsutil)
 add_dependencies(rpc BuildInfo.h)
 set_target_properties(rpc PROPERTIES UNITY_BUILD "ON")
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
@@ -83,6 +83,7 @@ void EndpointsMapping::addEthHandlers()
     m_handlers[methodString(EthMethod::eth_mining)] = &Endpoints::mining;
     m_handlers[methodString(EthMethod::eth_hashrate)] = &Endpoints::hashrate;
     m_handlers[methodString(EthMethod::eth_gasPrice)] = &Endpoints::gasPrice;
+    m_handlers[methodString(EthMethod::eth_feeHistory)] = &Endpoints::feeHistory;
     m_handlers[methodString(EthMethod::eth_accounts)] = &Endpoints::accounts;
     m_handlers[methodString(EthMethod::eth_blockNumber)] = &Endpoints::blockNumber;
     m_handlers[methodString(EthMethod::eth_getBalance)] = &Endpoints::getBalance;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -21,12 +21,24 @@
 #include "EngineEndpoint.h"
 #include <bcos-rpc/jsonrpc/Common.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h>
 #include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 
 using namespace bcos;
 using namespace bcos::rpc;
 
+namespace
+{
+/// Map engine exceptions to Engine API JSON-RPC codes (else they become -32603).
+[[noreturn]] void rethrowAsJsonRpcError(bcos::Exception const& e)
+{
+    // bcos::Error message is errorMessage(), not what().
+    auto msg = dynamic_cast<bcos::Error const*>(&e);
+    auto message = msg ? msg->errorMessage() : std::string(e.what());
+    throw JsonRpcException(mapEngineErrorCode(e), std::move(message));
+}
+}  // namespace
 
 EngineEndpoint::EngineEndpoint(NodeService::Ptr nodeService) : m_nodeService(std::move(nodeService))
 {}
@@ -80,12 +92,8 @@ task::Task<void> EngineEndpoint::exchangeCapabilities(
 void EngineEndpoint::buildUnimplementedVersionError(
     std::string_view method, Json::Value& response) const
 {
-    // -38005 Unsupported fork for a method version this node does not implement at all
-    // (currently only forkchoiceUpdatedV4: the service layer's forkchoice window tops out
-    // at V3, see isForkchoiceVersionSupported). This is NOT a declaration that older
-    // versions are incompatible: every version that IS implemented stays served, so a
-    // pre-Karst CL — the v1 Engine API harness kept alive by unsafe_allow_v1_executor, or
-    // a stock Lodestar driving V1-V3 — keeps working.
+    // -38005: method version not implemented. FCU stops at V3; raising it would break
+    // getPayload (payloadVersion==3 only). V1–V3 stay served.
     //
     // Built inline instead of through buildJsonError(request, ...) because a handler only
     // ever receives the params array, never the request envelope: the JSON-RPC id is
@@ -117,9 +125,10 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
     co_await handleForkchoiceUpdated(engine::ApiVersion::V3, request, response);
 }
 
-task::Task<void> EngineEndpoint::forkchoiceUpdatedV4(const Json::Value&, Json::Value& response)
+task::Task<void> EngineEndpoint::forkchoiceUpdatedV4(
+    const Json::Value& /*request*/, Json::Value& response)
 {
-    // Prague forkchoiceUpdated shape; not implemented (Karst builds payloads on V3).
+    // FCU V4 unused: builds stay V3; getPayload only accepts payloadVersion==3.
     buildUnimplementedVersionError("engine_forkchoiceUpdatedV4", response);
     co_return;
 }
@@ -136,13 +145,16 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
 
     auto forkchoiceState = parseForkchoiceState(request);
     auto payloadAttrs = parsePayloadAttributes(request, version);
-    // TODO: engineService->updateForkchoice() MUST throw JsonRpcException in these cases:
-    //   -38002 InvalidForkchoiceState: headBlockHash is VALID but finalizedBlockHash/safeBlockHash
-    //   not in chain -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <=
-    //   headBlockHash.timestamp -38005 UnsupportedFork: timestamp out of fork window (V2/V3
-    //   specific) -38006 TooDeepReorg: reorg depth exceeds limitation
-    auto engineResult = co_await engineService->updateForkchoice(forkchoiceState,
-        payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    bcos::engine::ForkchoiceUpdatedResult engineResult;
+    try
+    {
+        engineResult = co_await engineService->updateForkchoice(forkchoiceState,
+            payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    }
+    catch (bcos::Exception const& e)
+    {
+        rethrowAsJsonRpcError(e);
+    }
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);
 }
@@ -194,30 +206,15 @@ task::Task<void> EngineEndpoint::handleGetPayload(
             JsonRpcException(InvalidParams, "engine_getPayload expects [payloadId]"));
     }
     engine::PayloadID payloadId = request[0u].asString();
-    engine::GetPayloadResult engineResult;
+    bcos::engine::GetPayloadResult engineResult;
     try
     {
         engineResult =
             co_await engineService->getPayload(payloadId, static_cast<uint32_t>(version));
     }
-    catch (engine::UnknownPayload const&)
+    catch (bcos::Exception const& e)
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnknownPayload,
-            "Unknown payload: no build process identified by the given payloadId"));
-    }
-    catch (engine::IncompatiblePayloadVersion const&)
-    {
-        // The build behind this payloadId is outside the requested method's version
-        // window: either a version mismatch between the forkchoiceUpdated that built it
-        // and the getPayload asking for it, or a re-query AFTER the payload was committed
-        // through newPayload (a commit rewrites the cache entry with the newPayload
-        // version — PayloadEntry::version, EngineServiceImpl.h — so it no longer matches
-        // getPayloadV5's V3-build window). The mapping is -38005 to match op-geth, whose
-        // getPayload helper answers engine.UnsupportedFork when the payloadId's encoded
-        // build version is outside the method's allowed set (eth/catalyst/api.go:531-533,
-        // GetPayloadV5 allowing only PayloadV3).
-        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
-            "Unsupported fork: payload was built by a different method version"));
+        rethrowAsJsonRpcError(e);
     }
     if (!engineResult)
     {
@@ -261,11 +258,16 @@ task::Task<void> EngineEndpoint::handleNewPayload(
     }
 
     auto newPayloadReq = parseNewPayloadRequest(request, version);
-    // TODO: engineService->newPayload() MUST throw JsonRpcException in these cases:
-    //   -32602 InvalidParams: wrong version of ExecutionPayload structure (V2)
-    //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3)
-    auto engineResult =
-        co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
+    bcos::engine::PayloadStatus engineResult;
+    try
+    {
+        engineResult =
+            co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
+    }
+    catch (bcos::Exception const& e)
+    {
+        rethrowAsJsonRpcError(e);
+    }
     auto result = serializePayloadStatus(engineResult, version);
     buildJsonContent(result, response);
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -241,6 +241,11 @@ task::Task<void> EthEndpoint::feeHistory(const Json::Value& request, Json::Value
             percentiles.push_back(percentile);
         }
     }
+    if (request.size() < 2 || !request[1U].isString() || toView(request[1U]).empty())
+    {
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "newestBlock must be a QUANTITY or TAG"));
+    }
     auto const [newestNumber, _] = co_await getBlockNumberByTag(toView(request[1U]));
     if (newestNumber < 0)
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -28,7 +28,10 @@
 #include "bcos-protocol/TransactionStatus.h"
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-crypto/hash/Keccak256.h>
+#include <atomic>
+
 #include <bcos-executor/src/Common.h>
+#include <bcos-framework/engine/OpBaseFee.h>
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-framework/storage/LegacyStorageMethods.h>
 #include <bcos-framework/storage2/Storage.h>
@@ -50,7 +53,11 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <span>
 #include <string>
 #include <variant>
@@ -58,6 +65,12 @@
 
 using namespace bcos;
 using namespace bcos::rpc;
+
+namespace
+{
+// eth_call revert: JSON-RPC code 3 + decodeRevertMessage (Error(string) when present).
+constexpr int32_t c_executionReverted = 3;
+}  // namespace
 
 task::Task<void> EthEndpoint::protocolVersion(const Json::Value&, Json::Value&)
 {
@@ -96,10 +109,7 @@ task::Task<void> EthEndpoint::coinbase(const Json::Value&, Json::Value& response
 }
 task::Task<void> EthEndpoint::chainId(const Json::Value&, Json::Value& response)
 {
-    // Reads via LedgerConfig (not a raw SYS_CONFIG single-key read) so that L2-mode
-    // governance (SystemConfig.sol via L2ConfigLoader, wired in A4) flows through one
-    // path. getLedgerConfig over-fetches (~5 storage reads) per call; per plan decision,
-    // RPC-side caching is deferred to Phase B.
+    // Prefer LedgerConfig so L2 SystemConfig governance uses the same path as the rest of the node.
     auto const ledger = m_nodeService->ledger();
     auto const ledgerConfig = co_await ledger::getLedgerConfig(*ledger);
     Json::Value result;
@@ -127,9 +137,25 @@ task::Task<void> EthEndpoint::hashrate(const Json::Value&, Json::Value& response
 }
 task::Task<void> EthEndpoint::gasPrice(const Json::Value&, Json::Value& response)
 {
-    // result: gasPrice(QTY)
+    // Legacy gas suggestion. OP headers (baseFee present) return head baseFee (tip is 0).
+    // Must be >= head baseFee or cast --legacy txs never confirm. PBFT uses the static knob.
     auto const ledger = m_nodeService->ledger();
-    // TODO)): gas price can wrap in a class
+    if (auto const latest = co_await ledger::getCurrentBlockNumber(*ledger); latest >= 0)
+    {
+        // Missing header (pruned / mid-commit) falls back to the static gas-price knob.
+        auto block = co_await ledger::getBlockData(*ledger, latest, bcos::ledger::HEADER);
+        if (block)
+        {
+            if (auto const& header = block->blockHeader(); header && header->baseFee())
+            {
+                Json::Value result = toQuantity(*header->baseFee());
+                buildJsonContent(result, response);
+                co_return;
+            }
+        }
+    }
+    // Legacy PBFT path (headers without baseFee): keep serving the static
+    // SYSTEM_KEY_TX_GAS_PRICE knob so those chains' output stays byte-identical.
     auto config = co_await ledger::getSystemConfig(*ledger, ledger::SYSTEM_KEY_TX_GAS_PRICE);
     Json::Value result;
     if (config.has_value())
@@ -143,6 +169,207 @@ task::Task<void> EthEndpoint::gasPrice(const Json::Value&, Json::Value& response
         result = "0x0";
     }
     buildJsonContent(result, response);
+    co_return;
+}
+
+namespace
+{
+// feeHistory trailing entry: extraData >= 17 => Jovian. Formula is calcOpBaseFee.
+
+bool jovianFromExtraData(bcos::protocol::BlockHeader const& parent)
+{
+    return parent.extraData().size() >= 17;
+}
+}  // namespace
+
+task::Task<void> EthEndpoint::feeHistory(const Json::Value& request, Json::Value& response)
+{
+    // params: [blockCount(QTY), newestBlock(QTY|TAG), rewardPercentiles?(array of numbers)]
+    // result: {oldestBlock(QTY), baseFeePerGas(QTY[], resolved+1 entries with the trailing
+    //          predicted next base fee), gasUsedRatio(number[]), reward?(QTY[][])}
+    // (execution-apis fee_history). Foundry/alloy's EIP-1559 fee suggestion calls this on
+    // every send, so its absence breaks every default-fee cast send against the node.
+    uint64_t blockCount = 0;
+    try
+    {
+        blockCount = fromQuantity(std::string(toView(request[0U])));
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid blockCount"));
+    }
+    if (blockCount < 1 || blockCount > 1024)
+    {
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "blockCount must be between 1 and 1024"));
+    }
+    std::vector<double> percentiles;
+    if (request.size() > 2 && !request[2U].isNull())
+    {
+        if (!request[2U].isArray())
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "rewardPercentiles must be an array"));
+        }
+        // Bound the array: each entry materializes one JSON value per block (up to 1024),
+        // so an unbounded list is a response-size/CPU amplification vector.
+        if (request[2U].size() > 100)
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "rewardPercentiles must have at most 100 entries"));
+        }
+        for (auto const& p : request[2U])
+        {
+            if (!p.isNumeric())
+            {
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException(InvalidParams, "rewardPercentiles entries must be numbers"));
+            }
+            auto const percentile = p.asDouble();
+            // op-geth rejects out-of-range percentiles; a negative value would otherwise
+            // wrap through the later size_t cast (UB).
+            if (percentile < 0.0 || percentile > 100.0) [[unlikely]]
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(
+                    InvalidParams, "rewardPercentiles entries must be in [0, 100]"));
+            }
+            if (!percentiles.empty() && percentile <= percentiles.back()) [[unlikely]]
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(
+                    InvalidParams, "rewardPercentiles entries must be strictly increasing"));
+            }
+            percentiles.push_back(percentile);
+        }
+    }
+    auto const [newestNumber, _] = co_await getBlockNumberByTag(toView(request[1U]));
+    if (newestNumber < 0)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "newestBlock not found"));
+    }
+    auto const newest = static_cast<uint64_t>(newestNumber);
+    auto const wantReward = !percentiles.empty();
+    // Reward queries load every block's receipts; clamp to 128 so arrays stay aligned.
+    auto const resolvedBlockCount = wantReward ? (std::min)(blockCount, uint64_t(128)) : blockCount;
+    auto const oldest = newest >= resolvedBlockCount - 1 ? newest - (resolvedBlockCount - 1) : 0;
+
+    auto const ledger = m_nodeService->ledger();
+    Json::Value result;
+    result["oldestBlock"] = toQuantity(oldest);
+    result["baseFeePerGas"] = Json::arrayValue;
+    result["gasUsedRatio"] = Json::arrayValue;
+    if (wantReward)
+    {
+        result["reward"] = Json::arrayValue;
+    }
+    protocol::BlockHeader::Ptr newestHeader;
+    for (auto n = oldest; n <= newest; ++n)
+    {
+        auto block = co_await ledger::getBlockData(
+            *ledger, static_cast<protocol::BlockNumber>(n), bcos::ledger::HEADER);
+        if (!block || !block->blockHeader())
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(InternalError,
+                "feeHistory: block header unavailable at height " + std::to_string(n)));
+        }
+        auto const& header = block->blockHeader();
+        auto const baseFee = header->baseFee().value_or(bcos::u256(0));
+        auto const gasLimit = static_cast<uint64_t>(header->gasLimit());
+        auto const gasUsed = static_cast<uint64_t>(header->gasUsed());
+        result["baseFeePerGas"].append(toQuantity(baseFee));
+        result["gasUsedRatio"].append(
+            gasLimit > 0 ? Json::Value(double(gasUsed) / double(gasLimit)) : Json::Value(0.0));
+        if (wantReward)
+        {
+            // Per-tx priority fee = effectiveGasPrice - baseFee (0 for legacy txs paying
+            // exactly baseFee); the percentile entry selects from the sorted list the way
+            // geth's feeHistory does (floor index, clamped).
+            auto receiptsBlock = co_await ledger::getBlockData(
+                *ledger, static_cast<protocol::BlockNumber>(n), bcos::ledger::RECEIPTS);
+            if (!receiptsBlock)
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(InternalError,
+                    "feeHistory: receipts unavailable at height " + std::to_string(n)));
+            }
+            std::vector<std::pair<bcos::u256, bcos::u256>> priorities;
+            priorities.reserve(receiptsBlock->receipts().size());
+            bcos::u256 totalGasUsed{0};
+            for (auto const& receipt : receiptsBlock->receipts())
+            {
+                auto const& effective = receipt->effectiveGasPrice();
+                if (effective.empty())
+                {
+                    continue;
+                }
+                bcos::u256 effectiveFee{};
+                try
+                {
+                    effectiveFee = bcos::u256(std::string(effective));
+                }
+                catch (std::exception const& e)
+                {
+                    // A corrupt receipt must skip one feeHistory row + warn, never -32603
+                    // the whole response. Throttled to the first occurrence per process,
+                    // matching ReceiptResponse.cpp (finding BR: this sits on the polled
+                    // feeHistory path — up to 128 blocks x rows per request — so an
+                    // unthrottled warning re-fires on every poll of a corrupt row).
+                    static std::atomic<bool> warnedOnce{false};
+                    if (!warnedOnce.exchange(true))
+                    {
+                        WEB3_LOG(WARNING) << LOG_DESC("feeHistory: unparseable effectiveGasPrice")
+                                          << LOG_KV("value", effective) << LOG_KV("msg", e.what());
+                    }
+                    continue;
+                }
+                auto const priority =
+                    effectiveFee > baseFee ? effectiveFee - baseFee : bcos::u256(0);
+                auto const gasUsed = receipt->gasUsed();
+                priorities.emplace_back(priority, gasUsed);
+                totalGasUsed += gasUsed;
+            }
+            std::sort(priorities.begin(), priorities.end(),
+                [](auto const& lhs, auto const& rhs) { return lhs.first < rhs.first; });
+            Json::Value rewards(Json::arrayValue);
+            for (auto const p : percentiles)
+            {
+                if (priorities.empty() || totalGasUsed == 0)
+                {
+                    // geth emits null for a percentile of an empty reward set — an all-zero
+                    // entry would be misread as a real floor by fee-suggestion tooling.
+                    rewards.append(Json::Value(Json::nullValue));
+                    continue;
+                }
+                auto const threshold =
+                    totalGasUsed * bcos::u256(static_cast<uint64_t>(p)) / bcos::u256(100);
+                bcos::u256 cumulative{0};
+                auto selected = priorities.front().first;
+                for (auto const& [priority, gasUsed] : priorities)
+                {
+                    cumulative += gasUsed;
+                    selected = priority;
+                    if (cumulative >= threshold)
+                    {
+                        break;
+                    }
+                }
+                rewards.append(Json::Value(toQuantity(selected)));
+            }
+            result["reward"].append(std::move(rewards));
+        }
+        newestHeader = header;
+    }
+    // Trailing entry: the predicted base fee of newest+1 from newest's own header. Only OP
+    // headers carry baseFee; on PBFT chains every entry is 0x0, so the prediction must stay
+    // 0x0 there too (calcOpBaseFee would otherwise return 1 for a zero parent base fee).
+    if (newestHeader)
+    {
+        auto const predicted =
+            newestHeader->baseFee().has_value() ?
+                bcos::engine::calcOpBaseFee(*newestHeader, jovianFromExtraData(*newestHeader)) :
+                bcos::u256(0);
+        result["baseFeePerGas"].append(toQuantity(predicted));
+    }
+    buildJsonContent(result, response);
+    co_return;
 }
 task::Task<void> EthEndpoint::accounts(const Json::Value&, Json::Value& response)
 {
@@ -898,8 +1125,8 @@ task::Task<void> EthEndpoint::call(const Json::Value& request, Json::Value& resp
 {
     co_await call(request, response, nullptr, false);
 }
-task::Task<void> EthEndpoint::call(
-    const Json::Value& request, Json::Value& response, u256* gasUsed, bool isEstimate)
+task::Task<void> EthEndpoint::call(const Json::Value& request, Json::Value& response, u256* gasUsed,
+    bool isEstimate, std::optional<u256> preResolvedBaseFee)
 {
     // params: transaction(TX), blockNumber(QTY|TAG)
     // result: data(DATA)
@@ -921,8 +1148,32 @@ task::Task<void> EthEndpoint::call(
         WEB3_LOG(TRACE) << LOG_DESC("eth_call") << LOG_KV("call", call)
                         << LOG_KV("blockTag", blockTag) << LOG_KV("blockNumber", blockNumber);
     }
-    auto tx = call.takeToTransaction(
-        m_nodeService->blockFactory()->transactionFactory(), isEstimate ? scheduler : nullptr);
+    std::optional<u256> blockBaseFee = preResolvedBaseFee;
+    if (!blockBaseFee.has_value())
+    {
+        if (auto const ledger = m_nodeService->ledger())
+        {
+            if (auto block =
+                    co_await ledger::getBlockData(*ledger, blockNumber, bcos::ledger::HEADER))
+            {
+                if (auto const& header = block->blockHeader(); header && header->baseFee())
+                {
+                    blockBaseFee = *header->baseFee();
+                }
+            }
+        }
+    }
+    auto tx = [&]() {
+        try
+        {
+            return call.takeToTransaction(m_nodeService->blockFactory()->transactionFactory(),
+                isEstimate ? scheduler : nullptr, blockBaseFee);
+        }
+        catch (std::invalid_argument const& e)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, e.what()));
+        }
+    }();
     struct Awaitable
     {
         bcos::scheduler::SchedulerInterface& m_scheduler;
@@ -953,9 +1204,11 @@ task::Task<void> EthEndpoint::call(
                     else
                     {
                         // https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_call#returns
+                        // Reverted call -> op-geth style error: code 3 "execution reverted"
+                        // with the Error(string) reason decoded into the message.
                         Json::Value jsonResult = Json::objectValue;
-                        jsonResult["code"] = result->status();
-                        jsonResult["message"] = result->message();
+                        jsonResult["code"] = c_executionReverted;
+                        jsonResult["message"] = decodeRevertMessage(output);
                         jsonResult["data"] = output;
                         m_response["jsonrpc"] = "2.0";
                         m_response["error"] = std::move(jsonResult);
@@ -1006,19 +1259,146 @@ task::Task<void> EthEndpoint::estimateGas(const Json::Value& request, Json::Valu
                         << LOG_KV("blockTag", blockTag) << LOG_KV("blockNumber", blockNumber);
     }
 
+    // op-geth's estimator answers the smallest viable limit found by simulation. Run #1
+    // executes at min(object-form request gas, kRpcGasCap) (op-geth: "Caller gas above
+    // allowance, capping"), or at CallRequest's absent-gas default of 30M otherwise.
+    // A tx hopping through a proxy DELEGATECALL or internal CALL keeps 1/64 of available
+    // gas per hop (EIP-150), so the minimum viable limit can strictly exceed consumption —
+    // re-simulate at gasUsed first, then binary-search upward, mirroring op-geth. Only
+    // object-form params carry an overridable gas field; a raw signed tx embeds its own.
+    auto const objectForm = tx.isObject();
+    // Explicit request gas never raises the ceiling — it is clamped to kRpcGasCap BEFORE
+    // the first simulation, bounding both the run count and each run's workload for an
+    // unauthenticated request. A raw signed tx embeds its own gas and cannot be rewritten;
+    // its bound is the execution layer's (#5495).
+    constexpr uint64_t kRpcGasCap = 30'000'000;
+    // firstRunLimit is what run #1 actually executes at, hence the proven-viable upper
+    // anchor of the search: seeding the ceiling from anything the first run did not
+    // execute at once inverted the search bounds and wrapped the u256 width test.
+    std::optional<u256> explicitGas;
+    if (objectForm && tx.isMember("gas"))
+    {
+        if (!tx["gas"].isString()) [[unlikely]]
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "transaction gas must be a hex quantity"));
+        }
+        auto const parsed = safeFromQuantity(tx["gas"].asString());
+        if (!parsed) [[unlikely]]
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "invalid transaction gas quantity"));
+        }
+        explicitGas = *parsed;
+    }
+    auto const firstRunLimit =
+        u256{std::min(explicitGas.value_or(u256{kRpcGasCap}), u256{kRpcGasCap})};
+
+    // Resolve the head base fee ONCE: every call() below would otherwise re-read the header
+    // (one storage read per EVM execution — up to 18 reads for a single request).
+    std::optional<u256> blockBaseFee;
+    if (auto const ledger = m_nodeService->ledger())
+    {
+        if (auto block = co_await ledger::getBlockData(*ledger, blockNumber, bcos::ledger::HEADER))
+        {
+            if (auto const& header = block->blockHeader(); header && header->baseFee())
+            {
+                blockBaseFee = *header->baseFee();
+            }
+        }
+    }
+
+    // ONE deep copy of the request for the whole estimation (the data field can be MBs) —
+    // object-form ONLY: the gas field is the only thing ever rewritten, clamped to
+    // kRpcGasCap BEFORE run #1 when the caller self-declared more,
+    // then set per candidate during the search. A raw signed tx embeds its own gas, is never
+    // rewritten, and is simulated in place without the copy.
+    Json::Value bounded;
     u256 gasUsed;
     Json::Value callResponse;
-    co_await call(request, callResponse, std::addressof(gasUsed), true);
-
-    if (!callResponse.isMember("error"))
+    if (objectForm)
     {
-        Json::Value result = toQuantity(gasUsed);
-        buildJsonContent(result, response);
+        bounded = request;
+        if (explicitGas && *explicitGas > firstRunLimit)
+        {
+            bounded[0U]["gas"] = toQuantity(firstRunLimit);
+        }
+        co_await call(bounded, callResponse, std::addressof(gasUsed), true, blockBaseFee);
     }
     else
     {
-        response = std::move(callResponse);
+        co_await call(request, callResponse, std::addressof(gasUsed), true, blockBaseFee);
     }
+
+    if (callResponse.isMember("error"))
+    {
+        response = std::move(callResponse);
+        co_return;
+    }
+
+    auto estimate = gasUsed;
+    // Doubling and binary search share one hard budget with the gasUsed re-simulation —
+    // an uncapped doubling loop before a separately capped binary search lets a single
+    // unauthenticated request drive ~64 + 16 EVM simulations when the caller supplies a
+    // huge gas ceiling.
+    constexpr size_t kMaxEstimateSimulations = 16;
+    size_t remaining = kMaxEstimateSimulations;
+    if (objectForm && remaining > 0)
+    {
+        --remaining;
+        if (!co_await simulateAtGasLimit(bounded, estimate, blockBaseFee))
+        {
+            // op-geth starts the upward search at gasUsed*2: typical estimates converge to
+            // the exact limit within the shared simulation budget instead of stopping at
+            // the cap with a residual.
+            auto searchBounds = bcos::rpc::estimateSearchBounds(gasUsed, firstRunLimit);
+            auto& lowerBound = searchBounds.lowerBound;
+            auto& upperBound = searchBounds.upperBound;
+            auto candidate = std::max(gasUsed * 2, lowerBound + 1);
+            while (candidate < upperBound && remaining > 0)
+            {
+                --remaining;
+                if (co_await simulateAtGasLimit(bounded, candidate, blockBaseFee))
+                {
+                    upperBound = candidate;
+                    break;
+                }
+                // Failed probe is known-bad: advance lowerBound so the binary search does
+                // not re-probe proven-failed gas within the shared budget.
+                lowerBound = candidate;
+                candidate = std::min(candidate * 2, upperBound);
+            }
+            // else: upperBound stays put — when it equals firstRunLimit the cap-clamped
+            // run #1 already proved THAT limit viable. (The pre-P comment claimed
+            // viability for a ceiling the first run never executed at.)
+            while (upperBound - lowerBound > 1 && remaining > 0)
+            {
+                --remaining;
+                auto const mid = lowerBound + (upperBound - lowerBound) / 2;
+                if (co_await simulateAtGasLimit(bounded, mid, blockBaseFee))
+                {
+                    upperBound = mid;
+                }
+                else
+                {
+                    lowerBound = mid;
+                }
+            }
+            estimate = upperBound;
+        }
+    }
+
+    Json::Value result = toQuantity(estimate);
+    buildJsonContent(result, response);
+}
+
+task::Task<bool> EthEndpoint::simulateAtGasLimit(
+    Json::Value& bounded, u256 limit, std::optional<u256> blockBaseFee)
+{
+    bounded[0U]["gas"] = toQuantity(limit);
+    Json::Value callResponse;
+    co_await call(bounded, callResponse, nullptr, true, blockBaseFee);
+    co_return !callResponse.isMember("error");
 }
 task::Task<void> EthEndpoint::getBlockByHash(const Json::Value& request, Json::Value& response)
 {
@@ -1035,7 +1415,13 @@ task::Task<void> EthEndpoint::getBlockByHash(const Json::Value& request, Json::V
         auto flag = bcos::ledger::HEADER | bcos::ledger::RECEIPTS;
         flag |= fullTransaction ? bcos::ledger::TRANSACTIONS : bcos::ledger::TRANSACTIONS_HASH;
         auto block = co_await ledger::getBlockData(*ledger, number, flag);
-        combineBlockResponse(result, *block, fullTransaction);
+        // One hash for the block and every full-tx entry. Prefer the registered OP hash.
+        auto blockHash = co_await ledger::getBlockHash(*ledger, number);
+        if (blockHash == crypto::HashType{})
+        {
+            blockHash = bcos::rpc::opAwareBlockHash(*block->blockHeader());
+        }
+        combineBlockResponse(result, *block, fullTransaction, blockHash);
     }
     catch (std::exception const& e)
     {
@@ -1059,7 +1445,13 @@ task::Task<void> EthEndpoint::getBlockByNumber(const Json::Value& request, Json:
         auto flag = bcos::ledger::HEADER | bcos::ledger::RECEIPTS;
         flag |= fullTransaction ? bcos::ledger::TRANSACTIONS : bcos::ledger::TRANSACTIONS_HASH;
         auto block = co_await ledger::getBlockData(*ledger, blockNumber, flag);
-        combineBlockResponse(result, *block, fullTransaction);
+        // One hash for the block and every full-tx entry. Prefer the registered OP hash.
+        auto blockHash = co_await ledger::getBlockHash(*ledger, blockNumber);
+        if (blockHash == crypto::HashType{})
+        {
+            blockHash = bcos::rpc::opAwareBlockHash(*block->blockHeader());
+        }
+        combineBlockResponse(result, *block, fullTransaction, blockHash);
     }
     catch (std::exception const& e)
     {
@@ -1091,6 +1483,14 @@ task::Task<void> EthEndpoint::getTransactionByHash(
             co_return;
         }
         auto blockHash = co_await ledger::getBlockHash(*ledger, receipt->blockNumber());
+        if (blockHash == crypto::HashType{})
+        {
+            if (auto block = co_await ledger::getBlockData(
+                    *ledger, receipt->blockNumber(), bcos::ledger::HEADER))
+            {
+                blockHash = bcos::rpc::opAwareBlockHash(*block->blockHeader());
+            }
+        }
         combineTxResponse(result, *txs->at(0), *receipt, blockHash);
     }
     catch (std::exception const& e)
@@ -1161,7 +1561,12 @@ task::Task<void> EthEndpoint::getTransactionByBlockNumberAndIndex(
             BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid transaction index!"));
         }
         auto receipt = co_await ledger::getReceipt(*ledger, txHash);
-        auto blockHash = block->blockHeader()->hash();
+        // Same hash resolution as getBlockByHash / getBlockByNumber.
+        auto blockHash = co_await ledger::getBlockHash(*ledger, blockNumber);
+        if (blockHash == crypto::HashType{})
+        {
+            blockHash = bcos::rpc::opAwareBlockHash(*block->blockHeader());
+        }
         combineTxResponse(result, *(*tx)[0], *receipt, blockHash);
     }
     catch (std::exception const& e)
@@ -1194,6 +1599,14 @@ task::Task<void> EthEndpoint::getTransactionReceipt(
                 JsonRpcException(InvalidParams, "Invalid transaction hash: " + hash.hexPrefixed()));
         }
         auto blockHash = co_await ledger::getBlockHash(*ledger, receipt->blockNumber());
+        if (blockHash == crypto::HashType{})
+        {
+            if (auto block = co_await ledger::getBlockData(
+                    *ledger, receipt->blockNumber(), bcos::ledger::HEADER))
+            {
+                blockHash = bcos::rpc::opAwareBlockHash(*block->blockHeader());
+            }
+        }
         combineReceiptResponse(result, *receipt, *txs->at(0), blockHash);
     }
     catch (std::exception const& e)
@@ -1284,6 +1697,26 @@ task::Task<std::tuple<protocol::BlockNumber, bool>> EthEndpoint::getBlockNumberB
 {
     auto ledger = m_nodeService->ledger();
     auto latest = co_await ledger::getCurrentBlockNumber(*ledger);
+    // D2: safe/finalized route to the engine's FCU-tracked numbers (op-node
+    // L2BlockRefByLabel contract). With an engine service present but nothing tracked yet,
+    // op-geth semantics are "not found": getBlockByNumber's catch turns the throw into a
+    // JSON null result, while tag-taking state endpoints surface it as a JSON-RPC error.
+    // Nodes without an engine service (PBFT) keep the historical latest aliasing.
+    if (blockTag == SafeBlock || blockTag == FinalizedBlock)
+    {
+        auto& engineService = m_nodeService->engineService();
+        if (engineService)
+        {
+            auto tracked = (blockTag == SafeBlock) ? engineService->getSafeBlockNumber() :
+                                                     engineService->getFinalizedBlockNumber();
+            if (tracked.has_value())
+            {
+                co_return std::make_tuple(*tracked, *tracked == latest);
+            }
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                Web3DefaultError, std::string(blockTag) + " block head is not tracked yet"));
+        }
+    }
     auto [number, _] = bcos::rpc::getBlockNumberByTag(
         latest, blockTag, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     co_return std::make_tuple(number, std::cmp_equal(latest, number));
@@ -1319,6 +1752,13 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "storageKeys must be an array"));
     }
+    // Bound the array: each key triggers an O(depth) MPT walk — an unbounded list is a
+    // storage-I/O amplification vector (geth-style ~1000 cap).
+    if (keysJson.size() > 1024)
+    {
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "storageKeys must have at most 1024 entries"));
+    }
     std::vector<h256> slots;
     slots.reserve(keysJson.size());
     for (auto const& key : keysJson)
@@ -1333,7 +1773,7 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
         }
     }
     auto const blockTag = toView(request[2U]);
-    auto [blockNumber, _] = co_await getBlockNumberByTag(blockTag);
+    auto [blockNumber, isLatest] = co_await getBlockNumberByTag(blockTag);
     if (c_fileLogLevel == TRACE)
     {
         WEB3_LOG(TRACE) << "eth_getProof" << LOG_KV("address", address.hexPrefixed())
@@ -1348,37 +1788,68 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Block not found"));
     }
-    auto const stateRoot = block->blockHeader()->stateRoot();
+    auto stateRoot = block->blockHeader()->stateRoot();
 
-    // The MPT node reader is wired by the AIR initializer (AirNodeInitializer); unset means
-    // this node has no local path to MPT node rows (e.g. a tars-built NodeService) — a
-    // deployment matter, hence -32603 rather than -32004.
-    auto const mptReader = m_nodeService->mptNodeReader();
-    if (!mptReader) [[unlikely]]
+    ledger::mpt::EIP1186Proof proof;
+    if (block->blockHeader()->baseFee().has_value())
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
+        // OP headers have baseFee. Serve MPT proofs only; no rows => -32004, never a fake proof.
+        if (auto const mptReader = m_nodeService->mptNodeReader())
+        {
+            auto const fullTrie = co_await ledger::getFeature(
+                *ledger, ledger::Features::Flag::feature_l2_ethereum_compat, blockNumber);
+            auto result = co_await ledger::mpt::generateProof(
+                *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
+            if (auto* built = std::get_if<ledger::mpt::EIP1186Proof>(&result))
+            {
+                proof = std::move(*built);
+            }
+            else
+            {
+                // Root has no node rows.
+                BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable,
+                    "Proof unavailable for this block (flat rebuild lands with the "
+                    "eth_getProof PR)"));
+            }
+        }
+        else [[unlikely]]
+        {
+            // No MPT reader: fail closed.
+            BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
+        }
     }
-
-    // The exclusion-vs-cold-slot distinction is mode-driven (spec §5.9): only under
-    // feature_l2_ethereum_compat (scenario B) are the storage tries complete, making an
-    // exclusion walk a provable zero. Otherwise (scenario A) the trie omits slots never
-    // written after MPT activation, and generateProof marks such slots inMPT=false instead
-    // of emitting a lying value-0 exclusion proof. Single-flag read (one SYS_CONFIG row,
-    // same helper as resolveHistoricalMptContext); degrades to false (honest scenario-A
-    // behavior) on fetch failure.
-    auto const fullTrie = co_await ledger::getFeature(
-        *ledger, ledger::Features::Flag::feature_l2_ethereum_compat, blockNumber);
-
-    auto result = co_await ledger::mpt::generateProof(
-        *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
-    if (auto const* errorCode = std::get_if<ledger::mpt::ProofErrorCode>(&result))
+    else
     {
-        auto const* message = (*errorCode == ledger::mpt::ProofErrorCode::AccountNotInMPT) ?
-                                  "Account not in trie (dormant in scenario A)" :
-                                  "Block stateRoot not in MPT node storage";
-        BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable, message));
+        // The MPT node reader is wired by the AIR initializer (AirNodeInitializer); unset means
+        // this node has no local path to MPT node rows (e.g. a tars-built NodeService) — a
+        // deployment matter, hence -32603 rather than -32004.
+        auto const mptReader = m_nodeService->mptNodeReader();
+        if (!mptReader) [[unlikely]]
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
+        }
+
+        // The exclusion-vs-cold-slot distinction is mode-driven (spec §5.9): only under
+        // feature_l2_ethereum_compat (scenario B) are the storage tries complete, making an
+        // exclusion walk a provable zero. Otherwise (scenario A) the trie omits slots never
+        // written after MPT activation, and generateProof marks such slots inMPT=false instead
+        // of emitting a lying value-0 exclusion proof. Single-flag read (one SYS_CONFIG row,
+        // same helper as resolveHistoricalMptContext); degrades to false (honest scenario-A
+        // behavior) on fetch failure.
+        auto const fullTrie = co_await ledger::getFeature(
+            *ledger, ledger::Features::Flag::feature_l2_ethereum_compat, blockNumber);
+
+        auto result = co_await ledger::mpt::generateProof(
+            *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
+        if (auto const* errorCode = std::get_if<ledger::mpt::ProofErrorCode>(&result))
+        {
+            auto const* message = (*errorCode == ledger::mpt::ProofErrorCode::AccountNotInMPT) ?
+                                      "Account not in trie (dormant in scenario A)" :
+                                      "Block stateRoot not in MPT node storage";
+            BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable, message));
+        }
+        proof = std::move(std::get<ledger::mpt::EIP1186Proof>(result));
     }
-    auto& proof = std::get<ledger::mpt::EIP1186Proof>(result);
 
     Json::Value output = Json::objectValue;
     output["address"] = address.hexPrefixed();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
@@ -44,6 +44,7 @@ public:
     task::Task<void> mining(const Json::Value&, Json::Value&);
     task::Task<void> hashrate(const Json::Value&, Json::Value&);
     task::Task<void> gasPrice(const Json::Value&, Json::Value&);
+    task::Task<void> feeHistory(const Json::Value&, Json::Value&);
     task::Task<void> accounts(const Json::Value&, Json::Value&);
     task::Task<void> blockNumber(const Json::Value&, Json::Value&);
     task::Task<void> getBalance(const Json::Value&, Json::Value&);
@@ -85,7 +86,17 @@ private:
     FilterSystem::Ptr m_filterSystem;
     bool m_syncTransaction;
 
-    task::Task<void> call(const Json::Value&, Json::Value&, u256* gasUsed, bool isEstimate);
+
+    task::Task<void> call(const Json::Value&, Json::Value&, u256* gasUsed, bool isEstimate,
+        std::optional<u256> preResolvedBaseFee = std::nullopt);
+
+    // Runs an eth_call with the gas field rewritten in @p bounded (the caller's single
+    // request copy — mutated in place, no per-iteration deep copy) and the gas field pinned
+    // to @p limit; true when the simulation succeeds (estimateGas' minimum-viable-limit
+    // search). @p blockBaseFee is passed through to call() so the header is not re-read
+    // per iteration.
+    task::Task<bool> simulateAtGasLimit(
+        Json::Value& bounded, u256 limit, std::optional<u256> blockBaseFee);
 };
 
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
@@ -84,7 +84,11 @@ enum class EthMethod
     eth_getFilterLogs,
     eth_getLogs,
     eth_maxPriorityFeePerGas,
-    eth_getProof
+    eth_getProof,
+    // Finding BL: appended, NOT inserted mid-list. The in-tree dispatch keys handlers by
+    // magic_enum name strings, but installed-header consumers keying this enum numerically
+    // would have seen ~34 later entries silently remap if feeHistory took a mid-list slot.
+    eth_feeHistory,
 };
 
 [[maybe_unused]] static std::string methodString(EthMethod _method)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/NetEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/NetEndpoint.cpp
@@ -33,7 +33,7 @@ task::Task<void> NetEndpoint::version(const Json::Value&, Json::Value& response)
 {
     auto const ledger = m_nodeService->ledger();
     auto config = co_await ledger::getSystemConfig(*ledger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID);
-    Json::Value result;
+    Json::Value result = "0x4ee8";  // 20200 — default when unconfigured / unparseable
     if (config.has_value())
     {
         auto [chainId, _] = config.value();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -1,15 +1,28 @@
 #include "BlockResponse.h"
 #include "Log.h"
 
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-utilities/Bloom.h>
 
 #include <range/v3/view/enumerate.hpp>
 
-void bcos::rpc::combineBlockResponse(
-    Json::Value& result, const bcos::protocol::Block& block, bool fullTxs)
+bcos::crypto::HashType bcos::rpc::opAwareBlockHash(const bcos::protocol::BlockHeader& header)
+{
+    if (!header.withdrawalsRoot().has_value())
+    {
+        return header.hash();
+    }
+    return bcos::protocol::EthBlockHeader::computeHash(header);
+}
+
+void bcos::rpc::combineBlockResponse(Json::Value& result, const bcos::protocol::Block& block,
+    bool fullTxs, std::optional<bcos::crypto::HashType> canonicalHash)
 {
     auto blockHeader = block.blockHeader();
-    auto blockHash = blockHeader->hash();
+    // Lazy fallback: value_or's argument is evaluated eagerly, and both
+    // production callers always pass a canonical hash — the eager form made every OP header
+    // pay conversion+RLP+keccak once discarded per getBlockBy* response.
+    auto blockHash = canonicalHash ? *canonicalHash : opAwareBlockHash(*blockHeader);
     auto blockNumber = blockHeader->number();
     result["number"] = toQuantity(blockNumber);
     result["hash"] = blockHash.hexPrefixed();
@@ -50,12 +63,27 @@ void bcos::rpc::combineBlockResponse(
         result["miner"] = "0x0000000000000000000000000000000000000000";
         result["parentHash"] = "0x0000000000000000000000000000000000000000000000000000000000000000";
     }
+    // Engine-built blocks (OP sequencer path) have an empty sealerList — the miner/coinbase
+    // is the execution payload's feeRecipient, which is stored in the header's coinbase()
+    // field (set by rebuildOpEthHeader from the payload attributes). Clients like alloy/cast
+    // require this field for deserialization; without it eth_getBlockByNumber fails.
+    if (!result.isMember("miner"))
+    {
+        auto coinbase = blockHeader->coinbase();
+        auto coinbaseString = coinbase.hex();
+        auto coinbaseHash = crypto::keccak256Hash(bytesConstRef(coinbaseString)).hex();
+        toChecksumAddress(coinbaseString, coinbaseHash);
+        result["miner"] = "0x" + coinbaseString;
+    }
     result["difficulty"] = "0x0";
     result["totalDifficulty"] = "0x0";
     result["extraData"] = toHexStringWithPrefix(blockHeader->extraData());
     result["size"] = toQuantity(block.size());
-    // TODO: change it wen block gas limit apply
-    result["gasLimit"] = toQuantity(30000000ULL);
+    // gasLimit: engine-built/genesis blocks carry the real limit in the header (OP newPayload
+    // via rebuildOpEthHeader, genesis via applyEthGenesisHeader); PBFT blocks never write it
+    // (tars field empty -> u256(0)) and keep the legacy 30M so their output is byte-identical.
+    auto gasLimit = blockHeader->gasLimit();
+    result["gasLimit"] = (gasLimit == 0) ? toQuantity(30000000ULL) : toQuantity(gasLimit);
     result["gasUsed"] = toQuantity((uint64_t)blockHeader->gasUsed());
     result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);  // to seconds
     if (fullTxs)
@@ -79,12 +107,64 @@ void bcos::rpc::combineBlockResponse(
         result["transactions"] = std::move(txHashesList);
     }
     result["uncles"] = Json::Value(Json::arrayValue);
-    result["mixHash"] = crypto::HashType().hexPrefixed();
-    result["baseFeePerGas"] = "0x0";
+    // mixHash is the header's prevRandao slot. OP headers store the payload attributes'
+    // prevRandao there (op-node sets keccak256(L1 block hash)) and the blockHash covers it,
+    // so serving a fabricated zero breaks hash-recomputing clients (go-ethereum's ethclient,
+    // op-batcher, ...) — they derive a different hash and reject the chain ("block does not
+    // extend existing chain"). PBFT headers never write the tars field (empty -> zero h256),
+    // keeping their output byte-identical.
+    result["mixHash"] = blockHeader->prevRandao().hexPrefixed();
+    // baseFeePerGas: OP headers (engine-built / newPayload-rebuilt) carry the real EIP-1559
+    // value; PBFT headers never write the tars field (nullopt, or 0) and keep the legacy 0x0
+    // so their output stays byte-identical — same pattern as gasLimit above.
+    if (auto baseFee = blockHeader->baseFee(); baseFee.has_value() && *baseFee != 0)
+    {
+        result["baseFeePerGas"] = toQuantity(*baseFee);
+    }
+    else
+    {
+        result["baseFeePerGas"] = "0x0";
+    }
     result["withdrawals"] = Json::Value(Json::arrayValue);
-    // empty withdrawals trie root hash
-    result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
-    result["blobGasUsed"] = "0x0";
+    // Isthmus+: the header carries the MessagePasser storage root as withdrawalsRoot (the OP
+    // semantic — set by the executed seal and rebuilt by the engine); pre-Isthmus/PBFT headers
+    // have no value (nullopt) and keep the legacy zero.
+    if (auto withdrawalsRoot = blockHeader->withdrawalsRoot(); withdrawalsRoot.has_value())
+    {
+        result["withdrawalsRoot"] = withdrawalsRoot->hexPrefixed();
+    }
+    else
+    {
+        result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
+    }
+    // blobGasUsed: pre-Jovian OP headers store 0 (identical output); Jovian reuses the header
+    // slot for the DA footprint, which the RPC must surface. PBFT headers never write the
+    // tars field (nullopt) and keep the legacy 0x0. excessBlobGas stays the constant 0: OP
+    // Stack chains serve no blobs and no header field carries it.
+    if (auto blobGasUsed = blockHeader->blobGasUsed(); blobGasUsed.has_value())
+    {
+        result["blobGasUsed"] = toQuantity(*blobGasUsed);
+    }
+    else
+    {
+        result["blobGasUsed"] = "0x0";
+    }
     result["excessBlobGas"] = "0x0";
-    result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
+    // EIP-4788: pre-Cancun/PBFT headers have no PBBR (accessor returns nullopt when the
+    // tars field is < 32 bytes) -> zero, symmetric with withdrawalsRoot above.
+    if (auto parentBeaconRoot = blockHeader->parentBeaconBlockRoot(); parentBeaconRoot.has_value())
+    {
+        result["parentBeaconBlockRoot"] = parentBeaconRoot->hexPrefixed();
+    }
+    else
+    {
+        result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
+    }
+    // EIP-7685 requestsHash: Isthmus+ OP headers carry sha256('') (set by the seal and rebuilt
+    // by the engine); PBFT/pre-Isthmus headers have no value (nullopt) and keep the field
+    // absent -- symmetric with op-geth (internal/ethapi/api.go:1092-1094, omitempty).
+    if (auto requestsHash = blockHeader->requestsHash(); requestsHash.has_value())
+    {
+        result["requestsHash"] = requestsHash->hexPrefixed();
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.h
@@ -28,6 +28,18 @@
 
 namespace bcos::rpc
 {
-void combineBlockResponse(
-    Json::Value& result, const bcos::protocol::Block& block, bool fullTxs = false);
+/// Combine a block into the JSON response. @p canonicalHash, when given, is the SINGLE
+/// authoritative block hash used for result["hash"] AND every full-tx entry's blockHash —
+/// the endpoints resolve it once (ledger::getBlockHash, falling back to opAwareBlockHash)
+/// so one response never mixes two derivations of the same block's hash. When nullopt the
+/// OP-aware derivation is used (legacy callers / tests).
+void combineBlockResponse(Json::Value& result, const bcos::protocol::Block& block,
+    bool fullTxs = false, std::optional<bcos::crypto::HashType> canonicalHash = std::nullopt);
+
+/// OP-aware block hash. OP headers (Isthmus+ always carry `withdrawalsRoot`; FISCO non-OP
+/// headers never do) hash as keccak(encodeOpHeader) with the post-merge protocol constants — the
+/// hash the OP block tables (`s_number_2_hash`) and op-node agree on — instead of the tars
+/// `dataHash` fallback (which the read path re-derives as a FISCO tars hash). Shared by
+/// `combineBlockResponse` and the endpoints' canonical-hash resolution so all read paths agree.
+bcos::crypto::HashType opAwareBlockHash(const bcos::protocol::BlockHeader& header);
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
@@ -19,16 +19,36 @@
  */
 
 #include "CallRequest.h"
+#include "bcos-crypto/ChecksumAddress.h"
 #include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-task/Wait.h"
+#include <bcos-rlp-protocol/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <boost/throw_exception.hpp>
 #include <algorithm>
 
 using namespace bcos;
 using namespace bcos::rpc;
 
+namespace
+{
+std::optional<u256> parsePresentQuantity(std::optional<std::string> const& s)
+{
+    if (!s || s->empty())
+    {
+        return std::nullopt;
+    }
+    if (auto value = safeFromBigQuantity(*s))
+    {
+        return *value;
+    }
+    BOOST_THROW_EXCEPTION(std::invalid_argument("invalid quantity: " + *s));
+}
+}  // namespace
+
 bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
     bcos::protocol::TransactionFactory::Ptr const& factory,
-    bcos::scheduler::SchedulerInterface::Ptr const& scheduler) noexcept
+    bcos::scheduler::SchedulerInterface::Ptr const& scheduler, std::optional<u256> blockBaseFee)
 {
     std::string nonce;
     if (to.empty() && scheduler) [[unlikely]]
@@ -48,11 +68,10 @@ bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
                 // gets its decimal "12" misread as hex 0x12 = 18 (NONCE_TOO_HIGH). 0-9
                 // coincide in both bases, which is why only the 11th+ deployment would break.
                 //
-                // The all-digits guard keeps this noexcept-safe: bcos::u256 throws on an
-                // unparseable string (std::terminate out of noexcept), and an empty or
-                // non-numeric stored nonce is left unset (empty nonce string) — a corrupt
-                // row falls back to the executor reading the sender's state nonce rather
-                // than aborting the RPC.
+                // The all-digits guard keeps this path safe: bcos::u256 throws on an
+                // unparseable string, and an empty or non-numeric stored nonce is left unset
+                // (empty nonce string) — a corrupt row falls back to the executor reading the
+                // sender's state nonce rather than aborting the RPC.
                 if (auto const raw = entry->get();
                     !raw.empty() && std::all_of(raw.begin(), raw.end(),
                                         [](char c) { return c >= '0' && c <= '9'; }))
@@ -61,6 +80,46 @@ bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
                 }
             }
         }
+    }
+    // OP headers (baseFee present) need an RLP envelope. PBFT keeps the BCOS factory tx —
+    // a dummy envelope would price every call at 1 ether/gas. Malformed quantities fail closed.
+    if (blockBaseFee.has_value())
+    {
+        Web3Transaction w3{};
+        w3.type = TransactionType::Legacy;
+        w3.chainId = std::nullopt;
+        if (!to.empty())
+        {
+            w3.to = Address(to);
+        }
+        w3.data = data;
+        w3.value = parsePresentQuantity(value).value_or(u256(0));
+        // Nonce goes into the envelope. Unknown stays 0; executor then uses state nonce.
+        w3.nonce = safeFromQuantity(nonce).value_or(0);
+        // op-geth caps a gas-less eth_call at its RPC gas cap; default to the 30M block-gas
+        // convention so a pricing-less simulation passes the intrinsic-gas check.
+        w3.gasLimit = gas.value_or(30'000'000);
+        u256 const defaultFee = std::max(*blockBaseFee * 2, u256(2'000'000'000));
+        w3.maxPriorityFeePerGas = parsePresentQuantity(gasPrice).value_or(
+            parsePresentQuantity(maxFeePerGas).value_or(defaultFee));
+        w3.signatureV = 0;
+        w3.signatureR = bcos::bytes(32, 0x01);
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        // takeToTarsTransaction renders the numeric nonce; restore the passthrough semantics
+        // the RPC contract has (converted hex quantity, or empty when unknown — the executor
+        // then falls back to the sender's state nonce).
+        tarsHolder->data.nonce = nonce;
+        auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsHolder]() { return tarsHolder.get(); });
+        if (from.has_value())
+        {
+            if (auto const sender = safeFromHexWithPrefix(from.value()))
+            {
+                tx->forceSender(sender.value());
+            }
+        }
+        return tx;
     }
     auto tx = factory->createTransaction(1, std::move(this->to), this->data, nonce, 0, {}, {}, 0,
         "", value.value_or(""), gasPrice.value_or(""), gas.value_or(0), maxFeePerGas.value_or(""),
@@ -90,38 +149,69 @@ std::tuple<bool, CallRequest> rpc::decodeCallRequest(Json::Value const& _root)
     }
     if (dataValue != nullptr)
     {
-        if (auto dataBytes = bcos::safeFromHexWithPrefix(dataValue->asString()))
+        if (!dataValue->isString())
         {
-            _request.data = std::move(*dataBytes);
+            return {false, {}};
         }
+        auto dataBytes = bcos::safeFromHexWithPrefix(dataValue->asString());
+        if (!dataBytes)
+        {
+            // Present but malformed DATA must fail closed — never silently drop to empty.
+            return {false, {}};
+        }
+        _request.data = std::move(*dataBytes);
     }
     if (const auto* value = _root.find("to"))
     {
+        if (!value->isString())
+        {
+            return {false, {}};
+        }
         _request.to = value->asString();
     }
     if (const auto* value = _root.find("from"))
     {
+        if (!value->isString())
+        {
+            return {false, {}};
+        }
         _request.from = value->asString();
     }
     if (const auto* value = _root.find("gas"))
     {
-        _request.gas = fromQuantity(value->asString());
+        if (!value->isString())
+        {
+            return {false, {}};
+        }
+        auto gas = safeFromQuantity(value->asString());
+        if (!gas)
+        {
+            return {false, {}};
+        }
+        _request.gas = *gas;
     }
-    if (const auto* value = _root.find("gasPrice"))
+    auto takeQuantityField = [&](char const* key, std::optional<std::string>& field) -> bool {
+        if (const auto* value = _root.find(key); value != nullptr)
+        {
+            if (!value->isString())
+            {
+                return false;
+            }
+            auto const& raw = value->asString();
+            if (!safeFromBigQuantity(raw))
+            {
+                return false;
+            }
+            field = raw;
+        }
+        return true;
+    };
+    if (!takeQuantityField("gasPrice", _request.gasPrice) ||
+        !takeQuantityField("value", _request.value) ||
+        !takeQuantityField("maxPriorityFeePerGas", _request.maxPriorityFeePerGas) ||
+        !takeQuantityField("maxFeePerGas", _request.maxFeePerGas))
     {
-        _request.gasPrice = value->asString();
-    }
-    if (const auto* value = _root.find("value"))
-    {
-        _request.value = value->asString();
-    }
-    if (const auto* value = _root.find("maxPriorityFeePerGas"))
-    {
-        _request.maxPriorityFeePerGas = value->asString();
-    }
-    if (const auto* value = _root.find("maxFeePerGas"))
-    {
-        _request.maxFeePerGas = value->asString();
+        return {false, {}};
     }
     return {true, std::move(_request)};
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
@@ -96,9 +96,11 @@ bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
         w3.value = parsePresentQuantity(value).value_or(u256(0));
         // Nonce goes into the envelope. Unknown stays 0; executor then uses state nonce.
         w3.nonce = safeFromQuantity(nonce).value_or(0);
-        // op-geth caps a gas-less eth_call at its RPC gas cap; default to the 30M block-gas
-        // convention so a pricing-less simulation passes the intrinsic-gas check.
-        w3.gasLimit = gas.value_or(30'000'000);
+        // op-geth caps eth_call at its RPC gas cap — for a gas-less call AND a
+        // caller-supplied one ("Caller gas above allowance, capping"). Finding I1: an
+        // explicit 0xffffffffffffffff previously reached the executor unclamped; estimateGas
+        // already clamps the same way before run #1.
+        w3.gasLimit = std::min(gas.value_or(30'000'000), uint64_t{30'000'000});
         u256 const defaultFee = std::max(*blockBaseFee * 2, u256(2'000'000'000));
         w3.maxPriorityFeePerGas = parsePresentQuantity(gasPrice).value_or(
             parsePresentQuantity(maxFeePerGas).value_or(defaultFee));

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.h
@@ -58,9 +58,13 @@ struct CallRequest
         _out << "maxFeePerGas: " << _in.maxFeePerGas.value_or("") << ", ";
         return _out;
     }
+    // Throws std::invalid_argument when an explicitly present fee/value quantity is
+    // malformed on the OP envelope path. Decode already rejects those for RPC input;
+    // this fail-closed path covers direct CallRequest construction.
     bcos::protocol::Transaction::Ptr takeToTransaction(
         bcos::protocol::TransactionFactory::Ptr const&,
-        bcos::scheduler::SchedulerInterface::Ptr const&) noexcept;
+        bcos::scheduler::SchedulerInterface::Ptr const&,
+        std::optional<u256> blockBaseFee = std::nullopt);
 };
 [[maybe_unused]] std::tuple<bool, CallRequest> decodeCallRequest(Json::Value const& _root);
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.cpp
@@ -143,8 +143,7 @@ void bcos::rpc::combineDepositTxResponse(Json::Value& result, const DepositTrans
         // op-geth emits isSystemTx only when true.
         result["isSystemTx"] = true;
     }
-    // Deposits carry no nonce (the deposit nonce lives in the receipt), no gas price and
-    // no signature; op-geth emits zero quantities for these.
+    // No nonce/gasPrice/signature on the tx; depositNonce is on the receipt when mined.
     result["nonce"] = "0x0";
     result["gasPrice"] = "0x0";
     result["v"] = "0x0";

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -5,6 +5,7 @@
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <bcos-crypto/hash/Keccak256.h>
+#include <atomic>
 #include <cstdint>
 
 void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::TransactionReceipt& receipt,
@@ -18,7 +19,29 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     result["status"] = toQuantity(status);
     auto txHashHex = tx.hash().hexPrefixed();
     result["transactionHash"] = txHashHex;
-    auto cumulativeGasUsed = safeCastToU256(receipt.cumulativeGasUsed());
+    // cumulativeGasUsed is decimal on new receipts, hex on old ones. u256() accepts both;
+    // a corrupt value becomes 0x0 + WARN, not -32603.
+    bcos::u256 cumulativeGasUsed{};
+    auto const& cgs = receipt.cumulativeGasUsed();
+    if (!cgs.empty())
+    {
+        try
+        {
+            cumulativeGasUsed = bcos::u256(std::string(cgs));
+        }
+        catch (std::exception const& e)
+        {
+            // Throttle to the first occurrence per process: this sits on
+            // the polled eth_getTransactionReceipt path — a poller hitting a corrupt receipt
+            // would otherwise repeat the warning indefinitely.
+            static std::atomic<bool> warnedOnce{false};
+            if (!warnedOnce.exchange(true))
+            {
+                WEB3_LOG(WARNING) << LOG_DESC("ReceiptResponse: unparseable cumulativeGasUsed")
+                                  << LOG_KV("value", cgs) << LOG_KV("msg", e.what());
+            }
+        }
+    }
     size_t logIndex = receipt.logIndex();
     auto transactionIndex = toQuantity(receipt.transactionIndex());
     result["transactionIndex"] = transactionIndex;
@@ -27,9 +50,7 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     auto blockNumber = receipt.blockNumber();
     result["blockNumber"] = toQuantity(blockNumber);
     auto from = toHex(tx.sender());
-    // EIP-55 checksum needs keccak256(address) per recipient; RPC read path (not consensus),
-    // so the 3-4 hashes per receipt are acceptable — caching here would need shared-state
-    // synchronization for a marginal win (see review Finding J).
+    // EIP-55 checksum; RPC path only, not consensus.
     toChecksumAddress(from, bcos::crypto::keccak256Hash(bcos::bytesConstRef(from)).hex());
     result["from"] = "0x" + std::move(from);
     if (tx.to().empty())
@@ -44,6 +65,7 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
         result["to"] = "0x" + std::move(to);
     }
     result["cumulativeGasUsed"] = toQuantity(cumulativeGasUsed);
+    // effectiveGasPrice is already a quantity at seal time; missing => 0x0.
     result["effectiveGasPrice"] =
         receipt.effectiveGasPrice().empty() ? "0x0" : std::string(receipt.effectiveGasPrice());
     result["gasUsed"] = toQuantity(receipt.gasUsed());
@@ -64,7 +86,7 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     for (size_t i = 0; i < receiptLog.size(); i++)
     {
         Json::Value log;
-        auto address = std::string(receiptLog[i].address());
+        auto address = toLogAddressHex(receiptLog[i].address());
         toChecksumAddress(address, bcos::crypto::keccak256Hash(bcos::bytesConstRef(address)).hex());
         log["address"] = "0x" + std::move(address);
         log["topics"] = Json::arrayValue;
@@ -76,7 +98,10 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
         log["logIndex"] = toQuantity(logIndex + i);
         log["blockNumber"] = toQuantity(blockNumber);
         log["blockHash"] = blockHashHex;
-        log["transactionIndex"] = toQuantity(transactionIndex);
+        // transactionIndex is already the quantity string computed above; re-running it
+        // through toQuantity would hit the Binary overload (string is a contiguous range)
+        // and hex-encode the ASCII bytes ("0x1" -> "0x307831").
+        log["transactionIndex"] = transactionIndex;
         log["transactionHash"] = txHashHex;
         log["removed"] = false;
         result["logs"].append(std::move(log));

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -162,16 +162,20 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         // reconstructed from the stored parity byte — the storage layer keeps only the parity.
         if (web3Tx.type == TransactionType::Legacy)
         {
-            // sig[64] is unchecked; short signatures report v as 0x0.
+            // Finding S9: a short/corrupt signature has no trustworthy parity byte — omit v
+            // entirely instead of fabricating a valid-looking EIP-155 value from parity 0.
             auto const sig = tx.signatureData();
-            uint64_t const parity = (sig.size() >= 65) ? static_cast<uint64_t>(sig[64]) : 0;
-            if (web3Tx.chainId.has_value() && web3Tx.chainId.value() != 0)
+            if (sig.size() >= 65)
             {
-                result["v"] = toQuantity(u256(web3Tx.chainId.value()) * 2 + 35 + parity);
-            }
-            else
-            {
-                result["v"] = toQuantity(27 + parity);
+                auto const parity = static_cast<uint64_t>(sig[64]);
+                if (web3Tx.chainId.has_value() && web3Tx.chainId.value() != 0)
+                {
+                    result["v"] = toQuantity(u256(web3Tx.chainId.value()) * 2 + 35 + parity);
+                }
+                else
+                {
+                    result["v"] = toQuantity(27 + parity);
+                }
             }
         }
         if (web3Tx.type == TransactionType::EIP4844)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -14,6 +14,28 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         auto gasPrice = receipt.effectiveGasPrice();
         result["gasPrice"] = std::string{gasPrice.empty() ? "0x0" : gasPrice};
     }
+
+    // OP Stack deposit (0x7e): the tx JSON nonce must reflect the deposit's actual
+    // execution nonce (Regolith+ semantics — the deposit nonce lives in the receipt,
+    // deposits carry no nonce field of their own). The base combineTxResponse above
+    // emits 0x0; overwrite it with the receipt's depositNonce when present, so
+    // contract-address derivation (keccak(rlp([sender, nonce]))[12:]) and wallets see
+    // the value op-geth reports. Without the meta the deposit was never executed (or is
+    // a pre-Regolith block) and 0x0 stands.
+    if (auto extraBytes = tx.extraTransactionBytes();
+        !extraBytes.empty() && extraBytes[0] == c_depositTxType)
+    {
+        if (auto meta = receipt.opStackMeta(); meta.has_value() && meta->deposit_nonce)
+        {
+            result["nonce"] = toQuantity(*meta->deposit_nonce);
+            // op-geth also surfaces depositReceiptVersion on the tx object
+            // (internal/ethapi/api.go:1210-1213); absent without the meta.
+            if (meta->deposit_receipt_version)
+            {
+                result["depositReceiptVersion"] = toQuantity(*meta->deposit_receipt_version);
+            }
+        }
+    }
 }
 
 void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Transaction& tx,
@@ -134,6 +156,24 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
             result["maxFeePerGas"] = toQuantity(web3Tx.maxFeePerGas);
         }
         result["chainId"] = toQuantity(web3Tx.chainId.value_or(0));
+        // Legacy transactions encode v as the EIP-155 value chainId*2+35+parity (27+parity
+        // pre-EIP-155); typed transactions use the plain y-parity. Clients like op-geth's
+        // types.NewTx reject a legacy v < 35 when chainId is set, so the full value must be
+        // reconstructed from the stored parity byte — the storage layer keeps only the parity.
+        if (web3Tx.type == TransactionType::Legacy)
+        {
+            // sig[64] is unchecked; short signatures report v as 0x0.
+            auto const sig = tx.signatureData();
+            uint64_t const parity = (sig.size() >= 65) ? static_cast<uint64_t>(sig[64]) : 0;
+            if (web3Tx.chainId.has_value() && web3Tx.chainId.value() != 0)
+            {
+                result["v"] = toQuantity(u256(web3Tx.chainId.value()) * 2 + 35 + parity);
+            }
+            else
+            {
+                result["v"] = toQuantity(27 + parity);
+            }
+        }
         if (web3Tx.type == TransactionType::EIP4844)
         {
             result["maxFeePerBlobGas"] = toQuantity(web3Tx.maxFeePerBlobGas);
@@ -164,5 +204,10 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
     }
     result["r"] = toQuantity(tx.signatureData().getCroppedData(0, 32));
     result["s"] = toQuantity(tx.signatureData().getCroppedData(32, 32));
-    result["v"] = toQuantity(tx.signatureData().getCroppedData(64, 1));
+    // v: set for legacy transactions above (EIP-155 reconstruction); everything else
+    // reports the stored y-parity byte directly.
+    if (!result.isMember("v"))
+    {
+        result["v"] = toQuantity(tx.signatureData().getCroppedData(64, 1));
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/Common.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/Common.h
@@ -21,9 +21,36 @@
 #pragma once
 
 #include <bcos-rpc/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <string>
+#include <string_view>
 
 namespace bcos::rpc
 {
+/// Normalize a protocol::LogEntry address view to 40-char lowercase hex (no 0x prefix).
+/// Producers are inconsistent: the OP execution path stores the 20 raw address bytes,
+/// while legacy paths store the ASCII hex string (with or without 0x). Length 20 is
+/// unambiguous (a hex-string form is 40/42 chars), so branch on it.
+inline std::string toLogAddressHex(std::string_view address)
+{
+    if (address.size() == 20)
+    {
+        auto hex = bcos::toHex(address);
+        boost::algorithm::to_lower(hex);
+        return hex;
+    }
+    std::string_view view = address;
+    if (view.starts_with("0x") || view.starts_with("0X"))
+    {
+        view.remove_prefix(2);
+    }
+    std::string hex{view};
+    boost::algorithm::to_lower(hex);
+    return hex;
+}
+
 constexpr const uint64_t LowestGasPrice{21000};
 constexpr const uint64_t LowestGasUsed{21000};
 enum Web3JsonRpcError : int32_t

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h
@@ -1,0 +1,54 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EngineErrorMapper.h
+ * @brief Map engine-service exceptions to the execution-apis JSON-RPC error codes
+ */
+
+#pragma once
+
+#include "bcos-rpc/web3jsonrpc/utils/Common.h"  // EngineError
+#include <bcos-framework/engine/Errors.h>
+#include <bcos-framework/engine/Types.h>  // UnsupportedEngineApiVersion / UnknownPayload / IncompatiblePayloadVersion
+#include <bcos-rpc/jsonrpc/Common.h>  // JsonRpcError::InternalError
+#include <bcos-utilities/Exceptions.h>
+
+namespace bcos::rpc
+{
+/// Map engine exceptions to Engine API JSON-RPC codes. Unmapped / bcos::Error => -32603.
+inline int32_t mapEngineErrorCode(bcos::Exception const& e) noexcept
+{
+    if (dynamic_cast<bcos::engine::UnsupportedFork const*>(&e) ||
+        dynamic_cast<bcos::engine::IncompatiblePayloadVersion const*>(&e) ||
+        dynamic_cast<bcos::engine::UnsupportedEngineApiVersion const*>(&e))
+    {
+        return EngineError::UnsupportedFork;  // -38005
+    }
+    if (dynamic_cast<bcos::engine::UnknownPayload const*>(&e))
+    {
+        return EngineError::UnknownPayload;  // -38001
+    }
+    if (dynamic_cast<bcos::engine::UnknownForkchoiceHeadBlock const*>(&e) ||
+        dynamic_cast<bcos::engine::InvalidForkchoiceState const*>(&e))
+    {
+        return EngineError::InvalidForkchoiceState;  // -38002 (Errors.h groups both here)
+    }
+    if (dynamic_cast<bcos::engine::UnsupportedOpPayloadAttributes const*>(&e))
+    {
+        return EngineError::InvalidPayloadAttributes;  // -38003
+    }
+    return InternalError;  // -32603
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -358,7 +358,9 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
         }
-        // Hex-decode into transactions[].raw; rawTransactions is a derived mirror.
+        // Hex-decode into transactions[].raw — the single authoritative carrier
+        // (finding S11: the derived rawTransactions mirror had zero readers in-tree and
+        // doubled the payload bytes; it stays nullopt until an OP executor seam consumes it).
         payload.transactions.reserve(ep["transactions"].size());
         for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
@@ -367,12 +369,6 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
                 .raw = std::move(txData),
                 .decoded = nullptr,
             });
-        }
-        payload.rawTransactions.emplace();
-        payload.rawTransactions->reserve(payload.transactions.size());
-        for (auto const& tx : payload.transactions)
-        {
-            payload.rawTransactions->push_back(tx.raw);
         }
     }
     if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
@@ -832,11 +828,7 @@ void bcos::rpc::combineGetPayloadResponse(Json::Value& _result,
     {
         _result["parentBeaconBlockRoot"] = _response->parentBeaconBlockRoot->hexPrefixed();
     }
-    // V4 (Prague payload shape): executionRequests is a required member of the response. This
-    // chain produces none (no deposit/consolidation requests), so an empty list is the honest
-    // payload — op-geth's own no-request blocks serialize the same shape.
-    if (version == engine::ApiVersion::V4)
-    {
-        _result["executionRequests"] = Json::Value(Json::arrayValue);
-    }
+    // (Finding S10: the former ==V4 overwrite of executionRequests to [] duplicated the
+    // >=V4 gate above — the gate already renders nullopt as [], so a future non-empty
+    // executionRequests would have been silently dropped here.)
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -322,6 +322,7 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .baseFeePerGas = parseBigQuantity(ep["baseFeePerGas"], "executionPayload.baseFeePerGas"),
         .blockHash = parseH256Field(ep["blockHash"], "executionPayload.blockHash"),
         .transactions = {},
+        .rawTransactions = std::nullopt,
         .extraData = {},
         .feeRecipient = parseAddressField(ep["feeRecipient"], "executionPayload.feeRecipient"),
         .timestamp = engineSecondsToInternalMillis(
@@ -331,6 +332,8 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .withdrawals = std::nullopt,
         .blobGasUsed = std::nullopt,
         .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
         .withdrawalsRoot = std::nullopt,
     };
     if (ep.isMember("extraData"))
@@ -355,15 +358,21 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
         }
-        // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
-        // here — getPayload must later return exactly these bytes.
+        // Hex-decode into transactions[].raw; rawTransactions is a derived mirror.
         payload.transactions.reserve(ep["transactions"].size());
         for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
-            payload.transactions.push_back(bcos::engine::EngineTransaction{
-                .raw = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i),
+            auto txData = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i);
+            payload.transactions.push_back(engine::EngineTransaction{
+                .raw = std::move(txData),
                 .decoded = nullptr,
             });
+        }
+        payload.rawTransactions.emplace();
+        payload.rawTransactions->reserve(payload.transactions.size());
+        for (auto const& tx : payload.transactions)
+        {
+            payload.rawTransactions->push_back(tx.raw);
         }
     }
     if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
@@ -822,5 +831,12 @@ void bcos::rpc::combineGetPayloadResponse(Json::Value& _result,
     if (_response->parentBeaconBlockRoot.has_value())
     {
         _result["parentBeaconBlockRoot"] = _response->parentBeaconBlockRoot->hexPrefixed();
+    }
+    // V4 (Prague payload shape): executionRequests is a required member of the response. This
+    // chain produces none (no deposit/consolidation requests), so an empty list is the honest
+    // payload — op-geth's own no-request blocks serialize the same shape.
+    if (version == engine::ApiVersion::V4)
+    {
+        _result["executionRequests"] = Json::Value(Json::arrayValue);
     }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/util.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/util.h
@@ -22,6 +22,11 @@
 #include <bcos-rpc/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <json/json.h>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <string_view>
 
 namespace bcos::rpc
 {
@@ -32,6 +37,50 @@ void buildJsonErrorWithData(
     Json::Value& data, int32_t code, std::string message, Json::Value& response);
 
 bcos::bytes toBytesResponse(Json::Value const& jResp);
+
+/// Decode a solidity Error(string) revert payload (selector 0x08c379a0) into the op-geth
+/// style eth_call error message. Any non-Error(string) or malformed output degrades to the
+/// bare "execution reverted" message — a reverted call must never surface a fabricated
+/// reason, only the reason the contract actually emitted.
+inline std::string decodeRevertMessage(std::string_view outputHex)
+{
+    // std::string_view for the constexpr (a constexpr std::string is not a constant
+    // expression under gcc-14 -Werror: it refers to a result of operator new); every
+    // use converts explicitly so no compiler's implicit-conversion leniency is relied on.
+    static constexpr std::string_view kReverted = "execution reverted";
+    auto bytes = fromHexWithPrefix(outputHex);
+    // Error(string): selector(4) || offset==32 (32) || length (32) || payload
+    if (bytes.size() < 4U + 32U + 32U ||
+        !std::equal(bytes.begin(), bytes.begin() + 4,
+            std::array<bcos::byte, 4>{0x08, 0xc3, 0x79, 0xa0}.begin()))
+    {
+        return std::string(kReverted);
+    }
+    auto word = [&bytes](std::size_t offset) {
+        std::size_t value = 0;
+        for (std::size_t i = 0; i < 32; ++i)
+        {
+            if (value > (std::numeric_limits<std::size_t>::max() >> 8))
+            {
+                return std::numeric_limits<std::size_t>::max();
+            }
+            value = (value << 8) | static_cast<std::uint8_t>(bytes[offset + i]);
+        }
+        return value;
+    };
+    if (word(4) != 32)
+    {
+        return std::string(kReverted);
+    }
+    auto length = word(36);
+    if (length > bytes.size() - (4U + 32U + 32U))
+    {
+        return std::string(kReverted);
+    }
+    auto reason = std::string(
+        reinterpret_cast<char const*>(bytes.data() + 68), static_cast<std::size_t>(length));
+    return std::string(kReverted) + ": " + reason;
+}
 
 inline auto printJson(const Json::Value& value)
 {
@@ -50,5 +99,29 @@ inline std::string_view toView(const Json::Value& value)
     }
     std::string_view view(begin, end - begin);
     return view;
+}
+
+/// Pure initializer for the eth_estimateGas upward-search interval, regression-tested in
+/// EthEstimateGasBudgetTest. Given the first-run consumption (known bad) and the limit
+/// run #1 actually executed at (cap-clamped upstream), returns a well-ordered
+/// [lowerBound, upperBound] pair. Passing any ceiling run #1 did not execute at once
+/// inverted the bounds and wrapped the unsigned width test.
+struct EstimateSearchBounds
+{
+    u256 lowerBound;
+    u256 upperBound;
+};
+inline EstimateSearchBounds estimateSearchBounds(const u256& gasUsed, const u256& firstRunLimit)
+{
+    EstimateSearchBounds bounds{.lowerBound = gasUsed,  // known-bad
+        .upperBound = firstRunLimit};                   // proven-viable anchor
+    if (bounds.upperBound < bounds.lowerBound) [[unlikely]]
+    {
+        // Defensive floor: only reachable if the reported consumption exceeded even the
+        // cap-clamped run #1 limit (charge-reporting drift). Clamp so every width
+        // subtraction below stays non-negative; the loops then no-op.
+        bounds.upperBound = bounds.lowerBound;
+    }
+    return bounds;
 }
 }  // namespace bcos::rpc

--- a/bcos-rpc/test/unittests/common/RPCFixture.h
+++ b/bcos-rpc/test/unittests/common/RPCFixture.h
@@ -49,6 +49,7 @@
 #include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <functional>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -58,11 +59,18 @@ namespace bcos::test
 
 class FakeScheduler2 : public FakeScheduler
 {
+public:
     using FakeScheduler::FakeScheduler;
-    void call(protocol::Transaction::Ptr,
-        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)> callback) noexcept
-        override
+    using CallCallback = std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)>;
+    std::function<void(protocol::Transaction::Ptr, CallCallback)> callHandler;
+
+    void call(protocol::Transaction::Ptr tx, CallCallback callback) noexcept override
     {
+        if (callHandler)
+        {
+            callHandler(std::move(tx), std::move(callback));
+            return;
+        }
         auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
         callback({}, receipt);
     }
@@ -123,8 +131,8 @@ public:
         txPool->init();
         txPool->start();
 
-        nodeService = std::make_shared<rpc::NodeService>(
-            m_ledger, scheduler, txPool, nullptr, nullptr, m_blockFactory,
+        nodeService = std::make_shared<rpc::NodeService>(m_ledger, scheduler, txPool, nullptr,
+            nullptr, m_blockFactory,
             // EngineService not needed for existing RPC tests; pass nullptr as stub.
             nullptr);
 
@@ -141,8 +149,7 @@ public:
     }
     // ioServicePool MUST be declared before any member that creates Timer objects
     // referencing its io_context, to ensure it outlives them during destruction.
-    bcos::IOServicePool::Ptr ioServicePool =
-        std::make_shared<bcos::IOServicePool>(1, "rpcTest");
+    bcos::IOServicePool::Ptr ioServicePool = std::make_shared<bcos::IOServicePool>(1, "rpcTest");
 
     bcos::tool::NodeConfig::Ptr nodeConfig;
     RPCInterface::Ptr rpc;

--- a/bcos-rpc/test/unittests/rpc/CallRequestTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/CallRequestTest.cpp
@@ -56,11 +56,7 @@ BOOST_AUTO_TEST_CASE(decode_data_and_input_precedence)
 {
     // Given both "data" and "input" present, "data" should take precedence
     Json::Value root(Json::objectValue);
-    constexpr std::string_view hexData =
-        "0x26c8917e00000000000000000000000000000000000000000000000000000000000000600000000000000000"
-        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        "00000000000000000003e8000000000000000000000000000000000000000000000000000000000000002chszs"
-        "ray4r2rgyr8vmossvvgh2xawx7csbmhn4gbqmwhd00000000000000000000";
+    constexpr std::string_view hexData = "0x26c8917e";
     root["data"] = std::string{hexData};
     root["input"] = "0x1122";
     root["to"] = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -68,7 +64,7 @@ BOOST_AUTO_TEST_CASE(decode_data_and_input_precedence)
     auto [ok, req] = decodeCallRequest(root);
     BOOST_TEST(ok);
 
-    BOOST_TEST(req.data.empty());
+    BOOST_TEST(req.data == fromHexWithPrefix(hexData));
     BOOST_CHECK_EQUAL(req.to, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 }
 
@@ -110,17 +106,15 @@ BOOST_AUTO_TEST_CASE(decode_all_fields)
     BOOST_CHECK_EQUAL(req.maxFeePerGas.value(), "0x4");
 }
 
-BOOST_AUTO_TEST_CASE(decode_invalid_hex_data_is_ignored)
+BOOST_AUTO_TEST_CASE(decode_invalid_hex_data_is_rejected)
 {
-    // Given invalid hex in data, it should be ignored (kept empty) and not throw
     Json::Value root(Json::objectValue);
     root["data"] = "0xzzzz";  // invalid hex
     root["to"] = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
     auto [ok, req] = decodeCallRequest(root);
-    BOOST_TEST(ok);
+    BOOST_TEST(!ok);
     BOOST_TEST(req.data.empty());
-    BOOST_CHECK_EQUAL(req.to, "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 }
 
 BOOST_AUTO_TEST_CASE(decode_uses_input_when_data_missing)
@@ -136,24 +130,20 @@ BOOST_AUTO_TEST_CASE(decode_uses_input_when_data_missing)
 BOOST_AUTO_TEST_CASE(decode_invalid_gas_string)
 {
     Json::Value root(Json::objectValue);
-    root["gas"] = "zz";  // invalid hex with no leading valid digit -> stoull throws -> terminate
-    // Call function; expected to abort. If not aborted, exit(0) to mark failure in parent.
-    BOOST_CHECK_THROW(auto resultTuple = decodeCallRequest(root), std::invalid_argument);
-    int status = 0;
+    root["gas"] = "zz";
+    auto [ok, req] = decodeCallRequest(root);
+    BOOST_TEST(!ok);
+    BOOST_TEST(!req.gas.has_value());
 }
 
-BOOST_AUTO_TEST_CASE(decode_numeric_gas_treated_as_hex)
+BOOST_AUTO_TEST_CASE(decode_numeric_gas_is_rejected)
 {
-    // Given gas as a numeric JSON value, asString() yields decimal text
-    // but fromQuantity parses with base-16; verify current behavior is hex parse
     constexpr long long kGasDecimal = 21000;
-    constexpr unsigned kExpectedHexParsed = 135168U;  // 0x21000
     Json::Value root(Json::objectValue);
-    root["gas"] = Json::Int64(kGasDecimal);  // asString => "21000"; hex 0x21000 == 135168
+    root["gas"] = Json::Int64(kGasDecimal);
     auto [ok, req] = decodeCallRequest(root);
-    BOOST_TEST(ok);
-    BOOST_TEST(req.gas.has_value());
-    BOOST_CHECK_EQUAL(req.gas.value(), kExpectedHexParsed);
+    BOOST_TEST(!ok);
+    BOOST_TEST(!req.gas.has_value());
 }
 
 BOOST_AUTO_TEST_CASE(decode_invalid_from_does_not_fail)
@@ -167,24 +157,29 @@ BOOST_AUTO_TEST_CASE(decode_invalid_from_does_not_fail)
     BOOST_CHECK_EQUAL(req.from.value(), "not_an_address");
 }
 
-BOOST_AUTO_TEST_CASE(decode_invalid_fee_fields_pass_through)
+BOOST_AUTO_TEST_CASE(decode_invalid_fee_fields_are_rejected)
 {
-    // gasPrice/value/max* are kept as-is; invalid strings are not parsed here
-    Json::Value root(Json::objectValue);
-    root["gasPrice"] = "0xzz";
-    root["value"] = "-123";
-    root["maxPriorityFeePerGas"] = "abc";
-    root["maxFeePerGas"] = "\t";
-    auto [ok, req] = decodeCallRequest(root);
-    BOOST_TEST(ok);
-    BOOST_TEST(req.gasPrice.has_value());
-    BOOST_CHECK_EQUAL(req.gasPrice.value(), "0xzz");
-    BOOST_TEST(req.value.has_value());
-    BOOST_CHECK_EQUAL(req.value.value(), "-123");
-    BOOST_TEST(req.maxPriorityFeePerGas.has_value());
-    BOOST_CHECK_EQUAL(req.maxPriorityFeePerGas.value(), "abc");
-    BOOST_TEST(req.maxFeePerGas.has_value());
-    BOOST_CHECK_EQUAL(req.maxFeePerGas.value(), "\t");
+    for (auto const field : {"gasPrice", "value", "maxPriorityFeePerGas", "maxFeePerGas"})
+    {
+        Json::Value root(Json::objectValue);
+        root[field] = "0xzz";
+        auto [ok, req] = decodeCallRequest(root);
+        BOOST_TEST(!ok);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(opEnvelopeConstructionDoesNotDefaultMalformedQuantity)
+{
+    auto cryptoSuite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    auto txFactory = std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+
+    CallRequest req;
+    req.to = "0x1234567890abcdef1234567890abcdef12345678";
+    req.value = "0xzz";
+    BOOST_CHECK_THROW(req.takeToTransaction(txFactory, nullptr, bcos::u256(1'000'000'000)),
+        std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(deployEstimateGasParsesDecimalNonce)
@@ -213,9 +208,9 @@ BOOST_AUTO_TEST_CASE(deployEstimateGasParsesDecimalNonce)
 
 BOOST_AUTO_TEST_CASE(deployEstimateGasLeavesCorruptNonceUnset)
 {
-    // A stored nonce that is empty or non-numeric must not abort the RPC (this
-    // function is noexcept) — the nonce is left unset and the executor's dry-run
-    // falls back to the sender's state nonce.
+    // A stored nonce that is empty or non-numeric must not abort the RPC — the
+    // nonce is left unset and the executor's dry-run falls back to the sender's
+    // state nonce.
     auto cryptoSuite =
         std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
             std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
@@ -233,6 +228,21 @@ BOOST_AUTO_TEST_CASE(deployEstimateGasLeavesCorruptNonceUnset)
         auto tx = req.takeToTransaction(txFactory, nonceScheduler);
         BOOST_CHECK(tx->nonce().empty());
     }
+}
+
+BOOST_AUTO_TEST_CASE(pricingLessCallUsesBaseFeeTimesTwo)
+{
+    auto cryptoSuite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    auto txFactory = std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    CallRequest req;
+    req.to = "0x1234567890abcdef1234567890abcdef12345678";
+    auto const highBase = bcos::u256(8'000'000'000);  // 8 gwei > 2 gwei floor
+    auto tx = req.takeToTransaction(txFactory, nullptr, highBase);
+    BOOST_REQUIRE(tx);
+    auto const got = tx->maxPriorityFeePerGas().value_or(tx->gasPrice().value_or(bcos::u256(0)));
+    BOOST_CHECK_EQUAL(got, highBase * 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/DecodeRevertMessageTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/DecodeRevertMessageTest.cpp
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Unit tests for decodeRevertMessage: pins which eth_call revert payload shapes decode
+ *        a solidity Error(string) reason and which degrade to the bare op-geth "execution
+ *        reverted" message. A reverted call must never surface a fabricated reason.
+ * @file DecodeRevertMessageTest.cpp
+ */
+
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::test
+{
+namespace
+{
+/// Build the canonical Error(string) ABI payload: selector || offset(32) || length || reason,
+/// word-aligned. Used to construct both valid revert outputs and near-valid ones for the
+/// malformed cases (by post-editing a byte).
+std::string errorStringHex(std::string const& reason)
+{
+    bcos::bytes payload{0x08, 0xc3, 0x79, 0xa0};
+    auto pushWord = [&payload](std::size_t value) {
+        payload.insert(payload.end(), 24, 0);  // high bytes of the 32-byte word
+        for (int i = 7; i >= 0; --i)           // low 8 bytes, big-endian (value is size_t)
+        {
+            payload.push_back(static_cast<bcos::byte>((value >> (i * 8)) & 0xff));
+        }
+    };
+    pushWord(32);             // data offset
+    pushWord(reason.size());  // length
+    payload.insert(payload.end(), reason.begin(), reason.end());
+    payload.resize((payload.size() + 31U) / 32U * 32U, 0);  // word-align
+    return bcos::toHex(payload, "0x");                      // "0x"-prefixed
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(DecodeRevertMessageTest)
+
+// Outputs that carry no Error(string) at all must yield the bare message, never a reason
+// fabricated from arbitrary revert bytes.
+BOOST_AUTO_TEST_CASE(NonErrorStringOutputYieldsBareMessage)
+{
+    BOOST_TEST(bcos::rpc::decodeRevertMessage("") == "execution reverted");
+    BOOST_TEST(bcos::rpc::decodeRevertMessage("0x") == "execution reverted");
+    BOOST_TEST(bcos::rpc::decodeRevertMessage("0xdeadbeef") == "execution reverted");
+    // 0x4e487b71: solidity Panic(uint256) — not Error(string), must stay bare.
+    std::string const panic = "0x4e487b71" + std::string(62, '0') + "11" + std::string(64, '0');
+    BOOST_TEST(bcos::rpc::decodeRevertMessage(panic) == "execution reverted");
+}
+
+// A valid Error(string) appends the decoded reason in op-geth style.
+BOOST_AUTO_TEST_CASE(ErrorStringReasonIsAppended)
+{
+    BOOST_TEST(bcos::rpc::decodeRevertMessage(errorStringHex("Insufficient balance")) ==
+               "execution reverted: Insufficient balance");
+    BOOST_TEST(bcos::rpc::decodeRevertMessage(errorStringHex("revert with a longer reason")) ==
+               "execution reverted: revert with a longer reason");
+    // Empty string is a valid Error("") — the reason is empty but the shape is genuine, so
+    // the message keeps the ": " (exactly what op-geth's fmt.Errorf("%s: %v") produces).
+    BOOST_TEST(bcos::rpc::decodeRevertMessage(errorStringHex("")) == "execution reverted: ");
+}
+
+// Near-valid Error(string) shapes that must fail closed to the bare message: wrong offset,
+// a length that runs past the end of the payload, and an offset+length pair that cannot be
+// trusted as a reason.
+BOOST_AUTO_TEST_CASE(MalformedErrorStringYieldsBareMessage)
+{
+    // offset word says 0x21 instead of 0x20 (some nonstandard ABI layout): reject.
+    auto wrongOffset = errorStringHex("Insufficient balance");
+    wrongOffset[73] = '1';  // last hex char of the offset word (chars 2..9 selector, 10..73 offset)
+    BOOST_TEST(bcos::rpc::decodeRevertMessage(wrongOffset) == "execution reverted");
+
+    // length word claims 0xf4 (244) while only 20 payload bytes remain (the padded payload
+    // leaves 32 bytes after the fixed header): reject.
+    auto tooLong = errorStringHex("Insufficient balance");
+    tooLong[136] = 'f';  // length word chars 136,137 hold 0x14: "14" -> "f4"
+    BOOST_TEST(bcos::rpc::decodeRevertMessage(tooLong) == "execution reverted");
+
+    // Valid offset but a length word claiming max-size_t: the overflow-guarded read clamps
+    // to size_t max, which can never fit the remaining payload: reject.
+    BOOST_TEST(bcos::rpc::decodeRevertMessage("0x08c379a0" + std::string(62, '0') + "20" +
+                                              std::string(64, 'f') + std::string(64, '0')) ==
+               "execution reverted");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EngineRawTxB2B3Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRawTxB2B3Test.cpp
@@ -117,18 +117,15 @@ BOOST_AUTO_TEST_CASE(dispatchTableIsAuthoritative)
     BOOST_CHECK(kindOf({0xc0}) == RawTransactionKind::Legacy);
     BOOST_CHECK(kindOf({0xf8, 0x01}) == RawTransactionKind::Legacy);
     BOOST_CHECK(kindOf({0xff}) == RawTransactionKind::Legacy);
-    // Blob: parseable as a category, but never admissible.
+    // Blob: parseable as a category; admission policy (always rejected) lives at each
+    // entry gate, not in the dispatch table.
     BOOST_CHECK(kindOf({0x03, 0xaa}) == RawTransactionKind::Blob);
-    BOOST_CHECK(!isRawTransactionPayloadAdmissible(RawTransactionKind::Blob));
     // 0x00 is not a valid EIP-2718 type; reserved/unknown bytes are unsupported.
     BOOST_CHECK(kindOf({0x00, 0xaa}) == RawTransactionKind::Unsupported);
     BOOST_CHECK(kindOf({0x05, 0xaa}) == RawTransactionKind::Unsupported);
     BOOST_CHECK(kindOf({0x7f, 0xaa}) == RawTransactionKind::Unsupported);
     BOOST_CHECK(kindOf({0xbf, 0xaa}) == RawTransactionKind::Unsupported);
     BOOST_CHECK(kindOf({}) == RawTransactionKind::Unsupported);
-    BOOST_CHECK(!isRawTransactionPayloadAdmissible(RawTransactionKind::Unsupported));
-    BOOST_CHECK(isRawTransactionPayloadAdmissible(RawTransactionKind::Legacy));
-    BOOST_CHECK(isRawTransactionPayloadAdmissible(RawTransactionKind::Deposit));
 }
 
 BOOST_AUTO_TEST_CASE(rawTransactionBytesSurviveParseSerializeRoundTrip)

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -19,12 +19,14 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-framework/engine/AnyEngineService.h>
+#include <bcos-framework/engine/Types.h>
 #include <bcos-rpc/web3jsonrpc/endpoints/Endpoints.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h>
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/DataConvertUtility.h>
-#include <memory>
 #include <boost/test/unit_test.hpp>
+#include <memory>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -70,6 +72,14 @@ public:
         const engine::ForkchoiceState& forkchoiceState, const engine::PayloadAttributes*,
         std::uint32_t version)
     {
+        // Mirror EngineServiceImpl::isForkchoiceVersionSupported (V1–V3). A test that
+        // routes FCU V4 into the engine must not stay green while production rejects it.
+        if (version < static_cast<std::uint32_t>(engine::ApiVersion::V1) ||
+            version > static_cast<std::uint32_t>(engine::ApiVersion::V3))
+        {
+            BOOST_THROW_EXCEPTION(engine::UnsupportedEngineApiVersion{}
+                                  << bcos::errinfo_comment{"Unsupported Engine API version"});
+        }
         m_state->capturedForkchoiceState = forkchoiceState;
         m_state->capturedForkchoiceVersion = static_cast<int>(version);
         co_return m_state->forkchoiceUpdatedResult;
@@ -210,9 +220,7 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV3)
     BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 3);
 }
 
-// The one method version this node really does not implement: the service-layer forkchoice
-// window tops out at V3 (isForkchoiceVersionSupported), so V4 answers -38005 without
-// reaching the engine service.
+// FCU V4 is unimplemented: -38005, engine not called.
 BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV4)
 {
     Json::Value params(Json::arrayValue);
@@ -225,7 +233,7 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV4)
     Json::Value response;
     CALL_ENGINE(forkchoiceUpdatedV4, params, response);
 
-    BOOST_CHECK(response.isMember("error"));
+    BOOST_REQUIRE(response.isMember("error"));
     BOOST_CHECK_EQUAL(response["error"]["code"].asInt(), EngineError::UnsupportedFork);
     BOOST_CHECK(!mockService.m_state->capturedForkchoiceVersion.has_value());
 }
@@ -1009,6 +1017,28 @@ BOOST_AUTO_TEST_CASE(newPayloadAndGetPayloadRoundTrip)
         "0x9999999999999999999999999999999999999999999999999999999999999999");
     BOOST_CHECK_EQUAL(result["blockValue"].asString(), largeQuantity);
     BOOST_CHECK_EQUAL(result["executionRequests"].size(), 0);
+}
+
+// UnsupportedEngineApiVersion maps to -38005, not -32603. The FCU window tops out at V3;
+// V4 requests answer -38005 by design (Karst payload building is FCU V3 / getPayload V5 /
+// newPayload V4), so ops configuring Isthmus op-node must not expect V4 support.
+BOOST_AUTO_TEST_CASE(engineErrorMapperOutOfWindowVersion)
+{
+    BOOST_CHECK_EQUAL(bcos::rpc::mapEngineErrorCode(bcos::engine::UnsupportedEngineApiVersion{}),
+        EngineError::UnsupportedFork);
+    BOOST_CHECK_EQUAL(
+        bcos::rpc::mapEngineErrorCode(bcos::engine::UnknownPayload{}), EngineError::UnknownPayload);
+    // Errors.h groups UnknownForkchoiceHeadBlock with InvalidForkchoiceState under -38002;
+    // the mapper must not drop it to -32603 — part-5's forkchoice path throws it.
+    BOOST_CHECK_EQUAL(bcos::rpc::mapEngineErrorCode(bcos::engine::UnknownForkchoiceHeadBlock{}),
+        EngineError::InvalidForkchoiceState);
+    // Remaining mapped families (round-2 finding AX): IncompatiblePayloadVersion shares
+    // -38005 with UnsupportedFork; UnsupportedOpPayloadAttributes carries -38003. Both must
+    // stay pinned so a mapper refactor cannot silently drop them to -32603.
+    BOOST_CHECK_EQUAL(bcos::rpc::mapEngineErrorCode(bcos::engine::IncompatiblePayloadVersion{}),
+        EngineError::UnsupportedFork);
+    BOOST_CHECK_EQUAL(bcos::rpc::mapEngineErrorCode(bcos::engine::UnsupportedOpPayloadAttributes{}),
+        EngineError::InvalidPayloadAttributes);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/EthEstimateGasBudgetTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthEstimateGasBudgetTest.cpp
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief eth_estimateGas: shared simulation budget for upward + binary search.
+ */
+
+#include "../common/RPCFixture.h"
+#include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptImpl.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <future>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+class EthEstimateGasFixture : public RPCFixture
+{
+public:
+    EthEstimateGasFixture()
+    {
+        // Replace the default FakeScheduler2 with one we can instrument.
+        instrumented = std::make_shared<FakeScheduler2>(m_ledger, m_blockFactory);
+        auto svc = std::make_shared<rpc::NodeService>(
+            m_ledger, instrumented, txPool, nullptr, nullptr, m_blockFactory, nullptr);
+        rpc = factory->buildLocalRpc(groupInfo, svc);
+        rpc->groupManager()->updateGroupInfo(groupInfo);
+        web3JsonRpc = rpc->web3JsonRpc();
+        BOOST_REQUIRE(web3JsonRpc);
+    }
+
+    Json::Value call(std::string const& body)
+    {
+        std::promise<bcos::bytes> promise;
+        web3JsonRpc->onRPCRequest(body, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto jsonBytes = promise.get_future().get();
+        Json::Value value;
+        Json::Reader reader;
+        std::string_view json((char*)jsonBytes.data(), jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    std::shared_ptr<FakeScheduler2> instrumented;
+    Rpc::Ptr rpc;
+    Web3JsonRpcImpl::Ptr web3JsonRpc;
+};
+
+BOOST_FIXTURE_TEST_SUITE(EthEstimateGasBudgetTest, EthEstimateGasFixture)
+
+BOOST_AUTO_TEST_CASE(UpwardAndBinarySearchShareSimulationBudget)
+{
+    // First simulation succeeds with a small gasUsed; every re-simulation fails so the
+    // estimator enters the upward + binary search. Without a shared budget a uint64-scale
+    // ceiling would drive ~64 doubling probes; the shared 16-sim budget must bound it.
+    std::atomic<size_t> simulations{0};
+    std::atomic<int64_t> firstGasLimit{0};
+    instrumented->callHandler = [&](protocol::Transaction::Ptr tx,
+                                    FakeScheduler2::CallCallback cb) {
+        auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+        auto n = ++simulations;
+        if (n == 1)
+        {
+            firstGasLimit.store(tx->gasLimit());
+            receipt->inner().data.gasUsed = "21000";
+            receipt->inner().data.status = 0;
+        }
+        else
+        {
+            receipt->inner().data.gasUsed = "21000";
+            receipt->inner().data.status = 1;  // execution reverted
+        }
+        cb({}, receipt);
+    };
+
+    auto resp = call(
+        R"({"jsonrpc":"2.0","id":1,"method":"eth_estimateGas","params":[{"to":"0x0000000000000000000000000000000000000001","gas":"0xffffffffffffffff"},"latest"]})");
+    // First run + at most 16 search simulations.
+    BOOST_CHECK_LE(simulations.load(), 17U);
+    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    // Round-2 F2: the caller-declared gas (2^64-1) must be clamped to kRpcGasCap BEFORE
+    // run #1 (op-geth "Caller gas above allowance, capping") — not merely projected for
+    // the search bounds while the simulation itself runs at the self-declared gas.
+    BOOST_CHECK_EQUAL(firstGasLimit.load(), int64_t{30'000'000});
+}
+
+BOOST_AUTO_TEST_CASE(MalformedGasIsRejected)
+{
+    auto resp = call(
+        R"({"jsonrpc":"2.0","id":1,"method":"eth_estimateGas","params":[{"to":"0x0000000000000000000000000000000000000001","gas":"0xzz"},"latest"]})");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32602);
+}
+
+// Pure bounds initializer table. Regression anchor: upperBound must be the limit run #1
+// ACTUALLY executed at. The caller gas is clamped to kRpcGasCap BEFORE run #1, so an
+// over-cap projection can no longer coexist with a higher honored limit — any ceiling
+// run #1 did not execute at would place upperBound below the known-bad lowerBound and
+// wrap the unsigned width test.
+BOOST_AUTO_TEST_CASE(EstimateSearchBoundsOrderingTable)
+{
+    using bcos::rpc::estimateSearchBounds;
+    const u256 cap{30'000'000};
+
+    // (1) Gas-less request: run #1 executes at the 30M default; ordinary ordered range.
+    {
+        auto const bounds = estimateSearchBounds(u256{59'186}, cap);
+        BOOST_CHECK(bounds.lowerBound == u256{59'186} && bounds.upperBound == cap);
+        BOOST_CHECK_GE(bounds.upperBound, bounds.lowerBound);
+    }
+    // (2) Explicit gas within cap: run #1 executes at the honored limit; consumption below
+    //     it keeps the range ordered without touching the floor.
+    {
+        auto const bounds = estimateSearchBounds(u256{15'000}, u256{21'000});
+        BOOST_CHECK(bounds.lowerBound == u256{15'000});
+        BOOST_CHECK(bounds.upperBound == u256{21'000});
+    }
+    // (3) THE P REGRESSION, post-F2 shape: an over-cap request is clamped upstream, so run
+    //     #1 executes at the cap. If charge-reporting drift ever reports consumption ABOVE
+    //     that clamped limit, the shape would be [45M, 30M] — INVERTED — and the floor must
+    //     collapse the width so the search loops no-op instead of wrapping.
+    {
+        auto const bounds = estimateSearchBounds(u256{45'000'000}, cap);
+        BOOST_CHECK(bounds.lowerBound == u256{45'000'000} && bounds.upperBound == u256{45'000'000});
+    }
+    // (4) Defensive floor, generic shape: consumption above the run #1 limit (charge
+    //     drift). Width collapses so the search loops no-op instead of wrapping.
+    {
+        auto const bounds = estimateSearchBounds(u256{60'000'000}, u256{50'000'000});
+        BOOST_CHECK(bounds.lowerBound == u256{60'000'000} && bounds.upperBound == u256{60'000'000});
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EthFeeHistoryTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthFeeHistoryTest.cpp
@@ -238,5 +238,50 @@ BOOST_AUTO_TEST_CASE(OpHeaderTrailingPredictsNextBaseFee)
     BOOST_TEST(result["baseFeePerGas"][1U].asString() == "0x3e16926a");  // 1,041,666,666
 }
 
+// newestBlock is required and must be a non-empty QUANTITY/TAG string. Missing, non-string,
+// or empty values must not fall through toView() → latest.
+BOOST_AUTO_TEST_CASE(NewestBlockMustBeStringTag)
+{
+    Json::Value missing(Json::arrayValue);
+    missing.append("0x1");
+    auto missingResp = request(missing);
+    BOOST_REQUIRE(missingResp.isMember("error"));
+    BOOST_CHECK_EQUAL(missingResp["error"]["code"].asInt(), -32602);
+
+    Json::Value numeric(Json::arrayValue);
+    numeric.append("0x1");
+    numeric.append(1);
+    auto numericResp = request(numeric);
+    BOOST_REQUIRE(numericResp.isMember("error"));
+    BOOST_CHECK_EQUAL(numericResp["error"]["code"].asInt(), -32602);
+
+    Json::Value empty(Json::arrayValue);
+    empty.append("0x1");
+    empty.append("");
+    auto emptyResp = request(empty);
+    BOOST_REQUIRE(emptyResp.isMember("error"));
+    BOOST_CHECK_EQUAL(emptyResp["error"]["code"].asInt(), -32602);
+}
+
+// Jovian extraData (>=17 bytes) raises the trailing next-baseFee to minBaseFee when the
+// Holocene exact-target result would sit under the floor.
+BOOST_AUTO_TEST_CASE(JovianHeaderTrailingAppliesMinBaseFeeFloor)
+{
+    auto const header = m_ledger->ledgerData().back()->blockHeader();
+    header->setGasLimit(bcos::u256(30'000'000));
+    header->setGasUsed(bcos::u256(15'000'000));  // exact target → Holocene delta 0
+    header->setBaseFee(bcos::u256(100));
+    // version(0) || denominator 8 || elasticity 2 || minBaseFee 1000 (u64 BE)
+    header->setExtraData(bcos::bytes{0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x02, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xe8});
+
+    auto resp = request(params("0x1"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_REQUIRE_EQUAL(result["baseFeePerGas"].size(), 2U);
+    BOOST_TEST(result["baseFeePerGas"][0U].asString() == "0x64");   // parent 100
+    BOOST_TEST(result["baseFeePerGas"][1U].asString() == "0x3e8");  // floor 1000
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EthFeeHistoryTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthFeeHistoryTest.cpp
@@ -1,0 +1,242 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief eth_feeHistory: pins the request bounds (blockCount / rewardPercentiles), the
+ *        empty-priorities null reward entries, and the trailing predicted-baseFee behavior
+ *        (PBFT headers stay 0x0; an OP header carries the calcOpBaseFee prediction).
+ * @file EthFeeHistoryTest.cpp
+ */
+
+#include "../common/RPCFixture.h"
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <string>
+#include <vector>
+
+namespace bcos::test
+{
+class EthFeeHistoryFixture : public RPCFixture
+{
+public:
+    EthFeeHistoryFixture()
+    {
+        rpc = factory->buildLocalRpc(groupInfo, nodeService);
+        web3JsonRpc = rpc->web3JsonRpc();
+        BOOST_TEST(web3JsonRpc != nullptr);
+    }
+
+    Json::Value request(Json::Value const& params)
+    {
+        Json::Value req;
+        req["jsonrpc"] = "2.0";
+        req["id"] = 1;
+        req["method"] = "eth_feeHistory";
+        req["params"] = params;
+        return requestRaw(printJson(req));
+    }
+
+    Json::Value requestRaw(std::string const& body)
+    {
+        Json::Value value;
+        Json::Reader reader;
+        std::promise<bcos::bytes> promise;
+        web3JsonRpc->onRPCRequest(body, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto jsonBytes = promise.get_future().get();
+        std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    Json::Value params(
+        std::string const& blockCount, Json::Value const& percentiles = Json::nullValue)
+    {
+        Json::Value p(Json::arrayValue);
+        p.append(blockCount);
+        p.append("latest");
+        if (!percentiles.isNull())
+        {
+            p.append(percentiles);
+        }
+        return p;
+    }
+
+    Rpc::Ptr rpc;
+    Web3JsonRpcImpl::Ptr web3JsonRpc;
+};
+
+BOOST_FIXTURE_TEST_SUITE(EthFeeHistoryTest, EthFeeHistoryFixture)
+
+// blockCount is a QTY bound to [1, 1024]: 0 and 1025 must be rejected up front, before any
+// ledger read.
+BOOST_AUTO_TEST_CASE(BlockCountBoundsAreEnforced)
+{
+    auto zero = request(params("0x0"));
+    BOOST_REQUIRE(zero.isMember("error"));
+    BOOST_CHECK_EQUAL(zero["error"]["code"].asInt(), -32602);
+    BOOST_CHECK(zero["error"]["message"].asString().find("blockCount must be between 1 and 1024") !=
+                std::string::npos);
+
+    auto tooMany = request(params("0x401"));
+    BOOST_REQUIRE(tooMany.isMember("error"));
+    BOOST_CHECK_EQUAL(tooMany["error"]["code"].asInt(), -32602);
+    BOOST_CHECK(tooMany["error"]["message"].asString().find(
+                    "blockCount must be between 1 and 1024") != std::string::npos);
+}
+
+// rewardPercentiles entries outside [0, 100] (and lists longer than 100) are rejected:
+// a negative value would otherwise wrap through the later size_t cast.
+BOOST_AUTO_TEST_CASE(PercentileBoundsAreEnforced)
+{
+    Json::Value negative(Json::arrayValue);
+    negative.append(-0.1);
+    auto neg = request(params("0x1", negative));
+    BOOST_REQUIRE(neg.isMember("error"));
+    BOOST_CHECK_EQUAL(neg["error"]["code"].asInt(), -32602);
+    BOOST_CHECK(neg["error"]["message"].asString().find(
+                    "rewardPercentiles entries must be in [0, 100]") != std::string::npos);
+
+    Json::Value over(Json::arrayValue);
+    over.append(100.1);
+    auto tooHigh = request(params("0x1", over));
+    BOOST_REQUIRE(tooHigh.isMember("error"));
+    BOOST_CHECK_EQUAL(tooHigh["error"]["code"].asInt(), -32602);
+
+    Json::Value longList(Json::arrayValue);
+    for (int i = 0; i <= 100; ++i)
+    {
+        longList.append(50.0);
+    }
+    auto tooLong = request(params("0x1", longList));
+    BOOST_REQUIRE(tooLong.isMember("error"));
+    BOOST_CHECK_EQUAL(tooLong["error"]["code"].asInt(), -32602);
+    BOOST_CHECK(
+        tooLong["error"]["message"].asString().find("at most 100 entries") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(PercentilesMustBeStrictlyIncreasing)
+{
+    for (auto const& values : {std::vector<double>{10.0, 10.0}, std::vector<double>{80.0, 20.0}})
+    {
+        Json::Value percentiles(Json::arrayValue);
+        for (auto const value : values)
+        {
+            percentiles.append(value);
+        }
+        auto response = request(params("0x1", percentiles));
+        BOOST_REQUIRE(response.isMember("error"));
+        BOOST_CHECK_EQUAL(response["error"]["code"].asInt(), -32602);
+        BOOST_CHECK(response["error"]["message"].asString().find("strictly increasing") !=
+                    std::string::npos);
+    }
+}
+
+// PBFT headers never write the tars baseFee field: every baseFeePerGas entry — including
+// the trailing prediction, which must stay 0x0 instead of calcOpBaseFee's 1-for-zero — is
+// 0x0. reward is absent when no percentiles were requested.
+BOOST_AUTO_TEST_CASE(PbftHeadersYieldZeroBaseFeesAndZeroTrailing)
+{
+    auto resp = request(params("0x1"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_TEST(result["oldestBlock"].asString() == "0x13");  // latest = 19
+    BOOST_REQUIRE(result["baseFeePerGas"].isArray());
+    // 1 resolved block + 1 trailing prediction
+    BOOST_REQUIRE_EQUAL(result["baseFeePerGas"].size(), 2U);
+    BOOST_TEST(result["baseFeePerGas"][0U].asString() == "0x0");
+    BOOST_TEST(result["baseFeePerGas"][1U].asString() == "0x0");
+    BOOST_REQUIRE(result["gasUsedRatio"].isArray());
+    BOOST_REQUIRE_EQUAL(result["gasUsedRatio"].size(), 1U);
+    BOOST_TEST(!result.isMember("reward"));
+}
+
+// The fake chain's receipts carry no effectiveGasPrice, so every priority set is empty —
+// geth semantics: a percentile of an empty reward set is null, never a fabricated 0x0.
+// This also pins the multi-block shape (oldestBlock back-fill, one reward row per block).
+BOOST_AUTO_TEST_CASE(EmptyPrioritiesEmitNullRewards)
+{
+    Json::Value percentiles(Json::arrayValue);
+    percentiles.append(50.0);
+    auto resp = request(params("0x3", percentiles));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_TEST(result["oldestBlock"].asString() == "0x11");  // 19 - 3 + 1
+    BOOST_REQUIRE(result["baseFeePerGas"].isArray());
+    BOOST_REQUIRE_EQUAL(result["baseFeePerGas"].size(), 4U);
+    BOOST_REQUIRE(result["reward"].isArray());
+    BOOST_REQUIRE_EQUAL(result["reward"].size(), 3U);
+    for (Json::Value::ArrayIndex i = 0; i < 3; ++i)
+    {
+        BOOST_REQUIRE(result["reward"][i].isArray());
+        BOOST_REQUIRE_EQUAL(result["reward"][i].size(), 1U);
+        BOOST_CHECK(result["reward"][i][0U].isNull());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(RewardPercentilesAreWeightedByGasUsed)
+{
+    auto const block = m_ledger->ledgerData().back();
+    auto const header = block->blockHeader();
+    header->setBaseFee(bcos::u256(100));
+    header->setGasLimit(bcos::u256(100'000));
+    header->setGasUsed(bcos::u256(100'000));
+
+    auto const receiptFactory = m_blockFactory->receiptFactory();
+    auto makeReceipt = [&](bcos::u256 gasUsed, std::string effectiveGasPrice) {
+        std::vector<bcos::protocol::LogEntry> logs;
+        auto receipt = receiptFactory->createReceipt(
+            gasUsed, "", logs, /*status=*/0, bcos::bytesConstRef{}, header->number());
+        receipt->setEffectiveGasPrice(std::move(effectiveGasPrice));
+        return receipt;
+    };
+    block->clearReceipts();
+    block->appendReceipt(makeReceipt(bcos::u256(90'000), "0x65"));  // priority fee 1
+    block->appendReceipt(makeReceipt(bcos::u256(10'000), "0xc8"));  // priority fee 100
+
+    Json::Value percentiles(Json::arrayValue);
+    percentiles.append(50.0);
+    auto response = request(params("0x1", percentiles));
+    BOOST_REQUIRE(response.isMember("result"));
+    auto const& rewards = response["result"]["reward"];
+    BOOST_REQUIRE_EQUAL(rewards.size(), 1U);
+    BOOST_REQUIRE_EQUAL(rewards[0U].size(), 1U);
+    BOOST_TEST(rewards[0U][0U].asString() == "0x1");
+}
+
+// An OP header (baseFee present) drives the trailing entry through calcOpBaseFee; a Holocene
+// 9-byte extraData keeps the fork sniff away from Jovian. Golden values mirror CalcOpBaseFeeTest:
+// gasLimit 30M / elasticity 2 -> target 15M; gasUsed 20M -> deltaFee 41,666,666 over baseFee 1e9.
+BOOST_AUTO_TEST_CASE(OpHeaderTrailingPredictsNextBaseFee)
+{
+    auto const header = m_ledger->ledgerData().back()->blockHeader();
+    header->setGasLimit(bcos::u256(30'000'000));
+    header->setGasUsed(bcos::u256(20'000'000));
+    header->setBaseFee(bcos::u256(1'000'000'000));
+    // Holocene: version(0) || denominator 8 || elasticity 2 (9 bytes, not Jovian).
+    header->setExtraData(bcos::bytes{0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x02});
+
+    auto resp = request(params("0x1"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_REQUIRE_EQUAL(result["baseFeePerGas"].size(), 2U);
+    BOOST_TEST(result["baseFeePerGas"][0U].asString() == "0x3b9aca00");  // 1e9
+    BOOST_TEST(result["baseFeePerGas"][1U].asString() == "0x3e16926a");  // 1,041,666,666
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EthGetProofReaderWiringTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofReaderWiringTest.cpp
@@ -107,8 +107,9 @@ public:
         Json::Value value;
         Json::Reader reader;
         std::promise<bcos::bytes> promise;
-        web3JsonRpc->onRPCRequest(
-            req, [&promise](bcos::bytes resp, boost::beast::http::status) { promise.set_value(std::move(resp)); });
+        web3JsonRpc->onRPCRequest(req, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
         auto jsonBytes = promise.get_future().get();
         std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
         reader.parse(json.begin(), json.end(), value);
@@ -198,6 +199,66 @@ BOOST_AUTO_TEST_CASE(MissingRootThroughAdapterReturns32004)
     BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32004);
     BOOST_CHECK(
         resp["error"]["message"].asString().find("not in MPT node storage") != std::string::npos);
+}
+
+// --- OP-stack branch (EthEndpoint::getProof): a header carrying baseFee switches the endpoint
+// to the node-backed proof path (the PBFT branch above never writes the tars baseFee field).
+// The OP message strings differ from the PBFT ones, so the assertions below also prove which
+// branch actually ran.
+
+// Same trie, but the baseFee discriminator engages the OP branch while no reader is wired:
+// it must fail closed with -32603 exactly like the PBFT side — a node without the MPT node
+// reader never answers with a fabricated proof.
+BOOST_AUTO_TEST_CASE(OpHeaderWithoutReaderFailsClosed32603)
+{
+    buildTrie();
+    m_ledger->ledgerData().back()->blockHeader()->setBaseFee(bcos::u256(1));
+    // no wireReader()
+
+    auto resp = getProof(address.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32603);
+    BOOST_CHECK(resp["error"]["message"].asString().find("MPT not enabled") != std::string::npos);
+}
+
+// OP branch, reader wired, but the header's stateRoot has no node rows behind it: the proof
+// walk dead-ends at the missing root and generateProof reports BlockNotCommitted, which the
+// endpoint maps to -32004 with the OP-specific "flat rebuild" message — the message string is
+// what pins this test to the OP branch (the PBFT branch would say "not in MPT node storage").
+BOOST_AUTO_TEST_CASE(OpHeaderWithStaleRootFailsClosed32004)
+{
+    buildTrie();
+    wireReader();
+    m_ledger->ledgerData().back()->blockHeader()->setBaseFee(bcos::u256(1));
+    m_ledger->ledgerData().back()->blockHeader()->setStateRoot(h256{0x1234U});
+
+    auto resp = getProof(address.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32004);
+    BOOST_CHECK(resp["error"]["message"].asString().find("Proof unavailable for this block") !=
+                std::string::npos);
+}
+
+// Positive anchor for the OP branch: with a reader wired and real rows behind the stateRoot,
+// a baseFee-bearing header must serve the same proof as the PBFT path — proving the OP branch
+// is not just reachable but functional (the two negative cases above would pass even if the
+// baseFee discriminator silently fell through to PBFT; this one cannot).
+BOOST_AUTO_TEST_CASE(OpHeaderServesProofFromStateRows)
+{
+    buildTrie();
+    wireReader();
+    m_ledger->ledgerData().back()->blockHeader()->setBaseFee(bcos::u256(1));
+
+    auto resp =
+        getProof(address.hexPrefixed(), {slotA.hexPrefixed(), slotB.hexPrefixed()}, "latest");
+    BOOST_TEST(!resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_TEST(result["address"].asString() == address.hexPrefixed());
+    BOOST_TEST(result["balance"].asString() == "0x3e8");
+    BOOST_REQUIRE_EQUAL(result["storageProof"].size(), 2U);
+    BOOST_TEST(result["storageProof"][0U]["value"].asString() == "0x2a");
+    BOOST_TEST(result["storageProof"][1U]["value"].asString() == "0x1337");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3NodeStatusTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3NodeStatusTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-framework/sync/BlockSyncInterface.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <boost/test/unit_test.hpp>
@@ -70,7 +71,9 @@ public:
     {
         std::promise<bcos::bytes> promise;
         web3JsonRpc->onRPCRequest(
-            request, [&promise](bcos::bytes resp, boost::beast::http::status) { promise.set_value(std::move(resp)); });
+            request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+                promise.set_value(std::move(resp));
+            });
         auto jsonBytes = promise.get_future().get();
         Json::Value value;
         Json::Reader reader;
@@ -112,9 +115,23 @@ BOOST_AUTO_TEST_CASE(netPeerCountUsesSyncPeerStatus)
 
 BOOST_AUTO_TEST_CASE(netVersionReadsChainIdFromLedger)
 {
-    // net_version co_awaits the ledger system-config for the web3 chain id.
-    auto resp = call(req("net_version"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    // Decimal config — same parser as TxValidator / sendRawTransaction.
+    m_ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "1337");
+    auto decimal = call(req("net_version"));
+    BOOST_REQUIRE(decimal.isMember("result"));
+    BOOST_CHECK_EQUAL(decimal["result"].asString(), "0x539");
+
+    // 0x-prefixed config must not be truncated by std::stoull (which would yield 0).
+    m_ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "0x539");
+    auto hex = call(req("net_version"));
+    BOOST_REQUIRE(hex.isMember("result"));
+    BOOST_CHECK_EQUAL(hex["result"].asString(), "0x539");
+
+    // Corrupt config falls back to the historical default rather than throwing.
+    m_ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "not-a-number");
+    auto bad = call(req("net_version"));
+    BOOST_REQUIRE(bad.isMember("result"));
+    BOOST_CHECK_EQUAL(bad["result"].asString(), "0x4ee8");
 }
 
 BOOST_AUTO_TEST_CASE(netListeningIsConstantTrue)

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
@@ -600,6 +601,65 @@ BOOST_AUTO_TEST_CASE(combineTxResponseAccessAndAuthLists)
         BOOST_CHECK(!result.isMember("maxFeePerBlobGas"));
         BOOST_CHECK(!result.isMember("blobVersionedHashes"));
     }
+}
+
+// Matrix: T22 — non-canonical extraTransactionBytes must not crash combineTxResponse;
+// the undecodable branch emits zeroed web3 fields and keeps the tars hash.
+BOOST_AUTO_TEST_CASE(combineTxResponseUndecodableExtraTxBytes)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::rpc::Web3Transaction web3Tx;
+    web3Tx.type = bcos::rpc::TransactionType::EIP1559;
+    web3Tx.chainId = 1;
+    web3Tx.nonce = 7;
+    web3Tx.maxPriorityFeePerGas = 1;
+    web3Tx.maxFeePerGas = 2;
+    web3Tx.gasLimit = 21000;
+    web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+    web3Tx.value = 99;
+    web3Tx.signatureR = bcos::bytes(32, 0x11);
+    web3Tx.signatureS = bcos::bytes(32, 0x22);
+    web3Tx.signatureV = 0;
+
+    auto tarsTx = web3Tx.takeToTarsTransaction();
+    bcos::h256 arbitraryHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+
+    bcos::bytes items;
+    items.insert(items.end(), {0x82, 0x00, 0x01});  // nonce: non-canonical
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1234567890123456789012345678901234567890"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    items.push_back(rlp::LIST_HEAD_BASE);
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes(32, 0x11));
+    rlp::encode(items, bcos::bytes(32, 0x22));
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<bcos::byte>(bcos::rpc::TransactionType::EIP1559));
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+    tarsTx.extraTransactionBytes.assign(envelope.begin(), envelope.end());
+
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    BOOST_CHECK_EQUAL(result["hash"].asString(), arbitraryHash.hexPrefixed());
+    BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["type"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["value"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["chainId"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["v"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["r"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["s"].asString(), "0x0");
+    BOOST_CHECK(!result.isMember("accessList"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -1090,8 +1090,10 @@ BOOST_AUTO_TEST_CASE(testWideSignatureRejectedAtDecode)
     Web3Transaction tx{};
     auto err = rlp::decode(bRef, tx);
     BOOST_REQUIRE(err != nullptr);
-    // The width gate reports the EIP-2 signature error class, not a generic decode failure.
-    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+    // CanonInt now rejects a 33-byte r before the EIP-2 width gate: 33 bytes cannot
+    // decode into u256 (UnexpectedLength). Either rejection is a decode failure; pin
+    // the integer-width class so a regression back to decodeItems+truncate turns red.
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::UnexpectedLength));
 }
 
 // Leftover sealed-envelope path (decodeFromPayload / withSig=false) must still reject high-s.

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -20,6 +20,7 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>  // c_secp256k1n* + Secp256k1Crypto
+#include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rlp-protocol/Web3TxEnvelope.h>  // web3ChainIdFromEnvelope (F4 unit tests)
 #include <bcos-rlp-protocol/Web3TxHandler.h>
@@ -1093,6 +1094,81 @@ BOOST_AUTO_TEST_CASE(testWideSignatureRejectedAtDecode)
     BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
 }
 
+// Leftover sealed-envelope path (decodeFromPayload / withSig=false) must still reject high-s.
+// The leftover consume is what lets sealed blocks decode; skipping EIP-2 there is a fork vs
+// op-geth Sender.
+BOOST_AUTO_TEST_CASE(testNoSigLeftoverHighSRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    auto make1559 = [](bcos::bytes const& s) {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, static_cast<uint64_t>(1000000000));
+        rlp::encode(items, static_cast<uint64_t>(1000000000));
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        items.push_back(rlp::LIST_HEAD_BASE);
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes(32, 0x11));
+        rlp::encode(items, s);
+        bcos::bytes envelope;
+        envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+        rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+        envelope.insert(envelope.end(), items.begin(), items.end());
+        return envelope;
+    };
+    {
+        auto bytes = make1559(bcos::bytes(32, 0xff));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto err = rlp::decodeFromPayload(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+    }
+    {
+        auto bytes = make1559(bcos::bytes(32, 0x22));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        BOOST_REQUIRE(rlp::decodeFromPayload(bRef, tx) == nullptr);
+        BOOST_CHECK(tx.type == rpc::TransactionType::EIP1559);
+    }
+    // Legacy sealed leftover must populate signature* so EIP-2 still runs.
+    {
+        auto makeLegacy = [](bcos::bytes const& s) {
+            bcos::bytes items;
+            rlp::encode(items, static_cast<uint64_t>(0));           // nonce
+            rlp::encode(items, static_cast<uint64_t>(1000000000));  // gasPrice
+            rlp::encode(items, static_cast<uint64_t>(21000));       // gasLimit
+            rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+            rlp::encode(items, static_cast<uint64_t>(0));   // value
+            rlp::encode(items, bcos::bytes{});              // data
+            rlp::encode(items, static_cast<uint64_t>(38));  // v = chainId 1 * 2 + 35 + parity 1
+            rlp::encode(items, bcos::bytes(32, 0x11));      // r
+            rlp::encode(items, s);                          // s
+            // Legacy has no type byte: the RLP list itself IS the envelope.
+            bcos::bytes envelope;
+            rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+            envelope.insert(envelope.end(), items.begin(), items.end());
+            return envelope;
+        };
+        auto highBytes = makeLegacy(bcos::bytes(32, 0xff));
+        auto bRef = bcos::ref(highBytes);
+        Web3Transaction tx{};
+        auto err = rlp::decodeFromPayload(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+
+        auto lowBytes = makeLegacy(bcos::bytes(32, 0x22));
+        auto lowRef = bcos::ref(lowBytes);
+        Web3Transaction lowTx{};
+        BOOST_REQUIRE(rlp::decodeFromPayload(lowRef, lowTx) == nullptr);
+        BOOST_CHECK_EQUAL(lowTx.chainId.value_or(0), 1);
+    }
+}
+
 // Typed tx with chainId=0 must decode with chainId present (not nullopt).
 // A nullopt here would let the executor's chainId gate pass the tx unchecked (op-geth
 // modernSigner rejects chainId 0 != node-config; the decode layer must preserve the value).
@@ -1396,6 +1472,698 @@ BOOST_AUTO_TEST_CASE(testWeb3ChainIdFromEnvelope)
         auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(deposit));
         BOOST_CHECK(!result.has_value());
     }
+}
+
+// Classifier kinds, canonical integers, yParity, EIP-2.
+BOOST_AUTO_TEST_CASE(classifyWeb3EnvelopeChainIdKinds)
+{
+    namespace rlp = bcos::codec::rlp;
+    namespace envelope = bcos::rlp::protocol;
+    using Kind = envelope::Web3EnvelopeChainIdKind;
+
+    // Deposit is its own kind.
+    {
+        bcos::bytes deposit;
+        deposit.push_back(static_cast<byte>(bcos::rpc::TransactionType::Deposit));
+        BOOST_CHECK(
+            envelope::toString(envelope::classifyWeb3EnvelopeChainId(bcos::ref(deposit)).kind) ==
+            "Deposit");
+    }
+
+    // Empty / junk-first-byte envelopes are Malformed, not Unprotected.
+    BOOST_CHECK(
+        envelope::classifyWeb3EnvelopeChainId(bcos::bytesConstRef{}).kind == Kind::Malformed);
+    {
+        bcos::bytes junk{0xf0, 0x01, 0x02};
+        BOOST_CHECK(envelope::classifyWeb3EnvelopeChainId(bcos::ref(junk)).kind == Kind::Malformed);
+    }
+
+    // Non-minimal typed chainId is Malformed.
+    {
+        bcos::bytes items{0x82, 0x00, 0x01};  // non-canonical "1"
+        bcos::bytes env{static_cast<byte>(bcos::rpc::TransactionType::EIP1559)};
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        BOOST_CHECK(envelope::classifyWeb3EnvelopeChainId(bcos::ref(env)).kind == Kind::Malformed);
+
+        // Positive control: the minimal spelling of the same value stays Protected.
+        bcos::bytes ok;
+        rlp::encode(ok, static_cast<uint64_t>(1));
+        bcos::bytes envOk{static_cast<byte>(bcos::rpc::TransactionType::EIP1559)};
+        rlp::encodeHeader(envOk, {.isList = true, .payloadLength = ok.size()});
+        envOk.insert(envOk.end(), ok.begin(), ok.end());
+        auto const c = envelope::classifyWeb3EnvelopeChainId(bcos::ref(envOk));
+        BOOST_CHECK(c.kind == Kind::Protected && c.chainId == 1u);
+    }
+
+    // Leading-zero v in a legacy FULL envelope: same rejection, minimal-spelling twin yields
+    // Protected(chainId = (v-35)>>1). Tail keeps items 8/9 non-empty so the walker takes the
+    // full-form branch rather than the preimage one.
+    auto legacyFull = [](bcos::bytes const& vItem) {
+        bcos::bytes items;
+        for (int i = 0; i < 6; ++i)
+        {
+            rlp::encode(items, static_cast<uint64_t>(0));  // nonce..data fields
+        }
+        items.insert(items.end(), vItem.begin(), vItem.end());
+        items.push_back(0x01);  // r slot: non-empty single byte
+        items.push_back(0x01);  // s slot: non-empty single byte
+        bcos::bytes env;
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        return env;
+    };
+    BOOST_CHECK(
+        envelope::classifyWeb3EnvelopeChainId(bcos::ref(legacyFull({0x82, 0x00, 0x25}))).kind ==
+        Kind::Malformed);  // non-canonical "37"
+    {
+        auto const c = envelope::classifyWeb3EnvelopeChainId(bcos::ref(legacyFull({0x25})));
+        BOOST_CHECK(c.kind == Kind::Protected && c.chainId == 1u);  // 37 -> chainId 1
+    }
+
+    // Both Homestead unprotected spellings must classify Unprotected.
+    {
+        bcos::bytes items;
+        for (int i = 0; i < 6; ++i)
+        {
+            rlp::encode(items, static_cast<uint64_t>(i));  // nonce..data: exactly 6 fields
+        }
+        bcos::bytes env;
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        BOOST_CHECK(
+            envelope::classifyWeb3EnvelopeChainId(bcos::ref(env)).kind == Kind::Unprotected);
+    }
+    {
+        // Full legacy envelope with v=27 (parity 0): exempt pre-EIP-155 form.
+        auto const c = envelope::classifyWeb3EnvelopeChainId(bcos::ref(legacyFull({0x1b})));
+        BOOST_CHECK(c.kind == Kind::Unprotected);  // v=27 => Unprotected, no chainId binding
+        BOOST_CHECK(envelope::toString(c.kind) == "Unprotected");
+    }
+
+    // (Y) The documented Malformed v-bands of the legacy full form — 0/1 (Homestead parity
+    // slots must not gain a chainId binding) and 29..34 (below the EIP-155 base) — must NOT
+    // ride the 27/28 unprotected exemption. Only 27/28 and >=35 are exempt/protected.
+    {
+        // BS: interior values of the documented 29..34 band get their own cells — the
+        // endpoints alone would not catch a classifier that only special-cases 29/34.
+        for (uint64_t v : {0u, 1u, 26u, 29u, 30u, 31u, 32u, 33u, 34u})
+        {
+            bcos::bytes vItem;
+            rlp::encode(vItem, v);
+            BOOST_CHECK(envelope::classifyWeb3EnvelopeChainId(bcos::ref(legacyFull(vItem))).kind ==
+                        Kind::Malformed);
+        }
+        // Preimage-tail canonicality: a non-canonical chainId in the legacy PREIMAGE tail
+        // (fields 8/9 empty) hits the same canonical walker as the full-form branch and
+        // must fail closed rather than classify Protected.
+        {
+            bcos::bytes items;
+            for (int i = 0; i < 6; ++i)
+            {
+                rlp::encode(items, static_cast<uint64_t>(0));
+            }
+            bcos::bytes const nonCanonical{0x82, 0x00, 0x25};  // padded "37"
+            items.insert(items.end(), nonCanonical.begin(), nonCanonical.end());
+            items.push_back(0x80);  // r placeholder (empty)
+            items.push_back(0x80);  // s placeholder (empty)
+            bcos::bytes env;
+            rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+            env.insert(env.end(), items.begin(), items.end());
+            BOOST_CHECK(
+                envelope::classifyWeb3EnvelopeChainId(bcos::ref(env)).kind == Kind::Malformed);
+        }
+        // Over-wide preimage chainId (9-byte payload, above uint64 width): the shared
+        // walker cannot decode it, so the classifier fails closed.
+        {
+            bcos::bytes items;
+            for (int i = 0; i < 6; ++i)
+            {
+                rlp::encode(items, static_cast<uint64_t>(0));
+            }
+            items.push_back(0x89);  // 9-byte string item — canonical RLP but > uint64 width
+            items.push_back(0x01);
+            for (int i = 0; i < 8; ++i)
+            {
+                items.push_back(0x00);
+            }
+            items.push_back(0x80);
+            items.push_back(0x80);
+            bcos::bytes env;
+            rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+            env.insert(env.end(), items.begin(), items.end());
+            BOOST_CHECK(
+                envelope::classifyWeb3EnvelopeChainId(bcos::ref(env)).kind == Kind::Malformed);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(decodeCanonicalRlpUintAcceptsOnlyMinimalEncodings)
+{
+    namespace rlp = bcos::codec::rlp;
+
+    auto probe = [](std::initializer_list<uint8_t> raw) {
+        bcos::bytes buffer{raw};
+        bcos::bytesRef cursor(buffer.data(), buffer.size());
+        uint64_t value = 0;
+        auto const error = bcos::rlp::protocol::decodeCanonicalRlpUint(cursor, value);
+        return std::make_pair(error == nullptr, value);
+    };
+
+    // Minimal spellings accepted.
+    {
+        auto const [ok0, v0] = probe({0x80});
+        BOOST_CHECK(ok0 && v0 == 0u);
+    }
+    {
+        auto const [ok1, v1] = probe({0x01});
+        BOOST_CHECK(ok1 && v1 == 1u);
+    }
+    {
+        auto const [ok8453, v8453] = probe({0x82, 0x21, 0x05});
+        BOOST_CHECK(ok8453 && v8453 == 8453u);
+    }
+
+    // Non-minimal spellings rejected: bare zero byte, leading zeros, oversized prefix.
+    BOOST_CHECK(!probe({0x00}).first);
+    BOOST_CHECK(!probe({0x82, 0x00, 0x01}).first);
+    BOOST_CHECK(!probe({0x84, 0x00, 0x00, 0x00, 0x05}).first);
+}
+
+BOOST_AUTO_TEST_CASE(decodeCanonicalYParityStrictItemForms)
+{
+    namespace rlp = bcos::codec::rlp;
+
+    auto probeParity = [](std::initializer_list<uint8_t> item) {
+        bcos::bytes buffer{item};
+        bcos::bytesRef cursor(buffer.data(), buffer.size());
+        uint64_t parity = 99;
+        auto const error = bcos::rlp::protocol::decodeCanonicalYParity(cursor, parity);
+        return std::make_pair(error == nullptr, parity);
+    };
+
+    // Exactly two whole-item forms exist: empty-string 0x80 for zero, inline 0x01 for one.
+    {
+        auto const [okZero, p0] = probeParity({0x80});
+        BOOST_CHECK(okZero && p0 == 0u);
+    }
+    {
+        auto const [okOne, p1] = probeParity({0x01});
+        BOOST_CHECK(okOne && p1 == 1u);
+    }
+
+    // Everything else rejected: the bare non-minimal zero, other values, wider payloads,
+    // list shapes.
+    BOOST_CHECK(!probeParity({0x00}).first);
+    BOOST_CHECK(!probeParity({0x02}).first);
+    BOOST_CHECK(!probeParity({0x81, 0x00}).first);
+    BOOST_CHECK(!probeParity({0xc1, 0x80}).first);
+}
+
+// EIP-2: low-s and range on raw scalars.
+BOOST_AUTO_TEST_CASE(checkEip2SignatureBoundaryScalars)
+{
+    using bcos::crypto::c_secp256k1n;
+    using bcos::crypto::c_secp256k1nOver2;
+    auto scalarBytes = [](bcos::u256 const& value) {
+        auto be = bcos::toBigEndian(value);
+        if (be.size() < 32)
+        {
+            be.insert(be.begin(), 32 - be.size(), bcos::byte{0});
+        }
+        return be;
+    };
+
+    auto const r = scalarBytes(bcos::u256{1});                   // any in-range r
+    auto const sLowEdge = scalarBytes(c_secp256k1nOver2);        // boundary allowed (s <= n/2)
+    auto const sLowInside = scalarBytes(c_secp256k1nOver2 - 1);  // clearly legal
+    auto const sHigh = scalarBytes(c_secp256k1nOver2 + 1);       // malleable flip
+    auto const rZero = scalarBytes(bcos::u256{0});               // out of [1, n-1]
+    auto const rHuge = scalarBytes(c_secp256k1n);                // r >= n rejected
+
+    BOOST_CHECK(bcos::checkEip2Signature(r, sLowInside) == nullptr);
+    BOOST_CHECK(bcos::checkEip2Signature(r, sLowEdge) == nullptr);
+    BOOST_CHECK(bcos::checkEip2Signature(r, sHigh) != nullptr);
+    BOOST_CHECK(bcos::checkEip2Signature(rZero, sLowInside) != nullptr);
+    BOOST_CHECK(bcos::checkEip2Signature(rHuge, sLowInside) != nullptr);
+
+    // Width gate: a 33-byte scalar must reject even with a leading zero that would truncate
+    // into range.
+    auto wide = scalarBytes(bcos::u256{1});
+    wide.insert(wide.begin(), bcos::byte{0});
+    BOOST_REQUIRE_EQUAL(wide.size(), 33U);
+    BOOST_CHECK(bcos::checkEip2Signature(wide, sLowInside) != nullptr);
+
+    // AV: EIP-2 (Homestead) also rejects s = 0 — pin the cell so deleting the production
+    // s != 0 guard (Web3Transaction decode / this check) flips the suite red.
+    auto const sZero = scalarBytes(bcos::u256{0});
+    BOOST_CHECK(bcos::checkEip2Signature(r, sZero) != nullptr);
+
+    // AV: the extreme wide s (n - 1) sits in the malleable band (n/2, n) and must reject,
+    // not just the n/2 + 1 boundary.
+    auto const sMax = scalarBytes(c_secp256k1n - 1);
+    BOOST_CHECK(bcos::checkEip2Signature(r, sMax) != nullptr);
+}
+
+// Finding BN: a withSig=false decode of a SEALED typed envelope must store 32-byte
+// zero-padded r/s (matching the withSig sibling and the legacy handler), while the
+// unsigned spelling — empty r/s placeholders — stays empty instead of being padded
+// into fabricated 32 zero bytes.
+BOOST_AUTO_TEST_CASE(typedNoSigDecodePadsPresentSignature)
+{
+    namespace rlp = bcos::codec::rlp;
+    auto build = [](bcos::bytes const& yParityItem, bcos::bytes const& rItem,
+                     bcos::bytes const& sItem) {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));      // chainId
+        rlp::encode(items, static_cast<uint64_t>(0));      // nonce
+        rlp::encode(items, static_cast<uint64_t>(1));      // maxPriorityFeePerGas
+        rlp::encode(items, static_cast<uint64_t>(2));      // maxFeePerGas
+        rlp::encode(items, static_cast<uint64_t>(21000));  // gas
+        rlp::encode(items, bcos::bytes(20, 0x11));         // to
+        rlp::encode(items, static_cast<uint64_t>(0));      // value
+        rlp::encode(items, bcos::bytes{});                 // data
+        bcos::bytes accessList;
+        rlp::encodeHeader(accessList, {.isList = true, .payloadLength = 0});
+        items.insert(items.end(), accessList.begin(), accessList.end());
+        items.insert(items.end(), yParityItem.begin(), yParityItem.end());
+        items.insert(items.end(), rItem.begin(), rItem.end());
+        items.insert(items.end(), sItem.begin(), sItem.end());
+        bcos::bytes envelope;
+        envelope.push_back(static_cast<bcos::byte>(bcos::rpc::TransactionType::EIP1559));
+        rlp::encodeHeader(envelope, {.isList = true, .payloadLength = items.size()});
+        envelope.insert(envelope.end(), items.begin(), items.end());
+        return envelope;
+    };
+
+    // Sealed envelope with trimmed (non-32-byte) r/s and canonical yParity 0x01.
+    bcos::bytes sealed = build(bcos::bytes{0x01}, bcos::bytes{0x01}, bcos::bytes{0x02});
+    auto sealedRef = bcos::ref(sealed);
+    bcos::rpc::Web3Transaction tx{};
+    auto error = bcos::codec::rlp::decodeFromPayload(sealedRef, tx);
+    BOOST_REQUIRE_MESSAGE(error == nullptr,
+        "sealed-form decode failed: " << (error ? error->errorMessage() : std::string("<null>")));
+    BOOST_REQUIRE_EQUAL(tx.signatureR.size(), 32U);
+    BOOST_CHECK(tx.signatureR.front() == bcos::byte{0});
+    BOOST_CHECK(tx.signatureR.back() == bcos::byte{0x01});
+    BOOST_REQUIRE_EQUAL(tx.signatureS.size(), 32U);
+    BOOST_CHECK(tx.signatureS.back() == bcos::byte{0x02});
+
+    // Unsigned spelling per the handler contract: all-empty trailer (0x80 0x80 0x80) —
+    // parity 0 with empty r/s. Keeps empty r/s instead of fabricated zero padding.
+    bcos::bytes unsignedSpelling = build(bcos::bytes{0x80}, bcos::bytes{0x80}, bcos::bytes{0x80});
+    auto unsignedRef = bcos::ref(unsignedSpelling);
+    bcos::rpc::Web3Transaction unsignedDecoded{};
+    error = bcos::codec::rlp::decodeFromPayload(unsignedRef, unsignedDecoded);
+    BOOST_REQUIRE_MESSAGE(
+        error == nullptr, "unsigned-spelling decode failed: " << (error ? error->errorMessage() :
+                                                                          std::string("<null>")));
+    BOOST_CHECK(unsignedDecoded.signatureR.empty());
+    BOOST_CHECK(unsignedDecoded.signatureS.empty());
+}
+
+// Matrix: T03 — a sealed legacy envelope whose nonce is the non-minimal 0x82 0x00 0x01
+// must fail closed (NonCanonicalSize), not decode nonce=1.
+BOOST_AUTO_TEST_CASE(legacyEnvelopeNonCanonicalNonceRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    items.insert(items.end(), {0x82, 0x00, 0x01});  // nonce: padded 1
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    rlp::encode(items, static_cast<uint64_t>(38));
+    rlp::encode(items, bcos::bytes(32, 0x11));
+    rlp::encode(items, bcos::bytes(32, 0x22));
+    bcos::bytes envelope;
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto const err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::NonCanonicalSize));
+}
+
+// Matrix: T04 — deposit isSystemTx spelled 0x81 0x01 (canonical 1-byte string, not the
+// op-geth 0x01 / 0x80 whole-item forms) must reject and must not latch isSystemTx=true.
+BOOST_AUTO_TEST_CASE(depositNonCanonicalIsSystemTxRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    // depositGoldenEncoding false vector, with the isSystem empty-string 0x80 rewritten
+    // as 0x81 0x01 and the list payload length bumped 0x53 → 0x54 so the envelope stays
+    // structurally well-formed. Only the flag spelling is illegal.
+    std::string hex =
+        "7ef853a07bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8"
+        "94dead000000000000000000000000000000000011"
+        "944200000000000000000000000000000000000022"
+        "64"
+        "80"
+        "8307a120"
+        "80"
+        "80";
+    BOOST_REQUIRE(hex.starts_with("7ef853"));
+    BOOST_REQUIRE(hex.ends_with("8080"));
+    hex.replace(2, 4, "f854");
+    hex.replace(hex.size() - 4, 4, "810180");
+
+    auto bytes = fromHex(hex);
+    auto bRef = bcos::ref(bytes);
+    Web3Transaction tx{};
+    auto const err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::NonCanonicalSize));
+    BOOST_CHECK(!tx.isSystemTx);
+}
+
+// Matrix: T12 — EIP-1559 wire with a non-canonical maxFeePerGas must reject
+// NonCanonicalSize (not silently accept 1).
+BOOST_AUTO_TEST_CASE(eip1559EnvelopeNonCanonicalMaxFeeRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    items.insert(items.end(), {0x82, 0x00, 0x01});  // maxFeePerGas: padded 1
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    items.push_back(rlp::LIST_HEAD_BASE);
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes(32, 0x11));
+    rlp::encode(items, bcos::bytes(32, 0x22));
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto const err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::NonCanonicalSize));
+}
+
+// Matrix: T18 — parseWeb3ChainId is the shared config parser (decimal + 0x QUANTITY).
+BOOST_AUTO_TEST_CASE(parseWeb3ChainIdAcceptsDecimalAndHex)
+{
+    using bcos::ledger::parseWeb3ChainId;
+    {
+        auto const parsed = parseWeb3ChainId("1337");
+        BOOST_REQUIRE(parsed.has_value());
+        BOOST_CHECK(*parsed == 1337);
+    }
+    {
+        auto const parsed = parseWeb3ChainId("0x539");
+        BOOST_REQUIRE(parsed.has_value());
+        BOOST_CHECK(*parsed == 1337);
+    }
+    BOOST_CHECK(!parseWeb3ChainId("0x").has_value());
+    BOOST_CHECK(!parseWeb3ChainId("zz").has_value());
+    BOOST_CHECK(!parseWeb3ChainId("").has_value());
+    BOOST_CHECK(!parseWeb3ChainId("-5").has_value());
+}
+
+// Matrix: T06 — EIP-7702 auth yParity spelled 0x00 must reject InvalidVInSignature
+// and must not succeed as yParity=0 (only whole-item 0x80/0x01 are legal).
+BOOST_AUTO_TEST_CASE(authYParityBareZeroRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));  // chainId
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));  // nonce
+    items.push_back(0x00);                         // yParity: bare zero, not 0x80
+    rlp::encode(items, static_cast<uint64_t>(1));  // r
+    rlp::encode(items, static_cast<uint64_t>(1));  // s
+    bcos::bytes entry;
+    rlp::encodeHeader(entry, rlp::Header{.isList = true, .payloadLength = items.size()});
+    entry.insert(entry.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(entry);
+    AuthorizationListEntry decoded{};
+    decoded.yParity = 0;  // would be the silent-accept value
+    auto const err = rlp::decode(bRef, decoded);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+}
+
+// Matrix: T07 — deposit mint spelled 0x82 0x00 0x64 (padded 100) → NonCanonicalSize.
+BOOST_AUTO_TEST_CASE(depositNonCanonicalMintRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8"));
+    rlp::encode(items, Address("0xdead000000000000000000000000000000000011"));
+    rlp::encode(items, Address("0x4200000000000000000000000000000000000022"));
+    items.insert(items.end(), {0x82, 0x00, 0x64});  // mint: padded 100
+    rlp::encode(items, static_cast<uint64_t>(0));   // value
+    rlp::encode(items, static_cast<uint64_t>(500000));
+    items.push_back(0x80);  // isSystemTx = false
+    rlp::encode(items, bcos::bytes{});
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::Deposit));
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto const err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::NonCanonicalSize));
+}
+
+// Matrix: T08 — leftover (decodeFromPayload) 1559 yParity spelled 0x00 → InvalidVInSignature.
+BOOST_AUTO_TEST_CASE(leftoverYParityBareZeroRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    items.push_back(rlp::LIST_HEAD_BASE);
+    items.push_back(0x00);  // yParity: bare zero
+    rlp::encode(items, bcos::bytes(32, 0x11));
+    rlp::encode(items, bcos::bytes(32, 0x22));
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto const err = rlp::decodeFromPayload(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+}
+
+// Matrix: T09 — typed empty trailer 0x80 0x80 0x80 vs bare preimage both decode with
+// withSig=false, but the verbatim envelopes hash differently (handler NOTE).
+BOOST_AUTO_TEST_CASE(typedEmptyTrailerHashesDifferFromBarePreimage)
+{
+    namespace rlp = bcos::codec::rlp;
+    auto make1559Fields = []() {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+        rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        items.push_back(rlp::LIST_HEAD_BASE);
+        return items;
+    };
+    auto wrap = [](bcos::bytes const& items) {
+        bcos::bytes envelope;
+        envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+        rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+        envelope.insert(envelope.end(), items.begin(), items.end());
+        return envelope;
+    };
+
+    auto const bareItems = make1559Fields();
+    auto bare = wrap(bareItems);
+    auto paddedItems = bareItems;
+    paddedItems.insert(paddedItems.end(), {0x80, 0x80, 0x80});
+    auto padded = wrap(paddedItems);
+
+    Web3Transaction bareTx{};
+    auto bareRef = bcos::ref(bare);
+    BOOST_REQUIRE(rlp::decodeFromPayload(bareRef, bareTx) == nullptr);
+    BOOST_REQUIRE(bareRef.empty());
+    BOOST_CHECK(bareTx.type == rpc::TransactionType::EIP1559);
+
+    Web3Transaction paddedTx{};
+    auto paddedRef = bcos::ref(padded);
+    BOOST_REQUIRE(rlp::decodeFromPayload(paddedRef, paddedTx) == nullptr);
+    BOOST_REQUIRE(paddedRef.empty());
+    BOOST_CHECK(paddedTx.type == rpc::TransactionType::EIP1559);
+
+    // Verbatim commitment: the two envelopes are not the same bytes.
+    auto const bareHash = bcos::crypto::keccak256Hash(bcos::ref(bare));
+    auto const paddedHash = bcos::crypto::keccak256Hash(bcos::ref(padded));
+    BOOST_CHECK(bareHash != paddedHash);
+    // Re-encode always emits an empty trailer, so both decoded objects collapse to padded.
+    BOOST_CHECK(bareTx.encode() == padded);
+    BOOST_CHECK(paddedTx.encode() == padded);
+    BOOST_CHECK(bareTx.encodeForSign() == paddedTx.encodeForSign());
+}
+
+// Matrix: T15 — leftover high-s on EIP-2930 (0x01) must reject InvalidVInSignature.
+BOOST_AUTO_TEST_CASE(eip2930LeftoverHighSRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    auto make2930 = [](bcos::bytes const& s) {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, static_cast<uint64_t>(1'000'000'000));  // gasPrice
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        items.push_back(rlp::LIST_HEAD_BASE);
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes(32, 0x11));
+        rlp::encode(items, s);
+        bcos::bytes envelope;
+        envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP2930));
+        rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+        envelope.insert(envelope.end(), items.begin(), items.end());
+        return envelope;
+    };
+    {
+        auto bytes = make2930(bcos::bytes(32, 0xff));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto const err = rlp::decodeFromPayload(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+    }
+    {
+        auto bytes = make2930(bcos::bytes(32, 0x22));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        BOOST_REQUIRE(rlp::decodeFromPayload(bRef, tx) == nullptr);
+        BOOST_CHECK(tx.type == rpc::TransactionType::EIP2930);
+    }
+}
+
+// Matrix: T16 — legacy tail r non-empty + s empty is sealed, not preimage; v=5 →
+// InvalidVInSignature.
+BOOST_AUTO_TEST_CASE(legacyTailNonEmptyREmptySIsSealed)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    rlp::encode(items, static_cast<uint64_t>(5));  // item7 = v=5
+    items.push_back(0x01);                         // item8 = r non-empty
+    items.push_back(0x80);                         // item9 = s empty
+    bcos::bytes envelope;
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto const err = rlp::decodeFromPayload(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+}
+
+// Matrix: T17 — (chainId=27, 0, 0) preimage is preimage, not Homestead v=27.
+BOOST_AUTO_TEST_CASE(legacyPreimageChainId27NotHomesteadV)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    rlp::encode(items, static_cast<uint64_t>(27));  // chainId placeholder
+    items.push_back(0x80);
+    items.push_back(0x80);
+    bcos::bytes envelope;
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    BOOST_REQUIRE(rlp::decodeFromPayload(bRef, tx) == nullptr);
+    BOOST_CHECK(tx.type == rpc::TransactionType::Legacy);
+    BOOST_REQUIRE(tx.chainId.has_value());
+    BOOST_CHECK_EQUAL(tx.chainId.value(), 27U);
+}
+
+// Matrix: T13 — 7702 auth[0].chainId spelled 0x82 0x00 0x01 → decode fails NonCanonicalSize.
+BOOST_AUTO_TEST_CASE(authChainIdLeadingZeroRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    items.insert(items.end(), {0x82, 0x00, 0x01});  // chainId: padded 1
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    items.push_back(0x80);  // yParity = 0
+    rlp::encode(items, static_cast<uint64_t>(1));
+    rlp::encode(items, static_cast<uint64_t>(1));
+    bcos::bytes entry;
+    rlp::encodeHeader(entry, rlp::Header{.isList = true, .payloadLength = items.size()});
+    entry.insert(entry.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(entry);
+    AuthorizationListEntry decoded{};
+    auto const err = rlp::decode(bRef, decoded);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::NonCanonicalSize));
+}
+
+// Matrix: T14 — EIP-4844 wire with non-canonical maxFeePerBlobGas → NonCanonicalSize.
+BOOST_AUTO_TEST_CASE(eip4844EnvelopeNonCanonicalBlobFeeRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(1'000'000'000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    items.push_back(rlp::LIST_HEAD_BASE);           // empty accessList
+    items.insert(items.end(), {0x82, 0x00, 0x01});  // maxFeePerBlobGas: padded 1
+    items.push_back(rlp::LIST_HEAD_BASE);           // empty blobVersionedHashes
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes(32, 0x11));
+    rlp::encode(items, bcos::bytes(32, 0x22));
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP4844));
+    rlp::encodeHeader(envelope, rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto const err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::NonCanonicalSize));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- RPC half of #5496, stacked on split B: `feeHistory`, `getProof`, `estimateGas`, Engine error mapping, and Web3 response models.
- Depends on #5520 (decode/admission/`OpBaseFee`/`Errors.h`). After B merges, rebase this branch onto `release-3.18.0`.
- Review follow-up: `eth_feeHistory` `newestBlock` must be a non-empty QUANTITY/TAG string (no empty `toView` → latest); Jovian extraData fixture pins the minBaseFee floor on the trailing next-baseFee. Split-B fail-closed admission fixes are included until B merges.
- Original #5496 (`opstack-split-BC` @ `e63057ee4`) is unchanged.

## Test plan
- [ ] Review the latest C commit plus the stacked B follow-up until #5520 merges
- [x] `EthFeeHistoryTest` covers newestBlock InvalidParams and Jovian minBaseFee floor
- [ ] `EthEstimateGasBudgetTest` / Engine RPC mapping tests pass
- [ ] FCU V4 still maps to -38005