### PR TITLE
fix: RLP length estimation, system-account access in EthereumState, and ethereum trie roots in engine

### DIFF
--- a/bcos-codec/bcos-codec/rlp/Common.h
+++ b/bcos-codec/bcos-codec/rlp/Common.h
@@ -117,7 +117,12 @@ inline size_t length(T const& n) noexcept
     {
         return 1;
     }
-    size_t word = n.backend().internal_limb_count;
+    // Only iterate the VALID limbs (n.backend().size()), never internal_limb_count:
+    // boost's cpp_int_backend copies only the significant limbs on assignment and leaves
+    // higher limbs untouched, so limbs()[size()..internal_limb_count) may hold STALE garbage
+    // from a previous larger value. Counting those would over-estimate the byte length and
+    // produce an RLP header that disagrees with the actual encoded payload (corrupt trie leaf).
+    size_t word = n.backend().size();
     for (; word > 0; --word)
     {
         if (n.backend().limbs()[word - 1] != 0)

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -277,13 +277,14 @@ public:
       : m_storage(storage), m_tableName(std::move(tableName))
     {}
 
-    EVMAccount(Storage& storage, const evmc_address& address, bool binaryAddress)
+    EVMAccount(Storage& storage, const evmc_address& address, bool binaryAddress,
+        bool treatSystemAsUser = false)
       : m_storage(storage)
     {
         std::array<char, sizeof(address.bytes) * 2> table;  // NOLINT
         boost::algorithm::hex_lower(concepts::bytebuffer::toView(address.bytes), table.data());
-        if (auto view = std::string_view(table.data(), table.size());
-            precompiled::contains(bcos::precompiled::c_systemTxsAddress, view))
+        auto const view = std::string_view(table.data(), table.size());
+        if (!treatSystemAsUser && precompiled::contains(bcos::precompiled::c_systemTxsAddress, view))
         {
             m_tableName.reserve(ledger::SYS_DIRECTORY::SYS_APPS.size() + table.size());
             m_tableName.append(ledger::SYS_DIRECTORY::SYS_APPS);
@@ -313,9 +314,11 @@ public:
      * @param storage storage instance
      * @param address address of the account, hex string, should not contain 0x prefix
      */
-    EVMAccount(Storage& storage, std::string_view address, bool binaryAddress) : m_storage(storage)
+    EVMAccount(Storage& storage, std::string_view address, bool binaryAddress,
+        bool treatSystemAsUser = false)
+      : m_storage(storage)
     {
-        if (precompiled::contains(bcos::precompiled::c_systemTxsAddress, address))
+        if (!treatSystemAsUser && precompiled::contains(bcos::precompiled::c_systemTxsAddress, address))
         {
             m_tableName.reserve(ledger::SYS_DIRECTORY::SYS_APPS.size() + address.size());
             m_tableName.append(ledger::SYS_DIRECTORY::SYS_APPS);
@@ -340,7 +343,8 @@ public:
         }
     }
 
-    EVMAccount(Storage& storage, const bcos::Address& address, bool binaryAddress)
+    EVMAccount(Storage& storage, const bcos::Address& address, bool binaryAddress,
+        bool treatSystemAsUser = false)
       : EVMAccount(
             storage,
             [](const bcos::Address& address) {
@@ -348,7 +352,7 @@ public:
                 ::ranges::copy(address, std::span{evmcAddress.bytes}.data());
                 return evmcAddress;
             }(address),
-            binaryAddress)
+            binaryAddress, treatSystemAsUser)
     {}
     ~EVMAccount() noexcept = default;
 

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -32,6 +32,8 @@
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/EthTrieRoots.h"
+#include "bcos-rlp-protocol/EthReceipt.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -840,6 +842,12 @@ private:
         // and logsBloom is not part of BlockHeader hash computation in FISCO-BCOS).
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
 
+        // Ethereum-compatible roots (executor_version >= 2): txsRoot/receiptsRoot commit to
+        // the transaction / receipt tries and empty blocks get emptyRootHash(); legacy
+        // executors keep the Merkle roots and the zero empty-root behaviour.
+        const bool ethereumRoots =
+            ledgerConfig.executorVersion() >= ledger::ETHEREUM_EXECUTOR_VERSION;
+
         // Real EVM execution: execute transactions and compute real hashes.
         if (executionPayload.transactions.empty())
         {
@@ -857,12 +865,14 @@ private:
             // (bcos-tars-protocol/impl/TarsHashable.h).
             emptyHeader->setExtraData(std::move(extraData));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
-            emptyHeader->setReceiptsRoot(h256{});
-            emptyHeader->setTxsRoot(h256{});
+            emptyHeader->setReceiptsRoot(
+                ethereumRoots ? ledger::mpt::emptyRootHash() : h256{});
+            emptyHeader->setTxsRoot(ethereumRoots ? ledger::mpt::emptyRootHash() : h256{});
             emptyHeader->setGasUsed(0);
             emptyHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
             executionPayload.stateRoot = emptyHeader->stateRoot();
-            executionPayload.receiptsRoot = h256{};
+            executionPayload.receiptsRoot =
+                ethereumRoots ? ledger::mpt::emptyRootHash() : h256{};
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
@@ -900,11 +910,22 @@ private:
         auto receipts = co_await m_scheduler.get().executeBlock(view, m_executor.get(),
             *blockHeader, executableTransactions | ::ranges::views::indirect, ledgerConfig);
 
-        // Step 2d: Compute transaction root (Merkle over tx hashes)
-        // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
-        // once MPTStorage is available. The current tx->hash() call lacks exception
-        // handling for malformed transactions.
+        // Step 2d: Compute transaction root.
+        //  - Ethereum executor (v2): commit to the transaction trie over each transaction's
+        //    EIP-2718 wire bytes (ledger::mpt::calculateTransactionsRoot).
+        //  - legacy: Merkle over tx hashes (unchanged).
         h256 txRoot;
+        if (ethereumRoots)
+        {
+            std::vector<bcos::bytesConstRef> txRaws;
+            txRaws.reserve(executionPayload.transactions.size());
+            for (auto const& transaction : executionPayload.transactions)
+            {
+                txRaws.emplace_back(bcos::ref(transaction.raw));
+            }
+            txRoot = ledger::mpt::calculateTransactionsRoot(txRaws);
+        }
+        else
         {
             auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
             auto hasher = hashImpl.hasher();
@@ -929,14 +950,69 @@ private:
             }
         }
 
-        // Step 2e: Compute receipt root (Merkle over receipt hashes)
-        h256 receiptRoot;
+        // Step 2e-0: Validate receipts and (v2) fill per-receipt cumulativeGasUsed + logsBloom.
+        // The raw SchedulerSerialImpl path skips BaselineScheduler's receipt phase (the
+        // documented empty-logsBloom limitation) — the Ethereum receipts trie and the
+        // block-level bloom need those fields.
+        u256 cumulativeGasUsed;
+        for (auto& receipt : receipts)
         {
-            // Validate receipts are non-null before computing hashes
-            if (::ranges::any_of(receipts, [](auto& r) { return !r; }))
+            if (!receipt)
             {
                 BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
             }
+            if (ethereumRoots)
+            {
+                auto logBloom = bcos::getLogsBloom(receipt->logEntries());
+                receipt->setLogsBloom({logBloom.data(), logBloom.size()});
+                cumulativeGasUsed += receipt->gasUsed();
+                receipt->setCumulativeGasUsed(cumulativeGasUsed.str());
+            }
+        }
+
+        // Step 2e: Compute receipt root.
+        //  - Ethereum executor (v2): commit to the receipts trie over EthReceipt RLP
+        //    (ledger::mpt::calculateReceiptsRoot); the EIP-2718 type comes from the executed
+        //    transaction at the same index.
+        //  - legacy: Merkle over receipt hashes (unchanged).
+        h256 receiptRoot;
+        if (ethereumRoots)
+        {
+            std::vector<uint8_t> txTypes;
+            txTypes.reserve(executableTransactions.size());
+            for (auto const& transaction : executableTransactions)
+            {
+                txTypes.push_back(transaction->web3TypedTxKind());
+            }
+            std::vector<bcos::bytes> receiptRlps;
+            receiptRlps.reserve(receipts.size());
+            size_t index = 0;
+            for (auto const& receipt : receipts)
+            {
+                protocol::EthReceiptData eth;
+                if (auto err =
+                        protocol::toEthReceiptData(*receipt, txTypes[index], eth);
+                    err != nullptr)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        std::runtime_error("toEthReceiptData: " + err->errorMessage()));
+                }
+                bcos::bytes encoded;
+                protocol::EthReceipt ethReceipt(std::move(eth));
+                ethReceipt.rlpEncode(encoded);
+                receiptRlps.push_back(std::move(encoded));
+                ++index;
+            }
+            std::vector<bcos::bytesConstRef> refs;
+            refs.reserve(receiptRlps.size());
+            for (auto const& rlp : receiptRlps)
+            {
+                refs.emplace_back(bcos::ref(rlp));
+            }
+            receiptRoot = ledger::mpt::calculateReceiptsRoot(refs);
+        }
+        else
+        {
             auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
             auto hasher = hashImpl.hasher();
             crypto::merkle::Merkle<std::remove_reference_t<decltype(hasher)>> merkle(
@@ -959,14 +1035,9 @@ private:
         Bloom logsBloom{};
         for (auto& receipt : receipts)
         {
-            if (!receipt)
-            {
-                BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
-            }
             totalGasUsed += receipt->gasUsed();
-            // The v2 (pure-Ethereum) executor's receipts carry an empty logsBloom (a
-            // documented limitation — evmoneReceiptToBcos does not compute it), so tolerate
-            // empty blooms instead of indexing past their (zero) length.
+            // v2 receipts have their bloom filled in Step 2e-0; legacy receipts may carry an
+            // empty bloom (documented limitation), which is tolerated here.
             if (!receipt->logsBloom().empty())
             {
                 orBloom(logsBloom, receipt->logsBloom());

--- a/ethereum-executor/EthereumState.h
+++ b/ethereum-executor/EthereumState.h
@@ -239,7 +239,7 @@ class EthereumState
         using namespace bcos::ledger::account;
         auto& storage = m_storage;
 
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         // Do NOT gate on SYS_TABLES existence alone: the PoW reward path writes
         // the flat BALANCE row but (historically) never registers the account
@@ -351,7 +351,7 @@ class EthereumState
     {
         using namespace bcos::ledger::account;
         auto& storage = m_storage;
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         if (!co_await evmAccount.exists())
             co_return {};
@@ -380,7 +380,7 @@ class EthereumState
     {
         using namespace bcos::ledger::account;
         auto& storage = m_storage;
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         // SLOAD on a non-existent account returns 0 per EVM spec.
         // EVMAccount::storage() already returns empty bytes32 for missing
@@ -668,7 +668,7 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
         if (acc.erase_if_empty && rev >= EVMC_SPURIOUS_DRAGON && acc.is_empty())
             continue;
 
-        EVMAccount<Storage> bcosAcc(m_storage, addr, false);
+        EVMAccount<Storage> bcosAcc(m_storage, addr, false, /*treatSystemAsUser=*/true);
         if (!co_await bcosAcc.exists())
             co_await bcosAcc.create();
         co_await bcosAcc.setNonce(std::to_string(acc.nonce));
@@ -712,7 +712,7 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
         {
             // Genuine deletion: clear account state (including storage, so that
             // a later CREATE/CREATE2 at this address is not an EIP-7610 collision).
-            EVMAccount<Storage> bcosAcc(m_storage, addr, false);
+            EVMAccount<Storage> bcosAcc(m_storage, addr, false, /*treatSystemAsUser=*/true);
             if (co_await bcosAcc.exists())
             {
                 co_await bcosAcc.setBalance(0);
@@ -725,7 +725,7 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
                  !acc.just_created)
         {
             // EIP-161: empty touched account is deleted.
-            EVMAccount<Storage> bcosAcc(m_storage, addr, false);
+            EVMAccount<Storage> bcosAcc(m_storage, addr, false, /*treatSystemAsUser=*/true);
             if (co_await bcosAcc.exists())
             {
                 co_await bcosAcc.setBalance(0);


### PR DESCRIPTION
Base fixes extracted from the eth_sync branch — independent of the devp2p sync stack, each commit stands on its own.

## Commits

1. **fix(codec): count only valid limbs in RLP u256 length estimation**
   `boost::cpp_int_backend` copies only the significant limbs on assignment and leaves higher limbs untouched, so `limbs()[size()..internal_limb_count)` may hold stale garbage from a previous larger value. Counting those over-estimates the byte length and produces an RLP header that disagrees with the actual encoded payload (corrupt trie leaf). Iterate `n.backend().size()` instead of `internal_limb_count`.

2. **fix(executor): treat system contracts as user accounts in EthereumState**
   `EthereumState` maps every account through `EVMAccount`, which routes precompiled system addresses to `/sys/apps`. On an ethereum-compatible chain the system contracts hold real balances (e.g. PoW rewards), so reading/writing them must use the user account tables. Adds an opt-in `treatSystemAsUser` flag to `EVMAccount` (default keeps legacy routing) and passes it from `EthereumState`.

3. **feat(engine): commit ethereum txs/receipts trie roots for executor v2**
   For `executor_version >= 2`, `buildPayload` now:
   - fills per-receipt `cumulativeGasUsed` and `logsBloom` before hashing
   - computes `txsRoot`/`receiptsRoot` over the ethereum transaction / receipt tries (`mpt::calculateTransactionsRoot` / `calculateReceiptsRoot`)
   - uses `emptyRootHash()` for empty blocks instead of `h256{}`

   Legacy executors keep the Merkle roots and zero empty-root behaviour.

## Verification

Built and ran on this branch (Debug, gcc):

- `test-bcos-codec`: 68/68 cases passed
- `test-bcos-framework`: 67/67 cases passed
- `test-bcos-engine`: 41/41 cases passed
- `test-ethereum-state-smoke`: passed