### PR TITLE
feat(devp2p): add eth wire protocol messages, capability handler and fork id

### DIFF
--- a/bcos-devp2p/bcos-devp2p/eth/ForkId.cpp
+++ b/bcos-devp2p/bcos-devp2p/eth/ForkId.cpp
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ForkId.cpp
+ * @brief EIP-2124 forkid CRC32 implementation.
+ * @date 2026/8/18
+ */
+#include "ForkId.h"
+
+#include <array>
+#include <cstdint>
+
+namespace bcos::devp2p::eth
+{
+namespace
+{
+std::array<uint32_t, 256> const& crc32Table()
+{
+    static const std::array<uint32_t, 256> table = [] {
+        std::array<uint32_t, 256> t{};
+        for (uint32_t i = 0; i < 256; ++i)
+        {
+            uint32_t c = i;
+            for (int k = 0; k < 8; ++k)
+            {
+                c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            }
+            t[i] = c;
+        }
+        return t;
+    }();
+    return table;
+}
+}  // namespace
+
+uint32_t crc32(bytesConstRef _data, uint32_t _seed)
+{
+    uint32_t c = _seed ^ 0xFFFFFFFFu;
+    for (auto byte : _data)
+    {
+        c = crc32Table()[(c ^ byte) & 0xFF] ^ (c >> 8);
+    }
+    return c ^ 0xFFFFFFFFu;
+}
+
+uint32_t forkIdAddForkPoint(uint32_t _hash, uint64_t _forkPoint)
+{
+    // The fork point is encoded as a minimal big-endian u64 (the 8-byte form is
+    // canonical because every real fork point fits; matches geth forkid.go).
+    std::array<uint8_t, 8> forkBytes{};
+    for (int i = 0; i < 8; ++i)
+    {
+        forkBytes[7 - i] = static_cast<uint8_t>(_forkPoint >> (8 * i));
+    }
+    // geth seeds crc32 with the previous hash value.
+    return crc32(bytesConstRef(forkBytes.data(), forkBytes.size()), _hash);
+}
+
+}  // namespace bcos::devp2p::eth

--- a/bcos-devp2p/bcos-devp2p/eth/ForkId.h
+++ b/bcos-devp2p/bcos-devp2p/eth/ForkId.h
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ForkId.h
+ * @brief EIP-2124 fork identifier (CRC32 over genesis + fork points).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <cstdint>
+
+namespace bcos::devp2p::eth
+{
+// EIP-2124 fork identifier.
+struct ForkId
+{
+    uint32_t hash{0};  // first 4 bytes of the genesis hash, CRC32-chained with fork points
+    uint64_t next{0};  // next fork block/time greater than the head (0 if none)
+
+    bool operator==(ForkId const& _rhs) const { return hash == _rhs.hash && next == _rhs.next; }
+};
+
+// CRC-32 (IEEE 802.3, identical to zlib's crc32) over `_data`, continuing from `_seed`.
+uint32_t crc32(bytesConstRef _data, uint32_t _seed = 0);
+
+// Chain a fork point (block number or timestamp) into the fork-id hash.
+uint32_t forkIdAddForkPoint(uint32_t _hash, uint64_t _forkPoint);
+}  // namespace bcos::devp2p::eth

