### PR TITLE
Remove unnecessary shared_ptr usage in bcos-boostssl

### DIFF
--- a/bcos-boostssl/bcos-boostssl/httpserver/Common.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/Common.h
@@ -46,7 +46,7 @@ using HttpResponsePtr = std::shared_ptr<HttpResponse>;
 using HttpReqHandler = std::function<void(const HttpRequest& req,
     std::function<void(bcos::bytes, boost::beast::http::status)>)>;
 using WsUpgradeHandler =
-    std::function<void(std::shared_ptr<HttpStream>, HttpRequest&&, std::shared_ptr<std::string>)>;
+    std::function<void(std::shared_ptr<HttpStream>, HttpRequest&&, std::string)>;
 
 // cors config
 struct CorsConfig

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -121,6 +121,16 @@ void HttpServer::stop()
 
 void HttpServer::accept()
 {
+    if (!m_acceptor)
+    {
+        // the acceptor may have been reset by setAcceptor(nullptr); do not
+        // dereference an empty optional. This is a no-op rather than an
+        // exception because accept() is also called from onAccept retries,
+        // where throwing would escape into io_context::run
+        HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_DESC("acceptor is not initialized");
+        return;
+    }
+
     // The new connection gets its own strand
     m_acceptor->async_accept(*(m_ioservicePool->getIOService()),
         boost::beast::bind_front_handler(&HttpServer::onAccept, shared_from_this()));
@@ -264,6 +274,16 @@ boost::asio::ip::tcp::acceptor& HttpServer::acceptor()
 
 void HttpServer::setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor)
 {
+    if (m_acceptor)
+    {
+        // cancel any pending async_accept and close the old acceptor before it
+        // is replaced or destroyed, so that its completion handlers receive
+        // operation_aborted rather than referencing a destroyed acceptor
+        boost::system::error_code ec;
+        m_acceptor->cancel(ec);
+        m_acceptor->close(ec);
+    }
+
     if (_acceptor)
     {
         m_acceptor.emplace(std::move(*_acceptor));

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -121,16 +121,6 @@ void HttpServer::stop()
 
 void HttpServer::accept()
 {
-    if (!m_acceptor)
-    {
-        // the acceptor may have been reset by setAcceptor(nullptr); do not
-        // dereference an empty optional. This is a no-op rather than an
-        // exception because accept() is also called from onAccept retries,
-        // where throwing would escape into io_context::run
-        HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_DESC("acceptor is not initialized");
-        return;
-    }
-
     // The new connection gets its own strand
     m_acceptor->async_accept(*(m_ioservicePool->getIOService()),
         boost::beast::bind_front_handler(&HttpServer::onAccept, shared_from_this()));
@@ -272,7 +262,7 @@ boost::asio::ip::tcp::acceptor& HttpServer::acceptor()
     return *m_acceptor;
 }
 
-void HttpServer::setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor)
+void HttpServer::setAcceptor(boost::asio::ip::tcp::acceptor _acceptor)
 {
     if (m_acceptor)
     {
@@ -284,15 +274,7 @@ void HttpServer::setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _ac
         m_acceptor->close(ec);
     }
 
-    if (_acceptor)
-    {
-        m_acceptor.emplace(std::move(*_acceptor));
-    }
-    else
-    {
-        // reset the optional so that a previously set acceptor is not reused
-        m_acceptor.reset();
-    }
+    m_acceptor.emplace(std::move(_acceptor));
 }
 
 std::shared_ptr<boost::asio::ssl::context> HttpServer::ctx() const
@@ -322,7 +304,7 @@ HttpStreamFactory& HttpServer::httpStreamFactory()
 
 void HttpServer::setHttpStreamFactory(HttpStreamFactory _httpStreamFactory)
 {
-    m_httpStreamFactory = _httpStreamFactory;
+    m_httpStreamFactory = std::move(_httpStreamFactory);
 }
 
 bool HttpServer::disableSsl() const
@@ -378,9 +360,8 @@ HttpServer::Ptr HttpServerFactory::buildHttpServer(const std::string& _listenIP,
     // create httpserver and launch a listening port
     auto server =
         std::make_shared<HttpServer>(_listenIP, _listenPort, _httpBodySizeLimit, _corsConfig);
-    auto acceptor = std::make_shared<boost::asio::ip::tcp::acceptor>(*_ioc);
     server->setCtx(std::move(_ctx));
-    server->setAcceptor(acceptor);
+    server->setAcceptor(boost::asio::ip::tcp::acceptor{*_ioc});
     server->setHttpStreamFactory(HttpStreamFactory{});
 
     HTTP_SERVER(INFO) << LOG_BADGE("buildHttpServer") << LOG_KV("listenIP", _listenIP)

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -166,9 +166,9 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
     bool useSsl = !disableSsl();
     if (!useSsl)
     {  // non ssl , start http session
-        auto httpStream = m_httpStreamFactory->buildHttpStream(
+        auto httpStream = m_httpStreamFactory.buildHttpStream(
             std::make_shared<boost::beast::tcp_stream>(std::move(socket)));
-        buildHttpSession(httpStream, nullptr)->run();
+        buildHttpSession(httpStream, "")->run();
 
         accept();
         return;
@@ -197,8 +197,8 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
 
             if (auto server = self.lock())
             {
-                auto httpStream = server->httpStreamFactory()->buildHttpStream(ss);
-                server->buildHttpSession(httpStream, nodeId)->run();
+                auto httpStream = server->httpStreamFactory().buildHttpStream(ss);
+                server->buildHttpSession(httpStream, nodeId ? *nodeId : "")->run();
             }
         });
 
@@ -206,8 +206,7 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
 }
 
 
-HttpSession::Ptr HttpServer::buildHttpSession(
-    HttpStream::Ptr _httpStream, std::shared_ptr<std::string> _nodeId)
+HttpSession::Ptr HttpServer::buildHttpSession(HttpStream::Ptr _httpStream, std::string _nodeId)
 {
     auto session = std::make_shared<HttpSession>(m_httpBodySizeLimit, m_corsConfig);
 
@@ -249,14 +248,17 @@ void HttpServer::setHttpReqHandler(HttpReqHandler _httpReqHandler)
     m_httpReqHandler = std::move(_httpReqHandler);
 }
 
-std::shared_ptr<boost::asio::ip::tcp::acceptor> HttpServer::acceptor() const
+boost::asio::ip::tcp::acceptor& HttpServer::acceptor()
 {
-    return m_acceptor;
+    return *m_acceptor;
 }
 
 void HttpServer::setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor)
 {
-    m_acceptor = std::move(_acceptor);
+    if (_acceptor)
+    {
+        m_acceptor.emplace(std::move(*_acceptor));
+    }
 }
 
 std::shared_ptr<boost::asio::ssl::context> HttpServer::ctx() const
