### PR TITLE
feat(tx-validator): implement verify() over the routing table

### DIFF
--- a/bcos-framework/bcos-framework/ledger/LedgerConfigState.h
+++ b/bcos-framework/bcos-framework/ledger/LedgerConfigState.h
@@ -71,7 +71,7 @@ public:
     /// A null argument is replaced by an empty configuration rather than stored: the "never null"
     /// guarantee below has to hold at every entrance, and set() already enforces it. Storing null
     /// here would make every revision-dependent check throw on every transaction.
-    explicit LedgerConfigState(LedgerConfig::Ptr config)
+    explicit LedgerConfigState(std::shared_ptr<const LedgerConfig> config)
       : m_config(config ? std::move(config) : std::make_shared<LedgerConfig>())
     {}
 
@@ -90,7 +90,11 @@ public:
     /// Publish the configuration for a newly committed block. A null argument is ignored rather
     /// than published: losing the configuration entirely would turn every revision-dependent
     /// check into a stand-down, which is a worse failure than serving one stale block.
-    void set(LedgerConfig::Ptr config)
+    ///
+    /// Takes a pointer to const. The caller may keep a mutable handle of its own, but what is
+    /// published is read-only from here on: the snapshot contract in the signature, not in a
+    /// comment.
+    void set(std::shared_ptr<const LedgerConfig> config)
     {
         if (!config)
         {
@@ -102,6 +106,6 @@ public:
 
 private:
     mutable SharedMutex x_config;
-    LedgerConfig::Ptr m_config;
+    std::shared_ptr<const LedgerConfig> m_config;
 };
 }  // namespace bcos::ledger

--- a/bcos-framework/bcos-framework/ledger/LedgerConfigState.h
+++ b/bcos-framework/bcos-framework/ledger/LedgerConfigState.h
@@ -1,0 +1,103 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file LedgerConfigState.h
+ * @brief Node-wide ledger configuration, republished once per committed block.
+ * @date 2026/8/31
+ */
+#pragma once
+#include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-utilities/Common.h"
+#include <memory>
+#include <utility>
+
+namespace bcos::ledger
+{
+/// The ledger configuration as of the last committed block, shared by every component that needs
+/// it. Read on nearly every transaction; written once per block.
+///
+/// The contract is a SNAPSHOT, not a lock:
+///
+///   - get() returns the LedgerConfig that was current when it was called, and nothing mutates
+///     that object afterwards. The caller may hold it for as long as it likes.
+///   - set() publishes a NEW object. It does not edit the one readers are holding.
+///
+/// So a reader racing a commit sees either the previous block's configuration or the new one,
+/// complete either way. A reader can still be held behind the writer, but only for the writer's
+/// critical section: a pointer move-assign, plus at most dropping the last reference to the
+/// previous config. Never for the time it takes to BUILD a configuration, which is where the
+/// cost actually is. That is the property being bought: the config is assembled outside the
+/// lock and published as a finished object.
+///
+/// That property is the whole point, because the two holders this replaces do not have it:
+///
+///   - executor::LedgerCache mutates *m_ledgerConfig in place (via getLedgerConfig writing into
+///     the existing object) while ledgerConfig() hands out a reference to that same object, with
+///     no lock on the config at all. A concurrent reader can observe a half-updated config --
+///     some fields from block N, some from block N+1.
+///   - scheduler::SchedulerImpl assigns the pointer, which is the right shape, but a plain
+///     shared_ptr assignment concurrent with a read is a data race.
+///
+/// Callers must pass a freshly built config to set(), never a mutated copy of what get()
+/// returned: readers may still be holding that object.
+///
+/// One node process serves one group (NodeConfig::groupId is singular), so a single instance per
+/// process is per-group by construction.
+class LedgerConfigState
+{
+public:
+    using Ptr = std::shared_ptr<LedgerConfigState>;
+
+    /// Starts with an empty configuration so readers never see null before the first publish.
+    /// Until the first set(), gasLimit() is LedgerConfig's compile-time default rather than the
+    /// chain's tx_gas_limit -- looser, never stricter, so no check can reject on a stale value.
+    LedgerConfigState() : m_config(std::make_shared<LedgerConfig>()) {}
+    /// A null argument is replaced by an empty configuration rather than stored: the "never null"
+    /// guarantee below has to hold at every entrance, and set() already enforces it. Storing null
+    /// here would make every revision-dependent check throw on every transaction.
+    explicit LedgerConfigState(LedgerConfig::Ptr config)
+      : m_config(config ? std::move(config) : std::make_shared<LedgerConfig>())
+    {}
+
+    /// The configuration as of the last committed block. Never null.
+    ///
+    /// Returns a pointer to CONST. The snapshot contract -- "nothing mutates this object after
+    /// publication" -- is the whole value of this class, and a mutable pointer would leave it as
+    /// a comment that every caller is free to ignore. That is precisely how executor::LedgerCache
+    /// ended up mutating its config in place.
+    std::shared_ptr<const LedgerConfig> get() const
+    {
+        ReadGuard guard(x_config);
+        return m_config;
+    }
+
+    /// Publish the configuration for a newly committed block. A null argument is ignored rather
+    /// than published: losing the configuration entirely would turn every revision-dependent
+    /// check into a stand-down, which is a worse failure than serving one stale block.
+    void set(LedgerConfig::Ptr config)
+    {
+        if (!config)
+        {
+            return;
+        }
+        WriteGuard guard(x_config);
+        m_config = std::move(config);
+    }
+
+private:
+    mutable SharedMutex x_config;
+    LedgerConfig::Ptr m_config;
+};
+}  // namespace bcos::ledger

--- a/bcos-framework/bcos-framework/ledger/LedgerConfigState.h
+++ b/bcos-framework/bcos-framework/ledger/LedgerConfigState.h
@@ -61,8 +61,12 @@ public:
     using Ptr = std::shared_ptr<LedgerConfigState>;
 
     /// Starts with an empty configuration so readers never see null before the first publish.
-    /// Until the first set(), gasLimit() is LedgerConfig's compile-time default rather than the
-    /// chain's tx_gas_limit -- looser, never stricter, so no check can reject on a stale value.
+    /// Empty is not the chain's configuration, and it is not uniformly looser either: no EVM
+    /// revision is declared, which admission reads as "stand down", and gasLimit() is
+    /// LedgerConfig's compile-time default rather than the chain's tx_gas_limit -- but chainId()
+    /// is unset, which the chain-id check refuses. So the owner of a holder publishes a real
+    /// configuration at startup and then after every commit; the empty state is for
+    /// construction, not for serving traffic.
     LedgerConfigState() : m_config(std::make_shared<LedgerConfig>()) {}
     /// A null argument is replaced by an empty configuration rather than stored: the "never null"
     /// guarantee below has to hold at every entrance, and set() already enforces it. Storing null

--- a/bcos-framework/bcos-framework/testutils/faker/FakeLedger.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeLedger.h
@@ -128,7 +128,10 @@ public:
         FakeLedger* m_ledger;
     };
     using Ptr = std::shared_ptr<FakeLedger>;
-    FakeLedger() = default;
+    // m_ledgerConfig must exist even here: BOTH branches of asyncGetSystemConfigByKey read
+    // m_ledgerConfig->blockNumber(), so a default-constructed FakeLedger used only for system
+    // config -- no block factory, no chain -- would dereference null.
+    FakeLedger() : m_ledgerConfig(std::make_shared<LedgerConfig>()) {}
     FakeLedger(BlockFactory::Ptr _blockFactory, size_t _blockNumber, size_t _txsSize, size_t,
         std::vector<bytes> _sealerList)
       : m_blockFactory(std::move(_blockFactory)),

--- a/bcos-tx-validator/bcos-tx-validator/CheckSet.h
+++ b/bcos-tx-validator/bcos-tx-validator/CheckSet.h
@@ -108,6 +108,10 @@ enum class Check : uint32_t
     /// The nonce is already COMMITTED inside the block-limit window, or blockLimit itself is out
     /// of range (LedgerNonceChecker::checkNonce). Chain state.
     BcosLedgerNonce = 1U << 18,
+    /// The (sender, nonce) pair is already held by a PENDING Web3 transaction in this node's
+    /// pool (Web3NonceChecker::existsMemoryNonce). The Web3 counterpart of BcosPoolNonce, and
+    /// node-local in the same way -- but keyed on the SENDER, which BcosPoolNonce is not.
+    Web3PoolNonce = 1U << 19,
 };
 
 constexpr Check operator|(Check lhs, Check rhs) noexcept
@@ -140,7 +144,7 @@ constexpr bool contains(Check set, Check item) noexcept
 ///   state -- evmone's validate_transaction (bcos-evm/bcos-evm/eth/state/state.cpp, mirrored by
 ///            ethereum-executor/EthereumTransition.h), in ITS order, judged against one chain
 ///            view -- a configuration snapshot plus the fee and chain-id keys -- and, only when
-///            the set contains a sender-dependent check, one account read. evmone validates the
+///            the set contains an account-state check, one account read. evmone validates the
 ///            type-specific block BEFORE the shared fee rules -- for a 7702 envelope that is "to
 ///            present" and "authorization list non-empty" ahead of the tip/fee-cap comparison --
 ///            so a transaction violating both reports the same first error here as at execution.
@@ -172,6 +176,7 @@ inline constexpr std::array c_stateOrder{
     Check::IntrinsicGas,
 };
 inline constexpr std::array c_poolOrder{
+    Check::Web3PoolNonce,
     Check::BcosPoolNonce,
     Check::BcosLedgerNonce,
 };
@@ -240,14 +245,28 @@ inline constexpr Check c_poolStage = detail::unionOf(c_poolOrder);
 /// committed window, and checkBlockLimit reads only _tx.blockLimit(). None touches the sender,
 /// so including them would make SignaturePolicy::Disabled silently switch off BCOS replay
 /// protection as a side effect.
-inline constexpr Check c_senderDependent =
+///
+/// Checks that need the account's own state -- balance, nonce, code. Membership decides whether
+/// verify() performs that read, so a check that merely keys on the sender address must NOT be
+/// listed here or it would drag a storage read onto its path.
+inline constexpr Check c_accountStateDependent =
     Check::SenderIsEOA | Check::NonceNotMax | Check::Web3NonceWindow | Check::Balance;
 
+/// Web3PoolNonce IS sender-dependent, and that is the difference between the two pool rules: its
+/// key is the PAIR (sender, nonce), where BcosPoolNonce's is a nonce value alone. Run with an
+/// unrecovered sender it would file every pending Web3 transaction under the empty string, and
+/// one sender's nonce would then refuse another's. It needs the address, not the account, so it
+/// is here and not above -- which is why the two sets are stated separately: verify() asks one
+/// question to decide what to switch off without a sender, and the other to decide whether to
+/// read the account at all.
+inline constexpr Check c_senderDependent = c_accountStateDependent | Check::Web3PoolNonce;
+
 /// Checks shared by every Web3 kind.
-inline constexpr Check c_web3Common =
-    Check::TypeGate | Check::ToFieldFormat | Check::Signature | Check::MaxGasLimit |
-    Check::FeeCapVsBaseFee | Check::ChainId | Check::SenderIsEOA | Check::NonceNotMax |
-    Check::Web3NonceWindow | Check::InitCodeSize | Check::Balance | Check::IntrinsicGas;
+inline constexpr Check c_web3Common = Check::TypeGate | Check::ToFieldFormat | Check::Signature |
+                                      Check::MaxGasLimit | Check::FeeCapVsBaseFee | Check::ChainId |
+                                      Check::SenderIsEOA | Check::NonceNotMax |
+                                      Check::Web3NonceWindow | Check::InitCodeSize |
+                                      Check::Balance | Check::IntrinsicGas | Check::Web3PoolNonce;
 
 /// The check set for @p kind under PoolAdmission. The other two contexts are derived from this
 /// one rather than written out separately, so the columns cannot drift apart.
@@ -288,6 +307,9 @@ constexpr Check checkSet(TxKind kind, AdmissionContext context) noexcept
     case AdmissionContext::PoolAdmission:
         return base;
     case AdmissionContext::EESTReplay:
+        // Web3PoolNonce stays: a fixture whose transactions are all distinct never meets it, and
+        // one that does repeat a (sender, nonce) would be refused by the pool's reservation
+        // anyway, with the same status. Dropping it would let no additional fixture through.
         return base & ~(Check::Balance | Check::Web3NonceWindow);
     case AdmissionContext::ProposalVerification:
         // Everything a leader could violate stays ON. These are protocol invariants: their
@@ -323,15 +345,16 @@ constexpr Check checkSet(TxKind kind, AdmissionContext context) noexcept
         //   costs no safety: execution compares the nonce for exact equality, which is strictly
         //   stronger than a [n, n+600000] window.
         //
-        //   BcosPoolNonce -- the set it consults is this node's PENDING transactions, the same
-        //   class of node-local state as that cache. A leader's transactions are legitimately
-        //   absent from it, and two honest nodes' pools differ by whatever each has admitted
-        //   and not yet sealed, so a hit here is not something every honest node agrees on.
-        //   The pool-side validator already skipped it on this path
-        //   (checkTransaction(tx, onlyCheckLedgerNonce = true)). BcosLedgerNonce, the
-        //   committed-nonce and blockLimit half, is chain state and stays.
+        //   BcosPoolNonce and Web3PoolNonce -- the set each consults is this node's PENDING
+        //   transactions, the same class of node-local state as that cache. A leader's
+        //   transactions are legitimately absent from it, and two honest nodes' pools differ by
+        //   whatever each has admitted and not yet sealed, so a hit here is not something every
+        //   honest node agrees on. The pool-side validator already skipped both on this path
+        //   (checkTransaction(tx, onlyCheckLedgerNonce = true) -- the same flag that switches
+        //   its Web3 memory-nonce lookup off). BcosLedgerNonce, the committed-nonce and
+        //   blockLimit half, is chain state and stays.
         return base & ~(Check::Balance | Check::SenderIsEOA | Check::NonceNotMax |
-                          Check::Web3NonceWindow | Check::BcosPoolNonce);
+                          Check::Web3NonceWindow | Check::BcosPoolNonce | Check::Web3PoolNonce);
     }
     // See poolAdmissionCheckSet: unreachable for a real AdmissionContext, closed for anything
     // else.

--- a/bcos-tx-validator/bcos-tx-validator/CheckSet.h
+++ b/bcos-tx-validator/bcos-tx-validator/CheckSet.h
@@ -125,25 +125,36 @@ constexpr bool contains(Check set, Check item) noexcept
     return (set & item) != Check::None;
 }
 
-/// The single evaluation order. The bitmask expresses membership only; this array decides which
-/// code a transaction violating several rules reports -- and EEST fixtures assert specific error
-/// codes, so that has to be deterministic.
+/// The evaluation order, in three stages. The bitmask expresses membership only; the order
+/// decides which code a transaction violating several rules reports -- and EEST fixtures assert
+/// specific error codes, so that has to be deterministic.
 ///
-/// Follows evmone's validate_transaction (bcos-evm/bcos-evm/eth/state/state.cpp, mirrored by
-/// ethereum-executor/EthereumTransition.h), with the FISCO-only items slotted in. evmone
-/// validates the type-specific block BEFORE the shared fee rules -- for a 7702 envelope that is
-/// "to present" and "authorization list non-empty" ahead of the tip/fee-cap comparison -- so a
-/// transaction violating both reports the same first error here as it would at execution.
-/// TypeGate goes first (nothing else is meaningful for an envelope type that is refused
-/// outright), ToFieldFormat and Signature next (without a recovered sender the account-state
-/// checks cannot run), ChainId ahead of the account reads (one config read is cheaper than an
-/// account read), and the two BCOS nonce checks last, pool set before ledger, as the pool-side
-/// validator ran them.
-inline constexpr std::array c_checkOrder{
+/// A check belongs to the stage whose inputs it reads, and verify() fetches a stage's inputs
+/// once, before that stage's first check, never per check:
+///
+///   gate  -- reads the transaction alone. FISCO's own pre-checks: a refused envelope type, a
+///            malformed `to`, a bad signature or a foreign group/chain id is rejected without a
+///            single read, which is what keeps unauthenticated P2P input cheap to refuse.
+///   state -- evmone's validate_transaction (bcos-evm/bcos-evm/eth/state/state.cpp, mirrored by
+///            ethereum-executor/EthereumTransition.h), in ITS order, judged against one chain
+///            view -- a configuration snapshot plus the fee and chain-id keys -- and, only when
+///            the set contains a sender-dependent check, one account read. evmone validates the
+///            type-specific block BEFORE the shared fee rules -- for a 7702 envelope that is "to
+///            present" and "authorization list non-empty" ahead of the tip/fee-cap comparison --
+///            so a transaction violating both reports the same first error here as at execution.
+///   pool  -- the BCOS nonce checkers, pool set before ledger, as the pool-side validator ran
+///            them. Reads the pool, not the chain.
+///
+/// Per (kind, context) this yields exactly the reads the table implies: a BCOS transaction
+/// reads nothing, a Web3 proposal reads the chain view, a Web3 admission reads the chain view
+/// and the account.
+inline constexpr std::array c_gateOrder{
     Check::TypeGate,
     Check::ToFieldFormat,
     Check::Signature,
     Check::BcosGroupChainId,
+};
+inline constexpr std::array c_stateOrder{
     Check::TypeByRevision,
     Check::SetCodeHasTo,
     Check::AuthListNonEmpty,
@@ -157,9 +168,49 @@ inline constexpr std::array c_checkOrder{
     Check::InitCodeSize,
     Check::Balance,
     Check::IntrinsicGas,
+};
+inline constexpr std::array c_poolOrder{
     Check::BcosPoolNonce,
     Check::BcosLedgerNonce,
 };
+
+namespace detail
+{
+template <std::size_t... N>
+constexpr std::array<Check, (N + ...)> concat(std::array<Check, N> const&... stages)
+{
+    std::array<Check, (N + ...)> out{};
+    std::size_t index = 0;
+    auto append = [&](auto const& stage) {
+        for (auto check : stage)
+        {
+            out.at(index) = check;
+            ++index;
+        }
+    };
+    (append(stages), ...);
+    return out;
+}
+
+template <std::size_t N>
+constexpr Check unionOf(std::array<Check, N> const& stage)
+{
+    Check out = Check::None;
+    for (auto check : stage)
+    {
+        out = out | check;
+    }
+    return out;
+}
+}  // namespace detail
+
+/// The single evaluation order: the three stages back to back.
+inline constexpr std::array c_checkOrder = detail::concat(c_gateOrder, c_stateOrder, c_poolOrder);
+
+/// Membership masks of the stages that read something, so verify() can ask "does this set need
+/// the chain view / the pool" as one expression over the table.
+inline constexpr Check c_stateStage = detail::unionOf(c_stateOrder);
+inline constexpr Check c_poolStage = detail::unionOf(c_poolOrder);
 
 /// Checks that cannot run without a recovered sender, and must therefore be skipped when
 /// signature verification is switched off.

--- a/bcos-tx-validator/bcos-tx-validator/CheckSet.h
+++ b/bcos-tx-validator/bcos-tx-validator/CheckSet.h
@@ -26,13 +26,14 @@
 namespace bcos::txvalidator
 {
 
-/// Routing key. Decided from the SIGNED envelope's first byte during normalization, never from
-/// the tars mirror -- a peer can set the mirror kind to 0 and a legacy-keyed check set would
-/// then skip the fee-market rules a 1559 envelope is subject to.
+/// Routing key. Decided from the SIGNED envelope's first byte -- by kindOf() in TxValidator.cpp,
+/// once normalization has authenticated that envelope -- never from the tars mirror: a peer can
+/// set the mirror kind to 0 and a legacy-keyed check set would then skip the fee-market rules a
+/// 1559 envelope is subject to.
 ///
 /// The enumerator values are NOT EIP-2718 type bytes (Web3AccessList is 2 here and 0x01 on the
-/// wire). A TxKind is produced only by kindOf() in TxValidator.cpp, which dispatches on the
-/// decoded envelope; casting a type byte to this enum is always wrong.
+/// wire). kindOf() is the only producer, dispatching on the decoded envelope; casting a type
+/// byte to this enum is always wrong.
 enum class TxKind : uint8_t
 {
     Bcos,            ///< outer tars type == BCOSTransaction; no EIP-2718 envelope
@@ -68,9 +69,10 @@ enum class AdmissionContext : uint8_t
 /// eth_sendRawTransaction would be treated as pre-verified and skip signature, EOA, nonce and
 /// balance checks.
 ///
-/// The verified/not-verified STATE is read only inside the Signature check itself, where
-/// Transaction::verify() short-circuits on `if (!tainted()) return;`. That makes the check
-/// idempotent, so no "already verified" flag has to be threaded through any call chain.
+/// No "already verified" state is consulted at all. The Signature check re-taints the
+/// transaction (clearSenderAndHash) before Transaction::verify(), so recovery runs on every call
+/// and no flag has to be threaded through any call chain. The cost, one recovery per transaction
+/// on the sync path, is what the pool-side validator this replaces paid too.
 enum class SignaturePolicy : uint8_t
 {
     Required,
@@ -201,6 +203,23 @@ constexpr Check unionOf(std::array<Check, N> const& stage)
         out = out | check;
     }
     return out;
+}
+
+/// Position of @p check in @p stage, or the stage's size when absent. For static_asserts that
+/// pin one check's place relative to another's within a stage.
+template <std::size_t N>
+constexpr std::size_t indexOf(std::array<Check, N> const& stage, Check check)
+{
+    std::size_t index = 0;
+    for (auto entry : stage)
+    {
+        if (entry == check)
+        {
+            return index;
+        }
+        ++index;
+    }
+    return index;
 }
 }  // namespace detail
 

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
@@ -163,8 +163,12 @@ struct Envelope
     std::string_view chainId;
 };
 
-/// The chain as of one snapshot, read once per verify() before the state stage: every check in
+/// The chain as of one snapshot, taken once per verify() before the state stage: every check in
 /// one pass judges against a single block's configuration even if a commit lands mid-pass.
+///
+/// Everything here is derived from the LedgerConfigState snapshot; the stage performs no ledger
+/// read of its own. getLedgerConfig already fills the chain id and the base fee from the same
+/// SYS_CONFIG rows an earlier version fetched again, per transaction, through getSystemConfig.
 struct ChainView
 {
     /// const: LedgerConfigState hands out a snapshot nobody may mutate.
@@ -172,9 +176,13 @@ struct ChainView
     /// nullopt = the chain declares no EVM revision; revision-dependent checks stand down rather
     /// than guess, because admission must never be STRICTER than execution.
     std::optional<evmc_revision> revision;
-    /// nullopt = the key is unset in the chain config.
-    std::optional<std::string> txGasPrice;
-    std::optional<std::string> web3ChainId;
+    /// tx_gas_price. Zero = a free-gas chain: the sender is never debited, so the fee checks
+    /// stand down. An unset row reaches the snapshot as getLedgerConfig's "0x0" default, which
+    /// is the verdict the checks always gave an unset row anyway.
+    u256 baseFee;
+    /// web3_chain_id. nullopt only on a holder nothing has published to yet: getLedgerConfig
+    /// always sets it, serving an unset row as 0 exactly as the executor's CHAINID does.
+    std::optional<u256> web3ChainId;
 };
 
 /// Inputs of the state stage. `sender` is engaged exactly when the check set contains a
@@ -343,15 +351,11 @@ TransactionStatus checkMaxGasLimit(StateInputs const& in)
 
 TransactionStatus checkFeeCapVsBaseFee(StateInputs const& in)
 {
-    if (!in.chain.txGasPrice)
+    if (in.chain.baseFee == 0)
     {
-        return TransactionStatus::None;  // unset: no baseline to compare against
+        return TransactionStatus::None;  // free-gas chain: nothing to undercut
     }
-    if (*in.chain.txGasPrice == "0" || *in.chain.txGasPrice == "0x0")
-    {
-        return TransactionStatus::None;  // free-gas chain
-    }
-    if (protocol::effectiveGasPrice(in.tx) < u256(*in.chain.txGasPrice))
+    if (protocol::effectiveGasPrice(in.tx) < in.chain.baseFee)
     {
         // Today this is reported as InsufficientFunds, which tells the user their balance is
         // short when it is not.
@@ -385,13 +389,9 @@ TransactionStatus checkChainId(StateInputs const& in)
     }
     // The transaction claims a chain. From here the configuration is required: silently
     // accepting an unverifiable claim admits transactions signed for any chain -- which is what
-    // EthEndpoint does today when web3_chain_id is unset.
-    if (!in.chain.web3ChainId)
-    {
-        return TransactionStatus::InvalidChainId;
-    }
-    auto const expected = ledger::parseWeb3ChainId(*in.chain.web3ChainId);
-    if (!expected || u256(classified.chainId) != *expected)
+    // EthEndpoint does today when web3_chain_id is unset. The snapshot lacks a chain id only
+    // while nothing has been published to the holder, and that is refused too.
+    if (!in.chain.web3ChainId || u256(classified.chainId) != *in.chain.web3ChainId)
     {
         return TransactionStatus::InvalidChainId;
     }
@@ -467,8 +467,7 @@ TransactionStatus checkBalance(StateInputs const& in)
     // max_gas_price * gas_limit + value, because on a free-gas FISCO chain the sender is never
     // actually debited the fee cap they declared -- charging it at admission would reject
     // transactions that execute perfectly well.
-    const bool chargesGas =
-        in.chain.txGasPrice && !(*in.chain.txGasPrice == "0" || *in.chain.txGasPrice == "0x0");
+    const bool chargesGas = in.chain.baseFee != 0;
 
     u256 const balance = in.sender.value().balance;
 
@@ -633,34 +632,30 @@ u256 parseBalance(std::string_view raw)
     }
 }
 
