### PR TITLE
fix(executor): key the analyzed-code cache by code hash, not by address

### DIFF
--- a/bcos-executor/src/precompiled/common/Utilities.h
+++ b/bcos-executor/src/precompiled/common/Utilities.h
@@ -99,6 +99,27 @@ inline bool isDynamicPrecompiledAccountCode(const std::string_view& _code)
     return getDynamicPrecompiledCodeString(ACCOUNT_ADDRESS, "") == _code;
 }
 
+// An account that only holds a balance is materialised as a dynamic account
+// precompiled: its stored "code" is the marker above, an internal dispatch token
+// rather than bytecode. Ethereum semantics expect an externally owned account to
+// have no code, so the marker must not reach EXTCODESIZE / EXTCODECOPY /
+// EXTCODEHASH / getCode. The legacy executor already hides it (see
+// bcos-executor/src/vm/HostContext.cpp externalCodeRequest and
+// TransactionExecutor::getCode); executor v1 does so under
+// bugfix_v1_eoa_as_contract.
+//
+// The flag is deliberately its own: bugfix_eoa_as_contract and
+// bugfix_eoa_match_failed have been on since 3.8 / 3.9, while executor v1 has
+// been committing blocks with the marker visible, so reusing them would change
+// how existing history replays. Callers on the code-reading path share this
+// predicate; the dispatch path (getExecutable -> processDynamicPrecompiled) must
+// NOT use it, it consumes the same marker to route the call.
+inline bool hideDynamicAccountCode(const ledger::Features& _features, std::string_view _code)
+{
+    return _features.get(ledger::Features::Flag::bugfix_v1_eoa_as_contract) &&
+           matchDynamicAccountCode(_code);
+}
+
 inline std::string& trimHexPrefix(std::string& _hex)
 {
     if (_hex.size() >= 2 && (_hex.starts_with("0x") || _hex.starts_with("0X")))

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -48,12 +48,11 @@ public:
         return h256((const bcos::byte*)view.data(), view.size());
     }
 
-    // 用已经读出来的code hash条目取代码，避免重复读codeHash字段
+    // 用已经读出来的code hash条目取代码，避免重复读codeHash字段；账户没有code hash时传nullptr
     // Resolve the code for an already-read code hash entry. Callers that need both the hash and
     // the code read the entry once with codeHashEntry() and pass it here, instead of calling
-    // code(), which reads that field again.
-    task::Task<std::optional<storage::Entry>> code(
-        const std::optional<storage::Entry>& codeHashEntry)
+    // code(), which reads that field again. Pass nullptr when the account records no code hash.
+    task::Task<std::optional<storage::Entry>> code(const storage::Entry* codeHashEntry)
     {
         // 先通过code hash从s_code_binary找代码
         // Start by using the code hash to find the code from the s_code_binary
@@ -80,7 +79,8 @@ public:
 
     task::Task<std::optional<storage::Entry>> code()
     {
-        co_return co_await code(co_await codeHashEntry());
+        auto entry = co_await codeHashEntry();
+        co_return co_await code(entry ? &*entry : nullptr);
     }
 
     task::Task<void> setCode(bytes code, std::string abi, const crypto::HashType& codeHash)

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -36,12 +36,28 @@ public:
             storage::Entry{std::string_view{"value"}});
     }
 
-    task::Task<std::optional<storage::Entry>> code()
+    task::Task<std::optional<storage::Entry>> codeHashEntry()
+    {
+        co_return co_await storage2::readOne(m_storage.get(),
+            executor_v1::StateKeyView{m_tableName, ACCOUNT_TABLE_FIELDS::CODE_HASH});
+    }
+
+    static h256 toCodeHash(const storage::Entry& entry)
+    {
+        auto view = entry.get();
+        return h256((const bcos::byte*)view.data(), view.size());
+    }
+
+    // 用已经读出来的code hash条目取代码，避免重复读codeHash字段
+    // Resolve the code for an already-read code hash entry. Callers that need both the hash and
+    // the code read the entry once with codeHashEntry() and pass it here, instead of calling
+    // code(), which reads that field again.
+    task::Task<std::optional<storage::Entry>> code(
+        const std::optional<storage::Entry>& codeHashEntry)
     {
         // 先通过code hash从s_code_binary找代码
         // Start by using the code hash to find the code from the s_code_binary
-        if (auto codeHashEntry = co_await storage2::readOne(m_storage.get(),
-                executor_v1::StateKeyView{m_tableName, ACCOUNT_TABLE_FIELDS::CODE_HASH}))
+        if (codeHashEntry)
         {
             if (auto codeEntry = co_await storage2::readOne(m_storage.get(),
                     executor_v1::StateKeyView{ledger::SYS_CODE_BINARY, codeHashEntry->get()}))
@@ -60,6 +76,11 @@ public:
             co_return codeEntry;
         }
         co_return {};
+    }
+
+    task::Task<std::optional<storage::Entry>> code()
+    {
+        co_return co_await code(co_await codeHashEntry());
     }
 
     task::Task<void> setCode(bytes code, std::string abi, const crypto::HashType& codeHash)
@@ -89,12 +110,9 @@ public:
 
     task::Task<h256> codeHash()
     {
-        if (auto codeHashEntry = co_await storage2::readOne(m_storage.get(),
-                executor_v1::StateKeyView{m_tableName, ACCOUNT_TABLE_FIELDS::CODE_HASH}))
+        if (auto entry = co_await codeHashEntry())
         {
-            auto view = codeHashEntry->get();
-            h256 codeHash((const bcos::byte*)view.data(), view.size());
-            co_return codeHash;
+            co_return toCodeHash(*entry);
         }
         co_return {};
     }