@@ -279,14 +281,14 @@ void HttpServer::setWsUpgradeHandler(WsUpgradeHandler _wsUpgradeHandler)
     m_wsUpgradeHandler = std::move(_wsUpgradeHandler);
 }
 
-HttpStreamFactory::Ptr HttpServer::httpStreamFactory() const
+HttpStreamFactory& HttpServer::httpStreamFactory()
 {
     return m_httpStreamFactory;
 }
 
-void HttpServer::setHttpStreamFactory(HttpStreamFactory::Ptr _httpStreamFactory)
+void HttpServer::setHttpStreamFactory(HttpStreamFactory _httpStreamFactory)
 {
-    m_httpStreamFactory = std::move(_httpStreamFactory);
+    m_httpStreamFactory = _httpStreamFactory;
 }
 
 bool HttpServer::disableSsl() const
@@ -343,10 +345,9 @@ HttpServer::Ptr HttpServerFactory::buildHttpServer(const std::string& _listenIP,
     auto server =
         std::make_shared<HttpServer>(_listenIP, _listenPort, _httpBodySizeLimit, _corsConfig);
     auto acceptor = std::make_shared<boost::asio::ip::tcp::acceptor>(*_ioc);
-    auto httpStreamFactory = std::make_shared<HttpStreamFactory>();
     server->setCtx(std::move(_ctx));
     server->setAcceptor(acceptor);
-    server->setHttpStreamFactory(httpStreamFactory);
+    server->setHttpStreamFactory(HttpStreamFactory{});
 
     HTTP_SERVER(INFO) << LOG_BADGE("buildHttpServer") << LOG_KV("listenIP", _listenIP)
                       << LOG_KV("listenPort", _listenPort)

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -45,7 +45,12 @@ HttpServer::~HttpServer()
 // start http server
 void HttpServer::start()
 {
-    if (m_acceptor && m_acceptor->is_open())
+    if (!m_acceptor)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("acceptor is not initialized"));
+    }
+
+    if (m_acceptor->is_open())
     {
         HTTP_SERVER(INFO) << LOG_BADGE("startListen") << LOG_DESC("http server is running");
         return;
@@ -250,6 +255,10 @@ void HttpServer::setHttpReqHandler(HttpReqHandler _httpReqHandler)
 
 boost::asio::ip::tcp::acceptor& HttpServer::acceptor()
 {
+    if (!m_acceptor)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error("acceptor is not initialized"));
+    }
     return *m_acceptor;
 }
 
@@ -258,6 +267,11 @@ void HttpServer::setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _ac
     if (_acceptor)
     {
         m_acceptor.emplace(std::move(*_acceptor));
+    }
+    else
+    {
+        // reset the optional so that a previously set acceptor is not reused
+        m_acceptor.reset();
     }
 }
 

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.h
@@ -21,6 +21,7 @@
 
 #include <bcos-boostssl/httpserver/HttpSession.h>
 #include <bcos-utilities/IOServicePool.h>
+#include <optional>
 #include <utility>
 namespace bcos::boostssl::http
 {
@@ -44,13 +45,12 @@ public:
     // handle connection
     void onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::socket socket);
 
-    HttpSession::Ptr buildHttpSession(
-        HttpStream::Ptr _stream, std::shared_ptr<std::string> _nodeId);
+    HttpSession::Ptr buildHttpSession(HttpStream::Ptr _httpStream, std::string _nodeId);
 
     HttpReqHandler httpReqHandler() const;
     void setHttpReqHandler(HttpReqHandler _httpReqHandler);
 
-    std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor() const;
+    boost::asio::ip::tcp::acceptor& acceptor();
     void setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor);
 
     std::shared_ptr<boost::asio::ssl::context> ctx() const;
@@ -59,8 +59,8 @@ public:
     WsUpgradeHandler wsUpgradeHandler() const;
     void setWsUpgradeHandler(WsUpgradeHandler _wsUpgradeHandler);
 
-    HttpStreamFactory::Ptr httpStreamFactory() const;
-    void setHttpStreamFactory(HttpStreamFactory::Ptr _httpStreamFactory);
+    HttpStreamFactory& httpStreamFactory();
+    void setHttpStreamFactory(HttpStreamFactory _httpStreamFactory);
 
     bool disableSsl() const;
     void setDisableSsl(bool _disableSsl);