-/// The state stage's inputs, read once. Throws (never returns a status) when something cannot
-/// be read: a storage fault must not be reported as a defect in the transaction.
-task::Task<ChainView> readChainView(
-    ledger::LedgerConfigState const& configState, ledger::LedgerInterface& chainLedger)
+/// The state stage's inputs, taken once: a pointer copy and two field conversions. Whoever
+/// commits a block republishes the configuration, and nothing here goes to storage. Throws
+/// (never returns a status) on a snapshot that cannot be used -- infrastructure, not a defect in
+/// the transaction, and reported so that it cannot masquerade as a rejected transaction.
+ChainView readChainView(ledger::LedgerConfigState const& configState)
 {
     ChainView view;
-    // A snapshot, not a fetch: whoever commits a block republishes the configuration, and this
-    // is a pointer copy.
     view.config = configState.get();
     if (!view.config)
     {
         // LedgerConfigState never publishes null, so reaching here means the holder was
-        // corrupted. Infrastructure, not a defect in the transaction -- reported as an exception
-        // so it cannot masquerade as a rejected transaction.
+        // corrupted.
         BOOST_THROW_EXCEPTION(std::runtime_error("admission: ledger config state returned null"));
     }
     // Judged against the block it would execute in, which is the next one.
     view.revision = view.config->evmcRevisionForBlock(view.config->blockNumber() + 1);
-    if (auto entry = co_await ledger::getSystemConfig(chainLedger, ledger::SYSTEM_KEY_TX_GAS_PRICE))
+    // The raw SYS_CONFIG string: "0x0" by default, hex as SystemConfigPrecompiled enforces. A
+    // value u256 cannot parse throws here, as it did when the checks parsed it themselves.
+    view.baseFee = u256(std::get<0>(view.config->gasPrice()));
+    if (auto const& chainId = view.config->chainId())
     {
-        view.txGasPrice = std::get<0>(*entry);
+        view.web3ChainId = fromBigEndian<u256>(chainId->bytes);
     }
-    if (auto entry =
-            co_await ledger::getSystemConfig(chainLedger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID))
-    {
-        view.web3ChainId = std::get<0>(*entry);
-    }
-    co_return view;
+    return view;
 }
 }  // namespace
 
@@ -775,12 +770,13 @@ task::Task<TransactionStatus> TxValidator::verify(
         co_return status;
     }
 
