### PR TITLE
feat(tx-validator): add the (kind x context x policy) admission routing table

### DIFF
--- a/bcos-tx-validator/bcos-tx-validator/CheckSet.h
+++ b/bcos-tx-validator/bcos-tx-validator/CheckSet.h
@@ -1,0 +1,279 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file CheckSet.h
+ * @brief Which admission checks run, as a function of (transaction kind, context, policy).
+ * @date 2026/8/25
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace bcos::txvalidator
+{
+
+/// Routing key. Decided from the SIGNED envelope's first byte during normalization, never from
+/// the tars mirror -- a peer can set the mirror kind to 0 and a legacy-keyed check set would
+/// then skip the fee-market rules a 1559 envelope is subject to.
+///
+/// The enumerator values are NOT EIP-2718 type bytes (Web3AccessList is 2 here and 0x01 on the
+/// wire). A TxKind is produced only by kindOf() in TxValidator.cpp, which dispatches on the
+/// decoded envelope; casting a type byte to this enum is always wrong.
+enum class TxKind : uint8_t
+{
+    Bcos,            ///< outer tars type == BCOSTransaction; no EIP-2718 envelope
+    Web3Legacy,      ///< RLP list header, no type byte
+    Web3AccessList,  ///< 0x01, EIP-2930
+    Web3DynamicFee,  ///< 0x02, EIP-1559
+    Web3SetCode,     ///< 0x04, EIP-7702
+    Rejected,        ///< blob(0x03) / deposit(0x7e) / reserved -- TypeGate always fails
+};
+
+enum class AdmissionContext : uint8_t
+{
+    /// RPC and P2P broadcast into either transaction pool. Full check set.
+    PoolAdmission,
+
+    /// Consensus proposal verification. Returning a failure here fails the WHOLE proposal and
+    /// triggers a view change -- it does not reject one transaction. Balance, the nonce window
+    /// and the pool's pending-nonce set are local state that may legitimately differ from the
+    /// leader's view, so running them here is a liveness risk, not a safety gain.
+    ProposalVerification,
+
+    /// EEST fixture replay against a live node. Fixtures use arbitrary nonces and unfunded
+    /// accounts, so balance and the nonce window are dropped; everything else is unchanged.
+    EESTReplay,
+};
+
+/// Whether this chain verifies signatures at all (experimental.check_transaction_signature).
+///
+/// This is CONFIGURATION and is orthogonal to the context. It is deliberately NOT derived from
+/// Transaction::tainted(): `tainted` means "came from outside, MUST be verified" and defaults to
+/// true, so reading it as "already verified" inverts the meaning. EthEndpoint::sendRawTransaction
+/// constructs TransactionImpl directly, leaving m_tainted == true, so every ordinary
+/// eth_sendRawTransaction would be treated as pre-verified and skip signature, EOA, nonce and
+/// balance checks.
+///
+/// The verified/not-verified STATE is read only inside the Signature check itself, where
+/// Transaction::verify() short-circuits on `if (!tainted()) return;`. That makes the check
+/// idempotent, so no "already verified" flag has to be threaded through any call chain.
+enum class SignaturePolicy : uint8_t
+{
+    Required,
+    Disabled,
+};
+
+enum class Check : uint32_t
+{
+    None = 0,
+    TypeGate = 1U << 0,  ///< blob / deposit / unsupported envelope
+    ToFieldFormat = 1U << 1,
+    Signature = 1U << 2,
+    BcosGroupChainId = 1U << 3,
+    TypeByRevision = 1U << 4,
+    TipNotAboveCap = 1U << 5,
+    SetCodeHasTo = 1U << 6,
+    AuthListNonEmpty = 1U << 7,
+    MaxGasLimit = 1U << 8,  ///< the Osaka constant cap and the tx_gas_limit config, one item
+    FeeCapVsBaseFee = 1U << 9,
+    ChainId = 1U << 10,
+    SenderIsEOA = 1U << 11,
+    NonceNotMax = 1U << 12,
+    /// Lower bound and queue depth. The "committed nonce" it compares against is
+    /// Web3NonceChecker's in-process LRU cache, with a ledger read only on a miss -- node-local
+    /// state, which is why the proposal column drops it.
+    Web3NonceWindow = 1U << 13,
+    InitCodeSize = 1U << 14,
+    Balance = 1U << 15,
+    IntrinsicGas = 1U << 16,
+    /// The nonce is already held by a PENDING transaction in this node's pool
+    /// (TxPoolNonceChecker::checkNonce). Node-local state.
+    BcosPoolNonce = 1U << 17,
+    /// The nonce is already COMMITTED inside the block-limit window, or blockLimit itself is out
+    /// of range (LedgerNonceChecker::checkNonce). Chain state.
+    BcosLedgerNonce = 1U << 18,
+};
+
+constexpr Check operator|(Check lhs, Check rhs) noexcept
+{
+    return static_cast<Check>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+constexpr Check operator&(Check lhs, Check rhs) noexcept
+{
+    return static_cast<Check>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+constexpr Check operator~(Check value) noexcept
+{
+    return static_cast<Check>(~static_cast<uint32_t>(value));
+}
+constexpr bool contains(Check set, Check item) noexcept
+{
+    return (set & item) != Check::None;
+}
+
+/// The single evaluation order. The bitmask expresses membership only; this array decides which
+/// code a transaction violating several rules reports -- and EEST fixtures assert specific error
+/// codes, so that has to be deterministic.
+///
+/// Follows evmone's validate_transaction (bcos-evm/bcos-evm/eth/state/state.cpp, mirrored by
+/// ethereum-executor/EthereumTransition.h), with the FISCO-only items slotted in. evmone
+/// validates the type-specific block BEFORE the shared fee rules -- for a 7702 envelope that is
+/// "to present" and "authorization list non-empty" ahead of the tip/fee-cap comparison -- so a
+/// transaction violating both reports the same first error here as it would at execution.
+/// TypeGate goes first (nothing else is meaningful for an envelope type that is refused
+/// outright), ToFieldFormat and Signature next (without a recovered sender the account-state
+/// checks cannot run), ChainId ahead of the account reads (one config read is cheaper than an
+/// account read), and the two BCOS nonce checks last, pool set before ledger, as the pool-side
+/// validator ran them.
+inline constexpr std::array c_checkOrder{
+    Check::TypeGate,
+    Check::ToFieldFormat,
+    Check::Signature,
+    Check::BcosGroupChainId,
+    Check::TypeByRevision,
+    Check::SetCodeHasTo,
+    Check::AuthListNonEmpty,
+    Check::TipNotAboveCap,
+    Check::MaxGasLimit,
+    Check::FeeCapVsBaseFee,
+    Check::ChainId,
+    Check::SenderIsEOA,
+    Check::NonceNotMax,
+    Check::Web3NonceWindow,
+    Check::InitCodeSize,
+    Check::Balance,
+    Check::IntrinsicGas,
+    Check::BcosPoolNonce,
+    Check::BcosLedgerNonce,
+};
+
+/// Checks that cannot run without a recovered sender, and must therefore be skipped when
+/// signature verification is switched off.
+///
+/// BcosPoolNonce and BcosLedgerNonce are deliberately NOT here. A BCOS transaction's nonce is a
+/// global random value, not an account sequence number: TxPoolNonceChecker::checkNonce reads
+/// only _tx.nonce() against a global set, LedgerNonceChecker::checkNonce the same against the
+/// committed window, and checkBlockLimit reads only _tx.blockLimit(). None touches the sender,
+/// so including them would make SignaturePolicy::Disabled silently switch off BCOS replay
+/// protection as a side effect.
+inline constexpr Check c_senderDependent =
+    Check::SenderIsEOA | Check::NonceNotMax | Check::Web3NonceWindow | Check::Balance;
+
+/// Checks shared by every Web3 kind.
+inline constexpr Check c_web3Common =
+    Check::TypeGate | Check::ToFieldFormat | Check::Signature | Check::MaxGasLimit |
+    Check::FeeCapVsBaseFee | Check::ChainId | Check::SenderIsEOA | Check::NonceNotMax |
+    Check::Web3NonceWindow | Check::InitCodeSize | Check::Balance | Check::IntrinsicGas;
+
+/// The check set for @p kind under PoolAdmission. The other two contexts are derived from this
+/// one rather than written out separately, so the columns cannot drift apart.
+constexpr Check poolAdmissionCheckSet(TxKind kind) noexcept
+{
+    switch (kind)
+    {
+    case TxKind::Bcos:
+        // A BCOS transaction's dataHash covers its whole TransactionData, so none of the
+        // envelope-derived Web3 rules apply to it.
+        return Check::TypeGate | Check::ToFieldFormat | Check::Signature | Check::BcosGroupChainId |
+               Check::BcosPoolNonce | Check::BcosLedgerNonce;
+    case TxKind::Web3Legacy:
+        return c_web3Common;
+    case TxKind::Web3AccessList:
+        return c_web3Common | Check::TypeByRevision;
+    case TxKind::Web3DynamicFee:
+        return c_web3Common | Check::TypeByRevision | Check::TipNotAboveCap;
+    case TxKind::Web3SetCode:
+        return c_web3Common | Check::TypeByRevision | Check::TipNotAboveCap | Check::SetCodeHasTo |
+               Check::AuthListNonEmpty;
+    case TxKind::Rejected:
+        // TypeGate alone, and it necessarily fails.
+        return Check::TypeGate;
+    }
+    // Unreachable for a TxKind that kindOf() produced: every enumerator has a case above, and
+    // -Wswitch (an error in this build) refuses a new enumerator without one. Fail closed all the
+    // same: a value that is not a TxKind gets the gate alone, and the gate rejects any kind it
+    // does not recognise. Returning None here would admit such a value without a single check.
+    return Check::TypeGate;
+}
+
+constexpr Check checkSet(TxKind kind, AdmissionContext context) noexcept
+{
+    const auto base = poolAdmissionCheckSet(kind);
+    switch (context)
+    {
+    case AdmissionContext::PoolAdmission:
+        return base;
+    case AdmissionContext::EESTReplay:
+        return base & ~(Check::Balance | Check::Web3NonceWindow);
+    case AdmissionContext::ProposalVerification:
+        // Everything a leader could violate stays ON. These are protocol invariants: their
+        // answer is a function of the transaction and the chain config, so every honest node
+        // computes the same one and enforcing them cannot split a block. ChainId in particular
+        // MUST be here -- nothing downstream re-checks it (EthereumTransition.h: "validate_
+        // transaction does not check that field"), so admission is the only gate standing
+        // between a malicious leader and a transaction signed for another chain.
+        //
+        // Note this KEEPS Signature, and that it costs a real recovery per transaction: the
+        // check clears the wire-supplied hash before verifying (otherwise a forged dataHash
+        // binds a stolen signature to an attacker's body), so it cannot short-circuit on an
+        // already-verified transaction. Paying it here is the price of not trusting a hash a
+        // peer chose.
+        //
+        // FIVE come off, each for a different reason:
+        //
+        //   Balance -- its answer depends on WHERE in the block a transaction sits. One funded
+        //   by an earlier transaction in the same proposal fails it against pre-block state.
+        //
+        //   SenderIsEOA and NonceNotMax -- correctness-neutral here (execution enforces both)
+        //   but each pulls a full account read onto the consensus hot path.
+        //
+        //   Web3NonceWindow -- the "committed nonce" it compares against is not read from chain
+        //   state first: it comes from Web3NonceChecker's in-process LRU cache, and the ledger
+        //   is consulted only on a miss. That cache is raised from every Web3 transaction in a
+        //   committed block regardless of whether that transaction SUCCEEDED, is
+        //   capacity-bounded and evicts, and starts empty after a restart. Two honest nodes can
+        //   therefore hold different values for the same sender, and the one with the
+        //   stale-high value rejects a legitimate proposal. On this path a failed check fails
+        //   the whole proposal and triggers a view change -- so a node-local cache disagreement
+        //   becomes a liveness fault, repeated every time that leader proposes. Dropping it
+        //   costs no safety: execution compares the nonce for exact equality, which is strictly
+        //   stronger than a [n, n+600000] window.
+        //
+        //   BcosPoolNonce -- the set it consults is this node's PENDING transactions, the same
+        //   class of node-local state as that cache. A leader's transactions are legitimately
+        //   absent from it, and two honest nodes' pools differ by whatever each has admitted
+        //   and not yet sealed, so a hit here is not something every honest node agrees on.
+        //   The pool-side validator already skipped it on this path
+        //   (checkTransaction(tx, onlyCheckLedgerNonce = true)). BcosLedgerNonce, the
+        //   committed-nonce and blockLimit half, is chain state and stays.
+        return base & ~(Check::Balance | Check::SenderIsEOA | Check::NonceNotMax |
+                          Check::Web3NonceWindow | Check::BcosPoolNonce);
+    }
+    // See poolAdmissionCheckSet: unreachable for a real AdmissionContext, closed for anything
+    // else.
+    return Check::TypeGate;
+}
+
+constexpr Check effectiveCheckSet(
+    TxKind kind, AdmissionContext context, SignaturePolicy policy) noexcept
+{
+    const auto set = checkSet(kind, context);
+    return policy == SignaturePolicy::Required ? set :
+                                                 set & ~(Check::Signature | c_senderDependent);
+}
+
+}  // namespace bcos::txvalidator

--- a/bcos-tx-validator/test/unittests/CheckSetTest.cpp
+++ b/bcos-tx-validator/test/unittests/CheckSetTest.cpp
@@ -1,0 +1,322 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file CheckSetTest.cpp
+ * @brief The (kind x context x policy) routing table, asserted as a table.
+ */
+
+#include "bcos-tx-validator/CheckSet.h"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <iterator>
+#include <set>
+
+using namespace bcos::txvalidator;
+
+namespace bcos::test
+{
+namespace
+{
+constexpr std::array kKinds{TxKind::Bcos, TxKind::Web3Legacy, TxKind::Web3AccessList,
+    TxKind::Web3DynamicFee, TxKind::Web3SetCode, TxKind::Rejected};
+constexpr std::array kContexts{AdmissionContext::PoolAdmission,
+    AdmissionContext::ProposalVerification, AdmissionContext::EESTReplay};
+constexpr std::array kPolicies{SignaturePolicy::Required, SignaturePolicy::Disabled};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(CheckSetTest)
+
+// The PoolAdmission column, spelled out. If someone edits poolAdmissionCheckSet, this is what
+// says so.
+BOOST_AUTO_TEST_CASE(poolAdmissionColumnIsExact)
+{
+    BOOST_CHECK(checkSet(TxKind::Bcos, AdmissionContext::PoolAdmission) ==
+                (Check::TypeGate | Check::ToFieldFormat | Check::Signature |
+                    Check::BcosGroupChainId | Check::BcosPoolNonce | Check::BcosLedgerNonce));
+
+    constexpr auto legacy = Check::TypeGate | Check::ToFieldFormat | Check::Signature |
+                            Check::MaxGasLimit | Check::FeeCapVsBaseFee | Check::ChainId |
+                            Check::SenderIsEOA | Check::NonceNotMax | Check::Web3NonceWindow |
+                            Check::InitCodeSize | Check::Balance | Check::IntrinsicGas;
+    BOOST_CHECK(checkSet(TxKind::Web3Legacy, AdmissionContext::PoolAdmission) == legacy);
+    BOOST_CHECK(checkSet(TxKind::Web3AccessList, AdmissionContext::PoolAdmission) ==
+                (legacy | Check::TypeByRevision));
+    BOOST_CHECK(checkSet(TxKind::Web3DynamicFee, AdmissionContext::PoolAdmission) ==
+                (legacy | Check::TypeByRevision | Check::TipNotAboveCap));
+    BOOST_CHECK(checkSet(TxKind::Web3SetCode, AdmissionContext::PoolAdmission) ==
+                (legacy | Check::TypeByRevision | Check::TipNotAboveCap | Check::SetCodeHasTo |
+                    Check::AuthListNonEmpty));
+    BOOST_CHECK(checkSet(TxKind::Rejected, AdmissionContext::PoolAdmission) == Check::TypeGate);
+}
+
+// The other two columns are derived, not written out. These are the derivation rules.
+BOOST_AUTO_TEST_CASE(derivedColumnsHoldForEveryKind)
+{
+    for (auto kind : kKinds)
+    {
+        const auto pool = checkSet(kind, AdmissionContext::PoolAdmission);
+
+        BOOST_CHECK(checkSet(kind, AdmissionContext::EESTReplay) ==
+                    (pool & ~(Check::Balance | Check::Web3NonceWindow)));
+
+        // Proposal verification is a subset -- it may never check something pool admission does
+        // not, or a proposal could fail for a reason a directly-submitted transaction survives.
+        const auto proposal = checkSet(kind, AdmissionContext::ProposalVerification);
+        BOOST_CHECK((proposal & ~pool) == Check::None);
+
+        for (auto context : kContexts)
+        {
+            BOOST_CHECK(effectiveCheckSet(kind, context, SignaturePolicy::Required) ==
+                        checkSet(kind, context));
+            BOOST_CHECK(effectiveCheckSet(kind, context, SignaturePolicy::Disabled) ==
+                        (checkSet(kind, context) & ~(Check::Signature | c_senderDependent)));
+        }
+    }
+}
+
+// Reverse assertion 1 (the P0 guard). Under Required, every real kind must actually check the
+// signature. An earlier design derived this from Transaction::tainted(), which defaults to true
+// and means "must be verified" -- reading it as "already verified" made every ordinary
+// eth_sendRawTransaction skip signature recovery entirely.
+BOOST_AUTO_TEST_CASE(requiredPolicyAlwaysChecksTheSignature)
+{
+    for (auto kind : kKinds)
+    {
+        if (kind == TxKind::Rejected)
+        {
+            continue;  // TypeGate only, and it always fails
+        }
+        for (auto context : kContexts)
+        {
+            BOOST_CHECK_MESSAGE(
+                contains(
+                    effectiveCheckSet(kind, context, SignaturePolicy::Required), Check::Signature),
+                "Signature missing for kind " << static_cast<int>(kind) << " context "
+                                              << static_cast<int>(context));
+        }
+    }
+}
+
+// Reverse assertion 2. Turning signature verification off must not disable BCOS replay
+// protection: nonce/blockLimit for a BCOS transaction need no sender.
+BOOST_AUTO_TEST_CASE(disabledPolicyKeepsBcosReplayProtection)
+{
+    for (auto context : kContexts)
+    {
+        const auto effective = effectiveCheckSet(TxKind::Bcos, context, SignaturePolicy::Disabled);
+        // The committed-nonce half is chain state and survives every context.
+        BOOST_CHECK(contains(effective, Check::BcosLedgerNonce));
+        // The pending-nonce half is node-local and is dropped by the proposal column alone --
+        // by the CONTEXT, never by the policy.
+        BOOST_CHECK(contains(effective, Check::BcosPoolNonce) ==
+                    (context != AdmissionContext::ProposalVerification));
+    }
+    // ... and neither half may be classified as sender-dependent in the first place.
+    BOOST_CHECK(!contains(c_senderDependent, Check::BcosPoolNonce));
+    BOOST_CHECK(!contains(c_senderDependent, Check::BcosLedgerNonce));
+}
+
+BOOST_AUTO_TEST_CASE(disabledPolicyDropsEverySenderDependentCheck)
+{
+    for (auto kind : kKinds)
+    {
+        for (auto context : kContexts)
+        {
+            const auto effective = effectiveCheckSet(kind, context, SignaturePolicy::Disabled);
+            BOOST_CHECK(!contains(effective, Check::Signature));
+            BOOST_CHECK((effective & c_senderDependent) == Check::None);
+            // Checks that need no sender still run.
+            const auto declared = checkSet(kind, context);
+            BOOST_CHECK(
+                contains(effective, Check::TypeGate) == contains(declared, Check::TypeGate));
+            BOOST_CHECK(contains(effective, Check::ChainId) == contains(declared, Check::ChainId));
+            BOOST_CHECK(contains(effective, Check::IntrinsicGas) ==
+                        contains(declared, Check::IntrinsicGas));
+        }
+    }
+}
+
+// A check that is a member of some set but absent from c_checkOrder would silently never run.
+BOOST_AUTO_TEST_CASE(checkOrderCoversEveryReachableCheckExactlyOnce)
+{
+    std::set<uint32_t> seen;
+    for (auto check : c_checkOrder)
+    {
+        BOOST_CHECK_MESSAGE(seen.insert(static_cast<uint32_t>(check)).second,
+            "duplicate entry in c_checkOrder: " << static_cast<uint32_t>(check));
+    }
+
+    Check reachable = Check::None;
+    for (auto kind : kKinds)
+    {
+        for (auto context : kContexts)
+        {
+            for (auto policy : kPolicies)
+            {
+                reachable = reachable | effectiveCheckSet(kind, context, policy);
+            }
+        }
+    }
+    for (auto check : c_checkOrder)
+    {
+        // Every ordered check is reachable from some cell -- an unreachable one is dead weight.
+        BOOST_CHECK_MESSAGE(contains(reachable, check),
+            "c_checkOrder lists an unreachable check: " << static_cast<uint32_t>(check));
+    }
+    // ... and every reachable check is ordered.
+    Check ordered = Check::None;
+    for (auto check : c_checkOrder)
+    {
+        ordered = ordered | check;
+    }
+    BOOST_CHECK((reachable & ~ordered) == Check::None);
+}
+
+// TypeGate must be first: for a refused envelope type nothing else is meaningful, and the type
+// gate is what turns a blob or deposit arriving over P2P into a rejection.
+BOOST_AUTO_TEST_CASE(typeGateIsEvaluatedFirstAndSignatureBeforeAccountState)
+{
+    BOOST_CHECK(c_checkOrder.front() == Check::TypeGate);
+
+    const auto indexOf = [](Check target) {
+        return std::distance(c_checkOrder.begin(), std::ranges::find(c_checkOrder, target));
+    };
+    const auto signature = indexOf(Check::Signature);
+    for (auto dependent :
+        {Check::SenderIsEOA, Check::NonceNotMax, Check::Web3NonceWindow, Check::Balance})
+    {
+        BOOST_CHECK_MESSAGE(
+            signature < indexOf(dependent), "sender-dependent check ordered before Signature");
+    }
+    // One config read is cheaper than an account read.
+    BOOST_CHECK(indexOf(Check::ChainId) < indexOf(Check::Balance));
+
+    // The items evmone's validate_transaction also has, in the order it reports them
+    // (bcos-evm/bcos-evm/eth/state/state.cpp): the type-specific block -- revision gate, 7702
+    // "to" present, 7702 authorization list non-empty -- comes BEFORE the shared fee rules, so
+    // a 7702 envelope with an empty authorization list and a tip above its fee cap reports the
+    // list, not the tip. Asserted as a sequence so that inserting a check in the wrong place
+    // fails here rather than in an EEST fixture's expected exception.
+    constexpr std::array evmoneSequence{Check::TypeByRevision, Check::SetCodeHasTo,
+        Check::AuthListNonEmpty, Check::TipNotAboveCap, Check::MaxGasLimit, Check::FeeCapVsBaseFee,
+        Check::SenderIsEOA, Check::NonceNotMax, Check::Web3NonceWindow, Check::InitCodeSize,
+        Check::Balance, Check::IntrinsicGas};
+    const auto* const outOfOrder = std::ranges::adjacent_find(evmoneSequence,
+        [&](Check earlier, Check later) { return indexOf(earlier) >= indexOf(later); });
+    BOOST_CHECK_MESSAGE(outOfOrder == evmoneSequence.end(),
+        "c_checkOrder departs from evmone's order at "
+            << (outOfOrder == evmoneSequence.end() ?
+                       0U :
+                       static_cast<uint32_t>(*std::next(outOfOrder))));
+    // The two BCOS nonce checks run last, pool set before ledger, as the pool-side validator
+    // ran them.
+    BOOST_CHECK(indexOf(Check::BcosPoolNonce) + 1 == indexOf(Check::BcosLedgerNonce));
+    BOOST_CHECK(c_checkOrder.back() == Check::BcosLedgerNonce);
+}
+
+// The proposal column is what a malicious leader's proposal is judged against, so every check
+// whose answer is a function of the transaction and the chain config has to survive it: those
+// are identical on every honest node, and enforcing them cannot split a block.
+BOOST_AUTO_TEST_CASE(proposalVerificationKeepsProtocolInvariants)
+{
+    // Every column, spelled out as an equality. A membership sample ("contains ChainId") would
+    // stay green if BcosGroupChainId fell off the BCOS column or SetCodeHasTo off the 7702 one;
+    // an equality per kind fails here instead of on a live chain.
+    constexpr auto proposal = [](TxKind kind) {
+        return checkSet(kind, AdmissionContext::ProposalVerification);
+    };
+    BOOST_CHECK(
+        proposal(TxKind::Bcos) == (Check::TypeGate | Check::ToFieldFormat | Check::Signature |
+                                      Check::BcosGroupChainId | Check::BcosLedgerNonce));
+
+    constexpr auto legacy = Check::TypeGate | Check::ToFieldFormat | Check::Signature |
+                            Check::MaxGasLimit | Check::FeeCapVsBaseFee | Check::ChainId |
+                            Check::InitCodeSize | Check::IntrinsicGas;
+    BOOST_CHECK(proposal(TxKind::Web3Legacy) == legacy);
+    BOOST_CHECK(proposal(TxKind::Web3AccessList) == (legacy | Check::TypeByRevision));
+    BOOST_CHECK(proposal(TxKind::Web3DynamicFee) ==
+                (legacy | Check::TypeByRevision | Check::TipNotAboveCap));
+    BOOST_CHECK(
+        proposal(TxKind::Web3SetCode) == (legacy | Check::TypeByRevision | Check::TipNotAboveCap |
+                                             Check::SetCodeHasTo | Check::AuthListNonEmpty));
+    BOOST_CHECK(proposal(TxKind::Rejected) == Check::TypeGate);
+
+    // The same table read the other way: what comes off, per kind, is exactly the node-local
+    // set and nothing else. Balance depends on where in the block a transaction sits;
+    // SenderIsEOA and NonceNotMax are execution-enforced account reads; Web3NonceWindow and
+    // BcosPoolNonce consult node-local caches on which two honest nodes can disagree -- and on
+    // this path a disagreement is a view change, not a dropped transaction.
+    constexpr auto nodeLocal = Check::Balance | Check::SenderIsEOA | Check::NonceNotMax |
+                               Check::Web3NonceWindow | Check::BcosPoolNonce;
+    for (auto kind : kKinds)
+    {
+        const auto pool = checkSet(kind, AdmissionContext::PoolAdmission);
+        BOOST_CHECK_MESSAGE((pool & ~proposal(kind)) == (pool & nodeLocal),
+            "proposal column drops something other than the node-local set for kind "
+                << static_cast<int>(kind));
+    }
+
+    // ChainId above all: nothing downstream re-checks it. EthereumTransition.h states plainly
+    // that validate_transaction does not look at tx.chain_id, so dropping it here would let a
+    // leader have the whole network execute a transaction signed for a different chain.
+    for (auto kind :
+        {TxKind::Web3Legacy, TxKind::Web3AccessList, TxKind::Web3DynamicFee, TxKind::Web3SetCode})
+    {
+        BOOST_CHECK(contains(proposal(kind), Check::ChainId));
+    }
+}
+
+// A discriminator that is not an enumerator cannot come out of kindOf(), and -Wswitch refuses a
+// new enumerator without a case. This pins the remaining path: an out-of-range value gets the
+// type gate alone, which rejects it, rather than an empty set, which would admit it unchecked.
+BOOST_AUTO_TEST_CASE(unknownDiscriminatorsFailClosed)
+{
+    const auto unknownKind = static_cast<TxKind>(99);
+    const auto unknownContext = static_cast<AdmissionContext>(99);
+    for (auto context : kContexts)
+    {
+        BOOST_CHECK(checkSet(unknownKind, context) == Check::TypeGate);
+        for (auto policy : kPolicies)
+        {
+            BOOST_CHECK(effectiveCheckSet(unknownKind, context, policy) == Check::TypeGate);
+        }
+    }
+    for (auto kind : kKinds)
+    {
+        BOOST_CHECK(checkSet(kind, unknownContext) == Check::TypeGate);
+        for (auto policy : kPolicies)
+        {
+            BOOST_CHECK(effectiveCheckSet(kind, unknownContext, policy) == Check::TypeGate);
+        }
+    }
+    BOOST_CHECK(checkSet(unknownKind, unknownContext) == Check::TypeGate);
+}
+
+BOOST_AUTO_TEST_CASE(eestReplayDropsOnlyBalanceAndNonceWindow)
+{
+    const auto pool = checkSet(TxKind::Web3DynamicFee, AdmissionContext::PoolAdmission);
+    const auto eest = checkSet(TxKind::Web3DynamicFee, AdmissionContext::EESTReplay);
+    BOOST_CHECK((pool & ~eest) == (Check::Balance | Check::Web3NonceWindow));
+    // Everything else survives -- fixtures still have to be well-formed, correctly signed, and
+    // on the right chain.
+    BOOST_CHECK(contains(eest, Check::Signature));
+    BOOST_CHECK(contains(eest, Check::ChainId));
+    BOOST_CHECK(contains(eest, Check::IntrinsicGas));
+    BOOST_CHECK(contains(eest, Check::TypeGate));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test


### PR DESCRIPTION
### What

States as data which checks apply to a transaction, for each (transaction kind × admission context × signature policy).

Second of three PRs building the admission layer. #5501 has merged, so this is now a two-file diff on top of `release-3.18.0`. Header plus tests only; nothing calls this yet.

### Why

"Which checks apply" is not one answer. A Web3 EIP-1559 transaction submitted through JSON-RPC, the same transaction arriving from a peer, and a BCOS transaction inside a block proposal need different sets — and today that difference is spread across branches in two separate validators that disagree with each other.

`CheckSet.h` makes it a 19-bit mask, a fixed evaluation order, and one function mapping the triple to the mask. "What does the pool check that a block proposal does not" becomes one expression instead of a call-graph walk.

### The evaluation order

`c_checkOrder` follows evmone's `validate_transaction` (`bcos-evm/bcos-evm/eth/state/state.cpp`, mirrored by `ethereum-executor/EthereumTransition.h`), including its type-specific block ahead of the shared fee rules: a 7702 envelope is judged on "`to` present" and "authorization list non-empty" before tip-vs-fee-cap, so a transaction violating both reports the same first error here as it would at execution. The FISCO-only items (TypeGate, ToFieldFormat, Signature, the group/chain id, the two BCOS nonce checks) are slotted around that sequence.

### The part worth reviewing closely

The **proposal-verification set**. It keeps every protocol invariant: their answer is a function of the transaction and the chain config alone, so a malicious leader cannot make a bad transaction acceptable by putting it in a block.

`ChainId` in particular must stay. Nothing downstream re-checks it — `EthereumTransition.h` says so explicitly in a comment on `validate_transaction` — which makes admission the only gate. A transaction signed for a different chain would otherwise be executed by every follower.

Five checks come off, all of them node-local state, and the reason differs for each:

- **`Balance`** — its answer depends on *where in the block* a transaction sits. An account funded by an earlier transaction in the same block would be judged against its pre-block balance and wrongly rejected.
- **`SenderIsEOA`** and **`NonceNotMax`** — each pulls a full account read onto the consensus hot path, for every transaction of every block, with no correctness gain: execution enforces both.
- **`Web3NonceWindow`** — the "committed nonce" it compares against is not read from chain state first: it comes from `Web3NonceChecker`'s in-process LRU cache, and the ledger is consulted only on a miss. That cache is raised from every Web3 transaction in a committed block *regardless of whether that transaction succeeded*, is capacity-bounded and evicts, and starts empty after a restart. Two honest nodes can therefore hold different values for the same sender, and the one with the stale-high value rejects a legitimate proposal — which on this path is a view change, not a dropped transaction. Dropping it costs no safety: execution compares the nonce for exact equality, strictly stronger than a `[n, n+600000]` window.
- **`BcosPoolNonce`** — it consults this node's *pending* transaction set (`TxPoolNonceChecker`), which a leader's transactions are legitimately absent from, and which differs between honest nodes by whatever each has admitted and not yet sealed. The pool-side validator already skipped it on this path (`checkTransaction(tx, onlyCheckLedgerNonce = true)`). Its committed-nonce half is a separate bit, **`BcosLedgerNonce`** (`LedgerNonceChecker`: the committed window plus `blockLimit`), which is chain state and stays in every column. Splitting the two is what lets the proposal column be read off the table instead of out of a branch inside the check.

Removing `Web3NonceWindow` has a side benefit worth noting: it was the last check on the proposal path needing an account nonce, so proposal verification now performs **no account state reads at all** — it runs entirely on the transaction and the chain config.

### Unknown discriminators

Both `switch`es are exhaustive and this build has `-Wall -Werror`, so a new enumerator without a case is a compile error, and `kindOf()` (#5527) is the only producer of a `TxKind`. The fall-through after each switch nevertheless resolves to `Check::TypeGate` rather than `Check::None`: a value that is not a `TxKind` gets the gate alone, and the gate rejects it, instead of an empty set that would admit it without a single check.

### Test

`CheckSetTest` pins every column of every kind as an exact expression rather than a sample of members, so loosening one fails the build instead of failing the chain. It also reads the proposal column the other way (for every kind, what comes off is exactly `pool & nodeLocal`), asserts the shared evaluation sequence against evmone's order, and pins `static_cast<TxKind>(99)` / `static_cast<AdmissionContext>(99)` to the type gate.

Local run on this commit: `g++-16 -fsyntax-only -Wall -Wextra -Werror` on `CheckSetTest.cpp` clean; `test-bcos-tx-validator` reports `No errors detected`.

---

### Rebased 2026-09-01

#5501 merged, so its commits left this branch: the diff is `CheckSet.h` and
`CheckSetTest.cpp` and nothing else — 497 lines, down from 1330. The
status-code renumbering against #5520 that this PR used to carry went in with
#5501 and is no longer described here.

`CheckSet.h` includes only `<array>` and `<cstdint>`, so this PR is
self-contained: it was built and run on its own, not only as part of #5527.

### Review round 1 (2026-09-02): `60ea2127f` → `fe153fd11`

Same single commit, amended, and the base moved one commit forward from `19f834071` to `dd64800cd` (#5525) so that #5527 and #5535 no longer carry a replayed copy of #5525. `git diff 60ea2127f fe153fd11 -- bcos-tx-validator` is this PR's whole delta (2 files, +160/−56). Per finding:

| Finding | Disposition |
|---|---|
| @ywy2090 unknown kind/context returns `Check::None` | Fixed: both fall-throughs return `Check::TypeGate`; #5527's `checkTypeGate` is now an allow-list so the gate actually rejects an unknown kind. Test added. |
| @ywy2090 `c_checkOrder` vs evmone first-error order | Confirmed in both `state.cpp` and `EthereumTransition.h`; reordered `TypeByRevision, SetCodeHasTo, AuthListNonEmpty, TipNotAboveCap`. Sequence test added. |
| @ywy2090 `TxKind` values alias EIP-2718 bytes | The mapper is #5527's `kindOf()` (dispatches on the decoded envelope, never casts). Enum comment now says so. No change to the values. |
| @ywy2090 proposal column exact-pinned for DynamicFee only | Every kind pinned as an equality, plus the per-kind `pool & ~proposal == pool & nodeLocal` reading. |
| @ywy2090 `Web3NonceWindow` comment overstates "no ledger read" | Reworded: LRU first, ledger on a miss. |
| @ywy2090 commit message says three drops, mask drops four | Commit message rewritten (it now says five, see below). |
| @morebtcg `BcosPoolNonce` on the proposal path | Split into `BcosPoolNonce` (pending set, node-local, dropped) and `BcosLedgerNonce` (committed window + blockLimit, kept); the context branch inside #5527's check is gone. |
| @morebtcg node-local note at the enumerator | Added. |
| @morebtcg `<iterator>` | Added. |

#5527 and #5535 are rebased onto this commit.