@@ -81,10 +81,10 @@ private:
     HttpReqHandler m_httpReqHandler;
     WsUpgradeHandler m_wsUpgradeHandler;
 
-    std::shared_ptr<boost::asio::ip::tcp::acceptor> m_acceptor;
+    std::optional<boost::asio::ip::tcp::acceptor> m_acceptor;
     std::shared_ptr<boost::asio::ssl::context> m_ctx;
 
-    std::shared_ptr<HttpStreamFactory> m_httpStreamFactory;
+    HttpStreamFactory m_httpStreamFactory;
     bcos::IOServicePool::Ptr m_ioservicePool;
 
     uint32_t m_httpBodySizeLimit;
@@ -93,7 +93,7 @@ private:
 };
 
 // The http server factory
-class HttpServerFactory : public std::enable_shared_from_this<HttpServerFactory>
+class HttpServerFactory
 {
 public:
     using Ptr = std::shared_ptr<HttpServerFactory>;

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.h
@@ -51,7 +51,7 @@ public:
     void setHttpReqHandler(HttpReqHandler _httpReqHandler);
 
     boost::asio::ip::tcp::acceptor& acceptor();
-    void setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor);
+    void setAcceptor(boost::asio::ip::tcp::acceptor _acceptor);
 
     std::shared_ptr<boost::asio::ssl::context> ctx() const;
     void setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx);

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
@@ -241,11 +241,11 @@ void bcos::boostssl::http::HttpSession::setHttpStream(HttpStream::Ptr _httpStrea
 {
     m_httpStream = std::move(_httpStream);
 }
-std::shared_ptr<std::string> bcos::boostssl::http::HttpSession::nodeId()
+const std::string& bcos::boostssl::http::HttpSession::nodeId()
 {
     return m_nodeId;
 }
-void bcos::boostssl::http::HttpSession::setNodeId(std::shared_ptr<std::string> _nodeId)
+void bcos::boostssl::http::HttpSession::setNodeId(std::string _nodeId)
 {
     m_nodeId = std::move(_nodeId);
 }

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.h
@@ -81,8 +81,8 @@ public:
     HttpStream::Ptr httpStream();
     void setHttpStream(HttpStream::Ptr _httpStream);
 
-    std::shared_ptr<std::string> nodeId();
-    void setNodeId(std::shared_ptr<std::string> _nodeId);
+    const std::string& nodeId();
+    void setNodeId(std::string _nodeId);
 
     uint32_t httpBodySizeLimit() const;
     void setHttpBodySizeLimit(uint32_t _httpBodySizeLimit);
@@ -99,7 +99,7 @@ private:
     // the parser is stored in an optional container so we can
     // construct it from scratch it at the beginning of each new message.
     std::optional<boost::beast::http::request_parser<boost::beast::http::string_body>> m_parser;
-    std::shared_ptr<std::string> m_nodeId;
+    std::string m_nodeId;
 
     uint32_t m_httpBodySizeLimit;
     CorsConfig m_corsConfig;

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConfig.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConfig.cpp
@@ -150,14 +150,15 @@ void WsConfig::setEnableWebSocket(bool _enableWebSocket)
     m_enableWebSocket = _enableWebSocket;
 }
 
-std::shared_ptr<bcos::boostssl::context::ContextConfig> WsConfig::contextConfig() const
+const bcos::boostssl::context::ContextConfig& WsConfig::contextConfig() const
 {
     return m_contextConfig;
 }
 
-void WsConfig::setContextConfig(std::shared_ptr<bcos::boostssl::context::ContextConfig> _contextConfig)
+void WsConfig::setContextConfig(
+    const bcos::boostssl::context::ContextConfig& _contextConfig)
 {
-    m_contextConfig = std::move(_contextConfig);
+    m_contextConfig = _contextConfig;
 }
 
 bcos::boostssl::http::CorsConfig WsConfig::corsConfig() const

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConfig.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConfig.cpp
@@ -155,8 +155,7 @@ const bcos::boostssl::context::ContextConfig& WsConfig::contextConfig() const
     return m_contextConfig;
 }
 
-void WsConfig::setContextConfig(
-    const bcos::boostssl::context::ContextConfig& _contextConfig)
+void WsConfig::setContextConfig(const bcos::boostssl::context::ContextConfig& _contextConfig)
 {
     m_contextConfig = _contextConfig;
 }

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConfig.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConfig.h
@@ -89,7 +89,7 @@ private:
     bool m_enableWebSocket{true};
 
     // cert config for boostssl
-    std::shared_ptr<context::ContextConfig> m_contextConfig;
+    context::ContextConfig m_contextConfig;
 
     // the max message to be send or read
     uint32_t m_maxMsgSize{DEFAULT_MAX_MESSAGE_SIZE};
@@ -136,8 +136,8 @@ public:
     bool enableWebSocket() const;
     void setEnableWebSocket(bool _enableWebSocket);
 
-    std::shared_ptr<context::ContextConfig> contextConfig() const;
-    void setContextConfig(std::shared_ptr<context::ContextConfig> _contextConfig);
+    const context::ContextConfig& contextConfig() const;
+    void setContextConfig(const context::ContextConfig& _contextConfig);
 
     http::CorsConfig corsConfig() const;
     void setCorsConfig(http::CorsConfig _corsConfig);

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
@@ -23,16 +23,13 @@
 #include <bcos-boostssl/websocket/WsConnector.h>
 #include <bcos-utilities/BoostLog.h>
 #include <boost/asio/error.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <memory>
 
 using namespace bcos;
 using namespace bcos::boostssl;
 using namespace bcos::boostssl::ws;
 using namespace bcos::boostssl::context;