-    // Stage 2: evmone's sequence against one chain view, fetched once. The account is read only
+    // Stage 2: evmone's sequence against one chain view, taken once from the snapshot. The
+    // account is read only
     // when the set contains a check that needs it -- which is how the proposal column, whose
     // sender-dependent checks are off, performs no account read at all.
     if ((checks & c_stateStage) != Check::None)
     {
-        auto const chain = co_await readChainView(*m_ledgerConfigState, *m_ledger);
+        auto const chain = readChainView(*m_ledgerConfigState);
         std::optional<AccountState> sender;
         if ((checks & c_senderDependent) != Check::None)
         {

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
@@ -1,0 +1,862 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TxValidator.cpp
+ * @date 2026/8/25
+ */
+
+#include "bcos-tx-validator/TxValidator.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/protocol/GlobalConfig.h"
+#include "bcos-framework/protocol/Protocol.h"
+#include "bcos-framework/protocol/TxGasModel.h"
+#include "bcos-framework/txpool/Constant.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-rlp-protocol/Web3TxEnvelope.h"
+#include "bcos-tx-validator/Normalize.h"
+#include "bcos-utilities/BoostLog.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/throw_exception.hpp>
+#include <cctype>
+#include <stdexcept>
+
+using namespace bcos;
+using namespace bcos::protocol;
+
+#define TX_VALIDATOR_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("TXVALIDATOR")
+
+namespace bcos::txvalidator
+{
+namespace
+{
+/// EIP-7702 delegation designator. Code with this prefix still belongs to an EOA, so EIP-3607
+/// must let it send transactions.
+constexpr std::array<byte, 3> kDelegationPrefix{0xef, 0x01, 0x00};
+
+bool isDelegatedCode(bytes const& code) noexcept
+{
+    return code.size() >= kDelegationPrefix.size() &&
+           std::equal(kDelegationPrefix.begin(), kDelegationPrefix.end(), code.begin());
+}
+
+/// Route on the SIGNED envelope, never on web3TypedTxKind: the mirror is unauthenticated, and a
+/// peer that mis-declares a 1559 envelope as legacy would otherwise dodge TipNotAboveCap and
+/// TypeByRevision.
+TxKind kindOf(Transaction const& tx)
+{
+    if (tx.type() == static_cast<uint8_t>(TransactionType::BCOSTransaction))
+    {
+        return TxKind::Bcos;
+    }
+    switch (engine::dispatchRawTransaction(tx.extraTransactionBytes()))
+    {
+    case engine::RawTransactionKind::Legacy:
+        return TxKind::Web3Legacy;
+    case engine::RawTransactionKind::AccessList:
+        return TxKind::Web3AccessList;
+    case engine::RawTransactionKind::DynamicFee:
+        return TxKind::Web3DynamicFee;
+    case engine::RawTransactionKind::SetCode:
+        return TxKind::Web3SetCode;
+    default:
+        return TxKind::Rejected;
+    }
+}
+
+/// The hard fork each typed transaction requires.
+evmc_revision requiredRevision(TxKind kind) noexcept
+{
+    switch (kind)
+    {
+    case TxKind::Web3AccessList:
+        return EVMC_BERLIN;  // EIP-2930
+    case TxKind::Web3DynamicFee:
+        return EVMC_LONDON;  // EIP-1559
+    case TxKind::Web3SetCode:
+        return EVMC_PRAGUE;  // EIP-7702
+    default:
+        return EVMC_FRONTIER;
+    }
+}
+}  // namespace
+
+bool isValidToField(std::string_view toField)
+{
+    if (toField.empty() || g_BCOSConfig.isWasm())
+    {
+        return true;
+    }
+    if (toField.starts_with("0x") || toField.starts_with("0X"))
+    {
+        toField.remove_prefix(2);
+    }
+    constexpr size_t addressHexLength = 40;
+    return toField.size() == addressHexLength &&
+           std::ranges::all_of(
+               toField, [](unsigned char character) { return std::isxdigit(character) != 0; });
+}
+
+TxValidator::TxValidator(crypto::CryptoSuite::Ptr cryptoSuite,
+    std::shared_ptr<ledger::LedgerInterface> ledger,
+    ledger::LedgerConfigState::Ptr ledgerConfigState, NonceCheckerInterface::Ptr txPoolNonceChecker,
+    Web3NonceChecker::Ptr web3NonceChecker, SystemTxPredicate isSystemTx, std::string groupId,
+    std::string chainId)
+  : m_cryptoSuite(std::move(cryptoSuite)),
+    m_ledger(std::move(ledger)),
+    m_ledgerConfigState(std::move(ledgerConfigState)),
+    m_txPoolNonceChecker(std::move(txPoolNonceChecker)),
+    m_web3NonceChecker(std::move(web3NonceChecker)),
+    m_isSystemTx(std::move(isSystemTx)),
+    m_groupId(std::move(groupId)),
+    m_chainId(std::move(chainId))
+{
+    if (!m_ledgerConfigState)
+    {
+        // Every revision-dependent check reads through this. A null holder would silently turn
+        // all of them into stand-downs, which is exactly the "admission weaker than execution"
+        // failure this module exists to prevent -- so refuse to be built that way.
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("TxValidator: ledgerConfigState must not be null"));
+    }
+}
+
+void TxValidator::setLedgerNonceChecker(std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker)
+{
+    WriteGuard guard(x_lateBound);
+    m_ledgerNonceChecker = std::move(ledgerNonceChecker);
+}
+
+void TxValidator::setScheduler(std::weak_ptr<scheduler::SchedulerInterface> scheduler)
+{
+    WriteGuard guard(x_lateBound);
+    m_scheduler = std::move(scheduler);
+}
+
+namespace
+{
+/// The inputs a check may read beyond the transaction itself. Each one costs a ledger or
+/// storage round-trip, so admit() fetches one only when a check that actually runs declares it,
+/// and never fetches the same one twice.
+enum class Need : uint8_t
+{
+    None = 0,
+    Config = 1U << 0,       ///< LedgerConfig (block number, gas limit, EVM revision)
+    Revision = 1U << 1,     ///< evmc_revision for the next block; implies Config
+    SenderState = 1U << 2,  ///< balance + nonce + code, one account read
+    SenderNonce = 1U << 3,  ///< nonce alone; source depends on the context, see admit()
+    TxGasPrice = 1U << 4,   ///< SYSTEM_KEY_TX_GAS_PRICE
+    Web3ChainId = 1U << 5,  ///< SYSTEM_KEY_WEB3_CHAIN_ID
+};
+
+constexpr Need operator|(Need lhs, Need rhs) noexcept
+{
+    return static_cast<Need>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+}
+constexpr Need operator&(Need lhs, Need rhs) noexcept
+{
+    return static_cast<Need>(static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs));
+}
+constexpr Need operator~(Need value) noexcept
+{
+    return static_cast<Need>(static_cast<uint8_t>(~static_cast<uint8_t>(value)));
+}
+constexpr bool contains(Need set, Need item) noexcept
+{
+    return (set & item) != Need::None;
+}
+
+/// Everything a check function is allowed to see. The resolved fields below are filled in by
+/// admit() before the check runs, according to the Need mask its registry row declares -- so a
+/// check body contains rules only, never I/O, and stays synchronous and directly testable.
+struct AdmissionInputs
+{
+    protocol::Transaction& tx;
+    TxKind kind;
+    AdmissionContext context;
+    /// The nonce checkers, as raw pointers. ledgerNonceChecker is a snapshot the verify() frame
+    /// owns; txPoolNonceChecker points at a member of the validator, as do cryptoSuite,
+    /// isSystemTx, groupId and chainId below. So this struct is only valid while the validator
+    /// outlives the coroutine -- the ordinary contract for a Task-returning member, but worth
+    /// stating because these are read AFTER resumption. Either checker may be null: see
+    /// checkBcosPoolNonce and checkBcosLedgerNonce.
+    NonceCheckerInterface* txPoolNonceChecker;
+    LedgerNonceChecker* ledgerNonceChecker;
+    crypto::CryptoSuite& cryptoSuite;
+    SystemTxPredicate const& isSystemTx;
+    std::string_view groupId;
+    std::string_view chainId;
+
+    // --- resolved on demand ---
+    /// const: LedgerConfigState hands out a snapshot nobody may mutate, and a check receiving
+    /// AdmissionInputs const& could otherwise still write through this pointer.
+    std::shared_ptr<const ledger::LedgerConfig> config;
+    /// nullopt = the chain declares no EVM revision; revision-dependent checks stand down rather
+    /// than guess, because admission must never be STRICTER than execution.
+    std::optional<evmc_revision> revision;
+    /// nullopt = the account does not exist on chain yet.
+    std::optional<AccountState> senderState;
+    std::optional<u256> senderNonce;
+    /// nullopt = the key is unset in the chain config (distinct from "not resolved": a field is
+    /// only read by a check that declared the matching Need).
+    std::optional<std::string> txGasPrice;
+    std::optional<std::string> web3ChainId;
+};
+
+// ---------------------------------------------------------------- the checks
+//
+// One function per Check bit. Pure rules: no I/O, no co_await, no access to the validator's
+// members beyond what AdmissionInputs carries. Returns None to pass, any other status to reject.
+
+TransactionStatus checkTypeGate(AdmissionInputs const& in)
+{
+    // An allow-list, not a deny-list. normalize() already refused blob/deposit/reserved
+    // envelopes, so Rejected here means the routing key and the gate disagree; and a value that
+    // is no TxKind at all (which kindOf() cannot produce, but the table resolves to this gate
+    // alone precisely so that such a value is judged by something) must fall through to the
+    // rejection too. Fail closed either way.
+    switch (in.kind)
+    {
+    case TxKind::Bcos:
+    case TxKind::Web3Legacy:
+    case TxKind::Web3AccessList:
+    case TxKind::Web3DynamicFee:
+    case TxKind::Web3SetCode:
+        return TransactionStatus::None;
+    case TxKind::Rejected:
+        break;
+    }
+    return TransactionStatus::TxTypeNotSupported;
+}
+
+TransactionStatus checkToFieldFormat(AdmissionInputs const& in)
+{
+    return isValidToField(in.tx.to()) ? TransactionStatus::None : TransactionStatus::Malformed;
+}
+
+TransactionStatus checkSignature(AdmissionInputs const& in)
+{
+    try
+    {
+        // clearSenderAndHash() first, and it is NOT redundant with verify(). It wipes two things,
+        // and only one of them is the sender:
+        //
+        //   - the wire-supplied hash. For a BCOS transaction, TarsHashable.h returns dataHash
+        //     verbatim when it is non-empty, so calculateHash() inside verify() would recompute
+        //     nothing and signature recovery would run against a hash the sender chose. Any
+        //     (hash, signature) pair from a victim's broadcast transaction could then be attached
+        //     to an attacker's body and recover the victim as sender.
+        //   - the tainted flag. verify() early-returns on an untainted transaction, so without
+        //     this a transaction that arrived pre-marked skips verification entirely.
+        //
+        // This costs one signature recovery per transaction on the sync path, which the pool-side
+        // validator this replaces also paid. Trading it away for the branch below is what
+        // reintroduces the bypass.
+        in.tx.clearSenderAndHash();
+        in.tx.verify(*in.cryptoSuite.hashImpl(), *in.cryptoSuite.signatureImpl());
+    }
+    catch (...)
+    {
+        // Catch-all, deliberately, and the same policy the pool-side validator this replaces
+        // used: admission runs on unauthenticated input and must fail closed, and letting an
+        // exception escape a coroutine the caller does not wrap would take the node down over
+        // one bad transaction. The cost is that a genuine infrastructure fault -- a
+        // misconfigured crypto suite, say -- is reported as InvalidSignature, so log the reason
+        // rather than discard it: a burst of these with identical diagnostics is the signal
+        // that the problem is the node, not the traffic. DEBUG because the frequency is
+        // attacker-controlled.
+        TX_VALIDATOR_LOG(DEBUG) << LOG_DESC("signature verification threw")
+                                << LOG_KV(
+                                       "reason", boost::current_exception_diagnostic_information());
+        return TransactionStatus::InvalidSignature;
+    }
+    if (in.isSystemTx && in.isSystemTx(in.tx))
+    {
+        in.tx.setSystemTx(true);
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkBcosGroupChainId(AdmissionInputs const& in)
+{
+    if (in.tx.groupId() != in.groupId) [[unlikely]]
+    {
+        return TransactionStatus::InvalidGroupId;
+    }
+    if (in.tx.chainId() != in.chainId) [[unlikely]]
+    {
+        return TransactionStatus::InvalidChainId;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkTypeByRevision(AdmissionInputs const& in)
+{
+    if (in.revision.has_value() && *in.revision < requiredRevision(in.kind))
+    {
+        return TransactionStatus::TxTypeNotSupported;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkTipNotAboveCap(AdmissionInputs const& in)
+{
+    return in.tx.maxPriorityFeePerGas() > in.tx.maxFeePerGas() ?
+               TransactionStatus::TipGreaterThanFeeCap :
+               TransactionStatus::None;
+}
+
+TransactionStatus checkSetCodeHasTo(AdmissionInputs const& in)
+{
+    return in.tx.to().empty() ? TransactionStatus::CreateSetCodeTx : TransactionStatus::None;
+}
+
+TransactionStatus checkAuthListNonEmpty(AdmissionInputs const& in)
+{
+    return in.tx.authorizationList().empty() ? TransactionStatus::EmptyAuthorizationList :
+                                               TransactionStatus::None;
+}
+
+TransactionStatus checkMaxGasLimit(AdmissionInputs const& in)
+{
+    // gasLimit() is int64_t, but the Web3 envelope declares it as uint64: Web3TarsBridge assigns
+    // it straight across, so a declared value >= 2^63 lands here negative. Both comparisons below
+    // are signed, and a negative value passes them -- the EIP-7825 cap would miss the only inputs
+    // that can exceed it. Reject up front so the reported status matches the rule that was
+    // violated (EEST fixtures assert on the specific code, not just on rejection).
+    if (in.tx.gasLimit() < 0) [[unlikely]]
+    {
+        return TransactionStatus::MaxGasLimitExceeded;
+    }
+    // Two caps in one item: the EIP-7825 constant from Osaka onwards, and the chain's
+    // tx_gas_limit at all times. The optional comparison is deliberate -- a nullopt revision is
+    // ordered below every value, so an unconfigured chain does not get the Osaka cap.
+    if (in.revision >= EVMC_OSAKA && in.tx.gasLimit() > protocol::MAX_TX_GAS_LIMIT) [[unlikely]]
+    {
+        return TransactionStatus::MaxGasLimitExceeded;
+    }
+    // evmone compares against the block's remaining gas, which does not exist at admission;
+    // FISCO has no block gas limit either -- SYSTEM_KEY_TX_GAS_LIMIT is a per-transaction cap.
+    // This follows geth's head.GasLimit comparison instead.
+    if (auto [limit, _] = in.config->gasLimit();
+        limit > 0 && static_cast<uint64_t>(in.tx.gasLimit()) > limit)
+    {
+        return TransactionStatus::MaxGasLimitExceeded;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkFeeCapVsBaseFee(AdmissionInputs const& in)
+{
+    if (!in.txGasPrice)
+    {
+        return TransactionStatus::None;  // unset: no baseline to compare against
+    }
+    if (*in.txGasPrice == "0" || *in.txGasPrice == "0x0")
+    {
+        return TransactionStatus::None;  // free-gas chain
+    }
+    if (protocol::effectiveGasPrice(in.tx) < u256(*in.txGasPrice))
+    {
+        // Today this is reported as InsufficientFunds, which tells the user their balance is
+        // short when it is not.
+        return TransactionStatus::FeeCapLessThanBaseFee;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkChainId(AdmissionInputs const& in)
+{
+    // From the SIGNED envelope. The mirror cannot distinguish "no chainId" (pre-EIP-155) from
+    // "chainId 0" -- both serialise to "0" -- and a typed transaction may legitimately carry an
+    // explicit 0, which must still be compared.
+    //
+    // The three-way classifier, NOT web3ChainIdFromEnvelope: that walker collapses Unprotected
+    // and Malformed into the same nullopt, and a gate built on it grants the pre-EIP-155
+    // exemption to a legacy envelope whose v is neither 27/28 nor a valid EIP-155 value --
+    // executing a transaction op-geth's signer would reject. The exemption must be fail-closed,
+    // so it is granted only to an envelope positively classified as Unprotected.
+    auto const classified =
+        rlp::protocol::classifyWeb3EnvelopeChainId(in.tx.extraTransactionBytes());
+    if (classified.kind == rlp::protocol::Web3EnvelopeChainIdKind::Malformed)
+    {
+        return TransactionStatus::InvalidChainId;
+    }
+    if (classified.kind == rlp::protocol::Web3EnvelopeChainIdKind::Unprotected)
+    {
+        // A pre-EIP-155 legacy transaction makes no chainId claim at all -- there is nothing to
+        // compare it against, so this check has nothing to say about it.
+        return TransactionStatus::None;
+    }
+    // The transaction claims a chain. From here the configuration is required: silently
+    // accepting an unverifiable claim admits transactions signed for any chain -- which is what
+    // EthEndpoint does today when web3_chain_id is unset.
+    if (!in.web3ChainId)
+    {
+        return TransactionStatus::InvalidChainId;
+    }
+    auto const expected = ledger::parseWeb3ChainId(*in.web3ChainId);
+    if (!expected || u256(classified.chainId) != *expected)
+    {
+        return TransactionStatus::InvalidChainId;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkSenderIsEOA(AdmissionInputs const& in)
+{
+    // EIP-3607. Delegated code (0xef0100...) still belongs to an EOA.
+    if (in.senderState && !in.senderState->code.empty() && !isDelegatedCode(in.senderState->code))
+    {
+        return TransactionStatus::SenderNoEOA;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkNonceNotMax(AdmissionInputs const& in)
+{
+    // EIP-2681.
+    if (in.senderState && in.senderState->nonce.has_value() &&
+        *in.senderState->nonce >= std::numeric_limits<uint64_t>::max())
+    {
+        return TransactionStatus::NonceHasMaxValue;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkWeb3NonceWindow(AdmissionInputs const& in)
+{
+    // Lower bound and queue depth are one check: they share a single account-nonce read, and the
+    // existing implementation expresses both in one comparison.
+    if (!in.senderNonce.has_value())
+    {
+        // Account not on chain yet. The existing Web3NonceChecker also declines to judge in this
+        // case (its storage-miss branch falls through without comparing), and matching it keeps
+        // this a pure refactor. Whether an unknown account should instead be treated as nonce 0
+        // is a separate question -- it would tighten queue-flooding behaviour.
+        return TransactionStatus::None;
+    }
+    auto const txNonce = u256(in.tx.nonce());
+    if (txNonce < *in.senderNonce)
+    {
+        return TransactionStatus::NonceCheckFail;  // already used
+    }
+    if (txNonce > *in.senderNonce + DEFAULT_WEB3_NONCE_CHECK_LIMIT)
+    {
+        return TransactionStatus::NonceCheckFail;  // too far ahead to queue
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkInitCodeSize(AdmissionInputs const& in)
+{
+    // EIP-3860 applies to contract CREATION only. The current implementation keys on transaction
+    // type alone, so a 60000-byte call to a deployed contract is wrongly rejected with
+    // MaxInitCodeSizeExceeded.
+    if (in.revision.has_value() && *in.revision >= EVMC_SHANGHAI && in.tx.to().empty() &&
+        in.tx.input().size() > MAX_INITCODE_SIZE)
+    {
+        return TransactionStatus::MaxInitCodeSizeExceeded;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkBalance(AdmissionInputs const& in)
+{
+    // What the sender must be able to cover depends on whether this chain charges gas at all:
+    //   tx_gas_price unset or "0"  -> gas is free; only `value` has to be covered
+    //   tx_gas_price > 0           -> value + gasLimit * effectiveGasPrice
+    // This mirrors the existing rule. It differs from evmone, which always charges
+    // max_gas_price * gas_limit + value, because on a free-gas FISCO chain the sender is never
+    // actually debited the fee cap they declared -- charging it at admission would reject
+    // transactions that execute perfectly well.
+    const bool chargesGas = in.txGasPrice && !(*in.txGasPrice == "0" || *in.txGasPrice == "0x0");
+
+    u256 const balance = in.senderState ? in.senderState->balance : u256{0};
+
+    // 512-bit, deliberately. bcos::u256 carries boost::multiprecision::unchecked, so
+    // gasLimit * gasPrice + value is reduced mod 2^256 with no signal -- with a maxFeePerGas
+    // near 2^256-1 the product comes back small and an unfundable transaction is admitted.
+    // Widening FIRST is what makes this correct: two 256-bit operands multiply into at most 512
+    // bits, so the u512 product cannot wrap even though u512 is itself `unchecked`.
+    u512 required{in.tx.value()};
+    if (chargesGas)
+    {
+        required += u512{in.tx.gasLimit()} * u512{protocol::effectiveGasPrice(in.tx)};
+    }
+    if (u512{balance} < required)
+    {
+        return TransactionStatus::InsufficientFunds;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkIntrinsicGas(AdmissionInputs const& in)
+{
+    // Same formula the executor uses (TxGasModel.h). A separate copy would drift at the next
+    // fork that moves EIP-7623's floor, and the drift shows up as "admitted, then failed with
+    // OutOfGasLimit" -- a block carrying a certainly-failing transaction.
+    if (!in.revision.has_value())
+    {
+        // The intrinsic cost is revision-dependent (EIP-7623's floor, the calldata token price),
+        // so without one there is no figure to compare against.
+        return TransactionStatus::None;
+    }
+    auto const cost = protocol::gas::compute_tx_intrinsic_cost(*in.revision, in.tx);
+    if (in.tx.gasLimit() < std::max(cost.intrinsic, cost.min))
+    {
+        return TransactionStatus::OutOfGasLimit;
+    }
+    return TransactionStatus::None;
+}
+
+// The two halves of the old pool-side TxValidator::checkTransaction, minus its Web3 branch (Web3
+// nonce rules need only the account nonce and are their own check, Web3NonceWindow). They are
+// separate bits because they answer to different state: the pool set is node-local and the
+// proposal column drops it, the committed window is chain state and every column keeps it. That
+// decision lives in CheckSet.h, so neither function looks at the context.
+
+TransactionStatus checkBcosPoolNonce(AdmissionInputs const& in)
+{
+    if (in.txPoolNonceChecker == nullptr)
+    {
+        // No pool to be pending in (the mempool-side validator, or a test harness).
+        return TransactionStatus::None;
+    }
+    return in.txPoolNonceChecker->checkNonce(in.tx);
+}
+
+TransactionStatus checkBcosLedgerNonce(AdmissionInputs const& in)
+{
+    if (in.ledgerNonceChecker == nullptr)
+    {
+        // Bound only once the pool has read the chain's block limit. Before that there is no
+        // window to check against, and passing is correct: execution still enforces the nonce.
+        return TransactionStatus::None;
+    }
+    return in.ledgerNonceChecker->checkNonce(in.tx);
+}
+
+// ---------------------------------------------------------------- the registry
+
+struct CheckEntry
+{
+    Check bit;
+    Need needs;
+    TransactionStatus (*run)(AdmissionInputs const&);
+};
+
+/// Adding a check is three edits, and the compiler enforces two of them: write the function
+/// above, add one row here declaring which inputs it reads, and slot the bit into c_checkOrder
+/// (CheckSet.h) where it belongs in the evaluation order. The static_asserts below refuse to
+/// compile if the registry and the order disagree in either direction.
+constexpr std::array<CheckEntry, c_checkOrder.size()> c_checkRegistry{{
+    {Check::TypeGate, Need::None, &checkTypeGate},
+    {Check::ToFieldFormat, Need::None, &checkToFieldFormat},
+    {Check::Signature, Need::None, &checkSignature},
+    {Check::BcosGroupChainId, Need::None, &checkBcosGroupChainId},
+    {Check::TypeByRevision, Need::Revision, &checkTypeByRevision},
+    {Check::SetCodeHasTo, Need::None, &checkSetCodeHasTo},
+    {Check::AuthListNonEmpty, Need::None, &checkAuthListNonEmpty},
+    {Check::TipNotAboveCap, Need::None, &checkTipNotAboveCap},
+    {Check::MaxGasLimit, Need::Revision | Need::Config, &checkMaxGasLimit},
+    {Check::FeeCapVsBaseFee, Need::TxGasPrice, &checkFeeCapVsBaseFee},
+    {Check::ChainId, Need::Web3ChainId, &checkChainId},
+    {Check::SenderIsEOA, Need::SenderState, &checkSenderIsEOA},
+    {Check::NonceNotMax, Need::SenderState, &checkNonceNotMax},
+    {Check::Web3NonceWindow, Need::SenderNonce, &checkWeb3NonceWindow},
+    {Check::InitCodeSize, Need::Revision, &checkInitCodeSize},
+    {Check::Balance, Need::TxGasPrice | Need::SenderState, &checkBalance},
+    {Check::IntrinsicGas, Need::Revision, &checkIntrinsicGas},
+    {Check::BcosPoolNonce, Need::None, &checkBcosPoolNonce},
+    {Check::BcosLedgerNonce, Need::None, &checkBcosLedgerNonce},
+}};
+
+constexpr CheckEntry const* findCheck(Check bit) noexcept
+{
+    for (auto const& entry : c_checkRegistry)
+    {
+        if (entry.bit == bit)
+        {
+            return &entry;
+        }
+    }
+    return nullptr;
+}
+
+static_assert(
+    [] {
+        for (auto check : c_checkOrder)
+        {
+            if (findCheck(check) == nullptr)
+            {
+                return false;
+            }
+        }
+        return true;
+    }(),
+    "a check listed in c_checkOrder has no implementation in c_checkRegistry");
+
+static_assert(
+    [] {
+        for (auto const& entry : c_checkRegistry)
+        {
+            if (std::ranges::find(c_checkOrder, entry.bit) == c_checkOrder.end())
+            {
+                return false;
+            }
+        }
+        return true;
+    }(),
+    "c_checkRegistry implements a check that c_checkOrder never runs");
+
+}  // namespace
+
+namespace
+{
+/// Both balance planes are written with u256::str({}, {}) -- decimal, no prefix -- so both are
+/// read with the same parser. They used to disagree: the committed plane used u256(str), which
+/// silently yields 0 on malformed input, while the pending plane used boost::lexical_cast, which
+/// throws. One field with two parsers whose failure modes are opposites is how a discrepancy
+/// becomes a wrong balance on one path and an exception on the other.
+///
+/// A malformed balance is corruption, not unavailability, and is reported as such: returning 0
+/// would surface as InsufficientFunds and send the user hunting for funds they have.
+u256 parseBalance(std::string_view raw)
+{
+    try
+    {
+        return boost::lexical_cast<u256>(raw);
+    }
+    catch (boost::bad_lexical_cast const&)
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error(
+            "admission: account balance is not a parseable u256: '" + std::string(raw) + "'"));
+    }
+}
+}  // namespace
+
+task::Task<std::optional<AccountState>> TxValidator::readAccountState(std::string_view sender)
+{
+    AccountState state;
+
+    // Committed plane, through the FIB-59 cache. A miss leaves nonce unset rather than 0: the
+    // nonce window declines to judge an unknown account, and collapsing the two would start
+    // rejecting first-time senders whose nonce sits beyond the window measured from zero.
+    // Balance is read regardless -- an account absent from the committed plane may still hold a
+    // pending balance.
+    state.nonce = co_await m_web3NonceChecker->committedNonce(sender);
+
+    std::shared_ptr<scheduler::SchedulerInterface> scheduler;
+    {
+        ReadGuard guard(x_lateBound);
+        scheduler = m_scheduler.lock();
+    }
+
+    auto const senderHex = toHex(sender);
+    if (!scheduler)
+    {
+        // No scheduler bound (engine-driven mode, or before the pool wires one): fall back to
+        // the COMMITTED balance. The old pool validator described this fallback in a comment but
+        // never performed it -- it logged and left the balance at 0, so every transaction came
+        // back InsufficientFunds whenever the scheduler was missing.
+        //
+        // Contract code is unreadable without the scheduler, so `code` stays empty and EIP-3607
+        // consequently passes. That weakens ONE check in a configuration whose alternative is
+        // refusing all traffic; balance and nonce are still enforced.
+        if (auto const storageState = co_await m_ledger->getStorageState(senderHex, 0))
+        {
+            if (auto const& balance = storageState.value().balance; !balance.empty())
+            {
+                state.balance = parseBalance(balance);
+            }
+        }
+        co_return state;
+    }
+
+    auto const blockNumber = co_await ledger::getCurrentBlockNumber(*m_ledger);
+    // Pending plane: the latest executed-but-uncommitted layer.
+    if (auto entry = co_await scheduler->getPendingStorageAt(
+            senderHex, ledger::ACCOUNT_TABLE_FIELDS::BALANCE, blockNumber))
+    {
+        if (auto const value = entry->get(); !value.empty())
+        {
+            state.balance = parseBalance(value);
+        }
+    }
+    // Contract code is not read, so `code` stays empty and EIP-3607 (Check::SenderIsEOA) does
+    // not fire at admission on any path. Execution still enforces it, so this is a missed early
+    // rejection, not a hole: a contract-sender transaction occupies the pool until the executor
+    // rejects it. The check is kept because the rule is correct and starts working the moment
+    // this function fills the field.
+    //
+    // What it would take, since a previous version of this comment got it wrong: the code IS
+    // reachable from here. ACCOUNT_TABLE_FIELDS::CODE_HASH and ::CODE go through the same
+    // getPendingStorageAt coroutine used for BALANCE above -- SchedulerInterface::getCode is not
+    // the only route, and no callback is involved.
+    //
+    // It is left undone because codeHash ALONE is not sufficient and would be wrong. An EIP-7702
+    // delegated account has non-empty code and is still an EOA, so rejecting on
+    // "codeHash != EMPTY_CODE_HASH" would refuse transactions the executor accepts -- admission
+    // stricter than execution, the one failure this module exists to avoid. Doing it correctly
+    // needs the code BYTES to test the 0xef0100 delegation prefix, i.e. a second read on the
+    // rare non-empty-codeHash path. That is a behaviour change and belongs in its own commit.
+    co_return state;
+}
+
+task::Task<TransactionStatus> TxValidator::verify(
+    Transaction& tx, AdmissionContext context, SignaturePolicy policy)
+{
+    // A transaction already marked invalid failed normalization or signature recovery upstream
+    // (TransactionSync's catch block is the only non-test setInvalid(true) caller), so its
+    // mirror may not be trustworthy. Refuse before reading anything from it.
+    if (tx.invalid()) [[unlikely]]
+    {
+        co_return TransactionStatus::InvalidSignature;
+    }
+
+    // Normalization is unconditional and precedes the whole check sequence: every check below
+    // that reads a business field reads the mirror, and until this runs the mirror is whatever
+    // the sender chose. It is not a Check bit precisely so that no context can switch it off and
+    // nothing can order a mirror-reading check ahead of it.
+    if (auto status = normalize(tx); status != TransactionStatus::None)
+    {
+        co_return status;
+    }
+
+    const auto kind = kindOf(tx);
+    const auto checks = effectiveCheckSet(kind, context, policy);
+
+    // Copied out under the lock and held for the rest of the call: the checks run synchronously
+    // against this handle, and re-reading it mid-pass could have two checks judge the same
+    // transaction against different windows.
+    std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
+    {
+        ReadGuard guard(x_lateBound);
+        ledgerNonceChecker = m_ledgerNonceChecker;
+    }
+
+    // Every member is named, including the six resolved-on-demand ones. GCC's
+    // -Wmissing-field-initializers (in -Wextra, and -Werror here) fires on a designated
+    // initializer that skips a member with no default member initializer, even when the empty
+    // state is the intended one, so the empties are spelled out.
+    AdmissionInputs inputs{.tx = tx,
+        .kind = kind,
+        .context = context,
+        .txPoolNonceChecker = m_txPoolNonceChecker.get(),
+        .ledgerNonceChecker = ledgerNonceChecker.get(),
+        .cryptoSuite = *m_cryptoSuite,
+        .isSystemTx = m_isSystemTx,
+        .groupId = m_groupId,
+        .chainId = m_chainId,
+        .config = nullptr,
+        .revision = std::nullopt,
+        .senderState = std::nullopt,
+        .senderNonce = std::nullopt,
+        .txGasPrice = std::nullopt,
+        .web3ChainId = std::nullopt};
+
+    // Which inputs have already been fetched for this transaction. Resolution is driven by the
+    // registry rather than by each check, so two checks reading the same key (Balance and
+    // FeeCapVsBaseFee both want tx_gas_price) cost one ledger read, not two.
+    Need resolved = Need::None;
+
+    for (auto check : c_checkOrder)
+    {
+        if (!contains(checks, check))
+        {
+            continue;
+        }
+        auto const* entry = findCheck(check);
+
+        auto needs = entry->needs;
+        if (contains(needs, Need::Revision))
+        {
+            needs = needs | Need::Config;  // the revision is read off the config
+        }
+        if (contains(needs, Need::SenderNonce) && context != AdmissionContext::ProposalVerification)
+        {
+            // Outside consensus the nonce comes from the full account read, which other checks
+            // in the same pass want anyway; proposal verification would read the nonce alone.
+            //
+            // "would", because as the table stands the condition cannot be false here:
+            // Web3NonceWindow is the only check declaring Need::SenderNonce, and
+            // ProposalVerification strips it. The guard and the ProposalVerification arm below
+            // are kept rather than deleted so that re-enabling that check for consensus does
+            // not silently start pulling a full account read onto the consensus hot path --
+            // which is the cost the routing table drops it to avoid.
+            needs = needs | Need::SenderState;
+        }
+        const auto missing = needs & ~resolved;
+
+        if (contains(missing, Need::Config))
+        {
+            // A snapshot, not a fetch: whoever commits a block republishes the configuration,
+            // and this is a pointer copy. Holding it for the rest of the pass means every check
+            // in one verify() call judges against a single block's configuration, even if a
+            // commit lands mid-pass.
+            inputs.config = m_ledgerConfigState->get();
+            if (!inputs.config)
+            {
+                // LedgerConfigState never publishes null, so reaching here means the holder was
+                // corrupted. Infrastructure, not a defect in the transaction -- reported as an
+                // exception so it cannot masquerade as a rejected transaction.
+                BOOST_THROW_EXCEPTION(
+                    std::runtime_error("admission: ledger config state returned null"));
+            }
+        }
+        if (contains(missing, Need::Revision))
+        {
+            // Judged against the block it would execute in, which is the next one.
+            inputs.revision = inputs.config->evmcRevisionForBlock(inputs.config->blockNumber() + 1);
+        }
+        if (contains(missing, Need::SenderState))
+        {
+            inputs.senderState = co_await readAccountState(tx.sender());
+        }
+        if (contains(missing, Need::SenderNonce))
+        {
+            inputs.senderNonce =
+                context == AdmissionContext::ProposalVerification ?
+                    co_await m_web3NonceChecker->committedNonce(tx.sender()) :
+                    (inputs.senderState ? inputs.senderState->nonce : std::optional<u256>{});
+        }
+        if (contains(missing, Need::TxGasPrice))
+        {
+            auto config =
+                co_await ledger::getSystemConfig(*m_ledger, ledger::SYSTEM_KEY_TX_GAS_PRICE);
+            inputs.txGasPrice =
+                config ? std::optional{std::get<0>(config.value())} : std::optional<std::string>{};
+        }
+        if (contains(missing, Need::Web3ChainId))
+        {
+            auto config =
+                co_await ledger::getSystemConfig(*m_ledger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID);
+            inputs.web3ChainId =
+                config ? std::optional{std::get<0>(config.value())} : std::optional<std::string>{};
+        }
+        resolved = resolved | needs;
+
+        if (auto status = entry->run(inputs); status != TransactionStatus::None)
+        {
+            co_return status;
+        }
+    }
+    co_return TransactionStatus::None;
+}
+
+}  // namespace bcos::txvalidator

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
@@ -32,6 +32,7 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
+#include <algorithm>
 #include <cctype>
 #include <stdexcept>
 
@@ -149,80 +150,63 @@ void TxValidator::setScheduler(std::weak_ptr<scheduler::SchedulerInterface> sche
 
 namespace
 {
-/// The inputs a check may read beyond the transaction itself. Each one costs a ledger or
-/// storage round-trip, so admit() fetches one only when a check that actually runs declares it,
-/// and never fetches the same one twice.
-enum class Need : uint8_t
-{
-    None = 0,
-    Config = 1U << 0,       ///< LedgerConfig (block number, gas limit, EVM revision)
-    Revision = 1U << 1,     ///< evmc_revision for the next block; implies Config
-    SenderState = 1U << 2,  ///< balance + nonce + code, one account read
-    SenderNonce = 1U << 3,  ///< nonce alone; source depends on the context, see admit()
-    TxGasPrice = 1U << 4,   ///< SYSTEM_KEY_TX_GAS_PRICE
-    Web3ChainId = 1U << 5,  ///< SYSTEM_KEY_WEB3_CHAIN_ID
-};
-
-constexpr Need operator|(Need lhs, Need rhs) noexcept
-{
-    return static_cast<Need>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
-}
-constexpr Need operator&(Need lhs, Need rhs) noexcept
-{
-    return static_cast<Need>(static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs));
-}
-constexpr Need operator~(Need value) noexcept
-{
-    return static_cast<Need>(static_cast<uint8_t>(~static_cast<uint8_t>(value)));
-}
-constexpr bool contains(Need set, Need item) noexcept
-{
-    return (set & item) != Need::None;
-}
-
-/// Everything a check function is allowed to see. The resolved fields below are filled in by
-/// admit() before the check runs, according to the Need mask its registry row declares -- so a
-/// check body contains rules only, never I/O, and stays synchronous and directly testable.
-struct AdmissionInputs
+/// What every stage sees: the normalized transaction, its routing key and the validator's own
+/// configuration. References, not copies: the struct lives on the verify() frame and is only
+/// valid while the validator outlives the coroutine -- the ordinary contract for a
+/// Task-returning member, but worth stating because they are read AFTER resumption.
+struct Envelope
 {
     protocol::Transaction& tx;
     TxKind kind;
-    AdmissionContext context;
-    /// The nonce checkers, as raw pointers. ledgerNonceChecker is a snapshot the verify() frame
-    /// owns; txPoolNonceChecker points at a member of the validator, as do cryptoSuite,
-    /// isSystemTx, groupId and chainId below. So this struct is only valid while the validator
-    /// outlives the coroutine -- the ordinary contract for a Task-returning member, but worth
-    /// stating because these are read AFTER resumption. Either checker may be null: see
-    /// checkBcosPoolNonce and checkBcosLedgerNonce.
-    NonceCheckerInterface* txPoolNonceChecker;
-    LedgerNonceChecker* ledgerNonceChecker;
     crypto::CryptoSuite& cryptoSuite;
-    SystemTxPredicate const& isSystemTx;
     std::string_view groupId;
     std::string_view chainId;
+};
 
-    // --- resolved on demand ---
-    /// const: LedgerConfigState hands out a snapshot nobody may mutate, and a check receiving
-    /// AdmissionInputs const& could otherwise still write through this pointer.
+/// The chain as of one snapshot, read once per verify() before the state stage: every check in
+/// one pass judges against a single block's configuration even if a commit lands mid-pass.
+struct ChainView
+{
+    /// const: LedgerConfigState hands out a snapshot nobody may mutate.
     std::shared_ptr<const ledger::LedgerConfig> config;
     /// nullopt = the chain declares no EVM revision; revision-dependent checks stand down rather
     /// than guess, because admission must never be STRICTER than execution.
     std::optional<evmc_revision> revision;
-    /// nullopt = the account does not exist on chain yet.
-    std::optional<AccountState> senderState;
-    std::optional<u256> senderNonce;
-    /// nullopt = the key is unset in the chain config (distinct from "not resolved": a field is
-    /// only read by a check that declared the matching Need).
+    /// nullopt = the key is unset in the chain config.
     std::optional<std::string> txGasPrice;
     std::optional<std::string> web3ChainId;
+};
+
+/// Inputs of the state stage. `sender` is engaged exactly when the check set contains a
+/// sender-dependent check: verify() reads the account only then, and the four checks in
+/// c_senderDependent are the only readers, so they take it with value(). An absent account on
+/// that path is a programming error in the table, and bad_optional_access says so rather than a
+/// silent pass.
+struct StateInputs
+{
+    protocol::Transaction& tx;
+    TxKind kind;
+    ChainView const& chain;
+    std::optional<AccountState> const& sender;
+};
+
+/// Inputs of the pool stage. Either checker may be null: see checkBcosPoolNonce and
+/// checkBcosLedgerNonce.
+struct PoolInputs
+{
+    protocol::Transaction& tx;
+    NonceCheckerInterface* txPoolNonceChecker;
+    LedgerNonceChecker* ledgerNonceChecker;
 };
 
 // ---------------------------------------------------------------- the checks
 //
 // One function per Check bit. Pure rules: no I/O, no co_await, no access to the validator's
-// members beyond what AdmissionInputs carries. Returns None to pass, any other status to reject.
+// members beyond what its stage's inputs carry. The parameter type IS the stage: a gate check
+// cannot read the chain, a state check cannot reach the pool, and the compiler enforces it.
+// Returns None to pass, any other status to reject.
 
-TransactionStatus checkTypeGate(AdmissionInputs const& in)
+TransactionStatus checkTypeGate(Envelope const& in)
 {
     // An allow-list, not a deny-list. normalize() already refused blob/deposit/reserved
     // envelopes, so Rejected here means the routing key and the gate disagree; and a value that
@@ -243,12 +227,12 @@ TransactionStatus checkTypeGate(AdmissionInputs const& in)
     return TransactionStatus::TxTypeNotSupported;
 }
 
-TransactionStatus checkToFieldFormat(AdmissionInputs const& in)
+TransactionStatus checkToFieldFormat(Envelope const& in)
 {
     return isValidToField(in.tx.to()) ? TransactionStatus::None : TransactionStatus::Malformed;
 }
 
-TransactionStatus checkSignature(AdmissionInputs const& in)
+TransactionStatus checkSignature(Envelope const& in)
 {
     try
     {
@@ -284,14 +268,10 @@ TransactionStatus checkSignature(AdmissionInputs const& in)
                                        "reason", boost::current_exception_diagnostic_information());
         return TransactionStatus::InvalidSignature;
     }
-    if (in.isSystemTx && in.isSystemTx(in.tx))
-    {
-        in.tx.setSystemTx(true);
-    }
     return TransactionStatus::None;
 }
 
-TransactionStatus checkBcosGroupChainId(AdmissionInputs const& in)
+TransactionStatus checkBcosGroupChainId(Envelope const& in)
 {
     if (in.tx.groupId() != in.groupId) [[unlikely]]
     {
@@ -304,34 +284,34 @@ TransactionStatus checkBcosGroupChainId(AdmissionInputs const& in)
     return TransactionStatus::None;
 }
 
-TransactionStatus checkTypeByRevision(AdmissionInputs const& in)
+TransactionStatus checkTypeByRevision(StateInputs const& in)
 {
-    if (in.revision.has_value() && *in.revision < requiredRevision(in.kind))
+    if (in.chain.revision.has_value() && *in.chain.revision < requiredRevision(in.kind))
     {
         return TransactionStatus::TxTypeNotSupported;
     }
     return TransactionStatus::None;
 }
 
-TransactionStatus checkTipNotAboveCap(AdmissionInputs const& in)
+TransactionStatus checkTipNotAboveCap(StateInputs const& in)
 {
     return in.tx.maxPriorityFeePerGas() > in.tx.maxFeePerGas() ?
                TransactionStatus::TipGreaterThanFeeCap :
                TransactionStatus::None;
 }
 
-TransactionStatus checkSetCodeHasTo(AdmissionInputs const& in)
+TransactionStatus checkSetCodeHasTo(StateInputs const& in)
 {
     return in.tx.to().empty() ? TransactionStatus::CreateSetCodeTx : TransactionStatus::None;
 }
 
-TransactionStatus checkAuthListNonEmpty(AdmissionInputs const& in)
+TransactionStatus checkAuthListNonEmpty(StateInputs const& in)
 {
     return in.tx.authorizationList().empty() ? TransactionStatus::EmptyAuthorizationList :
                                                TransactionStatus::None;
 }
 
-TransactionStatus checkMaxGasLimit(AdmissionInputs const& in)
+TransactionStatus checkMaxGasLimit(StateInputs const& in)
 {
     // gasLimit() is int64_t, but the Web3 envelope declares it as uint64: Web3TarsBridge assigns
     // it straight across, so a declared value >= 2^63 lands here negative. Both comparisons below
@@ -345,14 +325,15 @@ TransactionStatus checkMaxGasLimit(AdmissionInputs const& in)
     // Two caps in one item: the EIP-7825 constant from Osaka onwards, and the chain's
     // tx_gas_limit at all times. The optional comparison is deliberate -- a nullopt revision is
     // ordered below every value, so an unconfigured chain does not get the Osaka cap.
-    if (in.revision >= EVMC_OSAKA && in.tx.gasLimit() > protocol::MAX_TX_GAS_LIMIT) [[unlikely]]
+    if (in.chain.revision >= EVMC_OSAKA && in.tx.gasLimit() > protocol::MAX_TX_GAS_LIMIT)
+        [[unlikely]]
     {
         return TransactionStatus::MaxGasLimitExceeded;
     }
     // evmone compares against the block's remaining gas, which does not exist at admission;
     // FISCO has no block gas limit either -- SYSTEM_KEY_TX_GAS_LIMIT is a per-transaction cap.
     // This follows geth's head.GasLimit comparison instead.
-    if (auto [limit, _] = in.config->gasLimit();
+    if (auto [limit, _] = in.chain.config->gasLimit();
         limit > 0 && static_cast<uint64_t>(in.tx.gasLimit()) > limit)
     {
         return TransactionStatus::MaxGasLimitExceeded;
@@ -360,17 +341,17 @@ TransactionStatus checkMaxGasLimit(AdmissionInputs const& in)
     return TransactionStatus::None;
 }
 
-TransactionStatus checkFeeCapVsBaseFee(AdmissionInputs const& in)
+TransactionStatus checkFeeCapVsBaseFee(StateInputs const& in)
 {
-    if (!in.txGasPrice)
+    if (!in.chain.txGasPrice)
     {
         return TransactionStatus::None;  // unset: no baseline to compare against
     }
-    if (*in.txGasPrice == "0" || *in.txGasPrice == "0x0")
+    if (*in.chain.txGasPrice == "0" || *in.chain.txGasPrice == "0x0")
     {
         return TransactionStatus::None;  // free-gas chain
     }
-    if (protocol::effectiveGasPrice(in.tx) < u256(*in.txGasPrice))
+    if (protocol::effectiveGasPrice(in.tx) < u256(*in.chain.txGasPrice))
     {
         // Today this is reported as InsufficientFunds, which tells the user their balance is
         // short when it is not.
@@ -379,7 +360,7 @@ TransactionStatus checkFeeCapVsBaseFee(AdmissionInputs const& in)
     return TransactionStatus::None;
 }
 
-TransactionStatus checkChainId(AdmissionInputs const& in)
+TransactionStatus checkChainId(StateInputs const& in)
 {
     // From the SIGNED envelope. The mirror cannot distinguish "no chainId" (pre-EIP-155) from
     // "chainId 0" -- both serialise to "0" -- and a typed transaction may legitimately carry an
@@ -405,11 +386,11 @@ TransactionStatus checkChainId(AdmissionInputs const& in)
     // The transaction claims a chain. From here the configuration is required: silently
     // accepting an unverifiable claim admits transactions signed for any chain -- which is what
     // EthEndpoint does today when web3_chain_id is unset.
-    if (!in.web3ChainId)
+    if (!in.chain.web3ChainId)
     {
         return TransactionStatus::InvalidChainId;
     }
-    auto const expected = ledger::parseWeb3ChainId(*in.web3ChainId);
+    auto const expected = ledger::parseWeb3ChainId(*in.chain.web3ChainId);
     if (!expected || u256(classified.chainId) != *expected)
     {
         return TransactionStatus::InvalidChainId;
@@ -417,32 +398,34 @@ TransactionStatus checkChainId(AdmissionInputs const& in)
     return TransactionStatus::None;
 }
 
-TransactionStatus checkSenderIsEOA(AdmissionInputs const& in)
+TransactionStatus checkSenderIsEOA(StateInputs const& in)
 {
     // EIP-3607. Delegated code (0xef0100...) still belongs to an EOA.
-    if (in.senderState && !in.senderState->code.empty() && !isDelegatedCode(in.senderState->code))
+    auto const& sender = in.sender.value();
+    if (!sender.code.empty() && !isDelegatedCode(sender.code))
     {
         return TransactionStatus::SenderNoEOA;
     }
     return TransactionStatus::None;
 }
 
-TransactionStatus checkNonceNotMax(AdmissionInputs const& in)
+TransactionStatus checkNonceNotMax(StateInputs const& in)
 {
     // EIP-2681.
-    if (in.senderState && in.senderState->nonce.has_value() &&
-        *in.senderState->nonce >= std::numeric_limits<uint64_t>::max())
+    auto const& nonce = in.sender.value().nonce;
+    if (nonce.has_value() && *nonce >= std::numeric_limits<uint64_t>::max())
     {
         return TransactionStatus::NonceHasMaxValue;
     }
     return TransactionStatus::None;
 }
 
-TransactionStatus checkWeb3NonceWindow(AdmissionInputs const& in)
+TransactionStatus checkWeb3NonceWindow(StateInputs const& in)
 {
     // Lower bound and queue depth are one check: they share a single account-nonce read, and the
     // existing implementation expresses both in one comparison.
-    if (!in.senderNonce.has_value())
+    auto const& senderNonce = in.sender.value().nonce;
+    if (!senderNonce.has_value())
     {
         // Account not on chain yet. The existing Web3NonceChecker also declines to judge in this
         // case (its storage-miss branch falls through without comparing), and matching it keeps
@@ -451,31 +434,31 @@ TransactionStatus checkWeb3NonceWindow(AdmissionInputs const& in)
         return TransactionStatus::None;
     }
     auto const txNonce = u256(in.tx.nonce());
-    if (txNonce < *in.senderNonce)
+    if (txNonce < *senderNonce)
     {
         return TransactionStatus::NonceCheckFail;  // already used
     }
-    if (txNonce > *in.senderNonce + DEFAULT_WEB3_NONCE_CHECK_LIMIT)
+    if (txNonce > *senderNonce + DEFAULT_WEB3_NONCE_CHECK_LIMIT)
     {
         return TransactionStatus::NonceCheckFail;  // too far ahead to queue
     }
     return TransactionStatus::None;
 }
 
-TransactionStatus checkInitCodeSize(AdmissionInputs const& in)
+TransactionStatus checkInitCodeSize(StateInputs const& in)
 {
     // EIP-3860 applies to contract CREATION only. The current implementation keys on transaction
     // type alone, so a 60000-byte call to a deployed contract is wrongly rejected with
     // MaxInitCodeSizeExceeded.
-    if (in.revision.has_value() && *in.revision >= EVMC_SHANGHAI && in.tx.to().empty() &&
-        in.tx.input().size() > MAX_INITCODE_SIZE)
+    if (in.chain.revision.has_value() && *in.chain.revision >= EVMC_SHANGHAI &&
+        in.tx.to().empty() && in.tx.input().size() > MAX_INITCODE_SIZE)
     {
         return TransactionStatus::MaxInitCodeSizeExceeded;
     }
     return TransactionStatus::None;
 }
 
-TransactionStatus checkBalance(AdmissionInputs const& in)
+TransactionStatus checkBalance(StateInputs const& in)
 {
     // What the sender must be able to cover depends on whether this chain charges gas at all:
     //   tx_gas_price unset or "0"  -> gas is free; only `value` has to be covered
@@ -484,9 +467,10 @@ TransactionStatus checkBalance(AdmissionInputs const& in)
     // max_gas_price * gas_limit + value, because on a free-gas FISCO chain the sender is never
     // actually debited the fee cap they declared -- charging it at admission would reject
     // transactions that execute perfectly well.
-    const bool chargesGas = in.txGasPrice && !(*in.txGasPrice == "0" || *in.txGasPrice == "0x0");
+    const bool chargesGas =
+        in.chain.txGasPrice && !(*in.chain.txGasPrice == "0" || *in.chain.txGasPrice == "0x0");
 
-    u256 const balance = in.senderState ? in.senderState->balance : u256{0};
+    u256 const balance = in.sender.value().balance;
 
     // 512-bit, deliberately. bcos::u256 carries boost::multiprecision::unchecked, so
     // gasLimit * gasPrice + value is reduced mod 2^256 with no signal -- with a maxFeePerGas
@@ -505,18 +489,18 @@ TransactionStatus checkBalance(AdmissionInputs const& in)
     return TransactionStatus::None;
 }
 
-TransactionStatus checkIntrinsicGas(AdmissionInputs const& in)
+TransactionStatus checkIntrinsicGas(StateInputs const& in)
 {
     // Same formula the executor uses (TxGasModel.h). A separate copy would drift at the next
     // fork that moves EIP-7623's floor, and the drift shows up as "admitted, then failed with
     // OutOfGasLimit" -- a block carrying a certainly-failing transaction.
-    if (!in.revision.has_value())
+    if (!in.chain.revision.has_value())
     {
         // The intrinsic cost is revision-dependent (EIP-7623's floor, the calldata token price),
         // so without one there is no figure to compare against.
         return TransactionStatus::None;
     }
-    auto const cost = protocol::gas::compute_tx_intrinsic_cost(*in.revision, in.tx);
+    auto const cost = protocol::gas::compute_tx_intrinsic_cost(*in.chain.revision, in.tx);
     if (in.tx.gasLimit() < std::max(cost.intrinsic, cost.min))
     {
         return TransactionStatus::OutOfGasLimit;
@@ -530,7 +514,7 @@ TransactionStatus checkIntrinsicGas(AdmissionInputs const& in)
 // proposal column drops it, the committed window is chain state and every column keeps it. That
 // decision lives in CheckSet.h, so neither function looks at the context.
 
-TransactionStatus checkBcosPoolNonce(AdmissionInputs const& in)
+TransactionStatus checkBcosPoolNonce(PoolInputs const& in)
 {
     if (in.txPoolNonceChecker == nullptr)
     {
@@ -540,7 +524,7 @@ TransactionStatus checkBcosPoolNonce(AdmissionInputs const& in)
     return in.txPoolNonceChecker->checkNonce(in.tx);
 }
 
-TransactionStatus checkBcosLedgerNonce(AdmissionInputs const& in)
+TransactionStatus checkBcosLedgerNonce(PoolInputs const& in)
 {
     if (in.ledgerNonceChecker == nullptr)
     {
@@ -551,78 +535,78 @@ TransactionStatus checkBcosLedgerNonce(AdmissionInputs const& in)
     return in.ledgerNonceChecker->checkNonce(in.tx);
 }
 
-// ---------------------------------------------------------------- the registry
+// ---------------------------------------------------------------- the registries
 
+template <class Inputs>
 struct CheckEntry
 {
     Check bit;
-    Need needs;
-    TransactionStatus (*run)(AdmissionInputs const&);
+    TransactionStatus (*run)(Inputs const&);
 };
 
-/// Adding a check is three edits, and the compiler enforces two of them: write the function
-/// above, add one row here declaring which inputs it reads, and slot the bit into c_checkOrder
-/// (CheckSet.h) where it belongs in the evaluation order. The static_asserts below refuse to
-/// compile if the registry and the order disagree in either direction.
-constexpr std::array<CheckEntry, c_checkOrder.size()> c_checkRegistry{{
-    {Check::TypeGate, Need::None, &checkTypeGate},
-    {Check::ToFieldFormat, Need::None, &checkToFieldFormat},
-    {Check::Signature, Need::None, &checkSignature},
-    {Check::BcosGroupChainId, Need::None, &checkBcosGroupChainId},
-    {Check::TypeByRevision, Need::Revision, &checkTypeByRevision},
-    {Check::SetCodeHasTo, Need::None, &checkSetCodeHasTo},
-    {Check::AuthListNonEmpty, Need::None, &checkAuthListNonEmpty},
-    {Check::TipNotAboveCap, Need::None, &checkTipNotAboveCap},
-    {Check::MaxGasLimit, Need::Revision | Need::Config, &checkMaxGasLimit},
-    {Check::FeeCapVsBaseFee, Need::TxGasPrice, &checkFeeCapVsBaseFee},
-    {Check::ChainId, Need::Web3ChainId, &checkChainId},
-    {Check::SenderIsEOA, Need::SenderState, &checkSenderIsEOA},
-    {Check::NonceNotMax, Need::SenderState, &checkNonceNotMax},
-    {Check::Web3NonceWindow, Need::SenderNonce, &checkWeb3NonceWindow},
-    {Check::InitCodeSize, Need::Revision, &checkInitCodeSize},
-    {Check::Balance, Need::TxGasPrice | Need::SenderState, &checkBalance},
-    {Check::IntrinsicGas, Need::Revision, &checkIntrinsicGas},
-    {Check::BcosPoolNonce, Need::None, &checkBcosPoolNonce},
-    {Check::BcosLedgerNonce, Need::None, &checkBcosLedgerNonce},
+/// One registry per stage, in evaluation order. Adding a check is three edits, and the compiler
+/// enforces all of them: write the function above with its stage's input type, add its row
+/// here, and slot the bit into the matching order array in CheckSet.h at the same position --
+/// the static_asserts below refuse to compile if a registry and its order differ in membership
+/// or in sequence.
+constexpr std::array<CheckEntry<Envelope>, c_gateOrder.size()> c_gateRegistry{{
+    {Check::TypeGate, &checkTypeGate},
+    {Check::ToFieldFormat, &checkToFieldFormat},
+    {Check::Signature, &checkSignature},
+    {Check::BcosGroupChainId, &checkBcosGroupChainId},
 }};
 
-constexpr CheckEntry const* findCheck(Check bit) noexcept
+constexpr std::array<CheckEntry<StateInputs>, c_stateOrder.size()> c_stateRegistry{{
+    {Check::TypeByRevision, &checkTypeByRevision},
+    {Check::SetCodeHasTo, &checkSetCodeHasTo},
+    {Check::AuthListNonEmpty, &checkAuthListNonEmpty},
+    {Check::TipNotAboveCap, &checkTipNotAboveCap},
+    {Check::MaxGasLimit, &checkMaxGasLimit},
+    {Check::FeeCapVsBaseFee, &checkFeeCapVsBaseFee},
+    {Check::ChainId, &checkChainId},
+    {Check::SenderIsEOA, &checkSenderIsEOA},
+    {Check::NonceNotMax, &checkNonceNotMax},
+    {Check::Web3NonceWindow, &checkWeb3NonceWindow},
+    {Check::InitCodeSize, &checkInitCodeSize},
+    {Check::Balance, &checkBalance},
+    {Check::IntrinsicGas, &checkIntrinsicGas},
+}};
+
+constexpr std::array<CheckEntry<PoolInputs>, c_poolOrder.size()> c_poolRegistry{{
+    {Check::BcosPoolNonce, &checkBcosPoolNonce},
+    {Check::BcosLedgerNonce, &checkBcosLedgerNonce},
+}};
+
+template <class Inputs, std::size_t N>
+constexpr bool followsOrder(
+    std::array<CheckEntry<Inputs>, N> const& registry, std::array<Check, N> const& order)
 {
-    for (auto const& entry : c_checkRegistry)
+    return std::ranges::equal(registry, order, {}, &CheckEntry<Inputs>::bit);
+}
+static_assert(followsOrder(c_gateRegistry, c_gateOrder), "c_gateRegistry departs from c_gateOrder");
+static_assert(
+    followsOrder(c_stateRegistry, c_stateOrder), "c_stateRegistry departs from c_stateOrder");
+static_assert(followsOrder(c_poolRegistry, c_poolOrder), "c_poolRegistry departs from c_poolOrder");
+
+/// Run one stage: the checks the set contains, in the registry's order, stopping at the first
+/// rejection.
+template <class Inputs, std::size_t N>
+TransactionStatus runStage(
+    std::array<CheckEntry<Inputs>, N> const& registry, Check checks, Inputs const& inputs)
+{
+    for (auto const& entry : registry)
     {
-        if (entry.bit == bit)
+        if (!contains(checks, entry.bit))
         {
-            return &entry;
+            continue;
+        }
+        if (auto status = entry.run(inputs); status != TransactionStatus::None)
+        {
+            return status;
         }
     }
-    return nullptr;
+    return TransactionStatus::None;
 }
-
-static_assert(
-    [] {
-        for (auto check : c_checkOrder)
-        {
-            if (findCheck(check) == nullptr)
-            {
-                return false;
-            }
-        }
-        return true;
-    }(),
-    "a check listed in c_checkOrder has no implementation in c_checkRegistry");
-
-static_assert(
-    [] {
-        for (auto const& entry : c_checkRegistry)
-        {
-            if (std::ranges::find(c_checkOrder, entry.bit) == c_checkOrder.end())
-            {
-                return false;
-            }
-        }
-        return true;
-    }(),
-    "c_checkRegistry implements a check that c_checkOrder never runs");
 
 }  // namespace
 
@@ -647,6 +631,36 @@ u256 parseBalance(std::string_view raw)
         BOOST_THROW_EXCEPTION(std::runtime_error(
             "admission: account balance is not a parseable u256: '" + std::string(raw) + "'"));
     }
+}
+
+/// The state stage's inputs, read once. Throws (never returns a status) when something cannot
+/// be read: a storage fault must not be reported as a defect in the transaction.
+task::Task<ChainView> readChainView(
+    ledger::LedgerConfigState const& configState, ledger::LedgerInterface& chainLedger)
+{
+    ChainView view;
+    // A snapshot, not a fetch: whoever commits a block republishes the configuration, and this
+    // is a pointer copy.
+    view.config = configState.get();
+    if (!view.config)
+    {
+        // LedgerConfigState never publishes null, so reaching here means the holder was
+        // corrupted. Infrastructure, not a defect in the transaction -- reported as an exception
+        // so it cannot masquerade as a rejected transaction.
+        BOOST_THROW_EXCEPTION(std::runtime_error("admission: ledger config state returned null"));
+    }
+    // Judged against the block it would execute in, which is the next one.
+    view.revision = view.config->evmcRevisionForBlock(view.config->blockNumber() + 1);
+    if (auto entry = co_await ledger::getSystemConfig(chainLedger, ledger::SYSTEM_KEY_TX_GAS_PRICE))
+    {
+        view.txGasPrice = std::get<0>(*entry);
+    }
+    if (auto entry =
+            co_await ledger::getSystemConfig(chainLedger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID))
+    {
+        view.web3ChainId = std::get<0>(*entry);
+    }
+    co_return view;
 }
 }  // namespace
 
@@ -739,122 +753,60 @@ task::Task<TransactionStatus> TxValidator::verify(
     }
 
     const auto kind = kindOf(tx);
+    // A system transaction is one whose `to` is a system contract: a property of the
+    // transaction, not of any check, so it is marked here regardless of which checks run. The
+    // pool-side validator marked it inside its signature path, which SignaturePolicy::Disabled
+    // would switch off along with the signature.
+    if (m_isSystemTx && m_isSystemTx(tx))
+    {
+        tx.setSystemTx(true);
+    }
     const auto checks = effectiveCheckSet(kind, context, policy);
 
-    // Copied out under the lock and held for the rest of the call: the checks run synchronously
-    // against this handle, and re-reading it mid-pass could have two checks judge the same
-    // transaction against different windows.
-    std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
+    // Stage 1: the transaction alone. Nothing has been read, and a rejection here costs nothing
+    // more -- which is what keeps unauthenticated input cheap to refuse.
+    const Envelope envelope{.tx = tx,
+        .kind = kind,
+        .cryptoSuite = *m_cryptoSuite,
+        .groupId = m_groupId,
+        .chainId = m_chainId};
+    if (auto status = runStage(c_gateRegistry, checks, envelope); status != TransactionStatus::None)
     {
-        ReadGuard guard(x_lateBound);
-        ledgerNonceChecker = m_ledgerNonceChecker;
+        co_return status;
     }
 
-    // Every member is named, including the six resolved-on-demand ones. GCC's
-    // -Wmissing-field-initializers (in -Wextra, and -Werror here) fires on a designated
-    // initializer that skips a member with no default member initializer, even when the empty
-    // state is the intended one, so the empties are spelled out.
-    AdmissionInputs inputs{.tx = tx,
-        .kind = kind,
-        .context = context,
-        .txPoolNonceChecker = m_txPoolNonceChecker.get(),
-        .ledgerNonceChecker = ledgerNonceChecker.get(),
-        .cryptoSuite = *m_cryptoSuite,
-        .isSystemTx = m_isSystemTx,
-        .groupId = m_groupId,
-        .chainId = m_chainId,
-        .config = nullptr,
-        .revision = std::nullopt,
-        .senderState = std::nullopt,
-        .senderNonce = std::nullopt,
-        .txGasPrice = std::nullopt,
-        .web3ChainId = std::nullopt};
-
-    // Which inputs have already been fetched for this transaction. Resolution is driven by the
-    // registry rather than by each check, so two checks reading the same key (Balance and
-    // FeeCapVsBaseFee both want tx_gas_price) cost one ledger read, not two.
-    Need resolved = Need::None;
-
-    for (auto check : c_checkOrder)
+    // Stage 2: evmone's sequence against one chain view, fetched once. The account is read only
+    // when the set contains a check that needs it -- which is how the proposal column, whose
+    // sender-dependent checks are off, performs no account read at all.
+    if ((checks & c_stateStage) != Check::None)
     {
-        if (!contains(checks, check))
+        auto const chain = co_await readChainView(*m_ledgerConfigState, *m_ledger);
+        std::optional<AccountState> sender;
+        if ((checks & c_senderDependent) != Check::None)
         {
-            continue;
+            sender = co_await readAccountState(tx.sender());
         }
-        auto const* entry = findCheck(check);
-
-        auto needs = entry->needs;
-        if (contains(needs, Need::Revision))
-        {
-            needs = needs | Need::Config;  // the revision is read off the config
-        }
-        if (contains(needs, Need::SenderNonce) && context != AdmissionContext::ProposalVerification)
-        {
-            // Outside consensus the nonce comes from the full account read, which other checks
-            // in the same pass want anyway; proposal verification would read the nonce alone.
-            //
-            // "would", because as the table stands the condition cannot be false here:
-            // Web3NonceWindow is the only check declaring Need::SenderNonce, and
-            // ProposalVerification strips it. The guard and the ProposalVerification arm below
-            // are kept rather than deleted so that re-enabling that check for consensus does
-            // not silently start pulling a full account read onto the consensus hot path --
-            // which is the cost the routing table drops it to avoid.
-            needs = needs | Need::SenderState;
-        }
-        const auto missing = needs & ~resolved;
-
-        if (contains(missing, Need::Config))
-        {
-            // A snapshot, not a fetch: whoever commits a block republishes the configuration,
-            // and this is a pointer copy. Holding it for the rest of the pass means every check
-            // in one verify() call judges against a single block's configuration, even if a
-            // commit lands mid-pass.
-            inputs.config = m_ledgerConfigState->get();
-            if (!inputs.config)
-            {
-                // LedgerConfigState never publishes null, so reaching here means the holder was
-                // corrupted. Infrastructure, not a defect in the transaction -- reported as an
-                // exception so it cannot masquerade as a rejected transaction.
-                BOOST_THROW_EXCEPTION(
-                    std::runtime_error("admission: ledger config state returned null"));
-            }
-        }
-        if (contains(missing, Need::Revision))
-        {
-            // Judged against the block it would execute in, which is the next one.
-            inputs.revision = inputs.config->evmcRevisionForBlock(inputs.config->blockNumber() + 1);
-        }
-        if (contains(missing, Need::SenderState))
-        {
-            inputs.senderState = co_await readAccountState(tx.sender());
-        }
-        if (contains(missing, Need::SenderNonce))
-        {
-            inputs.senderNonce =
-                context == AdmissionContext::ProposalVerification ?
-                    co_await m_web3NonceChecker->committedNonce(tx.sender()) :
-                    (inputs.senderState ? inputs.senderState->nonce : std::optional<u256>{});
-        }
-        if (contains(missing, Need::TxGasPrice))
-        {
-            auto config =
-                co_await ledger::getSystemConfig(*m_ledger, ledger::SYSTEM_KEY_TX_GAS_PRICE);
-            inputs.txGasPrice =
-                config ? std::optional{std::get<0>(config.value())} : std::optional<std::string>{};
-        }
-        if (contains(missing, Need::Web3ChainId))
-        {
-            auto config =
-                co_await ledger::getSystemConfig(*m_ledger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID);
-            inputs.web3ChainId =
-                config ? std::optional{std::get<0>(config.value())} : std::optional<std::string>{};
-        }
-        resolved = resolved | needs;
-
-        if (auto status = entry->run(inputs); status != TransactionStatus::None)
+        const StateInputs inputs{.tx = tx, .kind = kind, .chain = chain, .sender = sender};
+        if (auto status = runStage(c_stateRegistry, checks, inputs);
+            status != TransactionStatus::None)
         {
             co_return status;
         }
+    }
+
+    // Stage 3: the pool. The ledger nonce checker is copied out under the lock and held for the
+    // stage, so both pool checks judge against one window.
+    if ((checks & c_poolStage) != Check::None)
+    {
+        std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
+        {
+            ReadGuard guard(x_lateBound);
+            ledgerNonceChecker = m_ledgerNonceChecker;
+        }
+        const PoolInputs pool{.tx = tx,
+            .txPoolNonceChecker = m_txPoolNonceChecker.get(),
+            .ledgerNonceChecker = ledgerNonceChecker.get()};
+        co_return runStage(c_poolRegistry, checks, pool);
     }
     co_return TransactionStatus::None;
 }

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
@@ -135,6 +135,18 @@ TxValidator::TxValidator(crypto::CryptoSuite::Ptr cryptoSuite,
         BOOST_THROW_EXCEPTION(
             std::invalid_argument("TxValidator: ledgerConfigState must not be null"));
     }
+    if (!m_web3NonceChecker)
+    {
+        // Every Web3 nonce rule reads through this one, and readAccountState dereferences it
+        // unconditionally -- a null would be a crash on the first Web3 transaction, not a
+        // rejection. The BCOS checkers next to it ARE nullable on purpose (see
+        // checkBcosPoolNonce): their absence means "no pool to be pending in", a state the
+        // mempool-side validator is legitimately in. There is no such reading here -- the Web3
+        // committed nonce is chain state, so a validator that cannot read it cannot judge a Web3
+        // transaction at all.
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("TxValidator: web3NonceChecker must not be null"));
+    }
 }
 
 void TxValidator::setLedgerNonceChecker(std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker)
@@ -186,11 +198,11 @@ struct ChainView
     std::optional<u256> web3ChainId;
 };
 
-/// Inputs of the state stage. `sender` is engaged exactly when the check set contains a
-/// sender-dependent check: verify() reads the account only then, and the four checks in
-/// c_senderDependent are the only readers, so they take it with value(). An absent account on
-/// that path is a programming error in the table, and bad_optional_access says so rather than a
-/// silent pass.
+/// Inputs of the state stage. `sender` is engaged exactly when the check set contains an
+/// account-state check: verify() reads the account only then, and the four checks in
+/// c_accountStateDependent are the only readers, so they take it with value(). An absent account
+/// on that path is a programming error in the table, and bad_optional_access says so rather than
+/// a silent pass.
 struct StateInputs
 {
     protocol::Transaction& tx;
@@ -201,11 +213,21 @@ struct StateInputs
 
 /// Inputs of the pool stage. Either checker may be null: see checkBcosPoolNonce and
 /// checkBcosLedgerNonce.
+///
+/// `web3NonceHeldInPool` is the ANSWER to the Web3 reservation lookup, not the means of asking:
+/// that lookup is a coroutine, and a check function is a synchronous rule. verify() awaits it
+/// once before the stage, exactly as the other two stages take their inputs, which leaves the
+/// check what every other one is -- a comparison over data already in hand.
+///
+/// Engaged exactly when the set contains Web3PoolNonce, and read with value() for the same
+/// reason `sender` above is: the table says whether it was needed, so a missing answer is a
+/// programming error in verify(), not a transaction that passes.
 struct PoolInputs
 {
     protocol::Transaction& tx;
     NonceCheckerInterface* txPoolNonceChecker;
     LedgerNonceChecker* ledgerNonceChecker;
+    std::optional<bool> web3NonceHeldInPool;
 };
 
 // ---------------------------------------------------------------- the checks
@@ -536,11 +558,31 @@ TransactionStatus checkIntrinsicGas(StateInputs const& in)
     return TransactionStatus::None;
 }
 
-// The two halves of the old pool-side TxValidator::checkTransaction, minus its Web3 branch (Web3
-// nonce rules need only the account nonce and are their own check, Web3NonceWindow). They are
-// separate bits because they answer to different state: the pool set is node-local and the
-// proposal column drops it, the committed window is chain state and every column keeps it. That
-// decision lives in CheckSet.h, so neither function looks at the context.
+// The old pool-side TxValidator::checkTransaction, split by the state each part answers to: a
+// pending set is node-local and the proposal column drops it, a committed window is chain state
+// and every column keeps it. That decision lives in CheckSet.h, so none of these looks at the
+// context.
+//
+// Its Web3 branch splits the same way and lands in two places: the committed-nonce window is
+// Web3NonceWindow in the state stage (it needs the account, not the pool), and the pending-pair
+// rule is here.
+
+/// The Web3 half of the pool set, keyed on (sender, nonce) rather than on a nonce value alone.
+///
+/// This does not make MemoryStorage's reservation redundant. insertMemoryNonce is what refuses
+/// the second of two concurrent submissions of one pair, in a single atomic step, and it stays.
+/// What this restores is the answer before that write, and a row in the table saying the rule
+/// exists at all -- which is the whole claim of a module whose value is that the table is the
+/// full set of rules.
+///
+/// It costs a state stage the pool-side validator did not pay: it answered before
+/// validateBalance, and this answers after, since the pool stage runs last. A duplicate pair is
+/// therefore refused one account read later than it was on the old path.
+TransactionStatus checkWeb3PoolNonce(PoolInputs const& in)
+{
+    return in.web3NonceHeldInPool.value() ? TransactionStatus::NonceCheckFail :
+                                            TransactionStatus::None;
+}
 
 TransactionStatus checkBcosPoolNonce(PoolInputs const& in)
 {
@@ -601,6 +643,10 @@ constexpr std::array<CheckEntry<StateInputs>, c_stateOrder.size()> c_stateRegist
 }};
 
 constexpr std::array<CheckEntry<PoolInputs>, c_poolOrder.size()> c_poolRegistry{{
+    // Web3PoolNonce sits first because c_poolOrder puts it there; the position is not
+    // observable, since no check set contains both it and the BCOS rows -- kindOf() decides
+    // which pair of rules a transaction is subject to, and the two never overlap.
+    {Check::Web3PoolNonce, &checkWeb3PoolNonce},
     {Check::BcosPoolNonce, &checkBcosPoolNonce},
     {Check::BcosLedgerNonce, &checkBcosLedgerNonce},
 }};
@@ -800,14 +846,15 @@ task::Task<TransactionStatus> TxValidator::verify(
     }
 
     // Stage 2: evmone's sequence against one chain view, taken once from the snapshot. The
-    // account is read only
-    // when the set contains a check that needs it -- which is how the proposal column, whose
-    // sender-dependent checks are off, performs no account read at all.
+    // account is read only when the set contains a check that needs the account's own state --
+    // which is how the proposal column, whose account checks are off, performs no account read
+    // at all. c_senderDependent is the wider set and is deliberately NOT the condition here: its
+    // extra member keys on the sender address without reading anything.
     if ((checks & c_stateStage) != Check::None)
     {
         auto const chain = readChainView(*m_ledgerConfigState);
         std::optional<AccountState> sender;
-        if ((checks & c_senderDependent) != Check::None)
+        if ((checks & c_accountStateDependent) != Check::None)
         {
             sender = co_await readAccountState(tx.sender());
         }
@@ -820,7 +867,8 @@ task::Task<TransactionStatus> TxValidator::verify(
     }
 
     // Stage 3: the pool. The ledger nonce checker is copied out under the lock and held for the
-    // stage, so both pool checks judge against one window.
+    // stage, so both BCOS checks judge against one window, and the Web3 reservation is looked up
+    // here rather than inside its check -- the stage takes its inputs, then runs.
     if ((checks & c_poolStage) != Check::None)
     {
         std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
@@ -828,9 +876,18 @@ task::Task<TransactionStatus> TxValidator::verify(
             ReadGuard guard(x_lateBound);
             ledgerNonceChecker = m_ledgerNonceChecker;
         }
+        // Asked only when the set contains the check, the way the account read is: a BCOS
+        // transaction has no (sender, nonce) reservation to look up.
+        std::optional<bool> web3NonceHeldInPool;
+        if (contains(checks, Check::Web3PoolNonce))
+        {
+            web3NonceHeldInPool =
+                co_await m_web3NonceChecker->existsMemoryNonce(tx.sender(), tx.nonce());
+        }
         const PoolInputs pool{.tx = tx,
             .txPoolNonceChecker = m_txPoolNonceChecker.get(),
-            .ledgerNonceChecker = ledgerNonceChecker.get()};
+            .ledgerNonceChecker = ledgerNonceChecker.get(),
+            .web3NonceHeldInPool = web3NonceHeldInPool};
         co_return runStage(c_poolRegistry, checks, pool);
     }
     co_return TransactionStatus::None;

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
@@ -25,6 +25,7 @@
 #include "bcos-framework/protocol/TxGasModel.h"
 #include "bcos-framework/txpool/Constant.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
 #include "bcos-rlp-protocol/Web3TxEnvelope.h"
 #include "bcos-tx-validator/Normalize.h"
 #include "bcos-utilities/BoostLog.h"
@@ -260,6 +261,27 @@ TransactionStatus checkSignature(Envelope const& in)
         // reintroduces the bypass.
         in.tx.clearSenderAndHash();
         in.tx.verify(*in.cryptoSuite.hashImpl(), *in.cryptoSuite.signatureImpl());
+
+        // EIP-2 low-s, for Web3 transactions only. This is the ONLY place a tars-form Web3
+        // transaction meets the rule: the raw-bytes decode funnel on the RPC ingress rejects a
+        // high-s signature inline, but a transaction that arrives from a peer already in tars
+        // form never goes through that decode. Recovery SUCCEEDS on the high-s twin -- it just
+        // derives a different address -- so without this the same logical transaction enters the
+        // pool a second time under a distinct hash. An empty signature (deposits) is exempt, and
+        // anything shorter than 65 bytes was already rejected by verify() above.
+        if (in.tx.type() == static_cast<uint8_t>(protocol::TransactionType::Web3Transaction))
+        {
+            if (auto const sig = in.tx.signatureData();
+                sig.size() == static_cast<size_t>(crypto::SECP256K1_SIGNATURE_LEN))
+            {
+                if (checkEip2Signature(sig.getCroppedData(0, crypto::SECP256K1_SIGNATURE_R_LEN),
+                        sig.getCroppedData(crypto::SECP256K1_SIGNATURE_R_LEN,
+                            crypto::SECP256K1_SIGNATURE_S_LEN)) != nullptr)
+                {
+                    return TransactionStatus::InvalidSignature;
+                }
+            }
+        }
     }
     catch (...)
     {
@@ -419,6 +441,13 @@ TransactionStatus checkNonceNotMax(StateInputs const& in)
     }
     return TransactionStatus::None;
 }
+
+/// The window below adds DEFAULT_WEB3_NONCE_CHECK_LIMIT to the account nonce in u256, which is
+/// boost::multiprecision::unchecked and would wrap silently near 2^256. That is safe only because
+/// NonceNotMax has already refused any account nonce at or above 2^64 - 1 -- an ordering
+/// dependency between two checks, pinned here so a reorder cannot quietly reopen it.
+static_assert(detail::indexOf(c_stateOrder, Check::NonceNotMax) <
+              detail::indexOf(c_stateOrder, Check::Web3NonceWindow));
 
 TransactionStatus checkWeb3NonceWindow(StateInputs const& in)
 {

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.h
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.h
@@ -1,0 +1,144 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TxValidator.h
+ * @brief One admission entry point for both transaction pools.
+ * @date 2026/8/25
+ */
+
+#pragma once
+
+#include "bcos-crypto/interfaces/crypto/CryptoSuite.h"
+#include "bcos-framework/dispatcher/SchedulerInterface.h"
+#include "bcos-framework/ledger/LedgerConfigState.h"
+#include "bcos-framework/ledger/LedgerInterface.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-protocol/TransactionStatus.h"
+#include "bcos-task/Task.h"
+#include "bcos-tx-validator/CheckSet.h"
+#include "bcos-tx-validator/LedgerNonceChecker.h"
+#include "bcos-tx-validator/NonceCheckerInterface.h"
+#include "bcos-tx-validator/Web3NonceChecker.h"
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace bcos::txvalidator
+{
+
+/// Whether `to` is a well-formed recipient: empty (contract creation) or 20 hex bytes.
+/// Issue #5318 -- a malformed `to` accepted at admission reaches a block and stops the chain.
+bool isValidToField(std::string_view toField);
+
+/// What the account-state checks need. No codeHash: EIP-3607 is decided on the code BYTES
+/// (evmone::is_code_delegated recognises the 0xef0100 delegation prefix), and `code.empty()` is
+/// equivalent to `codeHash == EMPTY_CODE_HASH`. AIR has no ready codeHash read anyway --
+/// Ledger::getStorageState returns only nonce and balance -- so one fewer field is one fewer read.
+struct AccountState
+{
+    u256 balance;
+    /// std::nullopt = the account has no on-chain state yet. Distinct from nonce 0: the nonce
+    /// window declines to judge an unknown account (matching the existing Web3NonceChecker),
+    /// whereas nonce 0 is a real lower bound. Collapsing the two would reject a first-time
+    /// sender whose nonce sits beyond the queue window measured from zero -- while balance may
+    /// still be readable for that same account from the pending plane.
+    std::optional<u256> nonce;
+    bytes code;  ///< empty = EOA; non-empty and not 0xef0100-prefixed = contract, EIP-3607 rejects
+};
+
+/// Whether a transaction targets a system contract, injected rather than computed here: the
+/// answer needs precompiled::c_systemTxsAddress, and linking bcos-executor for one address list
+/// would drag evmone -- and wedprcrypto's bundled runtime, which breaks libc++ exception
+/// catching binary-wide -- into every module that admits a transaction.
+using SystemTxPredicate = std::function<bool(protocol::Transaction const&)>;
+
+/// The single place a transaction is judged admissible, for every ingress: Web3 JSON-RPC, P2P,
+/// and block-proposal verification.
+///
+/// It OWNS the nonce checkers rather than reaching them through callbacks. Nonce admission is
+/// the same question at every ingress, and routing it through a per-caller hook is how the pool
+/// and the RPC layer came to disagree about it in the first place.
+class TxValidator
+{
+public:
+    /// @p ledgerConfigState is read, never written: whoever commits a block publishes the new
+    /// configuration there, and verify() picks it up on the next transaction. Passing a
+    /// snapshot holder rather than the configuration itself is what keeps a long-lived
+    /// TxValidator from pinning the genesis config forever.
+    TxValidator(crypto::CryptoSuite::Ptr cryptoSuite,
+        std::shared_ptr<ledger::LedgerInterface> ledger,
+        ledger::LedgerConfigState::Ptr ledgerConfigState,
+        NonceCheckerInterface::Ptr txPoolNonceChecker, Web3NonceChecker::Ptr web3NonceChecker,
+        SystemTxPredicate isSystemTx, std::string groupId, std::string chainId);
+
+    /// Bound after construction: the ledger nonce checker cannot be built until the pool has read
+    /// the chain's block limit. Until it is bound there is nothing to check a BCOS nonce against,
+    /// and that check passes.
+    void setLedgerNonceChecker(std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker);
+
+    /// Also bound after construction -- the scheduler does not exist yet when the pools are
+    /// built. Until it is bound, and in engine-driven mode where there is none, the balance check
+    /// falls back to the committed ledger balance instead of the pending plane.
+    void setScheduler(std::weak_ptr<scheduler::SchedulerInterface> scheduler);
+
+    /// Run the check set for (kind of @p tx, @p context, @p policy), in c_checkOrder order.
+    ///
+    /// @p tx is non-const: normalization rewrites the mirror, signature verification writes the
+    /// recovered sender, and a system transaction gets setSystemTx(true).
+    ///
+    /// Returns the first failing check's status, or None. Throws (does not return a status) when
+    /// the data needed to decide is unavailable: a storage outage must not be reported to the
+    /// user as "your balance is too low", which is what swallowing the error would produce.
+    task::Task<protocol::TransactionStatus> verify(
+        protocol::Transaction& tx, AdmissionContext context, SignaturePolicy policy);
+
+    virtual ~TxValidator() = default;
+
+protected:
+    /// Balance, nonce and code for @p sender. Balance comes from the scheduler's PENDING plane
+    /// when a scheduler is bound and from the committed ledger otherwise; nonce always comes
+    /// from the COMMITTED plane through Web3NonceChecker's cache. That split is what AIR
+    /// already does, and unifying it is a separate change.
+    ///
+    /// `code` is left EMPTY on every path, so the EIP-3607 sender-is-an-EOA check cannot
+    /// currently fire; the implementation states what filling it correctly would require.
+    /// virtual so a test can supply code and pin the rule itself, which stays correct and starts
+    /// mattering the moment this fills the field.
+    virtual task::Task<std::optional<AccountState>> readAccountState(std::string_view sender);
+
+private:
+    crypto::CryptoSuite::Ptr m_cryptoSuite;
+    std::shared_ptr<ledger::LedgerInterface> m_ledger;
+    ledger::LedgerConfigState::Ptr m_ledgerConfigState;
+    NonceCheckerInterface::Ptr m_txPoolNonceChecker;
+    Web3NonceChecker::Ptr m_web3NonceChecker;
+    SystemTxPredicate m_isSystemTx;
+    std::string m_groupId;
+    std::string m_chainId;
+    /// The two late-bound dependencies, both written once from an init path that runs while
+    /// transactions may already be arriving, hence the lock. Readers copy the handle out and
+    /// release, so nothing is held across a co_await.
+    ///
+    /// The scheduler is weak on purpose: a strong edge would have the pool and the scheduler
+    /// co-own each other.
+    mutable SharedMutex x_lateBound;
+    /// Not LedgerNonceChecker::Ptr: that name is inherited from NonceCheckerInterface
+    /// and resolves to shared_ptr<NonceCheckerInterface>, which loses the derived type.
+    std::shared_ptr<LedgerNonceChecker> m_ledgerNonceChecker;
+    std::weak_ptr<scheduler::SchedulerInterface> m_scheduler;
+};
+
+}  // namespace bcos::txvalidator

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.h
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.h
@@ -31,10 +31,12 @@
 #include "bcos-tx-validator/LedgerNonceChecker.h"
 #include "bcos-tx-validator/NonceCheckerInterface.h"
 #include "bcos-tx-validator/Web3NonceChecker.h"
+#include "bcos-utilities/Common.h"
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace bcos::txvalidator
 {
@@ -117,6 +119,10 @@ protected:
     /// currently fire; the implementation states what filling it correctly would require.
     /// virtual so a test can supply code and pin the rule itself, which stays correct and starts
     /// mattering the moment this fills the field.
+    ///
+    /// @p sender is a view into the transaction verify() was handed, and is read after this
+    /// coroutine's awaits: that is sound because the caller keeps the transaction alive for the
+    /// whole of verify(), the ordinary contract for a Task-returning member.
     virtual task::Task<std::optional<AccountState>> readAccountState(std::string_view sender);
 
 private:

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.h
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.h
@@ -67,8 +67,10 @@ struct AccountState
 /// catching binary-wide -- into every module that admits a transaction.
 using SystemTxPredicate = std::function<bool(protocol::Transaction const&)>;
 
-/// The single place a transaction is judged admissible, for every ingress: Web3 JSON-RPC, P2P,
-/// and block-proposal verification.
+/// The one place a transaction is judged admissible, for every ingress: Web3 JSON-RPC, P2P, and
+/// block-proposal verification. As of this commit no ingress calls it yet -- the pool still runs
+/// txpool::TxValidator, and the callers move over in the wiring commits that follow. Read the
+/// sentence above as what this class is for, not as a claim about who calls it today.
 ///
 /// It OWNS the nonce checkers rather than reaching them through callbacks. Nonce admission is
 /// the same question at every ingress, and routing it through a per-caller hook is how the pool
@@ -80,6 +82,10 @@ public:
     /// configuration there, and verify() picks it up on the next transaction. Passing a
     /// snapshot holder rather than the configuration itself is what keeps a long-lived
     /// TxValidator from pinning the genesis config forever.
+    ///
+    /// @p ledgerConfigState and @p web3NonceChecker must be non-null and throw if they are not;
+    /// @p txPoolNonceChecker and the two late-bound setters below are nullable by design, each
+    /// with a check that says what its absence means.
     TxValidator(crypto::CryptoSuite::Ptr cryptoSuite,
         std::shared_ptr<ledger::LedgerInterface> ledger,
         ledger::LedgerConfigState::Ptr ledgerConfigState,

--- a/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.cpp
@@ -135,6 +135,28 @@ task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::st
     co_return true;
 }
 
+task::Task<std::optional<u256>> Web3NonceChecker::committedNonce(std::string_view sender)
+{
+    auto const senderView = std::string(sender);
+    if (auto const cached = co_await bcos::storage2::readOne(m_ledgerStateNonces, senderView))
+    {
+        co_return cached;
+    }
+    auto const senderHex = toHex(sender);
+    if (auto const storageState = co_await m_ledger->getStorageState(senderHex, 0);
+        storageState.has_value())
+    {
+        auto const nonceInStorage = u256(storageState.value().nonce);
+        // Monotonic: only ever raise the cached value (FIB-59).
+        co_await storage2::writeOneIf(m_ledgerStateNonces, senderView, nonceInStorage,
+            [&](u256 const& existing) { return nonceInStorage > existing; });
+        co_return nonceInStorage;
+    }
+    // The account has no on-chain state yet. Reported as absent, not as nonce 0 -- see
+    // txvalidator::AccountState::nonce.
+    co_return std::nullopt;
+}
+
 task::Task<std::optional<u256>> Web3NonceChecker::getPendingNonce(std::string_view sender)
 {
     const auto bytesSender = fromHex<std::string_view, std::string>(sender);

--- a/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.cpp
@@ -54,8 +54,7 @@ task::Task<bcos::protocol::TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     // sent by the address. For example, if 5 is stored in the storage, then the transactionCount
     // obtained from the rpc api by the web3 tool is 5; then the new transaction will be sent
     // from 5.
-    if (!onlyCheckLedgerNonce &&
-        co_await bcos::storage2::existsOne(m_memoryNonces, std::make_pair(sender, nonceU256)))
+    if (!onlyCheckLedgerNonce && co_await existsMemoryNonce(sender, nonce))
     {
         // memory nonce check nonce existence in memory first, if not exist, then check from storage
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: nonce mem check fail")
@@ -106,6 +105,12 @@ task::Task<TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     const bcos::protocol::Transaction& _tx, bool onlyCheckLedgerNonce)
 {
     co_return co_await checkWeb3Nonce(_tx.sender(), _tx.nonce(), onlyCheckLedgerNonce);
+}
+
+task::Task<bool> Web3NonceChecker::existsMemoryNonce(
+    std::string_view sender, std::string_view nonce)
+{
+    co_return co_await storage2::existsOne(m_memoryNonces, std::make_pair(sender, u256(nonce)));
 }
 
 task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)

--- a/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.h
+++ b/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.h
@@ -228,6 +228,23 @@ public:
     /// would undo FIB-59.
     virtual task::Task<std::optional<u256>> committedNonce(std::string_view sender);
 
+    /// Whether a PENDING transaction in this pool already holds (sender, nonce) -- the read half
+    /// of insertMemoryNonce's reservation, split out for the same reason committedNonce was:
+    /// the admission layer states the rule as its own check instead of calling a function that
+    /// also re-applies the ledger window it has already applied.
+    ///
+    /// This does NOT make insertMemoryNonce redundant. That call remains the authority: it
+    /// reserves and refuses in one atomic step, which is the only thing that closes the window
+    /// between two threads submitting the same pair (FIB-51). Asking here answers the same
+    /// question before that write, so the rule can be stated as a check rather than lived inside
+    /// the storage call.
+    ///
+    /// @param sender RAW 20 bytes, as committedNonce takes them and insertMemoryNonce stores
+    /// them -- not hex.
+    /// @param nonce decimal or 0x-prefixed; converted to u256 exactly as insertMemoryNonce
+    /// converts it, so "0x10" and "16" are one entry rather than two (FIB-58).
+    virtual task::Task<bool> existsMemoryNonce(std::string_view sender, std::string_view nonce);
+
     // only for test, inset nonce into ledgerStateNonces
     virtual void insert(std::string sender, u256 nonce);
 

--- a/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.h
+++ b/bcos-tx-validator/bcos-tx-validator/Web3NonceChecker.h
@@ -209,6 +209,25 @@ public:
 
     virtual task::Task<std::optional<u256>> getPendingNonce(std::string_view sender);
 
+    /// The account's nonce as of the last COMMITTED block: cache hit returns immediately, a miss
+    /// reads the ledger and back-fills the cache monotonically.
+    ///
+    /// @param sender RAW 20 bytes, as Transaction::sender() returns them -- not hex. Used
+    /// verbatim as the m_ledgerStateNonces key and hex-encoded once for the ledger read, which
+    /// is what checkWeb3Nonce() and insert() do. Note that getPendingNonce() above is the
+    /// exception on this class: it takes HEX and fromHex()es it to reach the same key. Passing
+    /// hex here would silently miss every cache entry and then hex-encode it a second time for
+    /// the ledger read -- a miss that looks like a cold cache, not like a bug.
+    ///
+    /// getPendingNonce() cannot be used for this. It prefers m_maxNonces, which is "the next
+    /// nonce this pool would accept" -- using that as a lower bound would reject every legitimate
+    /// queued transaction. This deliberately consults neither m_maxNonces nor m_memoryNonces.
+    ///
+    /// Split out of checkWeb3Nonce so the admission layer can apply the window itself while
+    /// keeping the m_ledgerStateNonces cache: reading through to storage on every transaction
+    /// would undo FIB-59.
+    virtual task::Task<std::optional<u256>> committedNonce(std::string_view sender);
+
     // only for test, inset nonce into ledgerStateNonces
     virtual void insert(std::string sender, u256 nonce);
 

--- a/bcos-tx-validator/test/unittests/AdmitTest.cpp
+++ b/bcos-tx-validator/test/unittests/AdmitTest.cpp
@@ -29,6 +29,7 @@
 #include "bcos-framework/testutils/faker/FakeScheduler.h"
 #include "bcos-framework/txpool/Constant.h"
 #include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-rlp-protocol/Web3TxEnvelope.h"
 #include "bcos-tars-protocol/protocol/TransactionImpl.h"
 #include "bcos-tx-validator/LedgerNonceChecker.h"
 #include "bcos-tx-validator/Normalize.h"
@@ -514,6 +515,49 @@ BOOST_AUTO_TEST_CASE(missingChainIdConfigRejectsRatherThanSkips)
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidChainId);
 }
 
+// The classifier answers three ways and the two cases above drive one of them. A pre-EIP-155
+// legacy transaction makes no claim about which chain it is for -- its signing preimage is the
+// bare six fields, with no chainId item to compare -- so the check stands down even though the
+// chain HAS a configured id, which is what separates this from the case above.
+BOOST_AUTO_TEST_CASE(unprotectedLegacyTransactionIsExemptFromTheChainIdCheck)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.type = rpc::TransactionType::Legacy, .chainId = std::nullopt});
+    BOOST_REQUIRE(harness.ledgerConfig->chainId().has_value());
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+// The third answer: Malformed, which checkChainId refuses rather than granting it the exemption
+// above. It never gets that far -- decoding rejects the same bytes first and normalization
+// reports that as Malformed -- so what this pins is the ORDER, not checkChainId's Malformed arm.
+// That arm is the second line of a defence whose first line is the decoder, kept because the
+// walker and the decoder are only in sync as long as someone keeps them so (Web3TxEnvelope.h
+// says exactly that). Should the order ever change, this case turns red and points at the arm
+// that then becomes reachable. Blob and deposit envelopes below are pinned the same way.
+//
+// The mutation is a junk item, not an invalid `v`: a transaction built the way this fixture (and
+// the RPC ingress) builds one carries the SIGNING PREIMAGE, with r/s/v in a separate tars field,
+// because that is what Web3TarsBridge's encodeForSign produces. A peer chooses its own
+// extraTransactionBytes and the block path carries sealed envelopes, so the classifier handles
+// both forms; there is simply no v in THESE bytes to corrupt.
+BOOST_AUTO_TEST_CASE(malformedEnvelopeIsRejectedBeforeTheChainIdCheck)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.type = rpc::TransactionType::Legacy});
+    auto& envelope = tx->mutableInner().extraTransactionBytes;
+    // Short list header (0xc0..0xf7): one length byte, so appending one item is a bump plus a
+    // push_back. The REQUIRE says so, rather than assuming it.
+    const auto header = static_cast<uint8_t>(envelope.at(0));
+    BOOST_REQUIRE(header >= 0xc0 && header < 0xf7);
+    envelope.at(0) = static_cast<tars::Char>(header + 1);
+    envelope.push_back(static_cast<tars::Char>(0x09));
+    // Both halves of the claim: the classifier calls these bytes Malformed, and verify() still
+    // answers with normalization's verdict rather than checkChainId's.
+    BOOST_REQUIRE(rlp::protocol::classifyWeb3EnvelopeChainId(tx->extraTransactionBytes()).kind ==
+                  rlp::protocol::Web3EnvelopeChainIdKind::Malformed);
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::Malformed);
+}
+
 /// A ledger whose SYS_CONFIG reads fail outright.
 struct SystemConfigUnreadableLedger : FakeLedger
 {
@@ -638,6 +682,22 @@ BOOST_AUTO_TEST_CASE(disabledSignaturePolicySkipsSenderDependentChecks)
     auto wrongChain = admitTx();
     BOOST_CHECK(harness.run(*wrongChain, AdmissionContext::PoolAdmission,
                     SignaturePolicy::Disabled) == TransactionStatus::InvalidChainId);
+}
+
+// Web3PoolNonce is sender-dependent for a reason worth its own case: its key is the PAIR
+// (sender, nonce), where BcosPoolNonce's is a nonce value alone. Run with no recovered sender it
+// would file every pending Web3 transaction under the empty string, and one sender's nonce would
+// then refuse another's.
+//
+// The reservation here is the one such an admission would have written: nonce 7 under the empty
+// sender. A transaction with nonce 7 from a real sender must still be admitted.
+BOOST_AUTO_TEST_CASE(disabledSignaturePolicySkipsTheWeb3PendingNonceCheck)
+{
+    AdmitHarness harness;
+    BOOST_REQUIRE(task::syncWait(harness.web3NonceChecker->insertMemoryNonce("", "7")));
+    auto tx = admitTx({.nonce = 7});
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::None);
 }
 
 // The P0 regression. This transaction is built exactly the way EthEndpoint::sendRawTransaction
@@ -784,6 +844,24 @@ BOOST_AUTO_TEST_CASE(highSSignatureIsRejected)
 
 // ------------------------------------------------------------ wiring guard
 
+// Two of the constructor's arguments are mandatory and the rest are not, so the difference is
+// pinned here. A null snapshot holder would turn every revision-dependent check into a
+// stand-down; a null Web3 nonce checker would be dereferenced by the first Web3 transaction's
+// account read. Neither can be answered with a transaction status, so neither is allowed to be
+// built.
+BOOST_AUTO_TEST_CASE(mandatoryCollaboratorsAreRefusedAtConstruction)
+{
+    AdmitHarness harness;
+    auto cryptoSuite = std::make_shared<crypto::CryptoSuite>(std::make_shared<crypto::Keccak256>(),
+        std::make_shared<crypto::Secp256k1Crypto>(), nullptr);
+    BOOST_CHECK_THROW(TxValidator(cryptoSuite, harness.ledger, nullptr, nullptr,
+                          harness.web3NonceChecker, harness.isSystemTx, "group0", "chain0"),
+        std::invalid_argument);
+    BOOST_CHECK_THROW(TxValidator(cryptoSuite, harness.ledger, harness.ledgerConfigState, nullptr,
+                          nullptr, harness.isSystemTx, "group0", "chain0"),
+        std::invalid_argument);
+}
+
 BOOST_AUTO_TEST_CASE(bcosLedgerNonceWithoutABoundCheckerPasses)
 {
     AdmitHarness harness;
@@ -847,6 +925,29 @@ BOOST_AUTO_TEST_CASE(bcosPendingNonceRejectsAdmissionButNotProposals)
         std::make_shared<StubLedgerNonceChecker>(TransactionStatus::NonceCheckFail);
     BOOST_CHECK(harness.run(*tx, AdmissionContext::ProposalVerification,
                     SignaturePolicy::Disabled) == TransactionStatus::NonceCheckFail);
+}
+
+// The Web3 counterpart, and the rule this module dropped when it stopped calling the pool-side
+// validator's checkWeb3Nonce: a (sender, nonce) pair a pending transaction already holds is
+// refused at admission, and ignored on the proposal path where two honest nodes' pools differ.
+//
+// MemoryStorage reserves the pair with insertMemoryNonce once verify() has passed, and THAT is
+// what refuses two concurrent submissions of one pair -- one atomic step, no window. What this
+// pins is that the answer is also given here, by a rule the table names, rather than only inside
+// that storage call.
+BOOST_AUTO_TEST_CASE(web3PendingNonceRejectsAdmissionButNotProposals)
+{
+    AdmitHarness harness;
+    auto first = admitTx();
+    BOOST_REQUIRE(harness.run(*first) == TransactionStatus::None);
+    // Exactly the call MemoryStorage makes after a successful admission.
+    BOOST_REQUIRE(task::syncWait(harness.web3NonceChecker->insertMemoryNonce(
+        std::string(first->sender()), std::string(first->nonce()))));
+
+    auto second = admitTx();
+    BOOST_CHECK(harness.run(*second) == TransactionStatus::NonceCheckFail);
+    BOOST_CHECK(
+        harness.run(*second, AdmissionContext::ProposalVerification) == TransactionStatus::None);
 }
 
 // A BCOS transaction's hash is NOT recomputed from its data when the wire already carries one:

--- a/bcos-tx-validator/test/unittests/AdmitTest.cpp
+++ b/bcos-tx-validator/test/unittests/AdmitTest.cpp
@@ -82,6 +82,10 @@ struct TxSpec
     bcos::bytes data{};
     u256 value = 1;
     bool withAuthorization = false;
+    /// Zero out r after signing: the envelope stays self-consistent (the hash commits to the
+    /// signature bytes as sent) but recovery is impossible, so the rejection is the signature
+    /// check's own and not normalization's.
+    bool unrecoverableSignature = false;
 };
 
 std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec = {})
@@ -111,6 +115,10 @@ std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec 
     web3.signatureR.assign(signature->begin(), signature->begin() + 32);
     web3.signatureS.assign(signature->begin() + 32, signature->begin() + 64);
     web3.signatureV = static_cast<uint64_t>((*signature)[64]);
+    if (spec.unrecoverableSignature)
+    {
+        web3.signatureR.assign(32, 0);
+    }
 
     auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
         [inner = web3.takeToTarsTransaction()]() mutable { return &inner; });
@@ -197,6 +205,8 @@ struct AdmitHarness
     /// Null by default: the mempool-side validator has no pool set, and most cases here are
     /// Web3, which never consult it.
     std::shared_ptr<NonceCheckerInterface> txPoolNonceChecker;
+    /// Nothing is a system transaction unless a case says so.
+    SystemTxPredicate isSystemTx = [](Transaction const&) { return false; };
     AccountState account{};
     bool accountExists = true;
 
@@ -243,9 +253,9 @@ struct AdmitHarness
         auto cryptoSuite =
             std::make_shared<crypto::CryptoSuite>(std::make_shared<crypto::Keccak256>(),
                 std::make_shared<crypto::Secp256k1Crypto>(), nullptr);
-        auto validator = std::make_unique<CodeInjectingValidator>(
-            cryptoSuite, ledger, ledgerConfigState, txPoolNonceChecker, web3NonceChecker,
-            [](Transaction const&) { return false; }, "group0", "chain0");
+        auto validator =
+            std::make_unique<CodeInjectingValidator>(cryptoSuite, ledger, ledgerConfigState,
+                txPoolNonceChecker, web3NonceChecker, isSystemTx, "group0", "chain0");
         validator->code = account.code;
         validator->setScheduler(scheduler);
         if (ledgerNonceChecker)
@@ -604,6 +614,41 @@ BOOST_AUTO_TEST_CASE(taintedTransactionWithABrokenSignatureIsStillRejected)
     // The hash commits to the signature, so normalization catches it first; either way it must
     // not be admitted.
     BOOST_CHECK(harness.run(*tx) != TransactionStatus::None);
+}
+
+// ------------------------------------------------------------ stages
+
+// The gate stage reads nothing. A transaction refused there -- here by an unrecoverable
+// signature, the case a P2P peer can manufacture for free -- costs no account read, which is what
+// keeps unauthenticated input cheap to refuse. Pinned by counting, as the proposal case above
+// is: a status assertion would pass just as well with the reads still happening.
+BOOST_AUTO_TEST_CASE(aRejectionAtTheGateReadsNoAccountState)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.unrecoverableSignature = true});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidSignature);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
+    BOOST_CHECK_EQUAL(harness.accountNonceReads(), 0);
+}
+
+// The system-transaction mark is a property of the transaction (its `to` is a system contract),
+// not of any check. The pool-side validator set it inside its signature path, which
+// SignaturePolicy::Disabled would switch off along with the signature; it is set before the
+// stages run, so the policy cannot reach it.
+BOOST_AUTO_TEST_CASE(systemTransactionIsMarkedRegardlessOfSignaturePolicy)
+{
+    AdmitHarness harness;
+    harness.isSystemTx = [](Transaction const&) { return true; };
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x0000000000000000000000000000000000001000";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.chainID = "chain0";
+    BOOST_REQUIRE(!tx->systemTx());
+
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::None);
+    BOOST_CHECK(tx->systemTx());
 }
 
 // ------------------------------------------------------------ wiring guard

--- a/bcos-tx-validator/test/unittests/AdmitTest.cpp
+++ b/bcos-tx-validator/test/unittests/AdmitTest.cpp
@@ -212,8 +212,10 @@ struct AdmitHarness
 
     AdmitHarness()
     {
-        ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, std::to_string(kChainId));
-        ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0");  // free gas by default
+        // The snapshot is the only chain configuration admission reads. The fake ledger's
+        // SYS_CONFIG map stays empty on purpose (see admissionReadsNoSystemConfig).
+        ledgerConfig->setChainId(evmc::bytes32{kChainId});
+        ledgerConfig->setGasPrice({"0", 0});  // free gas by default
         ledgerConfig->setBlockNumber(100);
         ledgerConfig->setGasLimit({3000000000ULL, 0});
         ledgerConfig->setEVMCRevision(EVMC_PRAGUE);
@@ -390,7 +392,7 @@ BOOST_AUTO_TEST_CASE(nonceBeyondTheQueueWindowIsRejected)
 BOOST_AUTO_TEST_CASE(feeCapBelowBaseFeeIsRejectedWithItsOwnCode)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0xfffffffffff");
+    harness.ledgerConfig->setGasPrice({"0xfffffffffff", 0});
     auto tx = admitTx({.maxFeePerGas = 1000, .maxPriorityFeePerGas = 1});
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::FeeCapLessThanBaseFee);
 }
@@ -417,7 +419,7 @@ BOOST_AUTO_TEST_CASE(gasLimitAboveTheChainCapIsRejected)
 BOOST_AUTO_TEST_CASE(insufficientBalanceIsRejected)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.ledgerConfig->setGasPrice({"1", 0});
     harness.account.balance = 1;
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::InsufficientFunds);
@@ -462,7 +464,7 @@ BOOST_AUTO_TEST_CASE(feeArithmeticDoesNotWrapAt256Bits)
     // Asserting on the arithmetic alone (which an earlier version of this case did) passes
     // whatever checkBalance is implemented in, so it pins nothing.
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0x1");  // gas is charged
+    harness.ledgerConfig->setGasPrice({"0x1", 0});  // gas is charged
 
     constexpr uint64_t gasLimit = 100000;
     const auto gasPrice = std::numeric_limits<u256>::max();
@@ -483,20 +485,44 @@ BOOST_AUTO_TEST_CASE(feeArithmeticDoesNotWrapAt256Bits)
 BOOST_AUTO_TEST_CASE(wrongChainIdIsRejected)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    harness.ledgerConfig->setChainId(evmc::bytes32{9999});
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidChainId);
 }
 
 // Fail closed. Skipping the check when the chain has no web3_chain_id would accept transactions