--- a/bcos-devp2p/bcos-devp2p/eth/Protocol.cpp
+++ b/bcos-devp2p/bcos-devp2p/eth/Protocol.cpp
@@ -1,0 +1,480 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Protocol.cpp
+ * @brief eth/68 message RLP codecs.
+ * @date 2026/8/18
+ */
+#include "Protocol.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <stdexcept>
+
+namespace bcos::devp2p::eth
+{
+namespace
+{
+// --- encode helpers (explicit header building to splice nested lists) ---
+bcos::bytes rlpItem(uint64_t _value)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _value);
+    return out;
+}
+
+bcos::bytes rlpItem(bytesConstRef _data)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _data);
+    return out;
+}
+
+bcos::bytes rlpItem(h256 const& _hash)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _hash);
+    return out;
+}
+
+bcos::bytes rlpList(std::vector<bcos::bytes> const& _items)
+{
+    bcos::bytes out;
+    size_t payloadLength = 0;
+    for (auto const& item : _items)
+    {
+        payloadLength += item.size();
+    }
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payloadLength});
+    for (auto const& item : _items)
+    {
+        out.insert(out.end(), item.begin(), item.end());
+    }
+    return out;
+}
+
+// --- decode helpers ---
+// Expects a list at `_view` and returns a view over its payload.
+bcos::bytesRef takeListPayload(bcos::bytesRef& _view)
+{
+    auto [error, header] = bcos::codec::rlp::decodeHeader(_view);
+    if (error || !header.isList)
+    {
+        throw std::runtime_error("eth: expected an RLP list");
+    }
+    bcos::bytesRef payload(_view.data(), header.payloadLength);
+    _view =
+        bcos::bytesRef(_view.data() + header.payloadLength, _view.size() - header.payloadLength);
+    return payload;
+}
+
+bcos::bytes takeBytes(bcos::bytesRef& _view)
+{
+    bcos::bytes out;
+    if (auto err = bcos::codec::rlp::decode(_view, out))
+    {
+        throw std::runtime_error("eth: bytes item decode failed");
+    }
+    return out;
+}
+
+// Extracts one COMPLETE RLP element (prefix + payload) as opaque bytes. Unlike
+// takeBytes (which only accepts RLP strings), this handles list elements too —
+// required for BlockHeaders entries (headers are RLP lists), BlockBodies
+// transactions (legacy txs are RLP lists) and withdrawals (RLP lists).
+bcos::bytes takeRlpItem(bcos::bytesRef& _view)
+{
+    size_t const originalSize = _view.size();
+    bcos::byte const* const originalData = _view.data();
+    auto [error, header] = bcos::codec::rlp::decodeHeader(_view);
+    if (error)
+    {
+        std::cerr << "[eth] takeRlpItem decodeHeader fail: err="
+                  << (error ? error->errorMessage() : "?") << " origSize=" << originalSize
+                  << " first="
+                  << (originalSize ? bcos::toHexStringWithPrefix(bytesConstRef(
+                                         originalData, std::min<size_t>(originalSize, 16))) :
+                                     std::string("empty"))
+                  << std::endl;
+        throw std::runtime_error("eth: rlp item decode failed");
+    }
+    // decodeHeader consumed the item prefix; rebuild prefix + payload.
+    size_t const prefixLen = originalSize - _view.size();
+    size_t const payloadLen = header.payloadLength;
+    bcos::byte const* begin = _view.data() - static_cast<std::ptrdiff_t>(prefixLen);
+    bcos::bytes out(begin, begin + prefixLen + payloadLen);
+    _view = bcos::bytesRef(_view.data() + payloadLen, _view.size() - payloadLen);
+    return out;
+}
+
+// Extracts one complete EIP-2718 transaction as opaque bytes. In an eth
+// BlockBodies transactions list each transaction is one RLP element:
+//   - legacy tx: an RLP list (0xc0..), taken whole via takeRlpItem
+//   - typed tx:  an RLP string (0x80..0xbf) whose CONTENT is 0xNN || rlp(payload)
+//     (the RLP serializer wraps the opaque typed bytes in a string); decode the
+//     string so only 0xNN||payload is returned
+//   - a bare 0xNN (< 0x80, only outside an RLP list) followed by rlp(payload)
+// A plain takeRlpItem on a typed tx would keep the string prefix (and treat
+// 0xNN as a one-byte integer) and misalign the payload.
+bcos::bytes takeTx(bcos::bytesRef& _view)
+{
+    if (_view.empty())
+    {
+        throw std::runtime_error("eth: empty transaction stream");
+    }
+    if (_view[0] >= 0x80 && _view[0] < 0xc0)
+    {
+        // Typed transaction wrapped as an RLP string: return its content
+        // (0xNN || rlp(payload)) without the string prefix.
+        return takeBytes(_view);
+    }
+    if (_view[0] >= 0xc0)
+    {
+        // Legacy transaction: a standalone RLP list (0xc0..).
+        return takeRlpItem(_view);
+    }
+    // Typed transaction: 0xNN || rlp(payload). Type byte 0x01..0x7f.
+    if (_view[0] == 0)
+    {
+        throw std::runtime_error("eth: invalid EIP-2718 type byte 0x00");
+    }
+    bcos::byte const type = _view[0];
+    _view = bcos::bytesRef(_view.data() + 1, _view.size() - 1);
+    bcos::bytes payload = takeRlpItem(_view);
+    payload.insert(payload.begin(), type);
+    return payload;
+}
+
+uint64_t takeUint(bcos::bytesRef& _view)
+{
+    uint64_t value = 0;
+    if (auto err = bcos::codec::rlp::decode(_view, value))
+    {
+        throw std::runtime_error("eth: uint item decode failed");
+    }
+    return value;
+}
+
+h256 takeH256(bcos::bytesRef& _view)
+{
+    h256 out;
+    if (auto err = bcos::codec::rlp::decode(_view, out))
+    {
+        throw std::runtime_error("eth: h256 item decode failed");
+    }
+    return out;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+bcos::bytes encodeStatus(StatusMessage const& _msg)
+{
+    bcos::bytes forkHash(4, 0);
+    forkHash[0] = static_cast<bcos::byte>((_msg.forkId.hash >> 24) & 0xff);
+    forkHash[1] = static_cast<bcos::byte>((_msg.forkId.hash >> 16) & 0xff);
+    forkHash[2] = static_cast<bcos::byte>((_msg.forkId.hash >> 8) & 0xff);
+    forkHash[3] = static_cast<bcos::byte>(_msg.forkId.hash & 0xff);
+
+    auto forkIdItem = rlpList(
+        {rlpItem(bytesConstRef(forkHash.data(), forkHash.size())), rlpItem(_msg.forkId.next)});
+
+    if (_msg.eip8085)
+    {
+        // eth/69+ (EIP-8085): [version, networkId, genesis, forkid, earliest, latest, latestHash]
+        return rlpList({rlpItem(_msg.protocolVersion), rlpItem(_msg.networkId),
+            rlpItem(_msg.genesisHash), forkIdItem, rlpItem(_msg.earliestBlock),
+            rlpItem(_msg.latestBlock), rlpItem(_msg.latestBlockHash)});
+    }
+    // eth/68: [version, networkId, td, head, genesis, forkid]
+    return rlpList({rlpItem(_msg.protocolVersion), rlpItem(_msg.networkId),
+        rlpItem(bytesConstRef(_msg.totalDifficulty.data(), _msg.totalDifficulty.size())),
+        rlpItem(_msg.headHash), rlpItem(_msg.genesisHash), forkIdItem});
+}
+
+StatusMessage decodeStatus(bytesConstRef _data)
+{
+    StatusMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+
+    msg.protocolVersion = takeUint(items);
+    msg.networkId = takeUint(items);
+    if (msg.protocolVersion >= kMinProtocolVersion + 1)  // eth/69+
+    {
+        // EIP-8085: [version, networkId, genesis, forkid, earliest, latest, latestHash]
+        msg.eip8085 = true;
+        msg.genesisHash = takeH256(items);
+        auto forkIdItems = takeListPayload(items);
+        auto forkHashBytes = takeBytes(forkIdItems);
+        if (forkHashBytes.size() != 4)
+        {
+            throw std::runtime_error("decodeStatus: invalid fork hash size");
+        }
+        msg.forkId.hash = (static_cast<uint32_t>(forkHashBytes[0]) << 24) |
+                          (static_cast<uint32_t>(forkHashBytes[1]) << 16) |
+                          (static_cast<uint32_t>(forkHashBytes[2]) << 8) |
+                          static_cast<uint32_t>(forkHashBytes[3]);
+        msg.forkId.next = takeUint(forkIdItems);
+        msg.earliestBlock = takeUint(items);
+        msg.latestBlock = takeUint(items);
+        msg.latestBlockHash = takeH256(items);
+        // Consumers still read headHash (e.g. for the peer-head log line); point it
+        // at the latest advertised block hash.
+        msg.headHash = msg.latestBlockHash;
+    }
+    else
+    {
+        // eth/68: [version, networkId, td, head, genesis, forkid]
+        msg.totalDifficulty = takeBytes(items);
+        msg.headHash = takeH256(items);
+        msg.genesisHash = takeH256(items);
+        auto forkIdItems = takeListPayload(items);
+        auto forkHashBytes = takeBytes(forkIdItems);
+        if (forkHashBytes.size() != 4)
+        {
+            throw std::runtime_error("decodeStatus: invalid fork hash size");
+        }
+        msg.forkId.hash = (static_cast<uint32_t>(forkHashBytes[0]) << 24) |
+                          (static_cast<uint32_t>(forkHashBytes[1]) << 16) |
+                          (static_cast<uint32_t>(forkHashBytes[2]) << 8) |
+                          static_cast<uint32_t>(forkHashBytes[3]);
+        msg.forkId.next = takeUint(forkIdItems);
+    }
+    return msg;
+}
+
+// ---------------------------------------------------------------------------
+// GetBlockHeaders
+// ---------------------------------------------------------------------------
+// The `reverse` flag is a BOOLEAN on the wire. Wire encodings differ between
+// clients: geth RLP-encodes bool as 0x00(false)/0x01(true), while ethrex's bool
+// decoder only accepts 0x80(false)/0x01(true) (RLP_NULL = false) and rejects
+// 0x00 with MalformedBoolean. geth's decoder reads the field as an integer, so
+// it accepts both 0x00 and 0x80. Use 0x80/0x01 for cross-client compatibility.
+bcos::bytes rlpBool(bool _value)
+{
+    return bcos::bytes{static_cast<bcos::byte>(_value ? 1 : 0x80)};
+}
+
+bcos::bytes encodeGetBlockHeaders(GetBlockHeadersMessage const& _msg)
+{
+    auto origin =
+        _msg.originHash.has_value() ? rlpItem(*_msg.originHash) : rlpItem(_msg.originNumber);
+    auto inner = rlpList({origin, rlpItem(_msg.amount), rlpItem(_msg.skip), rlpBool(_msg.reverse)});
+    return rlpList({rlpItem(_msg.requestId), inner});
+}
+
+GetBlockHeadersMessage decodeGetBlockHeaders(bytesConstRef _data)
+{
+    GetBlockHeadersMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+    msg.requestId = takeUint(items);
+
+    auto inner = takeListPayload(items);
+    // origin: either a hash (32 bytes) or a minimal big-endian number.
+    auto originBytes = takeBytes(inner);
+    if (originBytes.size() == 32)
+    {
+        msg.originHash = h256(bytesConstRef(originBytes.data(), originBytes.size()));
+    }
+    else
+    {
+        uint64_t originNumber = 0;
+        for (auto byte : originBytes)
+        {
+            originNumber = (originNumber << 8) | byte;
+        }
+        msg.originNumber = originNumber;
+    }
+    msg.amount = takeUint(inner);
+    msg.skip = takeUint(inner);
+    msg.reverse = (takeUint(inner) != 0);
+    return msg;
+}
+
+// ---------------------------------------------------------------------------
+// BlockHeaders
+// ---------------------------------------------------------------------------
+bcos::bytes encodeBlockHeaders(BlockHeadersMessage const& _msg)
+{
+    // Each header is an already-encoded RLP element (a list); splice them in
+    // directly — do NOT re-wrap them as strings (that changes the wire format).
+    std::vector<bcos::bytes> headers;
+    headers.reserve(_msg.headers.size());
+    for (auto const& header : _msg.headers)
+    {
+        headers.push_back(header);
+    }
+    auto inner = rlpList(headers);
+    return rlpList({rlpItem(_msg.requestId), inner});
+}
+
+BlockHeadersMessage decodeBlockHeaders(bytesConstRef _data)
+{
+    BlockHeadersMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+    msg.requestId = takeUint(items);
+    auto headers = takeListPayload(items);
+    while (!headers.empty())
+    {
+        msg.headers.push_back(takeRlpItem(headers));
+    }
+    return msg;
+}
+
+// ---------------------------------------------------------------------------
+// GetBlockBodies
+// ---------------------------------------------------------------------------
+bcos::bytes encodeGetBlockBodies(GetBlockBodiesMessage const& _msg)
+{
+    std::vector<bcos::bytes> hashes;
+    hashes.reserve(_msg.hashes.size());
+    for (auto const& hash : _msg.hashes)
+    {
+        hashes.push_back(rlpItem(hash));
+    }
+    return rlpList({rlpItem(_msg.requestId), rlpList(hashes)});
+}
+
+GetBlockBodiesMessage decodeGetBlockBodies(bytesConstRef _data)
+{
+    GetBlockBodiesMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+    msg.requestId = takeUint(items);
+    auto hashes = takeListPayload(items);
+    while (!hashes.empty())
+    {
+        msg.hashes.push_back(takeH256(hashes));
+    }
+    return msg;
+}
+
+// ---------------------------------------------------------------------------
+// BlockBodies
+// ---------------------------------------------------------------------------
+bcos::bytes encodeBlockBodies(BlockBodiesMessage const& _msg)
+{
+    std::vector<bcos::bytes> bodyItems;
+    bodyItems.reserve(_msg.bodies.size());
+    for (auto const& body : _msg.bodies)
+    {
+        // Transactions / uncles / withdrawals are already-encoded RLP elements
+        // (legacy txs are lists, typed txs are 0x01||payload bytes); splice them
+        // in directly — do NOT re-wrap them as strings.
+        std::vector<bcos::bytes> txs;
+        txs.reserve(body.transactions.size());
+        for (auto const& tx : body.transactions)
+        {
+            txs.push_back(tx);
+        }
+        std::vector<bcos::bytes> uncles;
+        uncles.reserve(body.uncles.size());
+        for (auto const& uncle : body.uncles)
+        {
+            uncles.push_back(uncle);
+        }
+        auto txsList = rlpList(txs);
+        auto unclesList = rlpList(uncles);
+        if (body.withdrawals.has_value())
+        {
+            std::vector<bcos::bytes> withdrawals;
+            withdrawals.reserve(body.withdrawals->size());
+            for (auto const& withdrawal : *body.withdrawals)
+            {
+                withdrawals.push_back(withdrawal);
+            }
+            bodyItems.push_back(rlpList({txsList, unclesList, rlpList(withdrawals)}));
+        }
+        else
+        {
+            bodyItems.push_back(rlpList({txsList, unclesList}));
+        }
+    }
+    return rlpList({rlpItem(_msg.requestId), rlpList(bodyItems)});
+}
+
+BlockBodiesMessage decodeBlockBodies(bytesConstRef _data)
+{
+    BlockBodiesMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+    msg.requestId = takeUint(items);
+    auto bodies = takeListPayload(items);
+    while (!bodies.empty())
+    {
+        auto bodyItems = takeListPayload(bodies);
+        auto txs = takeListPayload(bodyItems);
+        BlockBody body;
+        while (!txs.empty())
+        {
+            body.transactions.push_back(takeTx(txs));
+        }
+        auto uncles = takeListPayload(bodyItems);
+        while (!uncles.empty())
+        {
+            body.uncles.push_back(takeRlpItem(uncles));
+        }
+        // Shanghai+ bodies carry a third list of withdrawals.
+        if (!bodyItems.empty())
+        {
+            auto withdrawals = takeListPayload(bodyItems);
+            body.withdrawals = std::vector<bcos::bytes>{};
+            while (!withdrawals.empty())
+            {
+                body.withdrawals->push_back(takeRlpItem(withdrawals));
+            }
+        }
+        msg.bodies.push_back(std::move(body));
+    }
+    return msg;
+}
+
+// ---------------------------------------------------------------------------
+// NewBlockHashes
+// ---------------------------------------------------------------------------
+bcos::bytes encodeNewBlockHashes(NewBlockHashesMessage const& _msg)
+{
+    std::vector<bcos::bytes> entries;
+    entries.reserve(_msg.entries.size());
+    for (auto const& entry : _msg.entries)
+    {
+        entries.push_back(rlpList({rlpItem(entry.hash), rlpItem(entry.number)}));
+    }
+    return rlpList(entries);
+}
+
+NewBlockHashesMessage decodeNewBlockHashes(bytesConstRef _data)
+{
+    NewBlockHashesMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+    while (!items.empty())
+    {
+        auto entry = takeListPayload(items);
+        NewBlockHashesMessage::Entry e;
+        e.hash = takeH256(entry);
+        e.number = takeUint(entry);
+        msg.entries.push_back(std::move(e));
+    }
+    return msg;
+}
+
+}  // namespace bcos::devp2p::eth