-
-WsConnector::WsConnector(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver)
-  : m_resolver(std::move(_resolver))
-{}
 
 bool WsConnector::erasePendingConns(const std::string& _nodeIPEndpoint)
 {
@@ -45,16 +42,6 @@ bool WsConnector::insertPendingConns(const std::string& _nodeIPEndpoint)
     std::lock_guard<std::mutex> lock(x_pendingConns);
     auto result = m_pendingConns.insert(_nodeIPEndpoint);
     return result.second;
-}
-
-void WsConnector::setResolver(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver)
-{
-    m_resolver = std::move(_resolver);
-}
-
-std::shared_ptr<boost::asio::ip::tcp::resolver> WsConnector::resolver() const
-{
-    return m_resolver;
 }
 
 void WsConnector::setIOServicePool(IOServicePool::Ptr _ioservicePool)
@@ -70,16 +57,6 @@ void WsConnector::setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx)
 std::shared_ptr<boost::asio::ssl::context> WsConnector::ctx() const
 {
     return m_ctx;
-}
-
-void WsConnector::setBuilder(std::shared_ptr<WsStreamDelegateBuilder> _builder)
-{
-    m_builder = std::move(_builder);
-}
-
-std::shared_ptr<WsStreamDelegateBuilder> WsConnector::builder() const
-{
-    return m_builder;
 }
 
 // TODO: how to set timeout for connect to wsServer ???
@@ -102,13 +79,12 @@ void WsConnector::connectToWsServer(const std::string& _host, uint16_t _port, bo
         return;
     }
 
-    auto resolver = m_resolver;
-    auto builder = m_builder;
+    auto resolver = boost::asio::ip::tcp::resolver(*ioc);
     auto connector = shared_from_this();
 
     // resolve host