-// signed for any chain -- today EthEndpoint does exactly that.
+// signed for any chain -- today EthEndpoint does exactly that. A holder nothing has published
+// to is the one snapshot without a chain id (getLedgerConfig always sets one): the state between
+// a node's construction and its first publish. It refuses rather than skips.
 BOOST_AUTO_TEST_CASE(missingChainIdConfigRejectsRatherThanSkips)
 {
     AdmitHarness harness;
-    harness.ledger = std::make_shared<FakeLedger>();
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0");
+    harness.ledgerConfigState = std::make_shared<ledger::LedgerConfigState>();
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidChainId);
+}
+
+/// A ledger whose SYS_CONFIG reads fail outright.
+struct SystemConfigUnreadableLedger : FakeLedger
+{
+    void asyncGetSystemConfigByKey(std::string_view const&,
+        std::function<void(Error::Ptr, std::string, protocol::BlockNumber)>) override
+    {
+        throw std::runtime_error("SYS_CONFIG must not be read at admission");
+    }
+};
+
+// The snapshot is the only source of chain configuration: the chain id and the base fee come
+// from the LedgerConfig that getLedgerConfig built, not from a per-transaction getSystemConfig.
+// Two storage round trips fewer on the hot path, and one source of truth instead of two -- this
+// case is what keeps a later check from quietly bringing the second one back.
+BOOST_AUTO_TEST_CASE(admissionReadsNoSystemConfig)
+{
+    AdmitHarness harness;
+    harness.ledger = std::make_shared<SystemConfigUnreadableLedger>();
+    harness.web3NonceChecker = std::make_shared<CountingWeb3NonceChecker>(harness.ledger);
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
 }
 
 // ------------------------------------------------------------ contexts and policy
