### PR TITLE
feat(devp2p): add ethereum block header validator

### DIFF
--- a/bcos-devp2p/bcos-devp2p/sync/Block.h
+++ b/bcos-devp2p/bcos-devp2p/sync/Block.h
@@ -1,0 +1,65 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Block.h
+ * @brief A complete Ethereum block as assembled by the devp2p downloader.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "../rlpx/Crypto.h"
+#include <bcos-crypto/interfaces/crypto/CommonType.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-rlp-protocol/EthWithdrawal.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <optional>
+#include <vector>
+
+namespace bcos::devp2p::sync
+{
+// A block downloaded from a peer: the parsed header plus the opaque body
+// elements (transactions/uncles/withdrawals keep their wire encoding so the
+// block can be re-serialized losslessly).
+struct Block
+{
+    bcos::protocol::EthBlockHeaderData header;
+    bcos::h256 hash;  // keccak256(header RLP)
+    bcos::bytes headerRlp;
+    std::vector<bcos::bytes> transactions;                // opaque EIP-2718 encodings
+    std::vector<bcos::bytes> uncles;                      // raw header RLP (empty on PoS)
+    std::optional<std::vector<bcos::bytes>> withdrawals;  // raw EIP-4895 RLP, Shanghai+
+
+    uint64_t number() const { return static_cast<uint64_t>(header.number); }
+    bcos::h256 parentHash() const { return header.parentInfo.blockHash; }
+    bool hasWithdrawals() const { return withdrawals.has_value(); }
+};
+
+// Canonical empty-ommers-hash (keccak256(rlp([]))), used on every PoS block.
+inline bcos::h256 emptyOmmersHash()
+{
+    static const bcos::h256 hash = bcos::crypto::keccak256Hash(
+        bcos::bytesConstRef(reinterpret_cast<const bcos::byte*>("\xc0"), 1));
+    return hash;
+}
+
+// keccak256 of the canonical RLP encoding of an Ethereum header.
+inline bcos::h256 headerHash(bcos::protocol::EthBlockHeaderData const& _header)
+{
+    bcos::bytes rlp;
+    bcos::codec::rlp::encode(rlp, _header);
+    return bcos::crypto::keccak256Hash(bcos::bytesConstRef(rlp.data(), rlp.size()));
+}
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/HeaderValidator.h
+++ b/bcos-devp2p/bcos-devp2p/sync/HeaderValidator.h
@@ -1,0 +1,248 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HeaderValidator.h
+ * @brief Ethereum PoS header validation (EIP-1559 base fee, EIP-4844 blob gas,
+ *        gas-limit bounds, difficulty/uncle/extra-data rules).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Block.h"
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-utilities/Common.h>
+#include <string>
+
+namespace bcos::devp2p::sync
+{
+// Consensus constants (EIP-1559 / EIP-4844 / PoS).
+constexpr uint64_t kMinGasLimit = 5000;
+constexpr uint64_t kGasLimitBoundDivisor = 1024;
+constexpr uint64_t kElasticityMultiplier = 2;
+constexpr uint64_t kBaseFeeMaxChangeDenominator = 8;
+constexpr u256 kInitialBaseFee{1000000000};  // 1 gwei
+constexpr uint64_t kMaxExtraDataSize = 32;
+constexpr uint64_t kGasPerBlob = 1U << 17;                    // 131072
+constexpr uint64_t kTargetBlobGasPerBlock = 3 * kGasPerBlob;  // 393216
+constexpr uint64_t kMaxBlobGasPerBlock = 6 * kGasPerBlob;     // 786432
+
+// Minimal chain configuration for header validation (timestamp-based forks).
+struct ChainConfig
+{
+    uint64_t chainId{1};
+    // Fork activation timestamps; 0 means "active from genesis".
+    uint64_t londonTime{0};
+    uint64_t shanghaiTime{0};
+    uint64_t cancunTime{0};
+    uint64_t pragueTime{0};
+    // First PoS (merge) block number. Blocks below it are PoW and keep their
+    // PoW difficulty/ommers; blocks at or above it must satisfy PoS rules
+    // (difficulty == 0, no ommers). 0 (default) means "no merge yet": every
+    // block is validated as PoS (the pre-merge-PoW test-chain default).
+    uint64_t mergeBlock{0};
+    u256 initialBaseFee{kInitialBaseFee};
+};
+
+struct HeaderValidationResult
+{
+    bool valid{true};
+    std::string error;
+};
+
+// True if a fork activating at `_forkTime` activates in the block with the
+// given parent/header timestamps.
+inline bool isForkBlock(uint64_t _forkTime, int64_t _parentTimestamp, int64_t _headerTimestamp)
+{
+    if (_forkTime == 0)
+    {
+        return false;  // active from genesis
+    }
+    return static_cast<uint64_t>(_parentTimestamp) < _forkTime &&
+           static_cast<uint64_t>(_headerTimestamp) >= _forkTime;
+}
+
+inline bool isForkActive(uint64_t _forkTime, int64_t _timestamp)
+{
+    return _forkTime == 0 || static_cast<uint64_t>(_timestamp) >= _forkTime;
+}
+
+// EIP-1559: the base fee of the next block (the block after `_parent`).
+inline u256 computeNextBaseFee(bcos::protocol::EthBlockHeaderData const& _parent)
+{
+    auto parentGasTarget = _parent.gasLimit / kElasticityMultiplier;
+    u256 expected = _parent.baseFee.value_or(0);
+    if (_parent.gasUsed == parentGasTarget)
+    {
+        return expected;
+    }
+    if (_parent.gasUsed > parentGasTarget)
+    {
+        auto delta = expected * (_parent.gasUsed - parentGasTarget) / parentGasTarget /
+                     kBaseFeeMaxChangeDenominator;
+        return expected + (delta > 1 ? delta : 1);
+    }
+    auto delta = expected * (parentGasTarget - _parent.gasUsed) / parentGasTarget /
+                 kBaseFeeMaxChangeDenominator;
+    return expected > delta ? expected - delta : 0;
+}
+
+// EIP-4844: the excess blob gas of the next block (the block after `_parent`).
+inline u256 computeNextExcessBlobGas(bcos::protocol::EthBlockHeaderData const& _parent)
+{
+    u256 parentExcess = _parent.excessBlobGas.value_or(0);
+    u256 parentBlobGasUsed = _parent.blobGasUsed.value_or(0);
+    u256 total = parentBlobGasUsed + parentExcess;
+    return total > kTargetBlobGasPerBlock ? total - kTargetBlobGasPerBlock : 0;
+}
+
+namespace detail
+{
+inline std::optional<std::string> validateBaseFee(bcos::protocol::EthBlockHeaderData const& _header,
+    bcos::protocol::EthBlockHeaderData const& _parent, ChainConfig const& _config)
+{
+    bool londonActive = isForkActive(_config.londonTime, _header.timestamp);
+    if (londonActive && !_header.baseFee.has_value())
+    {
+        return "missing baseFeePerGas (London active)";
+    }
+    if (_header.baseFee.has_value() && !_parent.baseFee.has_value())
+    {
+        // Parent pre-London: only valid on the London activation block.
+        if (!isForkBlock(_config.londonTime, _parent.timestamp, _header.timestamp))
+        {
+            return "baseFeePerGas present but the parent is pre-London";
+        }
+        if (*_header.baseFee != _config.initialBaseFee)
+        {
+            return "baseFeePerGas must equal the initial base fee at London";
+        }
+    }
+    else if (_header.baseFee.has_value() && _parent.baseFee.has_value())
+    {
+        if (*_header.baseFee != computeNextBaseFee(_parent))
+        {
+            return "baseFeePerGas does not match the EIP-1559 recomputation";
+        }
+    }
+    return std::nullopt;
+}
+
+inline std::optional<std::string> validateBlobGas(bcos::protocol::EthBlockHeaderData const& _header,
+    bcos::protocol::EthBlockHeaderData const& _parent, ChainConfig const& _config)
+{
+    if (_header.blobGasUsed.has_value())
+    {
+        if (*_header.blobGasUsed > kMaxBlobGasPerBlock || *_header.blobGasUsed % kGasPerBlob != 0)
+        {
+            return "invalid blobGasUsed";
+        }
+    }
+    if (_header.excessBlobGas.has_value())
+    {
+        if (!_parent.excessBlobGas.has_value())
+        {
+            // Parent pre-Cancun: only valid on the Cancun activation block (excess = 0).
+            if (!isForkBlock(_config.cancunTime, _parent.timestamp, _header.timestamp))
+            {
+                return "excessBlobGas present but the parent is pre-Cancun";
+            }
+            if (*_header.excessBlobGas != 0)
+            {
+                return "excessBlobGas must be zero at Cancun activation";
+            }
+        }
+        else if (*_header.excessBlobGas != computeNextExcessBlobGas(_parent))
+        {
+            return "excessBlobGas does not match the EIP-4844 recomputation";
+        }
+    }
+    return std::nullopt;
+}
+}  // namespace detail
+
+// Validate `_header` against its parent per Ethereum consensus rules.
+// Chain-continuity (number/parentHash) is expected to have been checked by the
+// caller; this focuses on the per-header field rules. Blocks before the merge
+// (PoW, `number < mergeBlock`) follow PoW rules — difficulty is non-zero and
+// ommers are allowed — while merged blocks follow PoS rules.
+inline HeaderValidationResult validateHeaderPoS(bcos::protocol::EthBlockHeaderData const& _header,
+    bcos::protocol::EthBlockHeaderData const& _parent, ChainConfig const& _config)
+{
+    const bool pos =
+        _config.mergeBlock == 0 || static_cast<uint64_t>(_header.number) >= _config.mergeBlock;
+    if (pos)
+    {
+        // PoS: difficulty must be zero and no ommers.
+        if (_header.difficulty != 0)
+        {
+            return {false, "PoS difficulty must be zero"};
+        }
+        if (_header.uncleHash != emptyOmmersHash())
+        {
+            return {false, "PoS blocks must have no ommers"};
+        }
+    }
+    else
+    {
+        // PoW: on a plain PoW chain difficulty is always non-zero. EXCEPTION —
+        // Terminal Total Difficulty (TTD): on merge chains (Sepolia: TTD 17e15,
+        // reached at block 1450409), the first block at/after the TTD carries
+        // difficulty 0 while still being pre-merge (PoW) until the merge block
+        // (1735371). So a zero difficulty is legal here; ommers remain allowed.
+    }
+    // Extra-data vanity bound.
+    if (_header.extraData.size() > kMaxExtraDataSize)
+    {
+        return {false, "extraData exceeds the 32-byte PoS bound"};
+    }
+    // Number continuity and strictly-increasing timestamp.
+    if (_header.number != _parent.number + 1)
+    {
+        return {false, "header number must equal the parent number + 1"};
+    }
+    if (_header.timestamp <= _parent.timestamp)
+    {
+        return {false, "timestamp must be strictly greater than the parent"};
+    }
+    // Gas limit bounds: >= MIN_GAS_LIMIT and |Δ| <= parent / 1024.
+    if (_header.gasLimit < kMinGasLimit)
+    {
+        return {false, "gasLimit below the 5000 minimum"};
+    }
+    u256 parentGasLimit = _parent.gasLimit;
+    u256 delta = _header.gasLimit > parentGasLimit ? _header.gasLimit - parentGasLimit :
+                                                     parentGasLimit - _header.gasLimit;
+    if (delta > parentGasLimit / kGasLimitBoundDivisor)
+    {
+        return {false, "gasLimit differs from the parent by more than 1/1024"};
+    }
+    if (_header.gasUsed > _header.gasLimit)
+    {
+        return {false, "gasUsed exceeds gasLimit"};
+    }
+
+    // EIP-1559 base fee and EIP-4844 blob gas.
+    if (auto err = detail::validateBaseFee(_header, _parent, _config))
+    {
+        return {false, *err};
+    }
+    if (auto err = detail::validateBlobGas(_header, _parent, _config))
+    {
+        return {false, *err};
+    }
+
+    return {true, {}};
+}
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/test/HeaderValidatorTest.cpp
+++ b/bcos-devp2p/test/HeaderValidatorTest.cpp
@@ -1,0 +1,277 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HeaderValidatorTest.cpp
+ * @brief Unit tests for the Ethereum PoS header validator.
+ * @date 2026/8/18
+ */
+#include <bcos-devp2p/sync/Block.h>
+#include <bcos-devp2p/sync/HeaderValidator.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::devp2p::sync;
+
+namespace
+{
+// A minimal PoS-valid parent/child pair. Child's baseFee matches the EIP-1559
+// recomputation from the parent.
+struct PoSPair
+{
+    bcos::protocol::EthBlockHeaderData parent;
+    bcos::protocol::EthBlockHeaderData child;
+    ChainConfig config;
+};
+
+PoSPair makeValidPair()
+{
+    PoSPair p;
+    auto& parent = p.parent;
+    parent.number = 1;
+    parent.timestamp = 1600000000;
+    parent.difficulty = 0;
+    parent.uncleHash = emptyOmmersHash();
+    parent.gasLimit = 30000000;
+    parent.gasUsed = 21000;
+    parent.baseFee = u256(1000000000);
+
+    auto& child = p.child;
+    child.number = 2;
+    child.timestamp = 1600000001;
+    child.difficulty = 0;
+    child.uncleHash = emptyOmmersHash();
+    child.gasLimit = 30000000;
+    child.gasUsed = 21000;
+    child.baseFee = computeNextBaseFee(parent);  // 875175000 (golden)
+
+    p.config.chainId = 1;  // London active from genesis (londonTime = 0)
+    return p;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(HeaderValidatorTest)
+
+BOOST_AUTO_TEST_CASE(validPoSHeaderPasses)
+{
+    auto p = makeValidPair();
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(result.valid);
+    BOOST_CHECK(result.error.empty());
+}
+
+BOOST_AUTO_TEST_CASE(baseFeeGoldenVector)
+{
+    // Verified against an independent Python computation.
+    auto p = makeValidPair();
+    BOOST_CHECK_EQUAL(computeNextBaseFee(p.parent), u256(875175000));
+}
+
+BOOST_AUTO_TEST_CASE(excessBlobGasGoldenVectors)
+{
+    // Verified against an independent Python computation (EIP-4844).
+    auto parent = makeValidPair().parent;
+    parent.excessBlobGas = u256(0);
+    parent.blobGasUsed = u256(2 * kGasPerBlob);  // 262144
+    BOOST_CHECK_EQUAL(computeNextExcessBlobGas(parent), u256(0));
+
+    parent.excessBlobGas = u256(200000);
+    parent.blobGasUsed = u256(2 * kGasPerBlob);
+    BOOST_CHECK_EQUAL(computeNextExcessBlobGas(parent), u256(68928));
+
+    parent.excessBlobGas = u256(0);
+    parent.blobGasUsed = u256(0);
+    BOOST_CHECK_EQUAL(computeNextExcessBlobGas(parent), u256(0));
+}
+
+BOOST_AUTO_TEST_CASE(rejectsNonZeroDifficulty)
+{
+    auto p = makeValidPair();
+    p.child.difficulty = 1;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("difficulty") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsOmmers)
+{
+    auto p = makeValidPair();
+    p.child.uncleHash = h256{0x1234};
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("ommers") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsOversizedExtraData)
+{
+    auto p = makeValidPair();
+    p.child.extraData.assign(kMaxExtraDataSize + 1, 0xab);
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("extraData") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsNonIncreasingTimestamp)
+{
+    auto p = makeValidPair();
+    p.child.timestamp = p.parent.timestamp;  // equal, not strictly greater
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("timestamp") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsNonContiguousNumber)
+{
+    auto p = makeValidPair();
+    p.child.number = 5;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("number") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsGasLimitBelowMinimum)
+{
+    auto p = makeValidPair();
+    p.child.gasLimit = 4999;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("gasLimit") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsGasLimitDeltaTooLarge)
+{
+    auto p = makeValidPair();
+    // |Δ| = 30000 > 30000000 / 1024 ≈ 29296
+    p.child.gasLimit = 30030000;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("gasLimit") != std::string::npos);
+
+    // A bound-legal delta must pass.
+    auto p2 = makeValidPair();
+    p2.child.gasLimit = 30029000;  // Δ = 29000 <= 29296
+    auto ok = validateHeaderPoS(p2.child, p2.parent, p2.config);
+    BOOST_CHECK(ok.valid);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsGasUsedAboveLimit)
+{
+    auto p = makeValidPair();
+    p.child.gasUsed = p.child.gasLimit + 1;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("gasUsed") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsMissingBaseFeeWhenLondonActive)
+{
+    auto p = makeValidPair();
+    p.child.baseFee.reset();
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("baseFeePerGas") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsWrongBaseFee)
+{
+    auto p = makeValidPair();
+    p.child.baseFee = *p.child.baseFee + 1;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("baseFeePerGas") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(londonActivationBlockUsesInitialBaseFee)
+{
+    auto p = makeValidPair();
+    p.config.londonTime = 1600000001;  // the child block activates London
+    p.parent.baseFee.reset();          // parent is pre-London
+    p.child.baseFee = p.config.initialBaseFee;
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(result.valid);
+
+    // A non-initial base fee on the activation block is rejected.
+    auto p2 = makeValidPair();
+    p2.config.londonTime = 1600000001;
+    p2.parent.baseFee.reset();
+    p2.child.baseFee = p2.config.initialBaseFee + 1;
+    auto bad = validateHeaderPoS(p2.child, p2.parent, p2.config);
+    BOOST_CHECK(!bad.valid);
+}
+
+BOOST_AUTO_TEST_CASE(excessBlobGasValidation)
+{
+    // Parent with blob gas; child recomputes correctly.
+    auto p = makeValidPair();
+    p.parent.excessBlobGas = u256(200000);
+    p.parent.blobGasUsed = u256(2 * kGasPerBlob);
+    p.child.excessBlobGas = computeNextExcessBlobGas(p.parent);  // 68928
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(result.valid);
+
+    // Wrong excess blob gas is rejected.
+    auto p2 = p;
+    p2.child.excessBlobGas = *p2.child.excessBlobGas + 1;
+    auto bad = validateHeaderPoS(p2.child, p2.parent, p2.config);
+    BOOST_CHECK(!bad.valid);
+    BOOST_CHECK(bad.error.find("excessBlobGas") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(rejectsInvalidBlobGasUsed)
+{
+    auto p = makeValidPair();
+    p.child.blobGasUsed = u256(1);  // not a multiple of GAS_PER_BLOB
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(!result.valid);
+    BOOST_CHECK(result.error.find("blobGasUsed") != std::string::npos);
+
+    auto p2 = makeValidPair();
+    p2.child.blobGasUsed = u256(kMaxBlobGasPerBlock + 1);
+    auto bad = validateHeaderPoS(p2.child, p2.parent, p2.config);
+    BOOST_CHECK(!bad.valid);
+}
+
+BOOST_AUTO_TEST_CASE(cancunActivationBlockResetsExcess)
+{
+    auto p = makeValidPair();
+    p.config.cancunTime = 1600000001;  // child activates Cancun
+    p.parent.excessBlobGas.reset();
+    p.child.excessBlobGas = u256(0);  // expected zero at activation
+    auto result = validateHeaderPoS(p.child, p.parent, p.config);
+    BOOST_CHECK(result.valid);
+
+    auto p2 = makeValidPair();
+    p2.config.cancunTime = 1600000001;
+    p2.parent.excessBlobGas.reset();
+    p2.child.excessBlobGas = u256(1);
+    auto bad = validateHeaderPoS(p2.child, p2.parent, p2.config);
+    BOOST_CHECK(!bad.valid);
+}
+
+BOOST_AUTO_TEST_CASE(forkBlockHelpers)
+{
+    // forkTime == 0 → active from genesis.
+    BOOST_CHECK(isForkActive(0, 1));
+    BOOST_CHECK(!isForkBlock(0, 1, 2));
+    // Normal timestamp fork.
+    BOOST_CHECK(isForkBlock(100, 99, 100));
+    BOOST_CHECK(!isForkBlock(100, 100, 100));
+    BOOST_CHECK(!isForkBlock(100, 99, 99));
+    BOOST_CHECK(isForkActive(100, 100));
+    BOOST_CHECK(!isForkActive(100, 99));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 概述

从 eth_sync 分支拆分的 devp2p 子模块 PR:以太坊区块头校验器(header-only)。

- `sync/HeaderValidator.h`:以太坊区块头校验(PoS 时代规则:difficulty/nonce 必须为 0、gas limit 弹性范围、base fee 按 EIP-1559 推导、extraData 长度、时间戳单调等)
- `sync/Block.h`:校验测试使用的区块类型(基于 bcos-rlp-protocol 的 EthBlockHeader/EthWithdrawal)
- `test/HeaderValidatorTest.cpp`:校验规则单元测试

## 依赖

仅依赖 upstream 已合入代码(bcos-rlp-protocol、rlpx Crypto #5507),与其他待提的 devp2p PR 无相互依赖,可独立合入。

## 验证

- `tools/.ci/check-commit.sh` 通过,有效行数 valid_insertions = 130
- `test-bcos-devp2p` 编译通过,测试 28/28 通过(Debug / gcc)