--- a/bcos-devp2p/bcos-devp2p/eth/Protocol.h
+++ b/bcos-devp2p/bcos-devp2p/eth/Protocol.h
@@ -1,0 +1,161 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Protocol.h
+ * @brief eth/68 wire protocol: message codes and the messages needed for block
+ *        sync (Status, GetBlockHeaders/BlockHeaders, GetBlockBodies/BlockBodies,
+ *        NewBlockHashes). Ported from silkworm sentry/eth + sync/packets.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "../rlpx/Crypto.h"
+#include "../rlpx/Messages.h"
+#include "ForkId.h"
+#include <bcos-utilities/FixedBytes.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bcos::devp2p::eth
+{
+// eth/68 message codes (relative; the on-wire frame id adds kBaseProtocolLength).
+namespace msg
+{
+constexpr uint8_t Status = 0x00;
+constexpr uint8_t NewBlockHashes = 0x01;
+constexpr uint8_t Transactions = 0x02;
+constexpr uint8_t GetBlockHeaders = 0x03;
+constexpr uint8_t BlockHeaders = 0x04;
+constexpr uint8_t GetBlockBodies = 0x05;
+constexpr uint8_t BlockBodies = 0x06;
+constexpr uint8_t NewBlock = 0x07;
+constexpr uint8_t NewPooledTransactionHashes = 0x08;
+constexpr uint8_t GetPooledTransactions = 0x09;
+constexpr uint8_t PooledTransactions = 0x0a;
+constexpr uint8_t GetReceipts = 0x0f;
+constexpr uint8_t Receipts = 0x10;
+}  // namespace msg
+
+constexpr uint8_t kProtocolVersion = 69;  // highest eth version we support
+constexpr uint8_t kMinProtocolVersion = 68;
+// devp2p base-protocol message codes occupy 0..15; capability messages start at 16.
+constexpr uint16_t kBaseProtocolLength = 16;
+
+// On-wire frame id for an eth message (same offset for eth/68 and eth/69).
+inline uint16_t frameId(uint8_t _messageId)
+{
+    return static_cast<uint16_t>(kBaseProtocolLength) + _messageId;
+}
+
+// eth Status message. Two wire formats exist:
+//   eth/68: [protocolVersion, networkId, totalDifficulty, headHash, genesisHash, [forkHash,
+//   forkNext]] eth/69+ (EIP-8085 block range): [protocolVersion, networkId, genesisHash,
+//           [forkHash, forkNext], earliestBlock, latestBlock, latestBlockHash]
+struct StatusMessage
+{
+    uint64_t protocolVersion{kProtocolVersion};
+    uint64_t networkId{1};
+    bcos::bytes totalDifficulty;  // eth/68 only: minimal big-endian u256
+    bcos::h256 headHash;          // eth/68 only
+    bcos::h256 genesisHash;
+    ForkId forkId;
+    // eth/69+ (EIP-8085) block range fields.
+    uint64_t earliestBlock{0};
+    uint64_t latestBlock{0};
+    bcos::h256 latestBlockHash;
+    // true = encode/decode the EIP-8085 7-field form (eth/69+), false = eth/68 6-field form.
+    bool eip8085{false};
+};
+
+bcos::bytes encodeStatus(StatusMessage const& _msg);
+StatusMessage decodeStatus(bytesConstRef _data);
+
+// GetBlockHeaders (eth/66+): [requestId, [origin, amount, skip, reverse]]
+struct GetBlockHeadersMessage
+{
+    uint64_t requestId{0};
+    std::optional<bcos::h256> originHash;  // exactly one of originHash / originNumber is set
+    uint64_t originNumber{0};
+    uint64_t amount{1};
+    uint64_t skip{0};
+    bool reverse{false};
+};
+
+bcos::bytes encodeGetBlockHeaders(GetBlockHeadersMessage const& _msg);
+GetBlockHeadersMessage decodeGetBlockHeaders(bytesConstRef _data);
+
+// BlockHeaders (eth/66+): [requestId, [headerRlp, ...]]
+struct BlockHeadersMessage
+{
+    uint64_t requestId{0};
+    std::vector<bcos::bytes> headers;  // opaque RLP-encoded headers
+};
+
+bcos::bytes encodeBlockHeaders(BlockHeadersMessage const& _msg);
+BlockHeadersMessage decodeBlockHeaders(bytesConstRef _data);
+
+// GetBlockBodies (eth/66+): [requestId, [blockHash, ...]]
+struct GetBlockBodiesMessage
+{
+    uint64_t requestId{0};
+    std::vector<bcos::h256> hashes;
+};
+
+bcos::bytes encodeGetBlockBodies(GetBlockBodiesMessage const& _msg);
+GetBlockBodiesMessage decodeGetBlockBodies(bytesConstRef _data);
+
+// BlockBodies (eth/66+): [requestId, [[txs, uncles, withdrawals?], ...]]
+// Each body: [transactions (list of raw EIP-2718 tx bytes), uncles (list of raw headers),
+//             withdrawals? (list of raw EIP-4895 withdrawal RLP, Shanghai+)]
+struct BlockBody
+{
+    std::vector<bcos::bytes> transactions;
+    std::vector<bcos::bytes> uncles;
+    // nullopt = pre-Shanghai body; an (possibly empty) list for Shanghai+.
+    std::optional<std::vector<bcos::bytes>> withdrawals;
+};
+
+struct BlockBodiesMessage
+{
+    uint64_t requestId{0};
+    std::vector<BlockBody> bodies;
+};
+
+bcos::bytes encodeBlockBodies(BlockBodiesMessage const& _msg);
+BlockBodiesMessage decodeBlockBodies(bytesConstRef _data);
+
+// NewBlockHashes: [[blockHash, number], ...]
+struct NewBlockHashesMessage
+{
+    struct Entry
+    {
+        bcos::h256 hash;
+        uint64_t number{0};
+    };
+    std::vector<Entry> entries;
+};
+
+bcos::bytes encodeNewBlockHashes(NewBlockHashesMessage const& _msg);
+NewBlockHashesMessage decodeNewBlockHashes(bytesConstRef _data);
+
+// Capability entries advertised in the Hello message: eth/69 and eth/68. The
+// handshake negotiates the highest common version; eth/69 peers use the EIP-8085
+// Status format while eth/68 peers keep the legacy TD/head Status.
+inline std::vector<bcos::devp2p::rlpx::Capability> ethCapabilities()
+{
+    return {{std::string("eth"), kProtocolVersion}, {std::string("eth"), kMinProtocolVersion}};
+}
+}  // namespace bcos::devp2p::eth

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
@@ -1,0 +1,200 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Messages.cpp
+ * @brief devp2p base-protocol message RLP codecs.
+ * @date 2026/8/18
+ */
+#include "Messages.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <stdexcept>
+#include <vector>
+
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// Encode a pre-built payload as an RLP item (list or string).
+void appendEncoded(bcos::bytes& _to, bcos::bytes const& _item)
+{
+    _to.insert(_to.end(), _item.begin(), _item.end());
+}
+
+bcos::bytes encodeUint(uint64_t _value)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _value);
+    return out;
+}
+
+bcos::bytes encodeString(bytesConstRef _data)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _data);
+    return out;
+}
+
+// Expects a list at `_view` and returns a view over its payload.
+bcos::bytesRef takeListPayload(bcos::bytesRef& _view)
+{
+    auto [error, header] = bcos::codec::rlp::decodeHeader(_view);
+    if (error || !header.isList)
+    {
+        throw std::runtime_error("rlpx: expected an RLP list");
+    }
+    bcos::bytesRef payload(_view.data(), header.payloadLength);
+    _view =
+        bcos::bytesRef(_view.data() + header.payloadLength, _view.size() - header.payloadLength);
+    return payload;
+}
+}  // namespace
+
+bcos::bytes encodeHello(HelloMessage const& _msg)
+{
+    // caps payload: each cap = [name, version]
+    bcos::bytes capsPayload;
+    for (auto const& cap : _msg.capabilities)
+    {
+        bcos::codec::rlp::encode(capsPayload, cap.name, static_cast<uint64_t>(cap.version));
+    }
+    bcos::bytes capsList;
+    bcos::codec::rlp::encodeHeader(capsList, {.isList = true, .payloadLength = capsPayload.size()});
+    appendEncoded(capsList, capsPayload);
+
+    bcos::bytes versionItem = encodeUint(_msg.version);
+    bcos::bytes nameItem =
+        encodeString(bytesConstRef((const bcos::byte*)_msg.clientId.data(), _msg.clientId.size()));
+    bcos::bytes portItem = encodeUint(_msg.listenPort);
+    bcos::bytes idItem = encodeString(bytesConstRef(_msg.id.data(), _msg.id.size()));
+
+    size_t payloadLength =
+        versionItem.size() + nameItem.size() + capsList.size() + portItem.size() + idItem.size();
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payloadLength});
+    appendEncoded(out, versionItem);
+    appendEncoded(out, nameItem);
+    appendEncoded(out, capsList);
+    appendEncoded(out, portItem);
+    appendEncoded(out, idItem);
+    return out;
+}
+
+HelloMessage decodeHello(bytesConstRef _data)
+{
+    HelloMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("decodeHello: version decode failed");
+    }
+    msg.version = version;
+
+    if (auto err = bcos::codec::rlp::decode(items, msg.clientId))
+    {
+        throw std::runtime_error("decodeHello: clientId decode failed");
+    }
+
+    // caps list
+    auto capsPayload = takeListPayload(items);
+    while (!capsPayload.empty())
+    {
+        auto capItems = takeListPayload(capsPayload);
+        Capability cap;
+        if (auto err = bcos::codec::rlp::decode(capItems, cap.name))
+        {
+            throw std::runtime_error("decodeHello: cap name decode failed");
+        }
+        uint64_t capVersion = 0;
+        if (auto err = bcos::codec::rlp::decode(capItems, capVersion))
+        {
+            throw std::runtime_error("decodeHello: cap version decode failed");
+        }
+        cap.version = static_cast<uint8_t>(capVersion);
+        msg.capabilities.push_back(std::move(cap));
+    }
+
+    uint64_t listenPort = 0;
+    if (auto err = bcos::codec::rlp::decode(items, listenPort))
+    {
+        throw std::runtime_error("decodeHello: listenPort decode failed");
+    }
+    msg.listenPort = listenPort;
+
+    if (auto err = bcos::codec::rlp::decode(items, msg.id))
+    {
+        throw std::runtime_error("decodeHello: id decode failed");
+    }
+    return msg;
+}
+
+bcos::bytes encodeDisconnect(DisconnectMessage const& _msg)
+{
+    // geth wire format: disconnectMsg = [reason] — a one-element RLP list, NOT a
+    // bare integer. (We encode/disconnect with a bare integer before this fix, which
+    // made real geth peers reject the message and made decodeDisconnect fail on
+    // real Disconnect frames.)
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, std::vector<uint64_t>{static_cast<uint64_t>(_msg.reason)});
+    return out;
+}
+
+DisconnectMessage decodeDisconnect(bytesConstRef _data)
+{
+    DisconnectMessage msg;
+    // Wire format varies by client: geth/erigon send the EIP-8 list form [reason],
+    // while some clients (e.g. ethrex) send a bare integer. Accept both.
+    {
+        bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+        std::vector<uint64_t> reasons;
+        if (auto err = bcos::codec::rlp::decode(view, reasons); err == nullptr)
+        {
+            msg.reason = reasons.empty() ? DisconnectReason::DisconnectRequested :
+                                           static_cast<DisconnectReason>(reasons[0]);
+            return msg;
+        }
+    }
+    {
+        bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+        uint64_t reason = 0;
+        if (auto err = bcos::codec::rlp::decode(view, reason); err == nullptr)
+        {
+            msg.reason = static_cast<DisconnectReason>(reason);
+            return msg;
+        }
+    }
+    throw std::runtime_error("decodeDisconnect: reason decode failed payload=" +
+                             bcos::toHexStringWithPrefix(bcos::bytes(_data.begin(), _data.end())));
+}
+
+bcos::bytes encodePing()
+{
+    // Ping payload is the empty list: 0xc0.
+    return bcos::bytes{0xc0};
+}
+
+bcos::bytes encodePong()
+{
+    // Pong payload is the empty list: 0xc0.
+    return bcos::bytes{0xc0};
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
@@ -1,0 +1,86 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Messages.h
+ * @brief devp2p base-protocol messages: Hello, Disconnect, Ping, Pong.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <string>
+#include <vector>
+
+namespace bcos::devp2p::rlpx
+{
+// devp2p base-protocol message codes (shared by every capability).
+namespace baseMsg
+{
+constexpr uint8_t Hello = 0x00;
+constexpr uint8_t Disconnect = 0x01;
+constexpr uint8_t Ping = 0x02;
+constexpr uint8_t Pong = 0x03;
+}  // namespace baseMsg
+
+// Reason codes of the Disconnect message (EIP-8 / devp2p).
+enum class DisconnectReason : uint8_t
+{
+    DisconnectRequested = 0x00,
+    TcpSubsystemError = 0x01,
+    ProtocolBreach = 0x02,
+    UselessPeer = 0x03,
+    TooManyPeers = 0x04,
+    AlreadyConnected = 0x05,
+    IncompatibleP2pProtocolVersion = 0x06,
+    NullNodeIdentity = 0x07,
+    ClientQuitting = 0x08,
+    UnexpectedIdentity = 0x09,
+    LocalIdentity = 0x0a,
+    PingTimeout = 0x0b,
+    Unknown = 0x10,
+};
+
+struct Capability
+{
+    std::string name;
+    uint8_t version{0};
+};
+
+// RLP: [version, name, [[name, version], ...], listenPort, id]
+struct HelloMessage
+{
+    uint64_t version{5};
+    std::string clientId;
+    std::vector<Capability> capabilities;
+    uint64_t listenPort{0};
+    bcos::bytes id;  // 64-byte secp256k1 public key
+};
+
+bcos::bytes encodeHello(HelloMessage const& _msg);
+HelloMessage decodeHello(bytesConstRef _data);
+
+// RLP: [reason]
+struct DisconnectMessage
+{
+    DisconnectReason reason{DisconnectReason::DisconnectRequested};
+};
+
+bcos::bytes encodeDisconnect(DisconnectMessage const& _msg);
+DisconnectMessage decodeDisconnect(bytesConstRef _data);
+
+// Ping/Pong are the empty list RLP: 0xc0.
+bcos::bytes encodePing();
+bcos::bytes encodePong();
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/test/ProtocolTest.cpp
+++ b/bcos-devp2p/test/ProtocolTest.cpp
@@ -1,0 +1,290 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ProtocolTest.cpp
+ * @brief eth/68 message codec round trips + golden vectors + EIP-2124 forkid.
+ * @date 2026/8/18
+ */
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-devp2p/eth/Protocol.h>
+#include <bcos-devp2p/rlpx/Messages.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::devp2p;
+
+BOOST_AUTO_TEST_SUITE(ProtocolTest)
+
+// Golden from silkworm's packet_coding_test (eth/66):
+//   GetBlockHeaders66 [0x6b1a456ba6e2f81d, [0xb9ffff, 1, 0, 0]]
+BOOST_AUTO_TEST_CASE(getBlockHeadersGolden)
+{
+    eth::GetBlockHeadersMessage msg;
+    msg.requestId = 0x6b1a456ba6e2f81dull;
+    msg.originNumber = 0xb9ffff;
+    msg.amount = 1;
+    msg.skip = 0;
+    msg.reverse = false;
+
+    auto encoded = eth::encodeGetBlockHeaders(msg);
+    // The trailing byte is the `reverse` flag: a BOOLEAN on the wire. ethrex's
+    // bool decoder only accepts 0x80(false)/0x01(true) (RLP_NULL = false) and
+    // rejects geth's 0x00 encoding; geth's decoder reads the field as an integer
+    // and accepts both. Use 0x80/0x01 for cross-client compatibility.
+    BOOST_CHECK_EQUAL(toHex(encoded), "d1886b1a456ba6e2f81dc783b9ffff018080");
+
+    auto decoded = eth::decodeGetBlockHeaders(ref(encoded));
+    BOOST_CHECK_EQUAL(decoded.requestId, msg.requestId);
+    BOOST_CHECK(!decoded.originHash.has_value());
+    BOOST_CHECK_EQUAL(decoded.originNumber, msg.originNumber);
+    BOOST_CHECK_EQUAL(decoded.amount, msg.amount);
+    BOOST_CHECK_EQUAL(decoded.skip, msg.skip);
+    BOOST_CHECK_EQUAL(decoded.reverse, false);
+}
+
+BOOST_AUTO_TEST_CASE(getBlockHeadersByHashRoundTrip)
+{
+    eth::GetBlockHeadersMessage msg;
+    msg.requestId = 7;
+    msg.originHash =
+        h256(std::string_view("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+            h256::FromHex);
+    msg.amount = 128;
+    msg.skip = 1;
+    msg.reverse = true;
+
+    auto encoded = eth::encodeGetBlockHeaders(msg);
+    auto decoded = eth::decodeGetBlockHeaders(ref(encoded));
+    BOOST_CHECK_EQUAL(decoded.requestId, 7);
+    BOOST_REQUIRE(decoded.originHash.has_value());
+    BOOST_CHECK(*decoded.originHash == *msg.originHash);
+    BOOST_CHECK_EQUAL(decoded.amount, 128);
+    BOOST_CHECK_EQUAL(decoded.skip, 1);
+    BOOST_CHECK_EQUAL(decoded.reverse, true);
+}
+
+BOOST_AUTO_TEST_CASE(blockHeadersRoundTrip)
+{
+    eth::BlockHeadersMessage msg;
+    msg.requestId = 9;
+    // Headers on the wire are already-encoded RLP elements (lists) — they must
+    // NOT be re-wrapped as strings. Use small but COMPLETE RLP lists here.
+    msg.headers = {fromHex("c0"), fromHex("c101")};
+
+    auto encoded = eth::encodeBlockHeaders(msg);
+    auto decoded = eth::decodeBlockHeaders(ref(encoded));
+    BOOST_CHECK_EQUAL(decoded.requestId, 9);
+    BOOST_REQUIRE_EQUAL(decoded.headers.size(), 2u);
+    BOOST_CHECK(decoded.headers[0] == msg.headers[0]);
+    BOOST_CHECK(decoded.headers[1] == msg.headers[1]);
+}
+
+BOOST_AUTO_TEST_CASE(blockBodiesRoundTrip)
+{
+    eth::BlockBodiesMessage msg;
+    msg.requestId = 3;
+    eth::BlockBody body;
+    // Transactions / uncles / withdrawals are already-encoded RLP elements;
+    // legacy txs are lists, typed txs are 0xNN||payload. Use complete RLP here.
+    body.transactions = {fromHex("c3010203"), fromHex("c101")};
+    body.uncles = {fromHex("c0")};
+    body.withdrawals = std::vector<bcos::bytes>{fromHex("c101"), fromHex("c20203")};
+    msg.bodies.push_back(body);
+
+    auto encoded = eth::encodeBlockBodies(msg);
+    auto decoded = eth::decodeBlockBodies(ref(encoded));
+    BOOST_CHECK_EQUAL(decoded.requestId, 3);
+    BOOST_REQUIRE_EQUAL(decoded.bodies.size(), 1u);
+    BOOST_REQUIRE_EQUAL(decoded.bodies[0].transactions.size(), 2u);
+    BOOST_CHECK(decoded.bodies[0].transactions[0] == body.transactions[0]);
+    BOOST_CHECK(decoded.bodies[0].transactions[1] == body.transactions[1]);
+    BOOST_REQUIRE_EQUAL(decoded.bodies[0].uncles.size(), 1u);
+    BOOST_CHECK(decoded.bodies[0].uncles[0] == body.uncles[0]);
+}
+
+// On the wire a typed transaction is RLP-encoded as a STRING whose content is
+// 0xNN || rlp(payload) (legacy txs are RLP lists). decodeBlockBodies/takeTx must
+// strip the string prefix so the decoder receives exactly 0xNN||payload.
+BOOST_AUTO_TEST_CASE(blockBodiesTypedTxStringWrapped)
+{
+    // Real Sepolia block 33106 EIP-1559 (type 0x02) transfer: 0x02f877... .
+    auto typedTx = fromHex(
+        "02f87783aa36a7808459682f00851f71a335b5825208942f14582947e292a2ecd20c430b46f2"
+        "d27cfe213c8901a055690d9db8000080c080a06dd8b58b520530663fa1ce8bbbc3eb9b2e0b79"
+        "70138d781b9d9380e3dbf1f362a0098934613bfad8e42b3d93b26b450d1028c2288e212c8160"
+        "5a54d886028c5746");
+    // The same bytes as geth would encode them in a BlockBodies list: an RLP
+    // STRING wrapping the typed tx (string prefix + 0x02f877...).
+    bcos::bytes wireTypedTx;
+    bcos::codec::rlp::encode(wireTypedTx, bcos::bytesConstRef(typedTx.data(), typedTx.size()));
+
+    // Build the wire message by hand (decode path only): requestId, one body
+    // with transactions [string-wrapped typed tx, legacy list tx], uncles [].
+    auto txsList = [&]() {
+        bcos::bytes out;
+        bcos::codec::rlp::encodeHeader(
+            out, {.isList = true, .payloadLength = wireTypedTx.size() + 4 /* 0xc3 01 02 03 */});
+        out.insert(out.end(), wireTypedTx.begin(), wireTypedTx.end());
+        out.insert(out.end(), {0xc3, 0x01, 0x02, 0x03});
+        return out;
+    }();
+    auto unclesList = []() {
+        bcos::bytes out;
+        bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = 1});
+        out.push_back(0xc0);
+        return out;
+    }();
+    auto bodyList = [&]() {
+        bcos::bytes out;
+        bcos::codec::rlp::encodeHeader(
+            out, {.isList = true, .payloadLength = txsList.size() + unclesList.size()});
+        out.insert(out.end(), txsList.begin(), txsList.end());
+        out.insert(out.end(), unclesList.begin(), unclesList.end());
+        return out;
+    }();
+    bcos::bytes bodyItems;
+    bodyItems.insert(bodyItems.end(), bodyList.begin(), bodyList.end());
+    auto bodiesList = [&]() {
+        bcos::bytes out;
+        bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = bodyItems.size()});
+        out.insert(out.end(), bodyItems.begin(), bodyItems.end());
+        return out;
+    }();
+    auto wire = [&]() {
+        bcos::bytes out;
+        bcos::codec::rlp::encodeHeader(
+            out, {.isList = true, .payloadLength = 1 + bodiesList.size()});
+        out.push_back(0x07);  // requestId
+        out.insert(out.end(), bodiesList.begin(), bodiesList.end());
+        return out;
+    }();
+
+    auto decoded = eth::decodeBlockBodies(ref(wire));
+    BOOST_CHECK_EQUAL(decoded.requestId, 7);
+    BOOST_REQUIRE_EQUAL(decoded.bodies.size(), 1u);
+    BOOST_REQUIRE_EQUAL(decoded.bodies[0].transactions.size(), 2u);
+    // typed tx must come back WITHOUT the string prefix (0xNN||payload only)
+    BOOST_CHECK(decoded.bodies[0].transactions[0] == typedTx);
+    BOOST_CHECK(decoded.bodies[0].transactions[1] == (bcos::bytes{0xc3, 0x01, 0x02, 0x03}));
+}
+
+BOOST_AUTO_TEST_CASE(statusRoundTrip)
+{
+    eth::StatusMessage msg;
+    msg.protocolVersion = 68;
+    msg.networkId = 11155111;  // Sepolia
+    msg.totalDifficulty = fromHex("0102030405060708");
+    msg.headHash =
+        h256(std::string_view("0x1111111111111111111111111111111111111111111111111111111111111111"),
+            h256::FromHex);
+    msg.genesisHash =
+        h256(std::string_view("0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9"),
+            h256::FromHex);  // Sepolia genesis
+    msg.forkId = {0x12345678, 0};
+
+    auto encoded = eth::encodeStatus(msg);
+    auto decoded = eth::decodeStatus(ref(encoded));
+    BOOST_CHECK_EQUAL(decoded.protocolVersion, 68);
+    BOOST_CHECK_EQUAL(decoded.networkId, 11155111);
+    BOOST_CHECK(decoded.totalDifficulty == msg.totalDifficulty);
+    BOOST_CHECK(decoded.headHash == msg.headHash);
+    BOOST_CHECK(decoded.genesisHash == msg.genesisHash);
+    BOOST_CHECK_EQUAL(decoded.forkId.hash, 0x12345678u);
+    BOOST_CHECK_EQUAL(decoded.forkId.next, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(newBlockHashesRoundTrip)
+{
+    eth::NewBlockHashesMessage msg;
+    msg.entries = {
+        {h256(
+             std::string_view("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+             h256::FromHex),
+            1},
+        {h256(
+             std::string_view("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+             h256::FromHex),
+            2},
+    };
+    auto encoded = eth::encodeNewBlockHashes(msg);
+    auto decoded = eth::decodeNewBlockHashes(ref(encoded));
+    BOOST_REQUIRE_EQUAL(decoded.entries.size(), 2u);
+    BOOST_CHECK(decoded.entries[0].hash == msg.entries[0].hash);
+    BOOST_CHECK_EQUAL(decoded.entries[0].number, 1u);
+    BOOST_CHECK(decoded.entries[1].hash == msg.entries[1].hash);
+    BOOST_CHECK_EQUAL(decoded.entries[1].number, 2u);
+}
+
+// EIP-2124: mainnet genesis + forks → CRC32 chain (validated against zlib).
+BOOST_AUTO_TEST_CASE(forkIdMainnetChain)
+{
+    auto genesis =
+        h256(std::string_view("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
+            h256::FromHex);
+    // crc32 over the FULL 32-byte genesis hash.
+    auto hash = eth::crc32(bytesConstRef(genesis.data(), genesis.size()));
+    BOOST_CHECK_EQUAL(hash, 0xfc64ec04u);
+
+    // Chain mainnet fork block numbers (the same set geth's forkid tests use).
+    std::vector<uint64_t> forks = {1150000, 1920000, 2463000, 2675000, 4370000, 7280000, 7280000,
+        9069000, 9200000, 12244000, 12965000, 13773000, 15050000, 15537394, 17034870, 19426587};
+    for (auto fork : forks)
+    {
+        hash = eth::forkIdAddForkPoint(hash, fork);
+    }
+    // Full mainnet forkid after Cancun (validated against zlib.crc32).
+    BOOST_CHECK_EQUAL(hash, 0xa0455cf2u);
+}
+
+// Hello message golden (RLP built with an independent encoder).
+BOOST_AUTO_TEST_CASE(helloGolden)
+{
+    rlpx::HelloMessage hello;
+    hello.version = 5;
+    hello.clientId = "test";
+    hello.capabilities.push_back({std::string("eth"), 68});
+    hello.listenPort = 30303;
+    hello.id.assign(64, 0x01);
+
+    auto encoded = rlpx::encodeHello(hello);
+    // [5, "test", [["eth", 68]], 30303, 64x01]
+    std::string expected = "f852058474657374c6c5836574684482765fb840";
+    for (int i = 0; i < 64; ++i)
+    {
+        expected += "01";
+    }
+    BOOST_CHECK_EQUAL(toHex(encoded), expected);
+
+    auto decoded = rlpx::decodeHello(ref(encoded));
+    BOOST_CHECK_EQUAL(decoded.version, 5u);
+    BOOST_CHECK_EQUAL(decoded.clientId, "test");
+    BOOST_REQUIRE_EQUAL(decoded.capabilities.size(), 1u);
+    BOOST_CHECK_EQUAL(decoded.capabilities[0].name, "eth");
+    BOOST_CHECK_EQUAL(decoded.capabilities[0].version, 68);
+    BOOST_CHECK_EQUAL(decoded.listenPort, 30303u);
+    BOOST_CHECK(decoded.id == hello.id);
+}
+
+BOOST_AUTO_TEST_CASE(disconnectRoundTrip)
+{
+    rlpx::DisconnectMessage msg;
+    msg.reason = rlpx::DisconnectReason::UselessPeer;
+    auto encoded = rlpx::encodeDisconnect(msg);
+    auto decoded = rlpx::decodeDisconnect(ref(encoded));
+    BOOST_CHECK(decoded.reason == rlpx::DisconnectReason::UselessPeer);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 概述

从 eth_sync 分支拆分的 devp2p 子模块 PR:eth 线协议消息与能力协商。

- `rlpx/Messages.{h,cpp}`:devp2p 基础消息类型(Hello / Disconnect / Ping / Pong 等)的 RLP 编解码
- `eth/Protocol.{h,cpp}`:eth/68 能力协议(Status、GetBlockHeaders/BlockHeaders、GetBlockBodies/BlockBodies 等消息的编解码与处理)
- `eth/ForkId.{h,cpp}`:EIP-2124 fork id 计算与校验,用于 Status 握手时过滤异构链节点
- `test/ProtocolTest.cpp`:协议消息编解码单元测试

## 依赖

仅依赖 upstream 已合入代码(rlpx Crypto #5507)与 bcos-utilities / bcos-codec,与其他待提的 devp2p PR 无相互依赖,可独立合入。

## 验证

- `tools/.ci/check-commit.sh` 通过,有效行数 valid_insertions = 501
- `test-bcos-devp2p` 编译通过,测试 20/20 通过(Debug / gcc)