@@ -525,7 +551,7 @@ BOOST_AUTO_TEST_CASE(proposalVerificationReadsNoAccountState)
 BOOST_AUTO_TEST_CASE(proposalVerificationRejectsAForeignChainId)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    harness.ledgerConfig->setChainId(evmc::bytes32{9999});
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx, AdmissionContext::ProposalVerification) ==
                 TransactionStatus::InvalidChainId);
@@ -554,7 +580,7 @@ BOOST_AUTO_TEST_CASE(poolAdmissionReadsTheFullAccountState)
 BOOST_AUTO_TEST_CASE(proposalVerificationIgnoresLocalBalance)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.ledgerConfig->setGasPrice({"1", 0});
     harness.account.balance = 0;
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::InsufficientFunds);
@@ -568,14 +594,14 @@ BOOST_AUTO_TEST_CASE(proposalVerificationIgnoresLocalBalance)
 BOOST_AUTO_TEST_CASE(eestReplaySkipsBalanceAndNonceWindowOnly)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.ledgerConfig->setGasPrice({"1", 0});
     harness.account.balance = 0;
     harness.account.nonce = u256(999999);
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx, AdmissionContext::EESTReplay) == TransactionStatus::None);
 
     // The chainId check is NOT relaxed.
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    harness.ledgerConfig->setChainId(evmc::bytes32{9999});
     auto wrongChain = admitTx();
     BOOST_CHECK(harness.run(*wrongChain, AdmissionContext::EESTReplay) ==
                 TransactionStatus::InvalidChainId);