-    resolver->async_resolve(_host, std::to_string(_port),
-        [_host, _port, _disableSsl, endpoint, ioc, ctx, connector, builder, _callback](
+    resolver.async_resolve(_host, std::to_string(_port),
+        [_host, _port, _disableSsl, endpoint, ioc, ctx, connector, _callback](
             boost::beast::error_code _ec, boost::asio::ip::tcp::resolver::results_type _results) {
             if (_ec)
             {
@@ -131,8 +107,8 @@ void WsConnector::connectToWsServer(const std::string& _host, uint16_t _port, bo
 
             // async connect
             rawStream->async_connect(_results,
-                [_host, _port, _disableSsl, endpoint, ctx, connector, builder, rawStream,
-                    _callback](boost::beast::error_code _ec,
+                [_host, _port, _disableSsl, endpoint, ctx, connector, rawStream, _callback](
+                    boost::beast::error_code _ec,
                     boost::asio::ip::tcp::resolver::results_type::endpoint_type _ep) mutable {
                     if (_ec)
                     {
@@ -148,7 +124,7 @@ void WsConnector::connectToWsServer(const std::string& _host, uint16_t _port, bo
                         << LOG_BADGE("connectToWsServer") << LOG_DESC("async_connect success")
                         << LOG_KV("endpoint", endpoint);
 
-                    auto wsStreamDelegate = builder->build(_disableSsl, ctx, rawStream);
+                    auto wsStreamDelegate = WsStreamDelegateBuilder{}.build(_disableSsl, ctx, rawStream);
 
                     std::shared_ptr<std::string> nodeId = std::make_shared<std::string>();
                     wsStreamDelegate->setVerifyCallback(

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
@@ -79,12 +79,16 @@ void WsConnector::connectToWsServer(const std::string& _host, uint16_t _port, bo
         return;
     }
 
-    auto resolver = boost::asio::ip::tcp::resolver(*ioc);
+    // the resolver must outlive the async_resolve operation (it is only valid
+    // until the handler is invoked), so it is heap-allocated and captured by the
+    // async_resolve handler instead of being a stack-local that would be
+    // destroyed as soon as connectToWsServer returns
+    auto resolver = std::make_shared<boost::asio::ip::tcp::resolver>(*ioc);
     auto connector = shared_from_this();
 
     // resolve host
-    resolver.async_resolve(_host, std::to_string(_port),
-        [_host, _port, _disableSsl, endpoint, ioc, ctx, connector, _callback](
+    resolver->async_resolve(_host, std::to_string(_port),
+        [_host, _port, _disableSsl, endpoint, ioc, ctx, connector, resolver, _callback](
             boost::beast::error_code _ec, boost::asio::ip::tcp::resolver::results_type _results) {
             if (_ec)
             {

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
@@ -128,7 +128,8 @@ void WsConnector::connectToWsServer(const std::string& _host, uint16_t _port, bo
                         << LOG_BADGE("connectToWsServer") << LOG_DESC("async_connect success")
                         << LOG_KV("endpoint", endpoint);
 
-                    auto wsStreamDelegate = WsStreamDelegateBuilder{}.build(_disableSsl, ctx, rawStream);
+                    auto wsStreamDelegate =
+                        WsStreamDelegateBuilder{}.build(_disableSsl, ctx, rawStream);
 
                     std::shared_ptr<std::string> nodeId = std::make_shared<std::string>();
                     wsStreamDelegate->setVerifyCallback(

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.h
@@ -40,7 +40,7 @@ public:
     using Ptr = std::shared_ptr<WsConnector>;
     using ConstPtr = std::shared_ptr<const WsConnector>;
 
-        explicit WsConnector(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver);
+    WsConnector() = default;
 
     /**
      * @brief: connect to the server
@@ -59,20 +59,12 @@ public:
 
     bool insertPendingConns(const std::string& _nodeIPEndpoint);
 
-    void setResolver(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver);
-    std::shared_ptr<boost::asio::ip::tcp::resolver> resolver() const;
-
     void setIOServicePool(IOServicePool::Ptr _ioservicePool);
 
     void setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx);
     std::shared_ptr<boost::asio::ssl::context> ctx() const;
 
-    void setBuilder(std::shared_ptr<WsStreamDelegateBuilder> _builder);
-    std::shared_ptr<WsStreamDelegateBuilder> builder() const;
-
 private:
-    std::shared_ptr<WsStreamDelegateBuilder> m_builder;
-    std::shared_ptr<boost::asio::ip::tcp::resolver> m_resolver;
     std::shared_ptr<boost::asio::ssl::context> m_ctx;
 
     mutable std::mutex x_pendingConns;

--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
@@ -29,6 +29,7 @@
 #include <bcos-boostssl/websocket/WsTools.h>
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/IOServicePool.h>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/system/detail/error_code.hpp>
 
 using namespace bcos;
@@ -60,12 +61,9 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
     auto ioServicePool = m_ioServicePool;
     _wsService->setIOServicePool(ioServicePool);
 
-    auto resolver =
-        std::make_shared<boost::asio::ip::tcp::resolver>((*(ioServicePool->getIOService())));
-    auto connector = std::make_shared<WsConnector>(resolver);
+    auto resolver = boost::asio::ip::tcp::resolver(*(ioServicePool->getIOService()));
+    auto connector = std::make_shared<WsConnector>();
     connector->setIOServicePool(ioServicePool);
-
-    auto builder = std::make_shared<WsStreamDelegateBuilder>();
 
     std::shared_ptr<boost::asio::ssl::context> srvCtx = nullptr;
     std::shared_ptr<boost::asio::ssl::context> clientCtx = nullptr;
@@ -73,8 +71,8 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
     {
         auto contextBuilder = std::make_shared<ContextBuilder>();
 
-        srvCtx = contextBuilder->buildSslContext(true, *_config->contextConfig());
-        clientCtx = contextBuilder->buildSslContext(false, *_config->contextConfig());
+        srvCtx = contextBuilder->buildSslContext(true, _config->contextConfig());
+        clientCtx = contextBuilder->buildSslContext(false, _config->contextConfig());
     }
 
     if (_config->asServer())
@@ -106,12 +104,11 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
         {
             httpServer->setWsUpgradeHandler(
                 [wsServiceWeakPtr](std::shared_ptr<HttpStream> _httpStream,
-                    HttpRequest&& _httpRequest, std::shared_ptr<std::string> _nodeId) {
+                    HttpRequest&& _httpRequest, std::string _nodeId) {
                     auto service = wsServiceWeakPtr.lock();
                     if (service)
                     {
-                        std::string nodeIdString = _nodeId == nullptr ? "" : *_nodeId;
-                        auto session = service->newSession(_httpStream->wsStream(), nodeIdString);
+                        auto session = service->newSession(_httpStream->wsStream(), _nodeId);
                         session->startAsServer(std::move(_httpRequest));
                     }
                 });
@@ -139,7 +136,7 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
                     boost::system::error_code err;
 
                     // test if the address domain name
-                    resolver->resolve(peer.address(), boost::lexical_cast<std::string>(0), err);
+                    resolver.resolve(peer.address(), boost::lexical_cast<std::string>(0), err);
                     if (err)
                     {
                         BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment(
@@ -174,7 +171,6 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
     // The threadPoolSize was previously used for tbb::task_arena, now IOServicePool handles it.
 
     connector->setCtx(clientCtx);
-    connector->setBuilder(builder);
 
     _wsService->setConfig(_config);
     _wsService->setConnector(connector);

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
@@ -157,8 +157,7 @@ void WsService::start()
     // init m_timerFactory if it is not initialized
     if (!m_timerFactory)
     {
-        m_timerFactory =
-            std::make_shared<timer::TimerFactory>(m_ioservicePool->getIOService());
+        m_timerFactory = std::make_shared<timer::TimerFactory>(m_ioservicePool->getIOService());
     }
 
     // start as server
@@ -697,8 +696,7 @@ void WsService::asyncSendMessage(
 
     // pick one random session directly, avoid copying and shuffling the whole session list
     thread_local std::default_random_engine e(std::random_device{}());
-    const auto& session =
-        _ss[std::uniform_int_distribution<std::size_t>(0, _ss.size() - 1)(e)];
+    const auto& session = _ss[std::uniform_int_distribution<std::size_t>(0, _ss.size() - 1)(e)];
 
     if (!_respFunc)
     {

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
@@ -65,7 +65,6 @@ void WsService::setWaitConnectFinishTimeout(int32_t _timeout)
 void WsService::setIOServicePool(IOServicePool::Ptr _ioservicePool)
 {
     m_ioservicePool = std::move(_ioservicePool);
-    m_timerIoc = m_ioservicePool->getIOService();
 }
 
 std::shared_ptr<WsConnector> WsService::connector() const noexcept
@@ -158,7 +157,8 @@ void WsService::start()
     // init m_timerFactory if it is not initialized
     if (!m_timerFactory)
     {
-        m_timerFactory = std::make_shared<timer::TimerFactory>(m_timerIoc);
+        m_timerFactory =
+            std::make_shared<timer::TimerFactory>(m_ioservicePool->getIOService());
     }
 
     // start as server
@@ -460,7 +460,6 @@ std::shared_ptr<WsSession> WsService::newSession(
     auto session = std::make_shared<WsSession>(m_ioservicePool);
 
     session->setWsStreamDelegate(std::move(_wsStreamDelegate));
-    session->setIoc(m_ioservicePool->getIOService());
     session->setRawMessage(m_rawMessage);
     session->setEndPoint(endPoint);
     session->setMaxWriteMsgSize(m_config->maxMsgSize());

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.h
@@ -170,8 +170,6 @@ private:
     std::vector<DisconnectHandler> m_disconnectHandlers;
 
     IOServicePool::Ptr m_ioservicePool;
-
-    std::shared_ptr<boost::asio::io_context> m_timerIoc;
 };
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
@@ -95,16 +95,6 @@ const WsRecvMessageHandler& WsSession::recvMessageHandler()
     return m_recvMessageHandler;
 }
 
-std::shared_ptr<boost::asio::io_context> WsSession::ioc() const
-{
-    return m_ioc;
-}
-
-void WsSession::setIoc(std::shared_ptr<boost::asio::io_context> _ioc)
-{
-    m_ioc = std::move(_ioc);
-}
-
 void WsSession::setVersion(uint16_t _version)
 {
     m_version.store(_version);
@@ -544,7 +534,7 @@ void WsSession::asyncSendMessage(const WsMessage& _msg, Options _options, RespCa
         {
             // create new timer to handle timeout
             auto timer = std::make_shared<boost::asio::steady_timer>(
-                *m_ioc, std::chrono::milliseconds(timeout));
+                *(m_ioServicePool->getIOService()), std::chrono::milliseconds(timeout));
 
             callback->timer = timer;
             auto self = weak_from_this();

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
@@ -93,9 +93,6 @@ public:
     bool rawMessage() const { return m_rawMessage; }
     void setRawMessage(bool _rawMessage) { m_rawMessage = _rawMessage; }
 
-    std::shared_ptr<boost::asio::io_context> ioc() const;
-    void setIoc(std::shared_ptr<boost::asio::io_context> _ioc);
-
     void setVersion(uint16_t _version);
     uint16_t version() const;
 
@@ -182,8 +179,6 @@ protected:
     // raw wire format flag
     bool m_rawMessage = false;
 
-    // ioc
-    std::shared_ptr<boost::asio::io_context> m_ioc;
     // send message queue
     mutable bcos::Mutex x_writeQueue;
     std::priority_queue<std::shared_ptr<Message>> m_writeQueue;

--- a/bcos-boostssl/test/exec/boostssl_delay_perf.cpp
+++ b/bcos-boostssl/test/exec/boostssl_delay_perf.cpp
@@ -100,7 +100,7 @@ void workAsClient(
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();
@@ -182,7 +182,7 @@ void workAsServer(std::string listenIp, uint16_t listenPort, bool disableSsl)
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();

--- a/bcos-boostssl/test/exec/boostssl_throughput_perf.cpp
+++ b/bcos-boostssl/test/exec/boostssl_throughput_perf.cpp
@@ -106,7 +106,7 @@ void workAsClient(std::string serverIp, uint16_t serverPort, bool disableSsl, ui
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();
@@ -210,7 +210,7 @@ void workAsServer(std::string listenIp, uint16_t listenPort, bool disableSsl, ui
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();

--- a/bcos-boostssl/test/exec/echo_client_sample.cpp
+++ b/bcos-boostssl/test/exec/echo_client_sample.cpp
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();

--- a/bcos-boostssl/test/exec/echo_server_sample.cpp
+++ b/bcos-boostssl/test/exec/echo_server_sample.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();

--- a/bcos-boostssl/test/exec/http_server_sample.cpp
+++ b/bcos-boostssl/test/exec/http_server_sample.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv)
     {
         auto contextConfig = std::make_shared<ContextConfig>();
         contextConfig->initConfig("./boostssl.ini");
-        config->setContextConfig(contextConfig);
+        config->setContextConfig(*contextConfig);
     }
 
     auto wsService = std::make_shared<ws::WsService>();

--- a/bcos-boostssl/test/unittests/websocket/WsConnectorTest.cpp
+++ b/bcos-boostssl/test/unittests/websocket/WsConnectorTest.cpp
@@ -21,7 +21,10 @@
 
 #include <bcos-boostssl/websocket/WsConnector.h>
 
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/test/unit_test.hpp>
+#include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 
@@ -49,6 +52,50 @@ BOOST_AUTO_TEST_CASE(test_WsConnectorTest)
         r = connector->insertPendingConns(endpoint);
         BOOST_CHECK(r);
     }
+}
+
+// Drives connectToWsServer so the resolver lifetime is covered: the resolver
+// must outlive the call until the async_resolve handler runs. With the previous
+// stack-local resolver the resolve was cancelled on return and the callback
+// received operation_aborted; here the resolve must reach the connect stage,
+// which fails against a loopback port with no websocket server behind it.
+BOOST_AUTO_TEST_CASE(test_connectToWsServerResolveFailure)
+{
+    auto connector = std::make_shared<WsConnector>();
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    connector->setIOServicePool(ioServicePool);
+    connector->setCtx(std::make_shared<boost::asio::ssl::context>(
+        boost::asio::ssl::context::tls_client));
+
+    // grab a free loopback port, then release it so nothing listens on it
+    uint16_t port = 0;
+    {
+        boost::asio::io_context ioc;
+        boost::asio::ip::tcp::acceptor acceptor(
+            ioc, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), 0));
+        port = acceptor.local_endpoint().port();
+    }
+
+    std::string host = "127.0.0.1";
+    std::string endpoint = host + ":" + std::to_string(port);
+
+    std::promise<boost::beast::error_code> result;
+    auto future = result.get_future();
+    connector->connectToWsServer(host, port, true,
+        [&result](boost::beast::error_code _ec, const std::string&,
+            std::shared_ptr<WsStreamDelegate>, std::shared_ptr<std::string>) {
+            result.set_value(_ec);
+        });
+
+    BOOST_REQUIRE(future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
+    auto ec = future.get();
+    // no websocket server is listening, so the connect must fail eventually —
+    // but with a real connect/handshake error, not with operation_aborted,
+    // which would mean the resolver was destroyed before async_resolve finished
+    BOOST_CHECK_MESSAGE(ec && ec != boost::asio::error::operation_aborted,
+        "expected a connect-stage error, got: " << ec.message());
+    // the failed connect must erase the pending conns entry
+    BOOST_CHECK(connector->insertPendingConns(endpoint));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-boostssl/test/unittests/websocket/WsConnectorTest.cpp
+++ b/bcos-boostssl/test/unittests/websocket/WsConnectorTest.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(WsConnectorTest)
 
 BOOST_AUTO_TEST_CASE(test_WsConnectorTest)
 {
-    auto connector = std::make_shared<WsConnector>(nullptr);
+    auto connector = std::make_shared<WsConnector>();
     {
         std::string host = "0.0.0.0";
         uint16_t port = 1111;

--- a/bcos-boostssl/test/unittests/websocket/WsConnectorTest.cpp
+++ b/bcos-boostssl/test/unittests/websocket/WsConnectorTest.cpp
@@ -27,6 +27,7 @@
 #include <future>
 #include <memory>
 #include <string>
+#include <thread>
 
 using namespace bcos;
 
@@ -64,8 +65,8 @@ BOOST_AUTO_TEST_CASE(test_connectToWsServerResolveFailure)
     auto connector = std::make_shared<WsConnector>();
     auto ioServicePool = std::make_shared<IOServicePool>(1);
     connector->setIOServicePool(ioServicePool);
-    connector->setCtx(std::make_shared<boost::asio::ssl::context>(
-        boost::asio::ssl::context::tls_client));
+    connector->setCtx(
+        std::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::tls_client));
 
     // grab a free loopback port, then release it so nothing listens on it
     uint16_t port = 0;
@@ -79,13 +80,14 @@ BOOST_AUTO_TEST_CASE(test_connectToWsServerResolveFailure)
     std::string host = "127.0.0.1";
     std::string endpoint = host + ":" + std::to_string(port);
 
-    std::promise<boost::beast::error_code> result;
-    auto future = result.get_future();
+    // hold the promise on the heap and capture it by value, so it outlives the
+    // handler chain even if the test exits early (e.g. on the timeout path)
+    auto result = std::make_shared<std::promise<boost::beast::error_code>>();
+    auto future = result->get_future();
     connector->connectToWsServer(host, port, true,
-        [&result](boost::beast::error_code _ec, const std::string&,
-            std::shared_ptr<WsStreamDelegate>, std::shared_ptr<std::string>) {
-            result.set_value(_ec);
-        });
+        [result](boost::beast::error_code _ec, const std::string&,
+            std::shared_ptr<WsStreamDelegate>,
+            std::shared_ptr<std::string>) { result->set_value(_ec); });
 
     BOOST_REQUIRE(future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
     auto ec = future.get();
@@ -94,8 +96,19 @@ BOOST_AUTO_TEST_CASE(test_connectToWsServerResolveFailure)
     // which would mean the resolver was destroyed before async_resolve finished
     BOOST_CHECK_MESSAGE(ec && ec != boost::asio::error::operation_aborted,
         "expected a connect-stage error, got: " << ec.message());
+    // erasePendingConns runs on the io thread right after the callback fired,
+    // so poll briefly instead of racing it for the x_pendingConns lock
+    bool erased = false;
+    for (int i = 0; i < 100 && !erased; ++i)
+    {
+        erased = connector->insertPendingConns(endpoint);
+        if (!erased)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
     // the failed connect must erase the pending conns entry
-    BOOST_CHECK(connector->insertPendingConns(endpoint));
+    BOOST_CHECK(erased);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -312,7 +312,7 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initConfig(
                       << LOG_KV("enNodeKey", _nodeConfig->enSmNodeKey());
     }
 
-    wsConfig->setContextConfig(contextConfig);
+    wsConfig->setContextConfig(*contextConfig);
 
     return wsConfig;
 }

--- a/bcos-sdk/bcos-cpp-sdk/config/Config.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/config/Config.cpp
@@ -194,7 +194,7 @@ void Config::loadSslCert(
     auto contextConfig = std::make_shared<ContextConfig>();
     contextConfig->setSslType("ssl");
     contextConfig->setCertConfig(certConfig);
-    _config.setContextConfig(contextConfig);
+    _config.setContextConfig(*contextConfig);
 }
 
 void Config::loadSMSslCert(
@@ -240,5 +240,5 @@ void Config::loadSMSslCert(
     auto ctxConfig = std::make_shared<ContextConfig>();
     ctxConfig->setSslType("sm_ssl");
     ctxConfig->setSmCertConfig(cert);
-    _config.setContextConfig(ctxConfig);
+    _config.setContextConfig(*ctxConfig);
 }

--- a/bcos-sdk/sample/rpc/rpc_test.cpp
+++ b/bcos-sdk/sample/rpc/rpc_test.cpp
@@ -102,7 +102,7 @@ static std::shared_ptr<bcos::boostssl::ws::WsConfig> initWsConfig(
         certConfig.nodeCert = config->cert_config.node_cert;
         certConfig.nodeKey = config->cert_config.node_key;
         contextConfig->setCertConfig(certConfig);
-        wsConfig->setContextConfig(contextConfig);
+        wsConfig->setContextConfig(*contextConfig);
     }
     return wsConfig;
 }

--- a/tools/archive-tool/ArchiveService.h
+++ b/tools/archive-tool/ArchiveService.h
@@ -58,10 +58,9 @@ public:
             m_listenIP, m_listenPort, -1, bcos::boostssl::http::CorsConfig());
         auto acceptor =
             std::make_shared<boost::asio::ip::tcp::acceptor>((*m_ioServicePool->getIOService()));
-        auto httpStreamFactory = std::make_shared<bcos::boostssl::http::HttpStreamFactory>();
         m_httpServer->setDisableSsl(true);
         m_httpServer->setAcceptor(acceptor);
-        m_httpServer->setHttpStreamFactory(httpStreamFactory);
+        m_httpServer->setHttpStreamFactory(bcos::boostssl::http::HttpStreamFactory{});
         m_httpServer->setIOServicePool(m_ioServicePool);
         // m_httpServer->setThreadPool(std::make_shared<ThreadPool>("archiveThread", 1));
         m_methodToFunc["deleteArchivedData"] = [this](const Json::Value& request,

--- a/tools/archive-tool/ArchiveService.h
+++ b/tools/archive-tool/ArchiveService.h
@@ -56,10 +56,9 @@ public:
         m_ioServicePool = std::make_shared<IOServicePool>(std::thread::hardware_concurrency() + 1, "archive");
         m_httpServer = std::make_shared<bcos::boostssl::http::HttpServer>(
             m_listenIP, m_listenPort, -1, bcos::boostssl::http::CorsConfig());
-        auto acceptor =
-            std::make_shared<boost::asio::ip::tcp::acceptor>((*m_ioServicePool->getIOService()));
         m_httpServer->setDisableSsl(true);
-        m_httpServer->setAcceptor(acceptor);
+        m_httpServer->setAcceptor(
+            boost::asio::ip::tcp::acceptor{*m_ioServicePool->getIOService()});
         m_httpServer->setHttpStreamFactory(bcos::boostssl::http::HttpStreamFactory{});
         m_httpServer->setIOServicePool(m_ioServicePool);
         // m_httpServer->setThreadPool(std::make_shared<ThreadPool>("archiveThread", 1));


### PR DESCRIPTION
## 概述

精简 `bcos-boostssl/bcos-boostssl/` 中不必要的 `std::shared_ptr` 使用：由 175 处降至 140 处（-35），涉及 24 个文件，净改动 +68/-121 行。所有剩余 `shared_ptr` 均经过评估，确属跨模块共享所有权、异步生命周期或不可移动类型（如 `ssl::context`）所需。

## 改动内容

1. **HttpServer**：`m_acceptor` 改为 `std::optional<boost::asio::ip::tcp::acceptor>` 值成员；`m_httpStreamFactory` 改为值成员；`acceptor()`/`httpStreamFactory()` 改为返回引用；`setHttpStreamFactory` 按值接收。
2. **HttpServerFactory**：移除多余的 `enable_shared_from_this` 继承（该类无任何 `shared_from_this()` 调用，零行为变化）。
3. **WsConnector**：移除 `m_resolver`/`m_builder` 成员及对应 4 个 setter/getter；`connectToWsServer` 中本地构造 `tcp::resolver`，异步链内临时构造无状态 `WsStreamDelegateBuilder`。
4. **WsConfig**：`m_contextConfig` 改为 `ContextConfig` 值成员；`contextConfig()` 返回 `const&`；`setContextConfig` 接收 `const&`，并同步更新全部外部调用点（RpcFactory、bcos-sdk、测试与样例）。
5. **WsService/WsSession**：移除冗余借用的 `m_timerIoc`/`m_ioc` 成员（二者均来自 `IOServicePool`，非自有所有权），改为直接经 `m_ioservicePool->getIOService()` 取用。
6. **nodeId 传递链**：`HttpSession::m_nodeId` 由 `shared_ptr<std::string>` 改为 `std::string`；`nodeId()` 返回 `const std::string&`；`WsUpgradeHandler` 第三参数由 `shared_ptr<std::string>` 改为 `std::string`。

## 保留的 shared_ptr（技术上必需）

- 所有 `::Ptr`/`::ConstPtr` 类型别名及跨模块共享对象（`WsService`/`WsSession`/`WsConfig`/`HttpServer` 等）
- 异步回调签名中的 `shared_ptr<WsSession>`/`shared_ptr<WsStreamDelegate>` 等（跨线程触发，调用方持有所有权）
- `ssl::context`（加载证书后不可拷贝/移动，多连接共享，只能堆分配）
- SSL 握手期间的 `shared_ptr<std::string>` nodeId 缓冲区（`NodeInfoTools::newVerifyCallback` 在 `async_handshake` 期间同步触发而 `onAccept` 已返回，缓冲区必须堆上存活）
- `weak_ptr` 打破循环引用的既有设计保持不变

## 验证

- 编译通过：`bcos-boostssl` 库、`test-boostssl`、exec 样例、`bcos-rpc`、主 `fisco-bcos` 二进制
- `test-boostssl` 单元测试全部通过（`*** No errors detected`）
- 说明：`bcos-sdk`（CPPSDK）与 `tools/archive-tool` 不在当前构建配置（`WITH_CPPSDK=OFF`）中，其改动为机械适配（`setContextConfig(*ptr)` / 值构造 `HttpStreamFactory{}`），需在开启 CPPSDK 的构建中最终验证