--- a/bcos-framework/bcos-framework/ledger/Features.cpp
+++ b/bcos-framework/bcos-framework/ledger/Features.cpp
@@ -195,15 +195,18 @@ void Features::setUpgradeFeatures(
                     Flag::bugfix_v1_timestamp}},
             {.to = protocol::BlockVersion::V3_16_4_VERSION, .flags = {Flag::bugfix_revert_logs}},
             {.to = protocol::BlockVersion::V3_17_0_VERSION,
-                .flags = {
-                    Flag::bugfix_auth_check,
-                    Flag::bugfix_v1_error_handling,
-                    Flag::bugfix_gas_payment_balance_precheck,
-                    Flag::bugfix_precompiled_feature_gate,
-                    Flag::bugfix_evm_storage_status,
-                    Flag::bugfix_statestorage_hash_v3_17,
-                    Flag::bugfix_nonce_ordering,
-                }}});
+                .flags =
+                    {
+                        Flag::bugfix_auth_check,
+                        Flag::bugfix_v1_error_handling,
+                        Flag::bugfix_gas_payment_balance_precheck,
+                        Flag::bugfix_precompiled_feature_gate,
+                        Flag::bugfix_evm_storage_status,
+                        Flag::bugfix_statestorage_hash_v3_17,
+                        Flag::bugfix_nonce_ordering,
+                    }},
+            {.to = protocol::BlockVersion::V3_17_1_VERSION,
+                .flags = {Flag::bugfix_v1_eoa_as_contract}}});
     for (const auto& upgradeFeatures : upgradeRoadmap)
     {
         if (((toVersion < protocol::BlockVersion::V3_2_7_VERSION) &&

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -84,7 +84,10 @@ public:
         bugfix_precompiled_feature_gate,      // FIB-84
         bugfix_evm_storage_status,            // FIB-94
         bugfix_statestorage_hash_v3_17,       // FIB-99/105
-        bugfix_nonce_ordering,  // web3 EOA nonce must be independent of intra-block tx order
+        bugfix_nonce_ordering,      // web3 EOA nonce must be independent of intra-block tx order
+        bugfix_v1_eoa_as_contract,  // executor v1: hide the dynamic account-precompiled marker from
+                                    // EXTCODESIZE / EXTCODECOPY / EXTCODEHASH / getCode, the way
+                                    // bugfix_eoa_as_contract already does in the legacy executor
         feature_dmc2serial,
         feature_sharding,
         feature_rpbft,

--- a/bcos-framework/bcos-framework/protocol/Protocol.h
+++ b/bcos-framework/bcos-framework/protocol/Protocol.h
@@ -113,6 +113,7 @@ enum ProtocolVersion : uint32_t
 
 enum class BlockVersion : uint32_t
 {
+    V3_17_1_VERSION = 0x03110100,  // 3.17.1
     V3_17_0_VERSION = 0x03110000,  // 3.17.0
     V3_16_5_VERSION = 0x03100500,  // 3.16.5
     V3_16_4_VERSION = 0x03100400,  // 3.16.4
@@ -159,7 +160,7 @@ enum class BlockVersion : uint32_t
     V3_0_VERSION = 0x03000000,
     RC4_VERSION = 4,
     MIN_VERSION = RC4_VERSION,
-    MAX_VERSION = V3_17_0_VERSION,
+    MAX_VERSION = V3_17_1_VERSION,
 };
 
 enum class TransactionVersion : uint32_t

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -185,6 +185,7 @@ BOOST_AUTO_TEST_CASE(feature)
         "bugfix_evm_storage_status",
         "bugfix_statestorage_hash_v3_17",
         "bugfix_nonce_ordering",
+        "bugfix_v1_eoa_as_contract",
         "feature_dmc2serial",
         "feature_sharding",
         "feature_rpbft",
@@ -574,6 +575,16 @@ BOOST_AUTO_TEST_CASE(genesis)
     {
         BOOST_CHECK(features3_17_0.get(feature));
     }
+
+    // 3.17.1: everything in 3.17.0 plus the executor-v1 EOA code filter. The
+    // filter changes EXTCODESIZE / EXTCODEHASH / getCode, so it must stay off at
+    // 3.17.0 and below, where blocks were already committed without it.
+    Features features3_17_1;
+    features3_17_1.setGenesisFeatures(bcos::protocol::BlockVersion::V3_17_1_VERSION);
+    BOOST_CHECK_EQUAL(
+        validFlags(features3_17_1).size(), expect3_16_5.size() + extra3_17_0.size() + 1);
+    BOOST_CHECK(features3_17_1.get("bugfix_v1_eoa_as_contract"));
+    BOOST_CHECK(!features3_17_0.get("bugfix_v1_eoa_as_contract"));
 }
 
 

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
@@ -71,8 +71,13 @@ bcos::executor_v1::hostcontext::getCacheExecutables()
 
         CacheExecutables()
         {
+            // The LRU charges getSize(key) + getSize(value) per entry, so budget
+            // for both; otherwise the cache holds fewer entries than intended.
+            // This is a per-bucket ceiling, and a CONCURRENT storage has
+            // hardware_concurrency() * 2 + 1 buckets.
             constexpr static auto maxContracts = 100;
-            m_cachedExecutables.setMaxCapacity(sizeof(std::shared_ptr<Executable>) * maxContracts);
+            m_cachedExecutables.setMaxCapacity(
+                (sizeof(ExecutableKey) + sizeof(std::shared_ptr<Executable>)) * maxContracts);
         }
     } static cachedExecutables;
 

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -160,8 +160,7 @@ task::Task<std::shared_ptr<Executable>> getExecutable(
     // On a miss the bytes come back through the account: EVMAccount::code()
     // reads s_code_binary by hash and falls back to the account table's own
     // code field when that misses.
-    std::optional<storage::Entry> hashEntry(codeHashEntry);
-    if (auto codeEntry = co_await account.code(hashEntry))
+    if (auto codeEntry = co_await account.code(&codeHashEntry))
     {
         auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
         co_await storage2::writeOne(getCacheExecutables(), key, executable);
@@ -200,7 +199,7 @@ task::Task<std::shared_ptr<Executable>> resolveExecutable(
     // produced any more, but EVMAccount::code() still falls back to it and this
     // branch keeps that reachable. Either way there is nothing content-addressed
     // to key the cache on, so no entry is published.
-    if (auto codeEntry = co_await account.code(std::nullopt))
+    if (auto codeEntry = co_await account.code(nullptr))
     {
         co_return std::make_shared<Executable>(std::move(*codeEntry), revision);
     }
@@ -403,7 +402,7 @@ public:
     {
         auto account = getAccount(*this, address);
         auto codeHashEntry = co_await account.codeHashEntry();
-        if (auto codeEntry = co_await account.code(codeHashEntry);
+        if (auto codeEntry = co_await account.code(codeHashEntry ? &*codeHashEntry : nullptr);
             codeEntry &&
             !precompiled::hideDynamicAccountCode(m_ledgerConfig.get().features(), codeEntry->get()))
         {
@@ -445,7 +444,7 @@ public:
         // bytes are never read.
         if (m_ledgerConfig.get().features().get(ledger::Features::Flag::bugfix_v1_eoa_as_contract))
         {
-            auto codeEntry = co_await account.code(codeHashEntry);
+            auto codeEntry = co_await account.code(codeHashEntry ? &*codeHashEntry : nullptr);
             if (!codeEntry || precompiled::hideDynamicAccountCode(
                                   m_ledgerConfig.get().features(), codeEntry->get()))
             {

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -29,6 +29,7 @@
 #include "bcos-codec/abi/ContractABICodec.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
 #include "bcos-executor/src/Common.h"
+#include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/Ledger.h"
@@ -368,7 +369,9 @@ public:
         if (auto executable = co_await getExecutable(m_rollbackableStorage.get(), address,
                 m_revision,
                 m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
-            executable && executable->m_code)
+            executable && executable->m_code &&
+            !precompiled::hideDynamicAccountCode(
+                m_ledgerConfig.get().features(), executable->m_code->get()))
         {
             co_return executable->m_code;
         }
@@ -392,6 +395,16 @@ public:
 
     task::Task<h256> codeHashAt(const evmc_address& address, auto&&... /*unused*/)
     {
+        // Resolve through the same filtered path codeSizeAt uses, so EXTCODESIZE
+        // and EXTCODEHASH cannot disagree within one execution. code() also
+        // returns empty when the account records a code hash whose bytes are
+        // missing, and that case must report a zero hash too.
+        if (m_ledgerConfig.get().features().get(
+                ledger::Features::Flag::bugfix_v1_eoa_as_contract) &&
+            !co_await code(address))
+        {
+            co_return {};
+        }
         Account<Storage> account(m_rollbackableStorage.get(), address,
             m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
         co_return co_await account.codeHash();

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -176,6 +176,12 @@ task::Task<std::shared_ptr<Executable>> getExecutable(
 // address hold - and reads it from `storage` on every call, so nothing that
 // depends on the view can reach the cache. It also owns the uncached branch for
 // accounts that record no code hash.
+//
+// executeCall is the only production caller: it is about to run the bytecode,
+// so the analysis it pays for is used. The EXTCODE* family reads the bytes
+// straight off the account instead (see HostContext::code below) and analyzes
+// nothing. prepareCreate also builds an Executable, but from the deploy init
+// code it holds in hand, without going through the cache.
 task::Task<std::shared_ptr<Executable>> resolveExecutable(
     auto& storage, const evmc_address& address, evmc_revision revision, bool binaryAddress)
 {
@@ -382,17 +388,26 @@ public:
             m_rollbackableTransientStorage.get(), std::move(stateKey), std::move(valueEntry));
     }
 
+    // EXTCODECOPY and EXTCODESIZE want the bytes, not an analysis, so this reads
+    // them off the account and stops there. Going through resolveExecutable
+    // would run evmone::baseline::analyze() over bytecode nobody is about to
+    // execute and take an LRU slot for it - once per balance-only account,
+    // whose marker string embeds its own table name and so never shares a slot
+    // with anything.
+    //
+    // EVMAccount::code() keeps the two-step read this used to inherit: the
+    // s_code_binary lookup by hash, falling back to the account table's own
+    // code field.
     task::Task<std::optional<storage::Entry>> code(
         const evmc_address& address, auto&&... /*unused*/)
     {
-        if (auto executable = co_await resolveExecutable(m_rollbackableStorage.get(), address,
-                m_revision,
-                m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
-            executable && executable->m_code &&
-            !precompiled::hideDynamicAccountCode(
-                m_ledgerConfig.get().features(), executable->m_code->get()))
+        auto account = getAccount(*this, address);
+        auto codeHashEntry = co_await account.codeHashEntry();
+        if (auto codeEntry = co_await account.code(codeHashEntry);
+            codeEntry &&
+            !precompiled::hideDynamicAccountCode(m_ledgerConfig.get().features(), codeEntry->get()))
         {
-            co_return executable->m_code;
+            co_return codeEntry;
         }
         co_return {};
     }
@@ -414,9 +429,7 @@ public:
 
     task::Task<h256> codeHashAt(const evmc_address& address, auto&&... /*unused*/)
     {
-        using AccountType = Account<Storage>;
-        AccountType account(m_rollbackableStorage.get(), address,
-            m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
+        auto account = getAccount(*this, address);
         auto codeHashEntry = co_await account.codeHashEntry();
         if (!codeHashEntry)
         {
@@ -426,18 +439,20 @@ public:
         // Apply the same filter code() applies, so EXTCODESIZE and EXTCODEHASH
         // cannot disagree within one execution: an account whose code is hidden
         // reads as codeless and must hash as zero too, and so must one that
-        // records a code hash whose bytes are missing.
+        // records a code hash whose bytes are missing. Deciding that needs the
+        // bytes and nothing more, so this reads them without analyzing them.
+        // With the feature off the hash entry alone answers the opcode and the
+        // bytes are never read.
         if (m_ledgerConfig.get().features().get(ledger::Features::Flag::bugfix_v1_eoa_as_contract))
         {
-            auto executable = co_await getExecutable(account, *codeHashEntry, m_revision);
-            if (!executable || !executable->m_code ||
-                precompiled::hideDynamicAccountCode(
-                    m_ledgerConfig.get().features(), executable->m_code->get()))
+            auto codeEntry = co_await account.code(codeHashEntry);
+            if (!codeEntry || precompiled::hideDynamicAccountCode(
+                                  m_ledgerConfig.get().features(), codeEntry->get()))
             {
                 co_return {};
             }
         }
-        co_return AccountType::toCodeHash(*codeHashEntry);
+        co_return decltype(account)::toCodeHash(*codeHashEntry);
     }
 
     task::Task<bool> exists([[maybe_unused]] const evmc_address& address, auto&&... /*unused*/)

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -45,6 +45,7 @@
 #include "bcos-transaction-executor/EVMCResult.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include "bcos-utilities/FixedBytes.h"
 #include <bcos-task/Wait.h>
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>
@@ -53,6 +54,7 @@
 #include <boost/algorithm/hex.hpp>
 #include <boost/concept_archetype.hpp>
 #include <boost/exception/diagnostic_information.hpp>
+#include <boost/functional/hash.hpp>
 #include <boost/multiprecision/cpp_int/import_export.hpp>
 #include <boost/throw_exception.hpp>
 #include <functional>
@@ -91,27 +93,90 @@ struct Executable
 template <class Storage>
 using Account = ledger::account::EVMAccount<Storage>;
 
+// Key of the analyzed-code cache. It must name everything the cached
+// Executable depends on, and nothing that depends on the storage view:
+//   - codeHash identifies the bytecode itself. Code is content-addressed in
+//     storage (the account table holds a code hash, s_code_binary holds the
+//     bytes keyed by that hash), so the same hash always means the same bytes.
+//   - revision selects the analysis, because evmone::baseline::analyze() builds
+//     a revision-specific CodeAnalysis (see VMFactory::create).
+// The account address is deliberately NOT part of the key: "which code does
+// this address hold" is view-dependent state and must be read from the storage
+// view on every call.
+struct ExecutableKey
+{
+    h256 codeHash;
+    evmc_revision revision{};
+
+    friend bool operator==(const ExecutableKey& lhs, const ExecutableKey& rhs) noexcept = default;
+};
+
+struct ExecutableKeyHash
+{
+    size_t operator()(const ExecutableKey& key) const noexcept
+    {
+        size_t seed = std::hash<h256>{}(key.codeHash);
+        boost::hash_combine(seed, static_cast<int>(key.revision));
+        return seed;
+    }
+};
+
 using CacheExecutables =
-    storage2::memory_storage::MemoryStorage<evmc_address, std::shared_ptr<Executable>,
+    storage2::memory_storage::MemoryStorage<ExecutableKey, std::shared_ptr<Executable>,
         storage2::memory_storage::Attribute(
             storage2::memory_storage::LRU | storage2::memory_storage::CONCURRENT),
-        std::hash<evmc_address>>;
+        ExecutableKeyHash>;
 CacheExecutables& getCacheExecutables();
 
+// Resolve an account's code and its analyzed form.
+//
+// getCacheExecutables() is a process-wide singleton shared by every execution,
+// including speculative ones whose storage view is thrown away afterwards:
+// eth_call / eth_estimateGas (BaselineScheduler::call forks a view and never
+// pushes it), block execution that fails sync verification (returns before
+// pushView), and abandoned consensus proposals. Keying that cache by address
+// let such an execution publish "this address has code" to every later
+// execution on the node, including consensus ones, which then executed bytecode
+// absent from their own state view and diverged from the rest of the network.
+//
+// Reading the code hash from `storage` on every call keeps the view-dependent
+// half of the lookup inside the view; only the content-addressed half (bytecode
+// -> CodeAnalysis) is cached.
 task::Task<std::shared_ptr<Executable>> getExecutable(
     auto& storage, const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
 {
-    if (auto executable = co_await storage2::readOne(getCacheExecutables(), address))
+    using AccountType = Account<std::decay_t<decltype(storage)>>;
+    AccountType account(storage, address, binaryAddress);
+    auto codeHashEntry = co_await account.codeHashEntry();
+    if (codeHashEntry)
     {
-        co_return std::move(*executable);
+        ExecutableKey key{
+            .codeHash = AccountType::toCodeHash(*codeHashEntry), .revision = revision};
+        if (auto executable = co_await storage2::readOne(getCacheExecutables(), key))
+        {
+            co_return std::move(*executable);
+        }
+
+        if (auto codeEntry = co_await account.code(codeHashEntry))
+        {
+            auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
+            co_await storage2::writeOne(getCacheExecutables(), key, executable);
+            co_return executable;
+        }
+        co_return {};
     }
 
-    if (Account<std::decay_t<decltype(storage)>> account(storage, address, binaryAddress);
-        auto codeEntry = co_await account.code())
+    // The account table holds no code hash. Most callers land here: an EOA or a
+    // never-touched address has no code at all, account.code() comes back empty
+    // and nothing is analyzed. It also covers the historical layout where code
+    // sits in the account table's own code field with no hash beside it - every
+    // writer in the tree records a code hash today, so that shape is not
+    // produced any more, but EVMAccount::code() still falls back to it and this
+    // branch keeps that reachable. Either way there is nothing content-addressed
+    // to key the cache on, so no entry is published.
+    if (auto codeEntry = co_await account.code(codeHashEntry))
     {
-        auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
-        co_await storage2::writeOne(getCacheExecutables(), address, executable);
-        co_return executable;
+        co_return std::make_shared<Executable>(std::move(*codeEntry), revision);
     }
     co_return {};
 }

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -129,7 +129,8 @@ using CacheExecutables =
         ExecutableKeyHash>;
 CacheExecutables& getCacheExecutables();
 
-// Resolve an account's code and its analyzed form.
+// Turn the bytecode named by `codeHashEntry` into an analyzed Executable,
+// reusing the process-wide analysis cache.
 //
 // getCacheExecutables() is a process-wide singleton shared by every execution,
 // including speculative ones whose storage view is thrown away afterwards:
@@ -140,31 +141,49 @@ CacheExecutables& getCacheExecutables();
 // execution on the node, including consensus ones, which then executed bytecode
 // absent from their own state view and diverged from the rest of the network.
 //
-// Reading the code hash from `storage` on every call keeps the view-dependent
-// half of the lookup inside the view; only the content-addressed half (bytecode
-// -> CodeAnalysis) is cached.
+// This is the only function that touches the cache. The key is built from
+// `codeHashEntry` alone - the entry the caller already read from its storage
+// view; `account` is passed only so a miss can fetch the bytes through
+// EVMAccount::code(), and its address-derived table name must stay out of the
+// key. The view-dependent step - which code hash does this address hold -
+// belongs to resolveExecutable below.
 task::Task<std::shared_ptr<Executable>> getExecutable(
-    auto& storage, const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
+    auto& account, const storage::Entry& codeHashEntry, evmc_revision revision)
+{
+    using AccountType = std::decay_t<decltype(account)>;
+    ExecutableKey key{.codeHash = AccountType::toCodeHash(codeHashEntry), .revision = revision};
+    if (auto executable = co_await storage2::readOne(getCacheExecutables(), key))
+    {
+        co_return std::move(*executable);
+    }
+
+    // On a miss the bytes come back through the account: EVMAccount::code()
+    // reads s_code_binary by hash and falls back to the account table's own
+    // code field when that misses.
+    std::optional<storage::Entry> hashEntry(codeHashEntry);
+    if (auto codeEntry = co_await account.code(hashEntry))
+    {
+        auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
+        co_await storage2::writeOne(getCacheExecutables(), key, executable);
+        co_return executable;
+    }
+    co_return {};
+}
+
+// Resolve an account's code and its analyzed form.
+//
+// This owns the view-dependent half of the lookup - which code does this
+// address hold - and reads it from `storage` on every call, so nothing that
+// depends on the view can reach the cache. It also owns the uncached branch for
+// accounts that record no code hash.
+task::Task<std::shared_ptr<Executable>> resolveExecutable(
+    auto& storage, const evmc_address& address, evmc_revision revision, bool binaryAddress)
 {
     using AccountType = Account<std::decay_t<decltype(storage)>>;
     AccountType account(storage, address, binaryAddress);
-    auto codeHashEntry = co_await account.codeHashEntry();
-    if (codeHashEntry)
+    if (auto codeHashEntry = co_await account.codeHashEntry())
     {
-        ExecutableKey key{
-            .codeHash = AccountType::toCodeHash(*codeHashEntry), .revision = revision};
-        if (auto executable = co_await storage2::readOne(getCacheExecutables(), key))
-        {
-            co_return std::move(*executable);
-        }
-
-        if (auto codeEntry = co_await account.code(codeHashEntry))
-        {
-            auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
-            co_await storage2::writeOne(getCacheExecutables(), key, executable);
-            co_return executable;
-        }
-        co_return {};
+        co_return co_await getExecutable(account, *codeHashEntry, revision);
     }
 
     // The account table holds no code hash. Most callers land here: an EOA or a
@@ -175,7 +194,7 @@ task::Task<std::shared_ptr<Executable>> getExecutable(
     // produced any more, but EVMAccount::code() still falls back to it and this
     // branch keeps that reachable. Either way there is nothing content-addressed
     // to key the cache on, so no entry is published.
-    if (auto codeEntry = co_await account.code(codeHashEntry))
+    if (auto codeEntry = co_await account.code(std::nullopt))
     {
         co_return std::make_shared<Executable>(std::move(*codeEntry), revision);
     }
@@ -366,7 +385,7 @@ public:
     task::Task<std::optional<storage::Entry>> code(
         const evmc_address& address, auto&&... /*unused*/)
     {
-        if (auto executable = co_await getExecutable(m_rollbackableStorage.get(), address,
+        if (auto executable = co_await resolveExecutable(m_rollbackableStorage.get(), address,
                 m_revision,
                 m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
             executable && executable->m_code &&
@@ -395,19 +414,30 @@ public:
 
     task::Task<h256> codeHashAt(const evmc_address& address, auto&&... /*unused*/)
     {
-        // Resolve through the same filtered path codeSizeAt uses, so EXTCODESIZE
-        // and EXTCODEHASH cannot disagree within one execution. code() also
-        // returns empty when the account records a code hash whose bytes are
-        // missing, and that case must report a zero hash too.
-        if (m_ledgerConfig.get().features().get(
-                ledger::Features::Flag::bugfix_v1_eoa_as_contract) &&
-            !co_await code(address))
+        using AccountType = Account<Storage>;
+        AccountType account(m_rollbackableStorage.get(), address,
+            m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
+        auto codeHashEntry = co_await account.codeHashEntry();
+        if (!codeHashEntry)
         {
             co_return {};
         }
-        Account<Storage> account(m_rollbackableStorage.get(), address,
-            m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
-        co_return co_await account.codeHash();
+
+        // Apply the same filter code() applies, so EXTCODESIZE and EXTCODEHASH
+        // cannot disagree within one execution: an account whose code is hidden
+        // reads as codeless and must hash as zero too, and so must one that
+        // records a code hash whose bytes are missing.
+        if (m_ledgerConfig.get().features().get(ledger::Features::Flag::bugfix_v1_eoa_as_contract))
+        {
+            auto executable = co_await getExecutable(account, *codeHashEntry, m_revision);
+            if (!executable || !executable->m_code ||
+                precompiled::hideDynamicAccountCode(
+                    m_ledgerConfig.get().features(), executable->m_code->get()))
+            {
+                co_return {};
+            }
+        }
+        co_return AccountType::toCodeHash(*codeHashEntry);
     }
 
     task::Task<bool> exists([[maybe_unused]] const evmc_address& address, auto&&... /*unused*/)
@@ -800,7 +830,7 @@ private:
                 m_ledgerConfig.get().authCheckStatus(), m_ledgerConfig.get().features());
         }
 
-        if (m_executable = co_await getExecutable(m_rollbackableStorage.get(), ref.code_address,
+        if (m_executable = co_await resolveExecutable(m_rollbackableStorage.get(), ref.code_address,
                 m_revision,
                 m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
             !m_executable)

--- a/transaction-executor/tests/EOACodeVisibilityTest.cpp
+++ b/transaction-executor/tests/EOACodeVisibilityTest.cpp
@@ -182,16 +182,16 @@ BOOST_AUTO_TEST_CASE(contractCodeIsUnaffected)
 }
 
 // The filter must only hide the marker from the code-reading path. This asserts
-// the step executeCall depends on - getExecutable still returning the marker -
-// rather than dispatch itself; processDynamicPrecompiled consumes that same
-// m_executable->m_code to route the call to the account precompiled.
+// the step executeCall depends on - resolveExecutable still returning the
+// marker - rather than dispatch itself; processDynamicPrecompiled consumes that
+// same m_executable->m_code to route the call to the account precompiled.
 BOOST_AUTO_TEST_CASE(dispatchStillSeesTheMarker)
 {
     auto address = eoaAddress();
     seedAccountMarker(address);
     enableFilter(true);
 
-    auto executable = syncWait(getExecutable(rollbackableStorage, address, EVMC_CANCUN, false));
+    auto executable = syncWait(resolveExecutable(rollbackableStorage, address, EVMC_CANCUN, false));
     BOOST_REQUIRE(executable);
     BOOST_REQUIRE(executable->m_code);
     BOOST_CHECK(bcos::precompiled::matchDynamicAccountCode(executable->m_code->get()));

--- a/transaction-executor/tests/EOACodeVisibilityTest.cpp
+++ b/transaction-executor/tests/EOACodeVisibilityTest.cpp
@@ -1,0 +1,241 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief an account that only holds a balance must look codeless to the EVM
+ * @file EOACodeVisibilityTest.cpp
+ */
+
+#include "../bcos-transaction-executor/precompiled/PrecompiledManager.h"
+#include "../bcos-transaction-executor/vm/HostContext.h"
+#include "TestMemoryStorage.h"
+#include "bcos-executor/src/Common.h"
+#include "bcos-executor/src/precompiled/common/Utilities.h"
+#include "bcos-framework/executor/PrecompiledTypeDef.h"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-framework/protocol/Protocol.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
+#include "bcos-task/Wait.h"
+#include "bcos-transaction-executor/RollbackableStorage.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::task;
+using namespace bcos::executor_v1;
+using namespace bcos::executor_v1::hostcontext;
+
+namespace
+{
+evmc_address eoaAddress()
+{
+    evmc_address address{};
+    address.bytes[sizeof(address.bytes) - 1] = 0xe0;
+    return address;
+}
+
+const bytes REAL_CODE{0x60, 0x01, 0x60, 0x00, 0x55, 0x00};
+
+struct EOACodeVisibilityFixture
+{
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+    MutableStorage storage;
+    Rollbackable<MutableStorage> rollbackableStorage{storage};
+    using TransientStorageType = storage2::memory_storage::MemoryStorage<StateKey, StateValue,
+        storage2::memory_storage::Attribute(
+            storage2::memory_storage::ORDERED | storage2::memory_storage::LOGICAL_DELETION)>;
+    TransientStorageType transientStorage;
+    Rollbackable<TransientStorageType> rollbackableTransientStorage{transientStorage};
+    std::optional<PrecompiledManager> precompiledManager;
+    ledger::LedgerConfig ledgerConfig;
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    int64_t seq = 0;
+
+    EOACodeVisibilityFixture()
+    {
+        if (!bcos::executor::GlobalHashImpl::g_hashImpl)
+        {
+            bcos::executor::GlobalHashImpl::g_hashImpl = std::make_shared<crypto::Keccak256>();
+        }
+        precompiledManager.emplace(hashImpl);
+        blockHeader.setVersion(
+            static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_17_1_VERSION));
+        blockHeader.calculateHash(*hashImpl);
+    }
+
+    // Write `code` at `address` the way a deployment (or an account creation)
+    // does: bytes into s_code_binary keyed by their hash, hash into the account
+    // table.
+    void seedCode(const evmc_address& address, const bytes& code)
+    {
+        ledger::account::EVMAccount account(rollbackableStorage, address, false);
+        auto codeHash = hashImpl->hash(bytesConstRef(code.data(), code.size()));
+        syncWait(account.create());
+        syncWait(account.setCode(code, std::string{}, codeHash));
+    }
+
+    // The first two segments match what AccountPrecompiled /
+    // AccountManagerPrecompiled / BalancePrecompiled write when they materialise
+    // an account that only holds a balance ("[PRECOMPILED],<ACCOUNT_ADDRESS>,").
+    // They use getAccountTableName for the third segment and this uses the
+    // contract table path; the predicate only looks at the prefix.
+    void seedAccountMarker(const evmc_address& address)
+    {
+        ledger::account::EVMAccount account(rollbackableStorage, address, false);
+        auto tableName = std::string(syncWait(account.path()));
+        auto marker =
+            precompiled::getDynamicPrecompiledCodeString(precompiled::ACCOUNT_ADDRESS, tableName);
+        seedCode(address, bytes(marker.begin(), marker.end()));
+    }
+
+    void enableFilter(bool enable)
+    {
+        ledger::Features features;
+        if (enable)
+        {
+            features.set(ledger::Features::Flag::bugfix_v1_eoa_as_contract);
+        }
+        ledgerConfig.setFeatures(features);
+    }
+
+    auto makeHostContext(const evmc_address& address)
+    {
+        // HostContext keeps a reference_wrapper to origin, so it must outlive
+        // the returned context; message is stored by value and need not.
+        static evmc_address origin{};
+        evmc_message message{};
+        message.kind = EVMC_CALL;
+        message.recipient = address;
+        message.code_address = address;
+        return HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>(
+            rollbackableStorage, rollbackableTransientStorage, blockHeader, message, origin, "", 0,
+            seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0, bcos::task::syncWait);
+    }
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(EOACodeVisibility, EOACodeVisibilityFixture)
+
+// An account that only holds a balance is stored as a dynamic account
+// precompiled. Its marker string is an internal dispatch token; the EVM must see
+// an account with no code, or `addr.code.length != 0` is true for every funded
+// wallet - which is what made OpenZeppelin's ERC-721 safe transfers call
+// onERC721Received on plain wallets.
+BOOST_AUTO_TEST_CASE(balanceOnlyAccountHasNoCodeForTheEvm)
+{
+    auto address = eoaAddress();
+    seedAccountMarker(address);
+    enableFilter(true);
+    auto hostContext = makeHostContext(address);
+
+    BOOST_CHECK(!syncWait(hostContext.code(address)));
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeSizeAt(address)), 0U);
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeHashAt(address)), h256{});
+}
+
+// The filter is consensus visible, so it must stay off for chains below 3.17.1:
+// replaying their history has to reproduce the roots they already committed.
+BOOST_AUTO_TEST_CASE(markerStaysVisibleWithoutTheFeature)
+{
+    auto address = eoaAddress();
+    seedAccountMarker(address);
+    enableFilter(false);
+    auto hostContext = makeHostContext(address);
+
+    auto code = syncWait(hostContext.code(address));
+    BOOST_REQUIRE(code);
+    BOOST_CHECK_GT(code->get().size(), 0U);
+    BOOST_CHECK_GT(syncWait(hostContext.codeSizeAt(address)), 0U);
+    BOOST_CHECK_NE(syncWait(hostContext.codeHashAt(address)), h256{});
+}
+
+// Real contract code is untouched by the filter.
+BOOST_AUTO_TEST_CASE(contractCodeIsUnaffected)
+{
+    evmc_address address{};
+    address.bytes[sizeof(address.bytes) - 1] = 0xc0;
+    seedCode(address, REAL_CODE);
+    enableFilter(true);
+    auto hostContext = makeHostContext(address);
+
+    auto code = syncWait(hostContext.code(address));
+    BOOST_REQUIRE(code);
+    BOOST_CHECK_EQUAL(code->get().size(), REAL_CODE.size());
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeSizeAt(address)), REAL_CODE.size());
+    BOOST_CHECK_NE(syncWait(hostContext.codeHashAt(address)), h256{});
+}
+
+// The filter must only hide the marker from the code-reading path. This asserts
+// the step executeCall depends on - getExecutable still returning the marker -
+// rather than dispatch itself; processDynamicPrecompiled consumes that same
+// m_executable->m_code to route the call to the account precompiled.
+BOOST_AUTO_TEST_CASE(dispatchStillSeesTheMarker)
+{
+    auto address = eoaAddress();
+    seedAccountMarker(address);
+    enableFilter(true);
+
+    auto executable = syncWait(getExecutable(rollbackableStorage, address, EVMC_CANCUN, false));
+    BOOST_REQUIRE(executable);
+    BOOST_REQUIRE(executable->m_code);
+    BOOST_CHECK(bcos::precompiled::matchDynamicAccountCode(executable->m_code->get()));
+}
+
+// The activation version must not move: chains at 3.17.0 and below committed
+// blocks with the marker visible.
+BOOST_AUTO_TEST_CASE(featureActivatesAt3_17_1)
+{
+    ledger::Features at3_17_0;
+    at3_17_0.setGenesisFeatures(bcos::protocol::BlockVersion::V3_17_0_VERSION);
+    BOOST_CHECK(!at3_17_0.get(ledger::Features::Flag::bugfix_v1_eoa_as_contract));
+
+    ledger::Features at3_17_1;
+    at3_17_1.setGenesisFeatures(bcos::protocol::BlockVersion::V3_17_1_VERSION);
+    BOOST_CHECK(at3_17_1.get(ledger::Features::Flag::bugfix_v1_eoa_as_contract));
+}
+
+// BaselineScheduler::getCode (eth_getCode) shares this predicate with
+// HostContext::code. Asserting it directly covers the RPC half without standing
+// up a scheduler.
+BOOST_AUTO_TEST_CASE(sharedPredicateGatesOnTheFeature)
+{
+    ledger::account::EVMAccount account(rollbackableStorage, eoaAddress(), false);
+    auto tableName = std::string(syncWait(account.path()));
+    auto marker =
+        precompiled::getDynamicPrecompiledCodeString(precompiled::ACCOUNT_ADDRESS, tableName);
+
+    ledger::Features off;
+    ledger::Features on;
+    on.set(ledger::Features::Flag::bugfix_v1_eoa_as_contract);
+
+    BOOST_CHECK(precompiled::hideDynamicAccountCode(on, marker));
+    BOOST_CHECK(!precompiled::hideDynamicAccountCode(off, marker));
+
+    // Real bytecode is never hidden.
+    BOOST_CHECK(!precompiled::hideDynamicAccountCode(
+        on, std::string_view((const char*)REAL_CODE.data(), REAL_CODE.size())));
+
+    // Table precompileds carry the same [PRECOMPILED] envelope under a different
+    // address and must keep their code.
+    auto tableMarker = precompiled::getDynamicPrecompiledCodeString(
+        precompiled::KV_TABLE_ADDRESS, "/tables/t_test");
+    BOOST_CHECK(!precompiled::hideDynamicAccountCode(on, tableMarker));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-executor/tests/EOACodeVisibilityTest.cpp
+++ b/transaction-executor/tests/EOACodeVisibilityTest.cpp
@@ -27,6 +27,7 @@
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/protocol/Protocol.h"
+#include "bcos-framework/storage2/Storage.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
 #include "bcos-task/Wait.h"
 #include "bcos-transaction-executor/RollbackableStorage.h"
@@ -112,6 +113,15 @@ struct EOACodeVisibilityFixture
             features.set(ledger::Features::Flag::bugfix_v1_eoa_as_contract);
         }
         ledgerConfig.setFeatures(features);
+    }
+
+    // Does the process-wide analyzed-code cache hold an entry for these bytes
+    // under the revision HostContext pins (m_revision = EVMC_CANCUN)?
+    static bool isCached(const h256& codeHash)
+    {
+        return syncWait(storage2::readOne(getCacheExecutables(),
+                            ExecutableKey{.codeHash = codeHash, .revision = EVMC_CANCUN}))
+            .has_value();
     }
 
     auto makeHostContext(const evmc_address& address)
@@ -236,6 +246,61 @@ BOOST_AUTO_TEST_CASE(sharedPredicateGatesOnTheFeature)
     auto tableMarker = precompiled::getDynamicPrecompiledCodeString(
         precompiled::KV_TABLE_ADDRESS, "/tables/t_test");
     BOOST_CHECK(!precompiled::hideDynamicAccountCode(on, tableMarker));
+}
+
+// EXTCODESIZE / EXTCODECOPY / EXTCODEHASH only need the bytes. Serving them out
+// of the executable cache ran evmone::baseline::analyze() over bytecode nobody
+// was about to execute and spent an LRU slot on the result, so a contract
+// merely observed by another contract warmed - and evicted from - the cache
+// that the execution path depends on.
+BOOST_AUTO_TEST_CASE(extcodeReadsDoNotPublishToTheCache)
+{
+    // Bytes no other case uses, so this key cannot already be in the cache.
+    const bytes code{0x60, 0x05, 0x60, 0x00, 0x55, 0x00};  // PUSH1 5 PUSH1 0 SSTORE STOP
+    evmc_address address{};
+    address.bytes[sizeof(address.bytes) - 1] = 0xc5;
+    seedCode(address, code);
+    enableFilter(true);
+
+    auto codeHash = hashImpl->hash(bytesConstRef(code.data(), code.size()));
+    BOOST_REQUIRE(!isCached(codeHash));
+
+    auto hostContext = makeHostContext(address);
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeSizeAt(address)), code.size());
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeHashAt(address)), codeHash);
+    BOOST_CHECK(syncWait(hostContext.code(address)).has_value());
+
+    // Every EXTCODE* answer came back right, and none of them analyzed.
+    BOOST_CHECK(!isCached(codeHash));
+
+    // The execution path still fills the cache - this is a live cache, not a
+    // field nothing writes any more.
+    BOOST_REQUIRE(syncWait(resolveExecutable(rollbackableStorage, address, EVMC_CANCUN, false)));
+    BOOST_CHECK(isCached(codeHash));
+}
+
+// A balance-only account's marker embeds its own table name, so no two such
+// accounts share a code hash: observing one used to cost an analysis and an LRU
+// slot per account, for a string that is never run as bytecode.
+BOOST_AUTO_TEST_CASE(markerAccountIsNeverAnalyzed)
+{
+    evmc_address address{};
+    address.bytes[sizeof(address.bytes) - 1] = 0xe5;
+    ledger::account::EVMAccount account(rollbackableStorage, address, false);
+    auto tableName = std::string(syncWait(account.path()));
+    auto marker =
+        precompiled::getDynamicPrecompiledCodeString(precompiled::ACCOUNT_ADDRESS, tableName);
+    bytes markerBytes(marker.begin(), marker.end());
+    seedCode(address, markerBytes);
+    enableFilter(true);
+
+    auto markerHash = hashImpl->hash(bytesConstRef(markerBytes.data(), markerBytes.size()));
+    BOOST_REQUIRE(!isCached(markerHash));
+
+    auto hostContext = makeHostContext(address);
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeSizeAt(address)), 0U);
+    BOOST_CHECK_EQUAL(syncWait(hostContext.codeHashAt(address)), h256{});
+    BOOST_CHECK(!isCached(markerHash));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-executor/tests/ExecutableCacheIsolationTest.cpp
+++ b/transaction-executor/tests/ExecutableCacheIsolationTest.cpp
@@ -89,13 +89,14 @@ BOOST_AUTO_TEST_CASE(discardedViewDoesNotPublishCode)
 
     MutableStorage speculativeView;
     seedCode(speculativeView, address, CODE_A);
-    BOOST_REQUIRE(syncWait(getExecutable(speculativeView, address, EVMC_CANCUN, false)) != nullptr);
+    BOOST_REQUIRE(
+        syncWait(resolveExecutable(speculativeView, address, EVMC_CANCUN, false)) != nullptr);
 
     // A different view that never saw that deployment. The speculative view is
     // simply dropped here, exactly as BaselineScheduler drops a forked view it
     // never pushes.
     MutableStorage consensusView;
-    BOOST_CHECK(syncWait(getExecutable(consensusView, address, EVMC_CANCUN, false)) == nullptr);
+    BOOST_CHECK(syncWait(resolveExecutable(consensusView, address, EVMC_CANCUN, false)) == nullptr);
 }
 
 // The same address holding different code in two views must resolve to that
@@ -109,8 +110,8 @@ BOOST_AUTO_TEST_CASE(codeIsResolvedPerView)
     MutableStorage secondView;
     seedCode(secondView, address, CODE_B);
 
-    auto first = syncWait(getExecutable(firstView, address, EVMC_CANCUN, false));
-    auto second = syncWait(getExecutable(secondView, address, EVMC_CANCUN, false));
+    auto first = syncWait(resolveExecutable(firstView, address, EVMC_CANCUN, false));
+    auto second = syncWait(resolveExecutable(secondView, address, EVMC_CANCUN, false));
 
     BOOST_REQUIRE(first && first->m_code);
     BOOST_REQUIRE(second && second->m_code);
@@ -131,8 +132,8 @@ BOOST_AUTO_TEST_CASE(identicalCodeSharesOneAnalysis)
     seedCode(storage, first, CODE_A);
     seedCode(storage, second, CODE_A);
 
-    auto firstExecutable = syncWait(getExecutable(storage, first, EVMC_CANCUN, false));
-    auto secondExecutable = syncWait(getExecutable(storage, second, EVMC_CANCUN, false));
+    auto firstExecutable = syncWait(resolveExecutable(storage, first, EVMC_CANCUN, false));
+    auto secondExecutable = syncWait(resolveExecutable(storage, second, EVMC_CANCUN, false));
 
     BOOST_REQUIRE(firstExecutable);
     BOOST_CHECK_EQUAL(firstExecutable.get(), secondExecutable.get());
@@ -148,8 +149,8 @@ BOOST_AUTO_TEST_CASE(revisionIsPartOfTheCacheKey)
     auto address = makeAddress(0xc1);
     seedCode(storage, address, CODE_B);
 
-    auto shanghai = syncWait(getExecutable(storage, address, EVMC_SHANGHAI, false));
-    auto cancun = syncWait(getExecutable(storage, address, EVMC_CANCUN, false));
+    auto shanghai = syncWait(resolveExecutable(storage, address, EVMC_SHANGHAI, false));
+    auto cancun = syncWait(resolveExecutable(storage, address, EVMC_CANCUN, false));
 
     BOOST_REQUIRE(shanghai);
     BOOST_REQUIRE(cancun);
@@ -165,17 +166,22 @@ BOOST_AUTO_TEST_CASE(accountWithoutCodeYieldsNoExecutable)
     ledger::account::EVMAccount account(storage, address, false);
     syncWait(account.create());
 
-    BOOST_CHECK(syncWait(getExecutable(storage, address, EVMC_CANCUN, false)) == nullptr);
+    BOOST_CHECK(syncWait(resolveExecutable(storage, address, EVMC_CANCUN, false)) == nullptr);
 }
 
 // Contracts deployed before code was split into s_code_binary keep their bytes
-// in the account table's own code field. EVMAccount::code() falls back to it and
-// getExecutable must stay on that path.
+// in the account table's own code field. EVMAccount::code() falls back to it,
+// and the miss path in getExecutable must keep reaching that fallback.
 BOOST_AUTO_TEST_CASE(legacyCodeFieldIsStillResolved)
 {
+    // Bytes no other case uses: sharing a blob would put {hash, CANCUN} in the
+    // process-wide LRU before this case runs, and the cache hit would skip the
+    // fallback this case exists to cover.
+    const bytes code{0x60, 0x04, 0x60, 0x00, 0x55, 0x00};  // PUSH1 4 PUSH1 0 SSTORE STOP
+
     MutableStorage storage;
     auto address = makeAddress(0xd2);
-    auto codeHash = hashImpl->hash(bytesConstRef(CODE_A.data(), CODE_A.size()));
+    auto codeHash = hashImpl->hash(bytesConstRef(code.data(), code.size()));
 
     // Account table records the hash and the code, but s_code_binary is empty.
     ledger::account::EVMAccount account(storage, address, false);
@@ -186,13 +192,57 @@ BOOST_AUTO_TEST_CASE(legacyCodeFieldIsStillResolved)
         storage::Entry{bcos::concepts::bytebuffer::toView(codeHash)}));
     syncWait(storage2::writeOne(storage,
         executor_v1::StateKey{tableName, ledger::ACCOUNT_TABLE_FIELDS::CODE},
-        storage::Entry{std::string_view((const char*)CODE_A.data(), CODE_A.size())}));
+        storage::Entry{std::string_view((const char*)code.data(), code.size())}));
 
-    auto executable = syncWait(getExecutable(storage, address, EVMC_CANCUN, false));
+    auto executable = syncWait(resolveExecutable(storage, address, EVMC_CANCUN, false));
     BOOST_REQUIRE(executable);
     BOOST_REQUIRE(executable->m_code);
     BOOST_CHECK_EQUAL(
-        executable->m_code->get(), std::string_view((const char*)CODE_A.data(), CODE_A.size()));
+        executable->m_code->get(), std::string_view((const char*)code.data(), code.size()));
+}
+
+// The cache-touching half of the lookup keys on the entry it is handed, not on
+// the account it fetches the bytes through. That is what stops a discarded view
+// from publishing code under an address.
+BOOST_AUTO_TEST_CASE(cachedLookupTakesTheCodeHashEntry)
+{
+    const bytes code{0x60, 0x03, 0x60, 0x00, 0x55, 0x00};  // PUSH1 3 PUSH1 0 SSTORE STOP
+
+    MutableStorage storage;
+    auto address = makeAddress(0xe1);
+    seedCode(storage, address, code);
+
+    ledger::account::EVMAccount account(storage, address, false);
+    auto codeHashEntry = syncWait(account.codeHashEntry());
+    BOOST_REQUIRE(codeHashEntry);
+
+    auto executable = syncWait(getExecutable(account, *codeHashEntry, EVMC_CANCUN));
+    BOOST_REQUIRE(executable);
+    BOOST_REQUIRE(executable->m_code);
+    BOOST_CHECK_EQUAL(
+        executable->m_code->get(), std::string_view((const char*)code.data(), code.size()));
+
+    // A different address in a different view holding the same bytes hits the
+    // same cache entry, because the key is the content and not the address.
+    MutableStorage otherStorage;
+    auto otherAddress = makeAddress(0xe2);
+    seedCode(otherStorage, otherAddress, code);
+    ledger::account::EVMAccount otherAccount(otherStorage, otherAddress, false);
+    auto otherCodeHashEntry = syncWait(otherAccount.codeHashEntry());
+    BOOST_REQUIRE(otherCodeHashEntry);
+
+    auto other = syncWait(getExecutable(otherAccount, *otherCodeHashEntry, EVMC_CANCUN));
+    BOOST_CHECK_EQUAL(other.get(), executable.get());
+
+    // The entry decides the lookup, not the account. Handing the first account -
+    // which does hold code - a hash that names no bytes anywhere must resolve to
+    // nothing. An implementation that re-read the account's own code hash and
+    // ignored the parameter would return that account's executable and fail here.
+    const std::string_view neverDeployed{"bytes never deployed"};
+    auto unrelatedHash = hashImpl->hash(
+        bytesConstRef((const bcos::byte*)neverDeployed.data(), neverDeployed.size()));
+    storage::Entry unrelatedEntry{bcos::concepts::bytebuffer::toView(unrelatedHash)};
+    BOOST_CHECK(syncWait(getExecutable(account, unrelatedEntry, EVMC_CANCUN)) == nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-executor/tests/ExecutableCacheIsolationTest.cpp
+++ b/transaction-executor/tests/ExecutableCacheIsolationTest.cpp
@@ -1,0 +1,198 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief the analyzed-code cache must not leak code between storage views
+ * @file ExecutableCacheIsolationTest.cpp
+ */
+
+#include "../bcos-transaction-executor/vm/HostContext.h"
+#include "TestMemoryStorage.h"
+#include "bcos-concepts/ByteBuffer.h"
+#include "bcos-executor/src/Common.h"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/Storage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Wait.h"
+#include "bcos-utilities/Common.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::task;
+using namespace bcos::executor_v1;
+using namespace bcos::executor_v1::hostcontext;
+
+namespace
+{
+evmc_address makeAddress(uint8_t tag)
+{
+    evmc_address address{};
+    address.bytes[sizeof(address.bytes) - 1] = tag;
+    return address;
+}
+
+// Minimal but distinct runtime blobs; evmone analyzes arbitrary bytes.
+const bytes CODE_A{0x60, 0x01, 0x60, 0x00, 0x55, 0x00};  // PUSH1 1 PUSH1 0 SSTORE STOP
+const bytes CODE_B{0x60, 0x02, 0x60, 0x00, 0x55, 0x00};  // PUSH1 2 PUSH1 0 SSTORE STOP
+
+struct ExecutableCacheIsolationFixture
+{
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+
+    ExecutableCacheIsolationFixture()
+    {
+        if (!bcos::executor::GlobalHashImpl::g_hashImpl)
+        {
+            bcos::executor::GlobalHashImpl::g_hashImpl = std::make_shared<crypto::Keccak256>();
+        }
+    }
+
+    // Write `code` at `address` exactly the way a deployment does: the bytes go
+    // into s_code_binary keyed by their hash, the account table records the hash.
+    void seedCode(MutableStorage& storage, const evmc_address& address, const bytes& code) const
+    {
+        ledger::account::EVMAccount account(storage, address, false);
+        auto codeHash = hashImpl->hash(bytesConstRef(code.data(), code.size()));
+        syncWait(account.create());
+        syncWait(account.setCode(code, std::string{}, codeHash));
+    }
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(ExecutableCacheIsolation, ExecutableCacheIsolationFixture)
+
+// A contract deployed in a storage view that is later discarded (eth_call,
+// eth_estimateGas, a block that fails sync verification, an abandoned consensus
+// proposal) must not become visible to any other view. Keying the process-wide
+// executable cache by address made it visible, so EXTCODESIZE reported code for
+// an address that holds none and the node diverged from the network.
+BOOST_AUTO_TEST_CASE(discardedViewDoesNotPublishCode)
+{
+    auto address = makeAddress(0xa1);
+
+    MutableStorage speculativeView;
+    seedCode(speculativeView, address, CODE_A);
+    BOOST_REQUIRE(syncWait(getExecutable(speculativeView, address, EVMC_CANCUN, false)) != nullptr);
+
+    // A different view that never saw that deployment. The speculative view is
+    // simply dropped here, exactly as BaselineScheduler drops a forked view it
+    // never pushes.
+    MutableStorage consensusView;
+    BOOST_CHECK(syncWait(getExecutable(consensusView, address, EVMC_CANCUN, false)) == nullptr);
+}
+
+// The same address holding different code in two views must resolve to that
+// view's code, never to whichever one populated the cache first.
+BOOST_AUTO_TEST_CASE(codeIsResolvedPerView)
+{
+    auto address = makeAddress(0xa2);
+
+    MutableStorage firstView;
+    seedCode(firstView, address, CODE_A);
+    MutableStorage secondView;
+    seedCode(secondView, address, CODE_B);
+
+    auto first = syncWait(getExecutable(firstView, address, EVMC_CANCUN, false));
+    auto second = syncWait(getExecutable(secondView, address, EVMC_CANCUN, false));
+
+    BOOST_REQUIRE(first && first->m_code);
+    BOOST_REQUIRE(second && second->m_code);
+    BOOST_CHECK_EQUAL(
+        first->m_code->get(), std::string_view((const char*)CODE_A.data(), CODE_A.size()));
+    BOOST_CHECK_EQUAL(
+        second->m_code->get(), std::string_view((const char*)CODE_B.data(), CODE_B.size()));
+}
+
+// The cache is still doing its job, and now keys on content: proxies sharing one
+// runtime blob (the OpenZeppelin BeaconProxy / ERC1967 pattern) share a single
+// analysis instead of taking one LRU slot each.
+BOOST_AUTO_TEST_CASE(identicalCodeSharesOneAnalysis)
+{
+    MutableStorage storage;
+    auto first = makeAddress(0xb1);
+    auto second = makeAddress(0xb2);
+    seedCode(storage, first, CODE_A);
+    seedCode(storage, second, CODE_A);
+
+    auto firstExecutable = syncWait(getExecutable(storage, first, EVMC_CANCUN, false));
+    auto secondExecutable = syncWait(getExecutable(storage, second, EVMC_CANCUN, false));
+
+    BOOST_REQUIRE(firstExecutable);
+    BOOST_CHECK_EQUAL(firstExecutable.get(), secondExecutable.get());
+}
+
+// evmone::baseline::analyze() is revision-specific (VMFactory::create passes the
+// revision through), so the revision belongs in the key. HostContext currently
+// pins m_revision to EVMC_CANCUN, so no production path varies it today; this
+// guards the key against the day one does.
+BOOST_AUTO_TEST_CASE(revisionIsPartOfTheCacheKey)
+{
+    MutableStorage storage;
+    auto address = makeAddress(0xc1);
+    seedCode(storage, address, CODE_B);
+
+    auto shanghai = syncWait(getExecutable(storage, address, EVMC_SHANGHAI, false));
+    auto cancun = syncWait(getExecutable(storage, address, EVMC_CANCUN, false));
+
+    BOOST_REQUIRE(shanghai);
+    BOOST_REQUIRE(cancun);
+    BOOST_CHECK_NE(shanghai.get(), cancun.get());
+}
+
+// An account with no code hash resolves to no executable and publishes nothing:
+// this is the path every EOA and every never-touched address takes.
+BOOST_AUTO_TEST_CASE(accountWithoutCodeYieldsNoExecutable)
+{
+    MutableStorage storage;
+    auto address = makeAddress(0xd1);
+    ledger::account::EVMAccount account(storage, address, false);
+    syncWait(account.create());
+
+    BOOST_CHECK(syncWait(getExecutable(storage, address, EVMC_CANCUN, false)) == nullptr);
+}
+
+// Contracts deployed before code was split into s_code_binary keep their bytes
+// in the account table's own code field. EVMAccount::code() falls back to it and
+// getExecutable must stay on that path.
+BOOST_AUTO_TEST_CASE(legacyCodeFieldIsStillResolved)
+{
+    MutableStorage storage;
+    auto address = makeAddress(0xd2);
+    auto codeHash = hashImpl->hash(bytesConstRef(CODE_A.data(), CODE_A.size()));
+
+    // Account table records the hash and the code, but s_code_binary is empty.
+    ledger::account::EVMAccount account(storage, address, false);
+    syncWait(account.create());
+    auto tableName = std::string(syncWait(account.path()));
+    syncWait(storage2::writeOne(storage,
+        executor_v1::StateKey{tableName, ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH},
+        storage::Entry{bcos::concepts::bytebuffer::toView(codeHash)}));
+    syncWait(storage2::writeOne(storage,
+        executor_v1::StateKey{tableName, ledger::ACCOUNT_TABLE_FIELDS::CODE},
+        storage::Entry{std::string_view((const char*)CODE_A.data(), CODE_A.size())}));
+
+    auto executable = syncWait(getExecutable(storage, address, EVMC_CANCUN, false));
+    BOOST_REQUIRE(executable);
+    BOOST_REQUIRE(executable->m_code);
+    BOOST_CHECK_EQUAL(
+        executable->m_code->get(), std::string_view((const char*)CODE_A.data(), CODE_A.size()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -3,6 +3,7 @@
 #include "bcos-crypto/interfaces/crypto/Hash.h"
 #include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-executor/src/Common.h"
+#include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-framework/dispatcher/SchedulerInterface.h"
 #include "bcos-framework/dispatcher/SchedulerTypeDef.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
@@ -762,7 +763,11 @@ public:
                 ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address));
             auto code = co_await account.code();
 
-            if (!code)
+            // Report a balance-only account as codeless, the same way the EVM
+            // sees it (HostContext::code) and the legacy executor already
+            // reports it (TransactionExecutor::getCode). Shared predicate so the
+            // two paths cannot drift apart.
+            if (!code || precompiled::hideDynamicAccountCode(ledgerConfig->features(), code->get()))
             {
                 callback(nullptr, {});
                 co_return;


### PR DESCRIPTION
### Description

`getExecutable()` looked the process-wide `Executable` cache up on the account address alone, so the first execution to resolve an address decided what code that address holds for every later execution in the process.

That cache is a function-local static (`HostContext.cpp:65`) shared with executions whose storage view is discarded:

- `BaselineScheduler::call()` forks a view for `eth_call` / `eth_estimateGas` and never pushes it (`BaselineScheduler.h:731`);
- block execution that fails sync verification returns at `:400`, before the `pushView` at `:424`;
- abandoned consensus proposals are dropped the same way.

A contract created inside such a view stayed in the cache after the view was gone. A later execution on the same node then saw code at an address that holds none in its own state view: `codeSizeAt()` resolves through `code()` -> `getExecutable()`, so `EXTCODESIZE` reported a non-zero size, and `executeCall()` (`HostContext.h:782`) went on to execute that bytecode instead of raising `NotFoundCodeError`.

Because only the affected node took that branch, it produced a different `receiptsRoot` / `stateRoot` / `gasUsed` from the rest of the group for the same transactions and stopped committing blocks. Restarting the node cleared it, which is what a function-local static predicts.

This was observed in production on 3.16.4 with a contract that branches on `addr.code.length != 0` before deciding whether to deploy: the poisoned node took the "already deployed, reuse" branch, skipped two proxy deployments, and spent 600,899 less gas than the rest of the group on an otherwise identical block (same `txsRoot`, differing `receiptsRoot` / `stateRoot` / `gasUsed`, no revert).

The affected code is identical on `release-3.17.0`, `release-3.17.1` and `master`. `release-3.18.0` added an `isHistoricalStorage` guard that excludes historical-block calls, which does not cover any of the three discard paths above, so it is affected too. The legacy DMC executor (`bcos-executor/`) has no such cache and is unaffected.

### Fix

Key the cache on `(codeHash, revision)` instead of the address:

- storage already holds code content-addressed — the account table records a code hash, `s_code_binary` holds the bytes under that hash — so the hash names the bytecode without consulting any view;
- the account's code hash is read from the storage view on every call, which is the half of the lookup that legitimately depends on the view. An entry left behind by a discarded view stays in the cache but becomes unreachable, because no other view records that code hash for that address;
- `revision` joins the key because `evmone::baseline::analyze()` produces a revision-specific `CodeAnalysis`. `HostContext` pins `m_revision` to `EVMC_CANCUN` today, so nothing varies it; the key just stops understating what the cached value depends on.

`EVMAccount` gains `codeHashEntry()` and a `code()` overload taking an already-read code hash entry, so `getExecutable` reads the `codeHash` field once rather than twice (the third commit moves that read into `resolveExecutable`, see below). Plain `code()` is now those two composed, which keeps a single implementation of the `s_code_binary` lookup and its fallback to the account table's own `code` field.

Storage reads per call:

| | before | after |
|---|---|---|
| account with no code (every plain transfer) | 2 | 2 |
| code present, cache hit | 0 | 1 |
| code present, cache miss | 2 | 2 |

The one extra read on a cache hit is the cost of the fix. It goes through `MultiLayerStorage`'s mutable / immutable / LRU-cache layers before reaching RocksDB, so it is normally an in-memory lookup.

Two further consequences:

- contracts sharing one runtime blob — every proxy in an ERC1967 or beacon deployment — now share a single analysis instead of occupying one LRU slot each;
- whether `{tableName, "codeHash"}` lands in `ReadWriteSetStorage`'s read set no longer depends on how warm the process cache is, because the read is no longer skipped on a hit.

The LRU charges `getSize(key) + getSize(value)` per entry, so the capacity expression now budgets for the key as well; the effective per-bucket ceiling goes from 44 entries to the 100 the constant already claimed.

### Tests

`transaction-executor/tests/ExecutableCacheIsolationTest.cpp`, six cases. Four fail before this change and pass after; two guard the paths the change reroutes.

Measured on this branch, with only the three source files reverted to the base commit:

```
base (fec58e693) + the new test file:
  2 test cases out of 104 passed
  4 test cases out of 104 failed
  11 assertions out of 15 passed

with this change:
  104 test cases out of 104 passed
  519 assertions out of 519 passed
```

The most direct failure on base is `codeIsResolvedPerView`: the second view reads back the first view's bytecode rather than its own.

### End-to-end reproduction on a four-node chain

`build_chain.sh -l 127.0.0.1:4`, default genesis (`[executor] version=1`, so the node initialises the baseline scheduler, matching the affected production configuration), `web3_rpc` enabled on node0 only. The same chain data and the same script were used for both runs; only the `fisco-bcos` binary was swapped.

The reproduction contract deploys a `Target` at a CREATE2 address **and calls into it** — the call is what reaches `getExecutable()`; `EVMC_CREATE` builds its `Executable` directly at `HostContext.h:621` and writes no cache entry. Sequence:

1. deploy `Factory` (committed transaction);
2. `eth_call Factory.deployAndPing(salt)` against node0 — speculative, view discarded;
3. committed transaction `Factory.probe(salt)`, which records `EXTCODESIZE` of the predicted address into state;
4. read `Factory.lastSize()`.

Base (`release-3.17.1`, binary sha256 `ec87a34d…`), block 2:

| node | txRoot | receiptRoot | gasUsed | stateRoot |
|---|---|---|---|---|
| node0 (served the eth_call) | `77cd07a5f746cbd2…` | `e7fea0cba2a83e9e…` | 37492 | `8a605883b0a8fd60…` |
| node1 / node2 / node3 | `77cd07a5f746cbd2…` | `e7fea0cba2a83e9e…` | 37492 | `0764fb5ae2ce4149…` |

Identical transactions, one node against three, so PBFT cannot reach 2f+1. The chain stopped at block 1 and looped on view changes (`toView=37` and climbing); the script never returned.

With this change (binary sha256 `21b5ce18…`), same chain, same script: all four nodes report `stateRoot 264d8707966630de…` for block 2, the chain reaches height 2, and `lastSize()` is 0.

The production incident additionally diverged on `receiptsRoot` and `gasUsed` because the contract branched on `addr.code.length` and skipped two deployments. This reproduction takes the minimal form — `EXTCODESIZE` costs the same whatever it returns — so only `stateRoot` differs. Same mechanism, smaller blast radius.

### OpenZeppelin suite, as a no-regression check

The proxy and CREATE2 tests from openzeppelin-contracts (ERC1967Proxy, ERC1967Utils, BeaconProxy, UpgradeableBeacon, ProxyAdmin, TransparentUpgradeableProxy, UUPSUpgradeable, Initializable, Clones, Create2 — the contract shapes the incident involved) were run against the same four-node chain, once per binary, with `loadFixture` replaced by a plain fixture call since the node has no `evm_snapshot`:

```
base    : 120 passing, 13 failing
patched : 120 passing, 13 failing
failing sets are identical, item for item
```

All 13 shared failures involve sending value (`payable ... when sending some balance`, `construct with value`, `funds deposited in the factory`); the chain runs with `feature_balance` off, so they fail for a reason unrelated to this change.

This is a no-regression check, not evidence that the bug is fixed — the suite never calls into an address that a discarded speculative execution touched. The evidence for the fix is the four-node reproduction above and the unit tests.

---

## Second commit: hide the account-precompiled marker from EXTCODE* in executor v1

An account that only holds a balance is materialised as a dynamic account precompiled. Its stored code is the marker `[PRECOMPILED],<account precompiled address>,<table>`, written by `AccountPrecompiled`, `AccountManagerPrecompiled` and `BalancePrecompiled` through `getDynamicPrecompiledCodeString()`. It is a dispatch token, not bytecode.

The legacy executor already hides it from the EVM — `externalCodeRequest()` (`bcos-executor/src/vm/HostContext.cpp:525`), which serves EXTCODESIZE / EXTCODECOPY / EXTCODEHASH, and `TransactionExecutor::getCode` (`:2116`) both return empty under `bugfix_eoa_as_contract` / `bugfix_eoa_match_failed`. Executor v1 never read either flag: neither `transaction-executor/` nor `transaction-scheduler/` mentions them. So on a v1 chain `addr.code.length != 0` is true for every wallet that has ever been funded.

`ERC721._checkOnERC721Received` branches on exactly that before calling `onERC721Received`, so it called back into plain wallets and the request landed in `AccountPrecompiled`, which has no such selector. Running the openzeppelin-contracts suite against a four-node v1 chain whose accounts had been funded: 152 `safeTransferFrom` / `_safeTransfer` cases failed this way, plus five `BeaconProxy` / `UpgradeableBeacon` cases that use a non-contract address as a negative and no longer reverted. On that chain `eth_getCode` returned the marker for a funded wallet and `0x` for an address that had never been touched.

### Fix

Filter the marker out of the three paths that expose code to callers: `HostContext::code` (EXTCODESIZE and EXTCODECOPY resolve through it), `HostContext::codeHashAt`, and `BaselineScheduler::getCode`. All three share `precompiled::hideDynamicAccountCode` so they cannot drift apart.

`getExecutable` is deliberately left unfiltered: `executeCall` resolves the executable and `processDynamicPrecompiled` routes the call using that same marker, so filtering there would disable account precompileds entirely. A test pins this. (After the third commit `executeCall` goes through `resolveExecutable`, which is equally unfiltered.)

`codeHashAt` now resolves through `code()` rather than reading the stored code hash directly (superseded by the third commit, which reads the entry once and applies the same predicate directly). That keeps EXTCODESIZE and EXTCODEHASH from disagreeing inside one execution, and it also reports a zero hash for an account whose recorded code hash has no bytes behind it, which the previous form did not.

### Why a new feature flag

EXTCODESIZE and EXTCODEHASH are consensus visible, so this cannot reuse `bugfix_eoa_as_contract` (on since 3.8) or `bugfix_eoa_match_failed` (on since 3.9): executor v1 has been executing and committing blocks with the marker visible the whole time, and replaying that history with the filter enabled would produce different roots. `bugfix_v1_eoa_as_contract` activates at 3.17.1, added here as a `BlockVersion` entry with `MAX_VERSION` moved onto it. `DEFAULT_VERSION` stays at 3.17.0. `tools/version_sync.sh:281` already treats a `MAX_VERSION` ahead of the build version as valid, and `bash tools/version_sync.sh --check` passes.

`clang-format` reflowed the neighbouring 3.17.0 roadmap entry in `Features.cpp` and the comment column of the preceding line in `Features.h`. Those lines are not otherwise changed.

### How to activate

This does not take effect on its own. `CMakeLists.txt` VERSION and the genesis templates still say 3.17.0, so a chain built from this tree keeps the old behaviour until either the 3.17.1 release bump lands, or `compatibility_version` / `bugfix_v1_eoa_as_contract` is set through governance.

`master` and `release-3.18.0` carry the same defect and need the same change.

### Tests

`transaction-executor/tests/EOACodeVisibilityTest.cpp`, six cases.

```
HostContext.h and BaselineScheduler.h reverted, everything else in place:
  5 test cases out of 110 passed
  1 test case out of 110 failed        <- balanceOnlyAccountHasNoCodeForTheEvm
  17 assertions out of 20 passed

with this change:
  test-transaction-executor   110 / 110 cases, 539 / 539 assertions
  test-bcos-framework          35 / 35  cases, 1431 / 1431 assertions
  test-bcos-tool               56 / 56  cases, 240 / 240 assertions
```

The other five cases guard what must not change: the marker staying visible without the feature, real bytecode being untouched, `resolveExecutable` (then still named `getExecutable`) still seeing the marker so dispatch works, table precompileds keeping their code, and the flag being off at 3.17.0 and on at 3.17.1.

## Third commit: the cache-touching function takes the code hash entry

Follow-up to the first commit: the function that touches `getCacheExecutables()` should take the code hash in its signature rather than resolve it from an address inside, so "only content-addressed inputs reach the cache" is visible in the type and cannot be undone without changing that signature.

`getExecutable` is split in two:

- `getExecutable(account, codeHashEntry, revision)` — the only production function that reads or writes `getCacheExecutables()`. It builds the key from the entry it was handed and, on a miss, reads the bytes through `account.code(codeHashEntry)`, which keeps the `s_code_binary` lookup and the fallback to the account table's own `code` field.
- `resolveExecutable(storage, address, revision, binaryAddress)` — the previous preamble: build the account, read `codeHashEntry()`, delegate when there is one, otherwise take the uncached branch for accounts that record no code hash. `HostContext::code` and `executeCall` call it with the arguments they passed before.

`codeHashAt` reads the `codeHash` field once and reuses the entry for both the filter and the returned hash. With `bugfix_v1_eoa_as_contract` on it previously read that field through `code()` and then again through `account.codeHash()`. The second-commit note that it "resolves through `code()`" describes that earlier shape; the predicate is unchanged, applied to the executable resolved from the entry (the fourth commit applies it to the bytes instead, see below).

No behavior change. Paths compared old against new: no `codeHash` entry (with and without a legacy `code` field), entry with the feature off, entry with the feature on and the code visible, hidden, or missing.

Tests: the eleven call sites move to `resolveExecutable`. `ExecutableCacheIsolationTest.cpp` gains `cachedLookupTakesTheCodeHashEntry`, which calls the new `getExecutable` directly with an entry it read itself and checks that a different address in a different view holding the same bytes lands on the same cache entry.

```
test-transaction-executor     111 / 111 cases   (ExecutableCacheIsolation 7, EOACodeVisibility 6)
test-transaction-scheduler     49 / 49 cases, 2747 / 2747 assertions
g++-16 -fsyntax-only on both test files: clean
```

## Fourth commit: EXTCODE* read the bytes and never build an Executable

Review round 2: `HostContext::code()` (EXTCODESIZE / EXTCODECOPY) and `codeHashAt()` (EXTCODEHASH) only need the code bytes to apply the marker predicate, but they resolved through `getExecutable`, which on a miss runs `evmone::baseline::analyze()` and takes an LRU slot. So every balance-only account observed by EXTCODE* was analyzed and cached once (its marker embeds its own table name, so no two share an entry), EXTCODEHASH with `bugfix_v1_eoa_as_contract` on turned from a 32-byte read into bytes + analysis + cache write, and EXTCODE*-only callers warmed or evicted the execution cache.

Both now read the bytes off `EVMAccount` (the `s_code_binary` lookup with its table-code fallback, unchanged) and apply `hideDynamicAccountCode` to them. `executeCall` is the only caller of `resolveExecutable`, so the analysis cache is reached from the execute path alone. `getExecutable` / `resolveExecutable` are untouched.

Storage reads per EXTCODE* call: before, one read for the code hash plus one for the bytes on a cache miss (none on a hit); now one plus one, with no analysis and no cache write. With the feature off `codeHashAt` still reads the hash only. The one observable change is that EXTCODE* no longer depends on the bytes being analyzable: `VMFactory::create` rethrows an `analyze()` failure as `UnknownVMError`, and that path is no longer on the EXTCODE* route.

Tests, `EOACodeVisibilityTest.cpp`: `extcodeReadsDoNotPublishToTheCache` (EXTCODE* on a real contract leaves no `{hash, revision}` entry in the cache; the execute path then creates one) and `markerAccountIsNeverAnalyzed` (marker account with the feature on: size 0, hash zero, no cache entry). Both fail with `code()` reverted to the previous form, at the "not cached" assertion.

```
test-transaction-executor     113 / 113 cases   (EOACodeVisibility 8, ExecutableCacheIsolation 7)
test-transaction-scheduler     49 / 49 cases, 2747 / 2747 assertions
g++-16 -fsyntax-only on the touched test file: clean
```

## Fifth commit: `EVMAccount::code` takes the code hash entry as a pointer

`code(const std::optional<storage::Entry>&)` existed because its first caller held the optional from `codeHashEntry()`. `getExecutable` holds a plain `Entry` and had to copy it into an optional to make the call. The parameter is now `const storage::Entry*`, nullptr when the account records no code hash. Five call sites updated, no behavior change.

```
test-transaction-executor     113 / 113 cases, 557 / 557 assertions
test-transaction-scheduler     49 / 49 cases, 2747 / 2747 assertions
g++-16 -fsyntax-only on the two executor test files: clean
```