@@ -587,7 +613,7 @@ BOOST_AUTO_TEST_CASE(eestReplaySkipsBalanceAndNonceWindowOnly)
 BOOST_AUTO_TEST_CASE(disabledSignaturePolicySkipsSenderDependentChecks)
 {
     AdmitHarness harness;
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.ledgerConfig->setGasPrice({"1", 0});
     harness.account.balance = 0;
     harness.account.nonce = u256(999999);
     auto tx = admitTx();
@@ -596,7 +622,7 @@ BOOST_AUTO_TEST_CASE(disabledSignaturePolicySkipsSenderDependentChecks)
     BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
 
     // Checks that need no sender still run.
-    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    harness.ledgerConfig->setChainId(evmc::bytes32{9999});
     auto wrongChain = admitTx();
     BOOST_CHECK(harness.run(*wrongChain, AdmissionContext::PoolAdmission,
                     SignaturePolicy::Disabled) == TransactionStatus::InvalidChainId);

--- a/bcos-tx-validator/test/unittests/AdmitTest.cpp
+++ b/bcos-tx-validator/test/unittests/AdmitTest.cpp
@@ -1,0 +1,732 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AdmitTest.cpp
+ * @brief TxValidator::verify -- the checks that have no counterpart in the tree today.
+ *
+ * The module is stateless and every dependency is injected, so these run against fakes: no
+ * transaction pool, no block sequence, no scheduler.
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
+#include "bcos-framework/ledger/LedgerConfigState.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/protocol/TxGasModel.h"
+#include "bcos-framework/testutils/faker/FakeLedger.h"
+#include "bcos-framework/testutils/faker/FakeScheduler.h"
+#include "bcos-framework/txpool/Constant.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include "bcos-tx-validator/LedgerNonceChecker.h"
+#include "bcos-tx-validator/Normalize.h"
+#include "bcos-tx-validator/TxPoolNonceChecker.h"
+#include "bcos-tx-validator/TxValidator.h"
+#include "bcos-tx-validator/Web3NonceChecker.h"
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::protocol;
+using namespace bcos::txvalidator;
+
+namespace bcos::test
+{
+namespace
+{
+constexpr uint64_t kChainId = 5;
+
+/// One key pair for the whole suite, so `sender` is stable across cases.
+crypto::Secp256k1Crypto& signer()
+{
+    static crypto::Secp256k1Crypto instance;
+    return instance;
+}
+crypto::KeyPairInterface& senderKey()
+{
+    static auto keyPair = signer().generateKeyPair();
+    return *keyPair;
+}
+
+/// Build and genuinely SIGN a Web3 transaction, then project it to tars the way the RPC ingress
+/// does.
+///
+/// Signing here rather than using a static raw-transaction vector is deliberate: the RLP suite's
+/// vectors exist to round-trip the codec, so several carry arbitrary r/s that do not recover to
+/// any address -- and admit() runs signature recovery. Signing also makes gasLimit, chainId and
+/// the fee fields free variables, which several cases below need; a fixed vector cannot be
+/// edited without invalidating its own signature.
+struct TxSpec
+{
+    rpc::TransactionType type = rpc::TransactionType::EIP1559;
+    std::optional<uint64_t> chainId = kChainId;
+    uint64_t nonce = 7;
+    uint64_t gasLimit = 100000;
+    u256 maxFeePerGas = 30000000000ULL;
+    u256 maxPriorityFeePerGas = 1000000000ULL;
+    std::optional<Address> to = Address{"0x811a752c8cd697e3cb27279c330ed1ada745a8d7"};
+    bcos::bytes data{};
+    u256 value = 1;
+    bool withAuthorization = false;
+};
+
+std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec = {})
+{
+    rpc::Web3Transaction web3;
+    web3.type = spec.type;
+    web3.chainId = spec.chainId;
+    web3.nonce = spec.nonce;
+    web3.gasLimit = spec.gasLimit;
+    web3.maxFeePerGas = spec.maxFeePerGas;
+    web3.maxPriorityFeePerGas = spec.maxPriorityFeePerGas;
+    web3.to = spec.to;
+    web3.data = spec.data;
+    web3.value = spec.value;
+    if (spec.withAuthorization)
+    {
+        rpc::AuthorizationListEntry entry;
+        entry.chainId = kChainId;
+        entry.address = Address{"0x00000000000000000000000000000000000000aa"};
+        web3.authorizationList.push_back(entry);
+    }
+
+    crypto::Keccak256 hasher;
+    auto const signHash = web3.hashForSign();
+    auto signature = signer().sign(senderKey(), signHash, true);
+    BOOST_REQUIRE_EQUAL(signature->size(), 65U);
+    web3.signatureR.assign(signature->begin(), signature->begin() + 32);
+    web3.signatureS.assign(signature->begin() + 32, signature->begin() + 64);
+    web3.signatureV = static_cast<uint64_t>((*signature)[64]);
+
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [inner = web3.takeToTarsTransaction()]() mutable { return &inner; });
+    tx->calculateHash(hasher);
+    return tx;
+}
+
+/// Counts committedNonce() calls, so a test can state which plane a context consulted rather
+/// than inferring it from a status code.
+struct CountingWeb3NonceChecker : Web3NonceChecker
+{
+    using Web3NonceChecker::Web3NonceChecker;
+    int reads = 0;
+    task::Task<std::optional<u256>> committedNonce(std::string_view sender) override
+    {
+        ++reads;
+        co_return co_await Web3NonceChecker::committedNonce(sender);
+    }
+};
+
+/// The pending plane. Counting its reads is how the tests below say "this context did NOT do a
+/// full account-state read": the balance is the half of that read the nonce path never touches.
+struct CountingScheduler : FakeScheduler
+{
+    CountingScheduler() : FakeScheduler(nullptr, nullptr) {}
+    int reads = 0;
+    u256 balance;
+    task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(
+        std::string_view, std::string_view, bcos::protocol::BlockNumber) override
+    {
+        ++reads;
+        bcos::storage::Entry entry;
+        entry.set(balance.convert_to<std::string>());
+        co_return entry;
+    }
+};
+
+/// A ledger nonce checker whose verdict the test dictates. checkNonce is virtual on
+/// NonceCheckerInterface, so this needs no seam in the validator.
+struct StubLedgerNonceChecker : LedgerNonceChecker
+{
+    explicit StubLedgerNonceChecker(TransactionStatus verdict)
+      : LedgerNonceChecker({}, /*blockNumber=*/0, /*blockLimit=*/600,
+            /*checkBlockLimit=*/false),
+        m_verdict(verdict)
+    {}
+    TransactionStatus checkNonce(const Transaction&) override { return m_verdict; }
+    TransactionStatus m_verdict;
+};
+
+/// Supplies the one field readAccountState leaves empty on every real path. Nothing populates
+/// contract code at admission today (see readAccountState), so without this seam the EIP-3607
+/// rule would be untestable and would silently rot until code becomes readable.
+struct CodeInjectingValidator : TxValidator
+{
+    using TxValidator::TxValidator;
+    bytes code;
+
+protected:
+    task::Task<std::optional<AccountState>> readAccountState(std::string_view sender) override
+    {
+        auto state = co_await TxValidator::readAccountState(sender);
+        if (state)
+        {
+            state->code = code;
+        }
+        co_return state;
+    }
+};
+
+/// Everything the validator needs, with knobs for the cases below.
+///
+/// Unlike the callback-injected version this replaces, the account state is SEEDED into the
+/// fake ledger and read back through the validator's own path -- so the test exercises
+/// readAccountState and Web3NonceChecker rather than a stand-in for them.
+struct AdmitHarness
+{
+    std::shared_ptr<FakeLedger> ledger = std::make_shared<FakeLedger>();
+    ledger::LedgerConfig::Ptr ledgerConfig = std::make_shared<ledger::LedgerConfig>();
+    ledger::LedgerConfigState::Ptr ledgerConfigState;
+    std::shared_ptr<CountingWeb3NonceChecker> web3NonceChecker;
+    std::shared_ptr<CountingScheduler> scheduler = std::make_shared<CountingScheduler>();
+    std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
+    /// Null by default: the mempool-side validator has no pool set, and most cases here are
+    /// Web3, which never consult it.
+    std::shared_ptr<NonceCheckerInterface> txPoolNonceChecker;
+    AccountState account{};
+    bool accountExists = true;
+
+    AdmitHarness()
+    {
+        ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, std::to_string(kChainId));
+        ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0");  // free gas by default
+        ledgerConfig->setBlockNumber(100);
+        ledgerConfig->setGasLimit({3000000000ULL, 0});
+        ledgerConfig->setEVMCRevision(EVMC_PRAGUE);
+        ledgerConfigState = std::make_shared<ledger::LedgerConfigState>(ledgerConfig);
+        web3NonceChecker = std::make_shared<CountingWeb3NonceChecker>(ledger);
+        // Comfortably funded, nonce 7 (matches the fixture), plain EOA.
+        account.balance = u256("0xffffffffffffffffffffffffffff");
+        account.nonce = u256(7);
+    }
+
+    int accountStateReads() const { return scheduler->reads; }
+    int accountNonceReads() const { return web3NonceChecker->reads; }
+
+    /// The address the fixture key signs as. Committed state is keyed by it.
+    static std::string senderHex()
+    {
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        return toHex(senderKey().address(hashImpl));
+    }
+
+    /// Publish the account into the committed plane the validator actually reads.
+    void publishAccount()
+    {
+        scheduler->balance = account.balance;
+        if (!accountExists)
+        {
+            return;
+        }
+        ledger::StorageState state;
+        state.nonce = account.nonce ? account.nonce->convert_to<std::string>() : "0";
+        state.balance = account.balance.convert_to<std::string>();
+        ledger->setStorageState(senderHex(), std::move(state));
+    }
+
+    std::unique_ptr<CodeInjectingValidator> make()
+    {
+        auto cryptoSuite =
+            std::make_shared<crypto::CryptoSuite>(std::make_shared<crypto::Keccak256>(),
+                std::make_shared<crypto::Secp256k1Crypto>(), nullptr);
+        auto validator = std::make_unique<CodeInjectingValidator>(
+            cryptoSuite, ledger, ledgerConfigState, txPoolNonceChecker, web3NonceChecker,
+            [](Transaction const&) { return false; }, "group0", "chain0");
+        validator->code = account.code;
+        validator->setScheduler(scheduler);
+        if (ledgerNonceChecker)
+        {
+            validator->setLedgerNonceChecker(ledgerNonceChecker);
+        }
+        return validator;
+    }
+
+    TransactionStatus run(Transaction& tx,
+        AdmissionContext context = AdmissionContext::PoolAdmission,
+        SignaturePolicy policy = SignaturePolicy::Required)
+    {
+        publishAccount();
+        auto validator = make();
+        return task::syncWait(validator->verify(tx, context, policy));
+    }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(AdmitTest)
+
+BOOST_AUTO_TEST_CASE(wellFormedTransactionIsAdmitted)
+{
+    AdmitHarness harness;
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+// ------------------------------------------------------------ checks with no counterpart today
+
+// A gasLimit that cannot pay the base transaction cost is accepted today, sealed into a block,
+// and fails deterministically in the executor with OutOfGasLimit.
+BOOST_AUTO_TEST_CASE(gasLimitBelowIntrinsicCostIsRejected)
+{
+    // Accepted today, sealed into a block, then failed deterministically by the executor with
+    // OutOfGasLimit -- a block carrying a transaction that cannot succeed.
+    AdmitHarness harness;
+    auto tx = admitTx({.gasLimit = 20000});  // below the 21000 base cost
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::OutOfGasLimit);
+}
+
+BOOST_AUTO_TEST_CASE(intrinsicGasBoundaryMatchesTheExecutorsCostModel)
+{
+    AdmitHarness harness;
+    const auto calldata = bcos::bytes(100, 0x01);
+
+    // Take the floor from the same function the executor uses rather than restating the
+    // formula. Restating it is what the shared header exists to prevent -- and it would be
+    // wrong here: with 100 non-zero bytes the intrinsic cost is 22600, but EIP-7623's minimum
+    // (21000 + 400 tokens * 10) is 25000, and the transaction is charged the larger one.
+    auto probe = admitTx({.gasLimit = 1000000, .data = calldata});
+    const auto cost = protocol::gas::compute_tx_intrinsic_cost(EVMC_PRAGUE, *probe);
+    const auto floor = static_cast<uint64_t>(std::max(cost.intrinsic, cost.min));
+    BOOST_REQUIRE_GT(cost.min, cost.intrinsic);  // the EIP-7623 floor is what binds here
+
+    auto atFloor = admitTx({.gasLimit = floor, .data = calldata});
+    BOOST_CHECK(harness.run(*atFloor) == TransactionStatus::None);
+
+    auto belowFloor = admitTx({.gasLimit = floor - 1, .data = calldata});
+    BOOST_CHECK(harness.run(*belowFloor) == TransactionStatus::OutOfGasLimit);
+}
+
+// EIP-3860. The cap applies to contract CREATION only. The implementation this replaces keyed
+// on transaction type alone, so a large call to an already-deployed contract was rejected as if
+// its calldata were initcode.
+BOOST_AUTO_TEST_CASE(oversizedInitCodeIsRejectedOnCreationOnly)
+{
+    AdmitHarness harness;
+    const auto oversized = bcos::bytes(MAX_INITCODE_SIZE + 1, 0x01);
+
+    auto creation = admitTx({.to = std::nullopt, .data = oversized});
+    BOOST_CHECK(harness.run(*creation) == TransactionStatus::MaxInitCodeSizeExceeded);
+
+    // The same payload as calldata to a deployed contract is not initcode. It still fails --
+    // this gasLimit cannot pay for that much calldata -- but not with the initcode code, which
+    // is the distinction under test.
+    auto call = admitTx({.data = oversized});
+    BOOST_CHECK(harness.run(*call) != TransactionStatus::MaxInitCodeSizeExceeded);
+}
+
+// EIP-3607. A contract address must not be able to originate a transaction.
+BOOST_AUTO_TEST_CASE(contractSenderIsRejected)
+{
+    AdmitHarness harness;
+    harness.account.code = {0x60, 0x60, 0x60};
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::SenderNoEOA);
+}
+
+// ... but EIP-7702 delegated code still belongs to an EOA.
+BOOST_AUTO_TEST_CASE(delegatedSenderIsAccepted)
+{
+    AdmitHarness harness;
+    harness.account.code = {0xef, 0x01, 0x00, 0xaa, 0xbb};
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+// EIP-2681.
+BOOST_AUTO_TEST_CASE(accountNonceAtMaxIsRejected)
+{
+    AdmitHarness harness;
+    harness.account.nonce = u256(std::numeric_limits<uint64_t>::max());
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::NonceHasMaxValue);
+}
+
+BOOST_AUTO_TEST_CASE(alreadyUsedNonceIsRejected)
+{
+    AdmitHarness harness;
+    harness.account.nonce = u256(12);  // fixture nonce is 7
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::NonceCheckFail);
+}
+
+BOOST_AUTO_TEST_CASE(nonceBeyondTheQueueWindowIsRejected)
+{
+    AdmitHarness harness;
+    harness.account.nonce = u256(0);
+    // Just inside the window: queued, not rejected. Admission keeps future-nonce transactions,
+    // unlike execution, which requires an exact match.
+    auto inside = admitTx({.nonce = DEFAULT_WEB3_NONCE_CHECK_LIMIT});
+    BOOST_CHECK(harness.run(*inside) == TransactionStatus::None);
+
+    auto beyond = admitTx({.nonce = DEFAULT_WEB3_NONCE_CHECK_LIMIT + 1});
+    BOOST_CHECK(harness.run(*beyond) == TransactionStatus::NonceCheckFail);
+}
+
+// The chain's base fee. Today this is reported as InsufficientFunds, which points the user at
+// their balance instead of at their fee cap.
+BOOST_AUTO_TEST_CASE(feeCapBelowBaseFeeIsRejectedWithItsOwnCode)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0xfffffffffff");
+    auto tx = admitTx({.maxFeePerGas = 1000, .maxPriorityFeePerGas = 1});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::FeeCapLessThanBaseFee);
+}
+
+// A typed transaction on a chain whose revision predates its EIP.
+BOOST_AUTO_TEST_CASE(typedTransactionBeforeItsForkIsRejected)
+{
+    AdmitHarness harness;
+    harness.ledgerConfig->setEVMCRevision(EVMC_ISTANBUL);  // pre-Berlin, pre-London
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::TxTypeNotSupported);
+}
+
+BOOST_AUTO_TEST_CASE(gasLimitAboveTheChainCapIsRejected)
+{
+    AdmitHarness harness;
+    harness.ledgerConfig->setGasLimit({50000, 0});
+    auto tx = admitTx({.gasLimit = 60000});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::MaxGasLimitExceeded);
+}
+
+// ------------------------------------------------------------ balance, 512-bit
+
+BOOST_AUTO_TEST_CASE(insufficientBalanceIsRejected)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.account.balance = 1;
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InsufficientFunds);
+}
+
+// The overflow regression. gasLimit * effectiveGasPrice + value is computed at 512 bits because
+// bcos::u256 carries boost::multiprecision::unchecked: at 256 bits the product of the fixture's
+// gasLimit and a near-2^256 gas price wraps to a small number and an unfundable transaction is
+// admitted. Asserted against the arithmetic directly -- the fixture's own gas price cannot be
+// changed without re-signing it.
+// The old validateBalance rejected on `balance < required || balance == 0`. The second clause
+// is not carried over, and these two cases are why. On a free-gas chain it was unreachable --
+// that implementation set skipBalanceCheck and returned before reaching it -- and on a
+// gas-charging chain `balance < required` already covers a zero balance, because required is
+// then value + gasLimit * gasPrice > 0. What is left is a zero-value transaction on a free-gas
+// chain, which costs its sender nothing and which execution accepts.
+BOOST_AUTO_TEST_CASE(zeroBalanceSenderMayStillSendAFreeZeroValueTransaction)
+{
+    AdmitHarness harness;  // tx_gas_price is "0" by default here
+    harness.account.balance = 0;
+    auto tx = admitTx({.value = 0});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+// Free gas does not make `value` free: the old implementation skipped the whole balance check
+// when gas was free, so an unfunded transfer was admitted and then failed in the executor.
+BOOST_AUTO_TEST_CASE(freeGasStillRequiresTheValueToBeCovered)
+{
+    AdmitHarness harness;
+    harness.account.balance = 0;
+    auto tx = admitTx({.value = 5});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InsufficientFunds);
+}
+
+BOOST_AUTO_TEST_CASE(feeArithmeticDoesNotWrapAt256Bits)
+{
+    // bcos::u256 carries boost::multiprecision::unchecked, so gasLimit * gasPrice is reduced mod
+    // 2^256 with no signal. This drives a real transaction through checkBalance with a balance
+    // sitting BETWEEN the wrapped product and the true one: a 256-bit implementation computes a
+    // small requirement and admits it, a 512-bit one computes the real requirement and refuses.
+    //
+    // Asserting on the arithmetic alone (which an earlier version of this case did) passes
+    // whatever checkBalance is implemented in, so it pins nothing.
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0x1");  // gas is charged
+
+    constexpr uint64_t gasLimit = 100000;
+    const auto gasPrice = std::numeric_limits<u256>::max();
+    const u256 wrapped = u256(gasLimit) * gasPrice;
+    BOOST_REQUIRE_MESSAGE(u512{wrapped} < u512{gasLimit} * u512{gasPrice},
+        "the 256-bit product must be strictly smaller than the true one");
+
+    // Clears the wrapped figure by one, nowhere near the real one.
+    harness.account.balance = wrapped + 1;
+
+    auto tx = admitTx(
+        {.gasLimit = gasLimit, .maxFeePerGas = gasPrice, .maxPriorityFeePerGas = 0, .value = 0});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InsufficientFunds);
+}
+
+// ------------------------------------------------------------ chainId
+
+BOOST_AUTO_TEST_CASE(wrongChainIdIsRejected)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidChainId);
+}
+
+// Fail closed. Skipping the check when the chain has no web3_chain_id would accept transactions
+// signed for any chain -- today EthEndpoint does exactly that.
+BOOST_AUTO_TEST_CASE(missingChainIdConfigRejectsRatherThanSkips)
+{
+    AdmitHarness harness;
+    harness.ledger = std::make_shared<FakeLedger>();
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0");
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidChainId);
+}
+
+// ------------------------------------------------------------ contexts and policy
+
+// Proposal verification touches NO account state at all -- not balance, not code, not even the
+// nonce. Counting the reads is the only way to state that as a test; a status assertion would
+// pass just as well with every read still happening.
+//
+// This is stronger than it was: dropping Web3NonceWindow from the proposal column removed the
+// last check that needed a nonce, so the consensus path now runs entirely on the transaction and
+// the chain config. Anything that reintroduces a read here puts it on the hot path for every
+// transaction of every block, and this case is what says so.
+BOOST_AUTO_TEST_CASE(proposalVerificationReadsNoAccountState)
+{
+    AdmitHarness harness;
+    auto tx = admitTx();
+    BOOST_CHECK(
+        harness.run(*tx, AdmissionContext::ProposalVerification) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
+    BOOST_CHECK_EQUAL(harness.accountNonceReads(), 0);
+}
+
+// The vulnerability F2 names: nothing downstream re-checks tx.chainId (EthereumTransition.h
+// says validate_transaction does not look at that field), so if proposal verification skips it
+// a leader can have every follower execute a transaction signed for another chain.
+BOOST_AUTO_TEST_CASE(proposalVerificationRejectsAForeignChainId)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::ProposalVerification) ==
+                TransactionStatus::InvalidChainId);
+}
+
+// Protocol invariants are enforced on the proposal column too -- they cost no account read and
+// their answer is the same on every honest node.
+BOOST_AUTO_TEST_CASE(proposalVerificationRejectsUnderIntrinsicGas)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.gasLimit = 20000});
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::ProposalVerification) ==
+                TransactionStatus::OutOfGasLimit);
+}
+
+BOOST_AUTO_TEST_CASE(poolAdmissionReadsTheFullAccountState)
+{
+    AdmitHarness harness;
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+    BOOST_CHECK_GT(harness.accountStateReads(), 0);
+}
+
+// Proposal verification skips the checks whose inputs are local state, so a transaction the
+// local node would refuse to admit does not fail the whole proposal.
+BOOST_AUTO_TEST_CASE(proposalVerificationIgnoresLocalBalance)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.account.balance = 0;
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InsufficientFunds);
+
+    auto same = admitTx();
+    BOOST_CHECK(
+        harness.run(*same, AdmissionContext::ProposalVerification) == TransactionStatus::None);
+}
+
+// EEST fixtures use arbitrary nonces and unfunded accounts.
+BOOST_AUTO_TEST_CASE(eestReplaySkipsBalanceAndNonceWindowOnly)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.account.balance = 0;
+    harness.account.nonce = u256(999999);
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::EESTReplay) == TransactionStatus::None);
+
+    // The chainId check is NOT relaxed.
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    auto wrongChain = admitTx();
+    BOOST_CHECK(harness.run(*wrongChain, AdmissionContext::EESTReplay) ==
+                TransactionStatus::InvalidChainId);
+}
+
+// SignaturePolicy::Disabled drops the sender-dependent checks explicitly, instead of relying on
+// the sender happening to be empty -- which today makes every transaction look like it has a
+// zero balance.
+BOOST_AUTO_TEST_CASE(disabledSignaturePolicySkipsSenderDependentChecks)
+{
+    AdmitHarness harness;
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "1");
+    harness.account.balance = 0;
+    harness.account.nonce = u256(999999);
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::None);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
+
+    // Checks that need no sender still run.
+    harness.ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "9999");
+    auto wrongChain = admitTx();
+    BOOST_CHECK(harness.run(*wrongChain, AdmissionContext::PoolAdmission,
+                    SignaturePolicy::Disabled) == TransactionStatus::InvalidChainId);
+}
+
+// The P0 regression. This transaction is built exactly the way EthEndpoint::sendRawTransaction
+// builds one -- constructed directly, so tainted() is true. An implementation that read
+// tainted() as "already verified" would admit it despite the broken signature.
+BOOST_AUTO_TEST_CASE(taintedTransactionWithABrokenSignatureIsStillRejected)
+{
+    AdmitHarness harness;
+    auto tx = admitTx();
+    BOOST_REQUIRE(tx->tainted());
+    tx->mutableInner().signature[0] = static_cast<tars::Char>(tx->inner().signature[0] ^ 0x01);
+    // The hash commits to the signature, so normalization catches it first; either way it must
+    // not be admitted.
+    BOOST_CHECK(harness.run(*tx) != TransactionStatus::None);
+}
+
+// ------------------------------------------------------------ wiring guard
+
+BOOST_AUTO_TEST_CASE(bcosLedgerNonceWithoutABoundCheckerPasses)
+{
+    AdmitHarness harness;
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x1234567890123456789012345678901234567890";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.chainID = "chain0";
+    // The ledger nonce checker is bound only once the pool has read the chain's block limit.
+    // Before that there is no window to judge against, and PASSING is the correct answer:
+    // execution still enforces the nonce, whereas rejecting would refuse every transaction
+    // submitted during startup.
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(bcosLedgerNonceVerdictIsPropagated)
+{
+    AdmitHarness harness;
+    harness.ledgerNonceChecker =
+        std::make_shared<StubLedgerNonceChecker>(TransactionStatus::BlockLimitCheckFail);
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x1234567890123456789012345678901234567890";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.chainID = "chain0";
+
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::BlockLimitCheckFail);
+}
+
+// The pending-nonce set is this node's own pool: a leader's transactions are legitimately absent
+// from it, and two honest nodes' pools differ by what each has admitted and not yet sealed. So
+// it decides admission but not proposal verification -- the pool-side validator this module
+// replaces made the same call with checkTransaction(tx, onlyCheckLedgerNonce = true). The
+// routing table now says it (BcosPoolNonce is off the proposal column) and this case pins it
+// end to end, with the committed-nonce half still enforced on both paths.
+BOOST_AUTO_TEST_CASE(bcosPendingNonceRejectsAdmissionButNotProposals)
+{
+    AdmitHarness harness;
+    auto pool = std::make_shared<TxPoolNonceChecker>();
+    pool->insert("pending-nonce");
+    harness.txPoolNonceChecker = pool;
+    harness.ledgerNonceChecker = std::make_shared<StubLedgerNonceChecker>(TransactionStatus::None);
+
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x1234567890123456789012345678901234567890";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.chainID = "chain0";
+    tx->mutableInner().data.nonce = "pending-nonce";
+
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::NonceCheckFail);
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::ProposalVerification,
+                    SignaturePolicy::Disabled) == TransactionStatus::None);
+
+    // ... and the committed-nonce half is not what let the proposal through: a ledger verdict
+    // still fails it.
+    harness.ledgerNonceChecker =
+        std::make_shared<StubLedgerNonceChecker>(TransactionStatus::NonceCheckFail);
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::ProposalVerification,
+                    SignaturePolicy::Disabled) == TransactionStatus::NonceCheckFail);
+}
+
+// A BCOS transaction's hash is NOT recomputed from its data when the wire already carries one:
+// TarsHashable.h returns the supplied dataHash verbatim. So signature recovery runs against
+// whatever hash the sender put on the wire, and binds the recovered address to data that hash
+// does not cover.
+//
+// Concretely: take any (hash, signature) pair from a victim's broadcast transaction, attach it to
+// a body of your own choosing, and admission recovers the victim as the sender. The pool-side
+// validator this module replaces defended against exactly this by calling clearSenderAndHash()
+// before verify(), which wipes the wire hash and forces recomputation from `data`.
+BOOST_AUTO_TEST_CASE(forgedBcosDataHashDoesNotBindTheVictimAsSender)
+{
+    AdmitHarness harness;
+    auto hashImpl = std::make_shared<crypto::Keccak256>();
+    auto signatureImpl = std::make_shared<crypto::Secp256k1Crypto>();
+
+    // A legitimate transaction the victim broadcast. Its hash and signature are public.
+    bcostars::Transaction victimInner;
+    victimInner.data.to = "0x1111111111111111111111111111111111111111";
+    victimInner.data.nonce = "1";
+    victimInner.data.groupID = "group0";
+    victimInner.data.chainID = "chain0";
+    auto victim = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [inner = std::move(victimInner)]() mutable { return &inner; });
+    victim->calculateHash(*hashImpl);
+    auto signature = signatureImpl->sign(senderKey(), victim->hash(), true);
+    victim->setSignatureData(*signature);
+    auto const stolenHash = victim->hash();
+
+    // The attacker's body, carrying the victim's hash and signature.
+    bcostars::Transaction forgedInner;
+    forgedInner.data.to = "0x2222222222222222222222222222222222222222";
+    forgedInner.data.nonce = "2";
+    forgedInner.data.groupID = "group0";
+    forgedInner.data.chainID = "chain0";
+    forgedInner.dataHash.assign(stolenHash.begin(), stolenHash.end());
+    forgedInner.signature.assign(signature->begin(), signature->end());
+    auto forged = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [inner = std::move(forgedInner)]() mutable { return &inner; });
+
+    harness.run(*forged, AdmissionContext::PoolAdmission, SignaturePolicy::Required);
+
+    // What the victim's key actually signed.
+    auto const [ok, victimAddress] =
+        signatureImpl->recoverAddress(*hashImpl, stolenHash, ref(*signature));
+    BOOST_REQUIRE(ok);
+
+    // The forged body must NOT be attributed to the victim. Admission may still accept it as
+    // some other (meaningless) sender -- what must never happen is the victim's address ending
+    // up on a body the victim never signed.
+    std::string_view const victimView(
+        reinterpret_cast<char const*>(victimAddress.data()), victimAddress.size());
+    BOOST_CHECK(forged->sender() != victimView);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/bcos-tx-validator/test/unittests/AdmitTest.cpp
+++ b/bcos-tx-validator/test/unittests/AdmitTest.cpp
@@ -86,6 +86,10 @@ struct TxSpec
     /// signature bytes as sent) but recovery is impossible, so the rejection is the signature
     /// check's own and not normalization's.
     bool unrecoverableSignature = false;
+    /// Replace s by n - s after signing: the same envelope under the other of the two signatures
+    /// every ECDSA message has. Recovery succeeds on it (to a different address), and only the
+    /// EIP-2 low-s rule tells the twins apart.
+    bool highS = false;
 };
 
 std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec = {})
@@ -115,6 +119,14 @@ std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec 
     web3.signatureR.assign(signature->begin(), signature->begin() + 32);
     web3.signatureS.assign(signature->begin() + 32, signature->begin() + 64);
     web3.signatureV = static_cast<uint64_t>((*signature)[64]);
+    if (spec.highS)
+    {
+        auto const s = fromBigEndian<u256>(web3.signatureS);
+        BOOST_REQUIRE_LT(s, crypto::c_secp256k1nOver2);  // the signer emits low-s; the twin is high
+        bcos::bytes twin(32, 0);
+        toBigEndian(crypto::c_secp256k1n - s, twin);
+        web3.signatureS = std::move(twin);
+    }
     if (spec.unrecoverableSignature)
     {
         web3.signatureR.assign(32, 0);
@@ -675,6 +687,99 @@ BOOST_AUTO_TEST_CASE(systemTransactionIsMarkedRegardlessOfSignaturePolicy)
     BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
                 TransactionStatus::None);
     BOOST_CHECK(tx->systemTx());
+}
+
+// ------------------------------------------------------------ every kind, through verify()
+
+// The routing table names five kinds and the cases above drive one of them. These drive the rest,
+// so that each kind's own checks are exercised by verify() and not pinned on the table alone.
+BOOST_AUTO_TEST_CASE(legacyTransactionIsAdmitted)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.type = rpc::TransactionType::Legacy});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(accessListTransactionIsAdmitted)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.type = rpc::TransactionType::EIP2930});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(setCodeTransactionIsAdmitted)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.type = rpc::TransactionType::EIP7702, .withAuthorization = true});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+}
+
+// EIP-7702: a set-code transaction cannot create a contract, and cannot carry nothing to set.
+BOOST_AUTO_TEST_CASE(setCodeTransactionWithoutRecipientIsRejected)
+{
+    AdmitHarness harness;
+    auto tx = admitTx(
+        {.type = rpc::TransactionType::EIP7702, .to = std::nullopt, .withAuthorization = true});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::CreateSetCodeTx);
+}
+
+BOOST_AUTO_TEST_CASE(setCodeTransactionWithEmptyAuthorizationListIsRejected)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.type = rpc::TransactionType::EIP7702});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::EmptyAuthorizationList);
+}
+
+BOOST_AUTO_TEST_CASE(priorityFeeAboveTheFeeCapIsRejected)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.maxFeePerGas = 1000, .maxPriorityFeePerGas = 2000});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::TipGreaterThanFeeCap);
+}
+
+// A blob or deposit envelope is refused before the table is consulted: normalization classifies
+// the envelope and rejects both, so Check::TypeGate's Rejected arm is the second line, not the
+// first. What verify() answers for them is pinned here, whichever line answered.
+BOOST_AUTO_TEST_CASE(blobAndDepositEnvelopesAreRefused)
+{
+    AdmitHarness harness;
+    auto blob = admitTx();
+    blob->mutableInner().extraTransactionBytes.at(0) = 0x03;
+    BOOST_CHECK(harness.run(*blob) == TransactionStatus::BlobTxNotAllowed);
+
+    auto deposit = admitTx();
+    deposit->mutableInner().extraTransactionBytes.at(0) = 0x7e;
+    BOOST_CHECK(harness.run(*deposit) == TransactionStatus::TxTypeNotSupported);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
+}
+
+// The gate's `to` format check, on the only kind whose `to` is a free-form string: a Web3 `to`
+// is decoded from the envelope and is 20 bytes or empty by construction.
+BOOST_AUTO_TEST_CASE(malformedRecipientIsRejectedAtTheGate)
+{
+    AdmitHarness harness;
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x12";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.chainID = "chain0";
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::Malformed);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
+}
+
+// EIP-2. Every ECDSA signature has a twin with s' = n - s over the same message, and recovery
+// succeeds on it -- to a different address. Without the low-s rule the same envelope enters the
+// pool a second time, under a second sender and a second hash. This is the only place a
+// tars-form Web3 transaction from a peer meets the rule: the raw-bytes decode on the RPC
+// ingress is not on that path. Without the rule this case reaches the balance check as the
+// twin's sender and fails there instead.
+BOOST_AUTO_TEST_CASE(highSSignatureIsRejected)
+{
+    AdmitHarness harness;
+    auto tx = admitTx({.highS = true});
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidSignature);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
 }
 
 // ------------------------------------------------------------ wiring guard

--- a/bcos-tx-validator/test/unittests/CheckSetTest.cpp
+++ b/bcos-tx-validator/test/unittests/CheckSetTest.cpp
@@ -184,6 +184,37 @@ BOOST_AUTO_TEST_CASE(checkOrderCoversEveryReachableCheckExactlyOnce)
     BOOST_CHECK((reachable & ~ordered) == Check::None);
 }
 
+// The three stages partition the order: every check sits in exactly one, and back to back they
+// are c_checkOrder. What each stage may read is decided by its position, so the membership
+// facts verify() relies on are pinned here rather than assumed.
+BOOST_AUTO_TEST_CASE(stagesPartitionTheEvaluationOrder)
+{
+    BOOST_CHECK_EQUAL(
+        c_gateOrder.size() + c_stateOrder.size() + c_poolOrder.size(), c_checkOrder.size());
+    Check gate = Check::None;
+    for (auto check : c_gateOrder)
+    {
+        gate = gate | check;
+    }
+    BOOST_CHECK((gate & c_stateStage) == Check::None);
+    BOOST_CHECK((gate & c_poolStage) == Check::None);
+    BOOST_CHECK((c_stateStage & c_poolStage) == Check::None);
+
+    // Every sender-dependent check lives in the state stage: that is what lets verify() read the
+    // account once, before the stage, and only when the set contains one of them.
+    BOOST_CHECK((c_senderDependent & ~c_stateStage) == Check::None);
+    // A BCOS transaction has no state-stage check in any context, so it never reads the chain;
+    // a Web3 proposal has state-stage checks but no sender-dependent one, so it reads the chain
+    // view and not the account.
+    for (auto context : kContexts)
+    {
+        BOOST_CHECK((checkSet(TxKind::Bcos, context) & c_stateStage) == Check::None);
+    }
+    const auto proposal = checkSet(TxKind::Web3DynamicFee, AdmissionContext::ProposalVerification);
+    BOOST_CHECK((proposal & c_stateStage) != Check::None);
+    BOOST_CHECK((proposal & c_senderDependent) == Check::None);
+}
+
 // TypeGate must be first: for a refused envelope type nothing else is meaningful, and the type
 // gate is what turns a blob or deposit arriving over P2P into a rejection.
 BOOST_AUTO_TEST_CASE(typeGateIsEvaluatedFirstAndSignatureBeforeAccountState)

--- a/bcos-tx-validator/test/unittests/CheckSetTest.cpp
+++ b/bcos-tx-validator/test/unittests/CheckSetTest.cpp
@@ -49,7 +49,8 @@ BOOST_AUTO_TEST_CASE(poolAdmissionColumnIsExact)
     constexpr auto legacy = Check::TypeGate | Check::ToFieldFormat | Check::Signature |
                             Check::MaxGasLimit | Check::FeeCapVsBaseFee | Check::ChainId |
                             Check::SenderIsEOA | Check::NonceNotMax | Check::Web3NonceWindow |
-                            Check::InitCodeSize | Check::Balance | Check::IntrinsicGas;
+                            Check::InitCodeSize | Check::Balance | Check::IntrinsicGas |
+                            Check::Web3PoolNonce;
     BOOST_CHECK(checkSet(TxKind::Web3Legacy, AdmissionContext::PoolAdmission) == legacy);
     BOOST_CHECK(checkSet(TxKind::Web3AccessList, AdmissionContext::PoolAdmission) ==
                 (legacy | Check::TypeByRevision));
@@ -200,9 +201,15 @@ BOOST_AUTO_TEST_CASE(stagesPartitionTheEvaluationOrder)
     BOOST_CHECK((gate & c_poolStage) == Check::None);
     BOOST_CHECK((c_stateStage & c_poolStage) == Check::None);
 
-    // Every sender-dependent check lives in the state stage: that is what lets verify() read the
-    // account once, before the stage, and only when the set contains one of them.
-    BOOST_CHECK((c_senderDependent & ~c_stateStage) == Check::None);
+    // Every check that needs the ACCOUNT lives in the state stage: that is what lets verify()
+    // read it once, before the stage, and only when the set contains one of them.
+    BOOST_CHECK((c_accountStateDependent & ~c_stateStage) == Check::None);
+    // Sender-dependent is the wider set: it also covers the pool rule keyed on (sender, nonce),
+    // which needs the recovered address but no account read. Both live after the gate, since the
+    // sender does not exist until the signature check has run.
+    BOOST_CHECK(contains(c_senderDependent, Check::Web3PoolNonce));
+    BOOST_CHECK(!contains(c_accountStateDependent, Check::Web3PoolNonce));
+    BOOST_CHECK((c_senderDependent & ~(c_stateStage | c_poolStage)) == Check::None);
     // A BCOS transaction has no state-stage check in any context, so it never reads the chain;
     // a Web3 proposal has state-stage checks but no sender-dependent one, so it reads the chain
     // view and not the account.
@@ -225,8 +232,8 @@ BOOST_AUTO_TEST_CASE(typeGateIsEvaluatedFirstAndSignatureBeforeAccountState)
         return std::distance(c_checkOrder.begin(), std::ranges::find(c_checkOrder, target));
     };
     const auto signature = indexOf(Check::Signature);
-    for (auto dependent :
-        {Check::SenderIsEOA, Check::NonceNotMax, Check::Web3NonceWindow, Check::Balance})
+    for (auto dependent : {Check::SenderIsEOA, Check::NonceNotMax, Check::Web3NonceWindow,
+             Check::Balance, Check::Web3PoolNonce})
     {
         BOOST_CHECK_MESSAGE(
             signature < indexOf(dependent), "sender-dependent check ordered before Signature");
@@ -286,11 +293,11 @@ BOOST_AUTO_TEST_CASE(proposalVerificationKeepsProtocolInvariants)
 
     // The same table read the other way: what comes off, per kind, is exactly the node-local
     // set and nothing else. Balance depends on where in the block a transaction sits;
-    // SenderIsEOA and NonceNotMax are execution-enforced account reads; Web3NonceWindow and
-    // BcosPoolNonce consult node-local caches on which two honest nodes can disagree -- and on
-    // this path a disagreement is a view change, not a dropped transaction.
+    // SenderIsEOA and NonceNotMax are execution-enforced account reads; Web3NonceWindow and the
+    // two pending-nonce rules consult node-local state on which two honest nodes can disagree --
+    // and on this path a disagreement is a view change, not a dropped transaction.
     constexpr auto nodeLocal = Check::Balance | Check::SenderIsEOA | Check::NonceNotMax |
-                               Check::Web3NonceWindow | Check::BcosPoolNonce;
+                               Check::Web3NonceWindow | Check::BcosPoolNonce | Check::Web3PoolNonce;
     for (auto kind : kKinds)
     {
         const auto pool = checkSet(kind, AdmissionContext::PoolAdmission);

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -335,6 +335,34 @@ BOOST_AUTO_TEST_CASE(FIB58_NonceNormalizationDetectsDuplicates)
         task::syncWait(checker.checkWeb3Nonce(sender2, "0x10")), TransactionStatus::NonceCheckFail);
 }
 
+// existsMemoryNonce is the reservation lookup on its own: the same answer checkWeb3Nonce's
+// memory half gives, over the same value-keyed entries, and NOTHING else. The admission layer
+// applies the ledger window itself (Check::Web3NonceWindow), so a checker that also answered
+// "outside the window" here would make that check run twice and report through two paths.
+BOOST_AUTO_TEST_CASE(existsMemoryNonceAnswersTheReservationOnly)
+{
+    const std::string sender = Address::generateRandomFixedBytes().toRawString();
+    BOOST_CHECK(!task::syncWait(checker.existsMemoryNonce(sender, "0x1")));
+
+    task::syncWait(checker.insertMemoryNonce(sender, "0x1"));
+    BOOST_CHECK(task::syncWait(checker.existsMemoryNonce(sender, "0x1")));
+    // Same value, three spellings, one entry (FIB-58).
+    BOOST_CHECK(task::syncWait(checker.existsMemoryNonce(sender, "0x01")));
+    BOOST_CHECK(task::syncWait(checker.existsMemoryNonce(sender, "1")));
+    BOOST_CHECK(!task::syncWait(checker.existsMemoryNonce(sender, "0x2")));
+
+    // Another sender's pending nonce is not this sender's: the key is the pair.
+    const std::string other = Address::generateRandomFixedBytes().toRawString();
+    BOOST_CHECK(!task::syncWait(checker.existsMemoryNonce(other, "0x1")));
+
+    // A nonce nowhere near the committed window is still "not reserved" -- that verdict belongs
+    // to the window check, not here. The committed nonce has to be seeded for this to say
+    // anything: with none, checkWeb3Nonce's storage miss makes it decline to judge too, and an
+    // implementation that consulted the window would pass this case by accident.
+    checker.insert(sender, u256(0));
+    BOOST_CHECK(!task::syncWait(checker.existsMemoryNonce(sender, "0xfffffff")));
+}
+
 BOOST_AUTO_TEST_CASE(FIB59_CacheHitSkipsLedgerQuery)
 {
     // FIB-59: After checking m_ledgerStateNonces, the code unconditionally queried storage


### PR DESCRIPTION
### What

The admission decision itself: `TxValidator::verify()`.

Third of three PRs building the admission layer. #5501, #5525 and #5526 have all merged, so this is now a single commit of seven files on top of `release-3.18.0`: the validator, its test, the `LedgerConfigState` holder, and two small additions to `Web3NonceChecker` and `FakeLedger`. **No caller is wired up**, so nothing changes at runtime yet.

### How it works

`verify()` runs the check set for (kind, context, policy) in three stages, and a stage's inputs are read once, before its first check, never per check:

- **gate** reads the transaction alone: `TypeGate`, `ToFieldFormat`, `Signature`, `BcosGroupChainId`. A forged signature or a refused envelope type is rejected without a single read, which is what keeps unauthenticated P2P input cheap to refuse.
- **state** is evmone's `validate_transaction` sequence, in its order, judged against one `ChainView` — the `LedgerConfigState` snapshot, with the EVM revision, the base fee (`tx_gas_price`) and the chain id (`web3_chain_id`) derived from it, no storage read — and, only when the set contains a sender-dependent check, one account read.
- **pool** is the two BCOS nonce checkers.

Per (kind, context) that is exactly what the routing table implies: a BCOS transaction reads nothing, a Web3 proposal takes the chain view (a pointer copy), a Web3 admission takes the chain view and reads the account. The one conditional is the account read, decided by `c_senderDependent`, a constant the table already had.

Each stage has its own registry and input type (`Envelope`, `StateInputs`, `PoolInputs`), so a check's parameter type is its stage: a gate check cannot read the chain, a state check cannot reach the pool, and the compiler says so. `static_assert`s tie each registry to its order array in `CheckSet.h` by membership and by sequence, so adding a check without ordering it, or ordering it in the wrong stage, fails to compile.

### One call that looks defensive and is not

`checkSignature` calls `clearSenderAndHash()` before `verify()`. That call is load-bearing, and dropping it as redundant — which an earlier revision of this PR did — reopens a signature-binding bypass.

It clears two things, and only one is the sender. For a BCOS transaction, `TarsHashable.h` returns a non-empty `dataHash` **verbatim** rather than recomputing it, so `calculateHash()` inside `verify()` is a no-op and signature recovery runs against a hash the sender chose. Take any `(hash, signature)` pair from a victim's broadcast transaction, attach it to a body of your own, and admission recovers the victim as the sender — the subsequent group/chain-id and nonce checks read the attacker's own fields and cannot catch it. It also clears the `tainted` flag, without which `verify()` early-returns and skips verification entirely.

`AdmitTest` pins this with a forged-`dataHash` case that fails without the call and passes with it.

The cost is one signature recovery per transaction on the sync path, since the check is no longer idempotent. The pool-side validator this replaces paid the same cost for the same reason.

### It owns its dependencies

The validator holds the nonce checkers directly — the ones #5522 moved into this module — instead of reaching them through callbacks the caller supplies. Nonce admission is the same question at every ingress, and routing it through a per-caller hook is how the pool and the RPC layer came to disagree about it in the first place.

Account state is read here too: from the scheduler's pending plane when one is bound, from the committed ledger otherwise.

Two dependencies are bound after construction because they do not exist when the pools are built — `setLedgerNonceChecker()` needs the chain's block limit, `setScheduler()` needs a scheduler.

### Chain configuration is a snapshot

New: `bcos-framework/ledger/LedgerConfigState.h`. `get()` returns the configuration current at that instant and nothing mutates it afterwards; `set()` publishes a new one at commit. A reader racing a commit sees one block's configuration or the next, complete either way, and never blocks for longer than a pointer copy.

Worth flagging because neither existing holder has that property: `executor::LedgerCache` mutates `*m_ledgerConfig` in place while `ledgerConfig()` hands out a reference to that same object, with no lock on the config at all; `scheduler::SchedulerImpl` assigns the pointer, which is the right shape, but non-atomically. Folding those two in is a separate change — this PR only adds the holder and reads through it.

The snapshot is the **only** chain configuration admission reads: the chain id and the base fee come from it too (round 3 below), so `verify()` never touches `SYS_CONFIG`. The obligation that creates is stated on the holder: an empty one has no chain id and the chain-id check fails closed on it, so whoever owns the holder publishes at startup and after every commit. #5535, which owns it, does both.

### Known gap, stated rather than hidden

`readAccountState` leaves `code` empty, so `Check::SenderIsEOA` (EIP-3607) does not fire at admission.

The field **is** reachable from here: `ACCOUNT_TABLE_FIELDS::CODE_HASH` goes through the same `getPendingStorageAt` coroutine already used for `BALANCE`. (An earlier revision of this PR claimed `SchedulerInterface::getCode` was the only route and would deadlock; that was wrong, and the comment saying so has been removed.)

It is left undone because `codeHash` alone is not sufficient and would be actively wrong. An EIP-7702 delegated account has non-empty code and is still an EOA, so rejecting on `codeHash != EMPTY_CODE_HASH` would refuse transactions the executor accepts — admission **stricter** than execution, the one failure this module exists to prevent. Doing it correctly needs the code bytes to test the `0xef0100` delegation prefix, i.e. a second read on the rare non-empty-`codeHash` path. That is a behaviour change and belongs in its own commit.

Execution still enforces EIP-3607, so this is a missed early rejection, not a hole. The check and its test are kept: the rule is correct and starts working the moment this function fills the field.

### Follow-ups

Two wiring PRs, one per transaction pool. They touch disjoint file sets and can be reviewed and merged in either order once this lands.

### Test

`AdmitTest`, 29 cases (the whole `test-bcos-tx-validator` binary runs 61). The admission tests seed the fake ledger and read back through the validator's own path, so they exercise `readAccountState` and `Web3NonceChecker` rather than stand-ins for them.

Local run on this commit: full build clean (0 errors); `test-bcos-tx-validator` (61 cases), `test-bcos-tars-protocol`, `test-bcos-txpool`, `test-bcos-rpc`, `test-bcos-protocol`, `test-bcos-ledger`, `test-bcos-sync`, `test-bcos-pbft`, `test-sealer` and `test-transaction-scheduler` all report `No errors detected`. Two negative controls were run: the forged-`dataHash` case fails without `clearSenderAndHash()`, and the 256-bit wraparound case fails when `checkBalance` is reverted to `u256`. `TxValidator.cpp` and `Web3NonceChecker.cpp` were additionally compiled under GCC 16 with `-Wall -Wextra -pedantic`, since the CI Linux jobs use g++ and clang does not diagnose the same set: 32 diagnostics appear, all of them from pre-existing framework headers (`LedgerInterface.h`, `StorageInterface.h`, `BlockHeader.h`, `SchedulerInterface.h`, `ThreeWay4Apple.h`) and none from the files this PR adds.


---

---

### Rebased 2026-09-01 (after #5501 and #5525 merged)

Both dependencies landed, so their commits left this branch:

- #5501 took `TransactionStatus.h`, `Normalize.cpp/h` and `NormalizeTest.cpp`,
  along with the status-code renumbering against #5520 that this PR used to
  describe.
- #5525 took `TxGasModel.h`, `TxGasModelTest.cpp`, `EVMSupport.h` and
  `EthereumTransition.h`.

Total: **3578 → 2332 lines**, 13 files → 9. What remains is the validator
itself, plus #5526's two-file copy.

Both rebases were verified lossless rather than assumed: every file that
differed between the pre- and post-rebase trees came from upstream, and none of
this branch's own files moved a byte. Before dropping #5525's four files, each
was checked byte-identical against what actually landed on `release-3.18.0`.

History is now two commits — the routing table, then the validator — rather than
the six that accumulated during review.

### Rebased 2026-09-02 (after #5526 merged)

#5526 landed as `a571566e5`, so its two-file copy left this branch: **2332 → 1886 lines**, 9 files → 7, history one commit (`b72b682d3`). Verified lossless: `git diff` between the pre- and post-rebase trees restricted to `bcos-tx-validator/` is empty, and the only file both upstream and this branch touched since the previous base (`libinitializer/Initializer.cpp`, via #5535's commits below it) has the two sides' hunks in different functions.

The round-1 review changes from #5526 that live in this PR's commit — `checkBcosPoolNonce` split into pool/ledger halves with no context branch, `checkTypeGate` as an allow-list, registry order following the corrected `c_checkOrder`, `AdmitTest::bcosPendingNonceRejectsAdmissionButNotProposals` — are unchanged by the rebase.

### Review round 2 (2026-09-02): `b72b682d3` → second commit `a81d852f6`

The first version resolved inputs per check -- a `Need` bitmask on every registry row, a resolved/missing ledger inside the evaluation loop, six conditionals deciding what to fetch before each check -- a second dispatch mechanism beside the table, carrying a special case (a nonce-only read for proposal verification) the table had already made unreachable. Replaced by the three-stage structure described under "How it works"; `TxValidator.cpp` is 51 lines shorter and `Need` is gone.

Two findings from my own read-through of this PR ride along in the same commit:

- The system-transaction mark used to be set inside the signature check, so `SignaturePolicy::Disabled` switched it off; the pool-side validator set it on the proposal path regardless. It is now set in `verify()` before the stages, and `AdmitTest::systemTransactionIsMarkedRegardlessOfSignaturePolicy` pins it.
- The "nullopt = account does not exist" note on the sender state described a value `readAccountState` never returned. The optional now means "not fetched for this set", which is what it is.

New pins: `CheckSetTest::stagesPartitionTheEvaluationOrder` (each check in exactly one stage, the three back to back are `c_checkOrder`, every sender-dependent check in the state stage, BCOS with no state-stage check in any context) and `AdmitTest::aRejectionAtTheGateReadsNoAccountState`.

### Review round 3 (2026-09-03): third commit `7676fc11d`

Reviewer question on `readChainView`: why fetch `tx_gas_price` and `web3_chain_id` through `getSystemConfig` when `LedgerConfig` already carries both?

It should not have. The object `LedgerConfigState` publishes is the one `ledger::getLedgerConfig` builds, and that fills `gasPrice()` (`LedgerMethods.cpp:440`) and `chainId()` (`:493`) from the same two `SYS_CONFIG` rows, under the same effective-block rule (`fetchAllSystemConfigs(blockNumber + 1)` against `asyncGetSystemConfigByKey`'s `blockNumber + 1` gate). The two reads were carried over from the validators this module replaces (`bcos-rpc/validator/TxValidator.cpp:67`, `EthEndpoint.cpp:796`), not chosen: two storage round trips per Web3 transaction on the RPC hot path, each preceded by an `asyncGetBlockNumber`, for values the snapshot already had.

`ChainView` now derives `baseFee` and `web3ChainId` from the snapshot, `readChainView` is a plain function, and the state stage performs no ledger read. Verdicts do not move: an unset `tx_gas_price` reaches the snapshot as `getLedgerConfig`'s `"0x0"` default, which the checks already read as free gas; genesis has written a `web3_chain_id` row since 3.9 (`Ledger.cpp:2565`), so on any chain that carries Web3 transactions both paths compared against the same row. Only a chain without the row changes, from refusing a claim of chain 0 to comparing against 0, which is the rule the executor's `CHAINID` already applies (`LedgerCache.h:121`).

What does change is the empty holder: it has no chain id, and the chain-id check fails closed on that. `LedgerConfigState.h` now states the owner's obligation (publish at startup and after every commit); the startup publish is in #5535's new commit.

Tests: `AdmitTest` seeds the snapshot instead of the fake ledger's `SYS_CONFIG` map; `missingChainIdConfigRejectsRatherThanSkips` models the unpublished holder; new `admissionReadsNoSystemConfig` runs a full pool admission against a ledger whose `SYS_CONFIG` reads throw. Negative control: with the previous `readChainView` swapped back in, that case fails with `std::runtime_error: SYS_CONFIG must not be read at admission`. `test-bcos-tx-validator` 67 cases green (`AdmitTest` 33); `TxValidator.cpp` and `AdmitTest.cpp` clean under GCC 16 `-Wall -Wextra -pedantic`.

### Review round 3b (2026-09-04): fourth commit `54d5d21ca`

ywy2090's three blocking items and morebtcg's inline notes, answered in the threads; the code changes:

- **EIP-2 low-s is enforced here.** `checkSignature` stopped after recovery; the pool-side validator this module replaces applied EIP-2 after recovery, and that is the only place a tars-form Web3 transaction from a peer meets the rule (the raw-bytes decode on the RPC ingress is not on that path). The block was in the stack — #5535 added it in its wiring commit, since that PR deletes the pool's copy — but a validator that claims to replace the pool's must carry it on its own. It now lives here; #5535 no longer touches `checkSignature`. `AdmitTest::highSSignatureIsRejected` builds the twin (`s' = n - s`) and pins `InvalidSignature`; with the block removed, recovery succeeds on the twin and the case fails at the balance check as the twin's sender (verified).
- **Every kind goes through `verify()`.** `TxSpec.type` was never set off EIP-1559 and `withAuthorization` had no caller, so Legacy, AccessList and SetCode never ran through this suite, nor did `TipNotAboveCap`, `SetCodeHasTo`, `AuthListNonEmpty`, a `ToFieldFormat` failure or a blob/deposit envelope. Nine cases now do, each asserting the production status. Blob and deposit are refused by normalization before the table is consulted (`BlobTxNotAllowed`, `TxTypeNotSupported`); `Check::TypeGate`'s `Rejected` arm is the second line behind it, and the case says so.
- **Web3 in-pool nonce uniqueness is not added to `verify()`**, because it is enforced one step later and atomically: `MemoryStorage` reserves the (sender, nonce) pair at insert through `insertMemoryNonce` (`storage2::insertIfAbsent`), and a duplicate gets `NonceCheckFail` — the same verdict as the live `checkWeb3Nonce`, without its check-then-insert window. The asymmetry with `BcosPoolNonce` is real and is cost, not correctness; the thread has the details.
- Smaller: a `static_assert` that `NonceNotMax` precedes `Web3NonceWindow` (the window adds the queue limit to the account nonce in unchecked `u256`; safe only because `NonceNotMax` refused anything at or above 2^64 − 1 first); `LedgerConfigState` stores and accepts `shared_ptr<const LedgerConfig>`; the `SignaturePolicy` and `TxKind` docs say what the code does; `TxValidator.h` includes what it uses.

`test-bcos-tx-validator` 76 cases green (`AdmitTest` 42); `TxValidator.cpp`, `AdmitTest.cpp` and `CheckSetTest.cpp` clean under GCC 16. check-commit: 481 valid lines.
