### PR TITLE
feat(devp2p): add RLPx blocking socket and ECIES handshake

### DIFF
--- a/bcos-devp2p/bcos-devp2p/rlpx/Handshake.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Handshake.cpp
@@ -1,0 +1,316 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Handshake.cpp
+ * @brief RLPx v4 handshake implementation (port of silkworm auth messages).
+ * @date 2026/8/18
+ */
+#include "Handshake.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-crypto/random/CryptoRandom.h>
+#include <stdexcept>
+
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// 2-byte big-endian size prefix (EIP-8 auth-size).
+bcos::bytes serializeSizeImpl(size_t _size)
+{
+    bcos::bytes size(2, 0);
+    size[0] = static_cast<bcos::byte>((_size >> 8) & 0xff);
+    size[1] = static_cast<bcos::byte>(_size & 0xff);
+    return size;
+}
+
+size_t deserializeSize(bytesConstRef _data)
+{
+    if (_data.size() < 2)
+    {
+        throw std::runtime_error("handshake: size prefix too short");
+    }
+    return (static_cast<size_t>(_data[0]) << 8) | static_cast<size_t>(_data[1]);
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// AuthMessage
+// ---------------------------------------------------------------------------
+AuthMessage::AuthMessage(EccKeyPair const& _initiatorKeyPair, bytesConstRef _recipientPublicKey,
+    EccKeyPair const& _ephemeralKeyPair)
+  : m_initiatorPublicKey(_initiatorKeyPair.publicKey()),
+    m_recipientPublicKey(_recipientPublicKey.begin(), _recipientPublicKey.end()),
+    m_ephemeralPublicKey(_ephemeralKeyPair.publicKey())
+{
+    auto const& initiatorPrivateKey = _initiatorKeyPair.privateKey();
+    auto const& ephemeralPrivateKey = _ephemeralKeyPair.privateKey();
+    bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(
+        _recipientPublicKey, bytesConstRef(initiatorPrivateKey.data(), initiatorPrivateKey.size()));
+    m_nonce = bcos::crypto::cryptoRandomBytes(sharedSecret.size());
+    xorBytes(sharedSecret, bytesConstRef(m_nonce.data(), m_nonce.size()));
+    m_signature = signRecoverable(bytesConstRef(sharedSecret.data(), sharedSecret.size()),
+        bytesConstRef(ephemeralPrivateKey.data(), ephemeralPrivateKey.size()));
+}
+
+AuthMessage::AuthMessage(bytesConstRef _data, bytesConstRef _recipientPrivateKey)
+{
+    auto plainText = decryptBody(_data, _recipientPrivateKey);
+    initFromRlp(bytesConstRef(plainText.data(), plainText.size()));
+
+    bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(
+        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
+        _recipientPrivateKey);
+    if (sharedSecret.size() != m_nonce.size())
+    {
+        throw std::runtime_error("AuthMessage: invalid nonce size");
+    }
+    xorBytes(sharedSecret, bytesConstRef(m_nonce.data(), m_nonce.size()));
+    m_ephemeralPublicKey = recoverPublicKey(bytesConstRef(sharedSecret.data(), sharedSecret.size()),
+        bytesConstRef(m_signature.data(), m_signature.size()));
+}
+
+bcos::bytes AuthMessage::bodyAsRlp() const
+{
+    bcos::bytes data;
+    bcos::codec::rlp::encode(data, bytesConstRef(m_signature.data(), m_signature.size()),
+        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
+        bytesConstRef(m_nonce.data(), m_nonce.size()), static_cast<uint64_t>(kVersion));
+    return data;
+}
+
+void AuthMessage::initFromRlp(bytesConstRef _data)
+{
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto [listError, listHeader] = bcos::codec::rlp::decodeHeader(view);
+    if (listError || !listHeader.isList)
+    {
+        throw std::runtime_error("AuthMessage: auth body is not an RLP list");
+    }
+    bcos::bytesRef items(view.data(), listHeader.payloadLength);
+    auto decodeBytes = [&items](bcos::bytes& out) {
+        if (auto err = bcos::codec::rlp::decode(items, out))
+        {
+            throw std::runtime_error("AuthMessage: item decode failed");
+        }
+    };
+    decodeBytes(m_signature);
+    decodeBytes(m_initiatorPublicKey);
+    decodeBytes(m_nonce);
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("AuthMessage: version decode failed");
+    }
+    // Ignore trailing items (EIP-8 forward compatibility).
+    if (m_signature.size() != 65 || m_initiatorPublicKey.size() != 64 || m_nonce.size() != 32)
+    {
+        throw std::runtime_error("AuthMessage: invalid item sizes");
+    }
+}
+
+bcos::bytes AuthMessage::serializeSize(size_t _bodySize)
+{
+    return serializeSizeImpl(_bodySize);
+}
+
+bcos::bytes AuthMessage::decryptBody(bytesConstRef _data, bytesConstRef _recipientPrivateKey)
+{
+    auto size = serializeSizeImpl(_data.size());
+    return EciesCipher::decrypt(
+        _data, _recipientPrivateKey, bytesConstRef(size.data(), size.size()));
+}
+
+bcos::bytes AuthMessage::serialize() const
+{
+    bcos::bytes bodyRlp = bodyAsRlp();
+    bodyRlp.resize(EciesCipher::roundUpToBlockSize(bodyRlp.size()));
+    size_t bodySize = EciesCipher::estimateEncryptedSize(bodyRlp.size());
+
+    auto size = serializeSizeImpl(bodySize);
+    auto body = EciesCipher::encrypt(bytesConstRef(bodyRlp.data(), bodyRlp.size()),
+        bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()),
+        bytesConstRef(size.data(), size.size()));
+    body.insert(body.begin(), size.begin(), size.end());
+    return body;
+}
+
+// ---------------------------------------------------------------------------
+// AuthAckMessage
+// ---------------------------------------------------------------------------
+AuthAckMessage::AuthAckMessage(EccKeyPair const& _ephemeralKeyPair,
+    bytesConstRef _initiatorPublicKey, bytesConstRef _recipientNonce)
+  : m_ephemeralPublicKey(_ephemeralKeyPair.publicKey()),
+    m_initiatorPublicKey(_initiatorPublicKey.begin(), _initiatorPublicKey.end()),
+    m_nonce(_recipientNonce.begin(), _recipientNonce.end())
+{}
+
+AuthAckMessage::AuthAckMessage(bytesConstRef _data, bytesConstRef _initiatorPrivateKey)
+{
+    auto plainText = decryptBody(_data, _initiatorPrivateKey);
+    initFromRlp(bytesConstRef(plainText.data(), plainText.size()));
+}
+
+bcos::bytes AuthAckMessage::bodyAsRlp() const
+{
+    bcos::bytes data;
+    bcos::codec::rlp::encode(data,
+        bytesConstRef(m_ephemeralPublicKey.data(), m_ephemeralPublicKey.size()),
+        bytesConstRef(m_nonce.data(), m_nonce.size()), static_cast<uint64_t>(kVersion));
+    return data;
+}
+
+void AuthAckMessage::initFromRlp(bytesConstRef _data)
+{
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto [listError, listHeader] = bcos::codec::rlp::decodeHeader(view);
+    if (listError || !listHeader.isList)
+    {
+        throw std::runtime_error("AuthAckMessage: ack body is not an RLP list");
+    }
+    bcos::bytesRef items(view.data(), listHeader.payloadLength);
+    auto decodeBytes = [&items](bcos::bytes& out) {
+        if (auto err = bcos::codec::rlp::decode(items, out))
+        {
+            throw std::runtime_error("AuthAckMessage: item decode failed");
+        }
+    };
+    decodeBytes(m_ephemeralPublicKey);
+    decodeBytes(m_nonce);
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("AuthAckMessage: version decode failed");
+    }
+    if (m_ephemeralPublicKey.size() != 64 || m_nonce.size() != 32)
+    {
+        throw std::runtime_error("AuthAckMessage: invalid item sizes");
+    }
+}
+
+bcos::bytes AuthAckMessage::serializeSize(size_t _bodySize)
+{
+    return serializeSizeImpl(_bodySize);
+}
+
+bcos::bytes AuthAckMessage::decryptBody(bytesConstRef _data, bytesConstRef _initiatorPrivateKey)
+{
+    auto size = serializeSizeImpl(_data.size());
+    return EciesCipher::decrypt(
+        _data, _initiatorPrivateKey, bytesConstRef(size.data(), size.size()));
+}
+
+bcos::bytes AuthAckMessage::serialize() const
+{
+    bcos::bytes bodyRlp = bodyAsRlp();
+    bodyRlp.resize(EciesCipher::roundUpToBlockSize(bodyRlp.size()));
+    size_t bodySize = EciesCipher::estimateEncryptedSize(bodyRlp.size());
+
+    auto size = serializeSizeImpl(bodySize);
+    auto body = EciesCipher::encrypt(bytesConstRef(bodyRlp.data(), bodyRlp.size()),
+        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
+        bytesConstRef(size.data(), size.size()));
+    body.insert(body.begin(), size.begin(), size.end());
+    return body;
+}
+
+// ---------------------------------------------------------------------------
+// Handshake orchestration
+// ---------------------------------------------------------------------------
+AuthKeys Handshake::execute(Socket& _socket)
+{
+    if (m_isInitiator)
+    {
+        return authInitiator(_socket);
+    }
+    return authRecipient(_socket);
+}
+
+AuthKeys Handshake::authInitiator(Socket& _socket)
+{
+    if (m_recipientPublicKey.size() != 64)
+    {
+        throw std::invalid_argument("Handshake: initiator requires the recipient public key");
+    }
+    EccKeyPair ephemeralKeyPair;
+
+    AuthMessage authMessage(m_keyPair,
+        bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()), ephemeralKeyPair);
+    auto authData = authMessage.serialize();
+    _socket.sendAll(bytesConstRef(authData.data(), authData.size()));
+
+    // Read the ack: 2-byte size || encrypted body.
+    auto sizeData = _socket.recvFixed(2);
+    size_t size = deserializeSize(bytesConstRef(sizeData.data(), sizeData.size()));
+    if (size > 2048)
+    {
+        throw std::runtime_error("Handshake: ack message too big");
+    }
+    auto ackData = _socket.recvFixed(size);
+
+    AuthAckMessage ackMessage(
+        bytesConstRef(ackData.data(), ackData.size()), ref(m_keyPair.privateKey()));
+
+    AuthKeys keys;
+    keys.peerEphemeralPublicKey = ackMessage.ephemeralPublicKey();
+    keys.ephemeralPrivateKey = ephemeralKeyPair.privateKey();
+    keys.initiatorNonce = authMessage.nonce().toBytes();
+    keys.recipientNonce = ackMessage.nonce().toBytes();
+    keys.initiatorFirstMessageData = authData;
+    // The MAC seed uses the FULL wire message, including the 2-byte size prefix.
+    keys.recipientFirstMessageData = sizeData;
+    keys.recipientFirstMessageData.insert(
+        keys.recipientFirstMessageData.end(), ackData.begin(), ackData.end());
+    return keys;
+}
+
+AuthKeys Handshake::authRecipient(Socket& _socket)
+{
+    // Read the auth: 2-byte size || encrypted body.
+    auto sizeData = _socket.recvFixed(2);
+    size_t size = deserializeSize(bytesConstRef(sizeData.data(), sizeData.size()));
+    if (size > 2048)
+    {
+        throw std::runtime_error("Handshake: auth message too big");
+    }
+    auto authData = _socket.recvFixed(size);
+
+    AuthMessage authMessage(
+        bytesConstRef(authData.data(), authData.size()), ref(m_keyPair.privateKey()));
+
+    EccKeyPair ephemeralKeyPair;
+    // The ack carries a fresh recipient nonce (independent of the initiator's).
+    auto recipientNonce = bcos::crypto::cryptoRandomBytes(32);
+    AuthAckMessage ackMessage(ephemeralKeyPair, ref(authMessage.initiatorPublicKey()),
+        bytesConstRef(recipientNonce.data(), recipientNonce.size()));
+    auto ackData = ackMessage.serialize();
+    _socket.sendAll(bytesConstRef(ackData.data(), ackData.size()));
+
+    AuthKeys keys;
+    keys.peerEphemeralPublicKey = authMessage.ephemeralPublicKey();
+    keys.ephemeralPrivateKey = ephemeralKeyPair.privateKey();
+    keys.initiatorNonce = authMessage.nonce().toBytes();
+    keys.recipientNonce = recipientNonce;
+    // The MAC seed uses the FULL wire message, including the 2-byte size prefix.
+    keys.initiatorFirstMessageData = sizeData;
+    keys.initiatorFirstMessageData.insert(
+        keys.initiatorFirstMessageData.end(), authData.begin(), authData.end());
+    keys.recipientFirstMessageData = ackData;
+    return keys;
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Handshake.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Handshake.h
@@ -1,0 +1,120 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Handshake.h
+ * @brief RLPx v4 encrypted handshake (EIP-8): Auth/Ack messages, ECIES
+ *        encapsulation, shared-secret derivation. Ported from silkworm
+ *        sentry/rlpx/auth; wire-compatible with geth p2p/rlpx.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Crypto.h"
+#include "Socket.h"
+
+namespace bcos::devp2p::rlpx
+{
+// RLPx v4 auth message: ECIES(recipientPub, rlp([sig, initiatorPub, nonce, 4])).
+class AuthMessage
+{
+public:
+    // Build as the initiator.
+    AuthMessage(EccKeyPair const& _initiatorKeyPair, bytesConstRef _recipientPublicKey,
+        EccKeyPair const& _ephemeralKeyPair);
+    // Parse + verify as the recipient.
+    AuthMessage(bytesConstRef _data, bytesConstRef _recipientPrivateKey);
+
+    // Wire bytes: 2-byte size || ECIES body.
+    bcos::bytes serialize() const;
+
+    PublicKey const& initiatorPublicKey() const { return m_initiatorPublicKey; }
+    PublicKey const& ephemeralPublicKey() const { return m_ephemeralPublicKey; }
+    bytesConstRef nonce() const { return bytesConstRef(m_nonce.data(), m_nonce.size()); }
+
+private:
+    bcos::bytes bodyAsRlp() const;
+    void initFromRlp(bytesConstRef _data);
+    static bcos::bytes serializeSize(size_t _bodySize);
+    static bcos::bytes decryptBody(bytesConstRef _data, bytesConstRef _recipientPrivateKey);
+
+    PublicKey m_initiatorPublicKey;
+    bcos::bytes m_recipientPublicKey;
+    PublicKey m_ephemeralPublicKey;
+    bcos::bytes m_nonce;
+    bcos::bytes m_signature;
+    static constexpr uint8_t kVersion{4};
+};
+
+// RLPx v4 ack message: ECIES(initiatorPub, rlp([ephemeralPub, nonce, 4])).
+class AuthAckMessage
+{
+public:
+    AuthAckMessage(EccKeyPair const& _ephemeralKeyPair, bytesConstRef _initiatorPublicKey,
+        bytesConstRef _recipientNonce);
+    // Parse as the initiator (we already know the recipient static key).
+    explicit AuthAckMessage(bytesConstRef _data, bytesConstRef _initiatorPrivateKey);
+
+    bcos::bytes serialize() const;
+
+    PublicKey const& ephemeralPublicKey() const { return m_ephemeralPublicKey; }
+    bytesConstRef nonce() const { return bytesConstRef(m_nonce.data(), m_nonce.size()); }
+
+private:
+    bcos::bytes bodyAsRlp() const;
+    void initFromRlp(bytesConstRef _data);
+    static bcos::bytes serializeSize(size_t _bodySize);
+    static bcos::bytes decryptBody(bytesConstRef _data, bytesConstRef _initiatorPrivateKey);
+
+    PublicKey m_ephemeralPublicKey;
+    bcos::bytes m_initiatorPublicKey;
+    bcos::bytes m_nonce;
+    static constexpr uint8_t kVersion{4};
+};
+
+// The keys derived from a completed handshake, plus the wire bytes of the
+// auth/ack messages (needed to seed the framing MACs).
+struct AuthKeys
+{
+    PublicKey peerEphemeralPublicKey;
+    PrivateKey ephemeralPrivateKey;
+    bcos::bytes initiatorNonce;
+    bcos::bytes recipientNonce;
+    bcos::bytes initiatorFirstMessageData;
+    bcos::bytes recipientFirstMessageData;
+};
+
+// Runs the encrypted handshake over a socket.
+//   initiator side: send auth, receive ack (needs the recipient static pubkey)
+//   recipient side: receive auth, send ack
+class Handshake
+{
+public:
+    Handshake(EccKeyPair const& _keyPair, bool _isInitiator, bytesConstRef _recipientPublicKey = {})
+      : m_keyPair(_keyPair),
+        m_isInitiator(_isInitiator),
+        m_recipientPublicKey(_recipientPublicKey.begin(), _recipientPublicKey.end())
+    {}
+
+    AuthKeys execute(Socket& _socket);
+
+private:
+    AuthKeys authInitiator(Socket& _socket);
+    AuthKeys authRecipient(Socket& _socket);
+
+    EccKeyPair const& m_keyPair;
+    bool m_isInitiator;
+    bcos::bytes m_recipientPublicKey;  // set for the initiator side
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
@@ -1,0 +1,285 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Socket.cpp
+ * @brief Blocking TCP socket implementation (POSIX sockets).
+ * @date 2026/8/18
+ */
+#include "Socket.h"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+
+namespace bcos::devp2p::rlpx
+{
+// Connect timeout for outbound RLPx dials. A bootnode behind a black-hole firewall
+// (packets silently dropped) would otherwise make the blocking connect() hang for
+// the kernel's TCP timeout (tens of seconds to minutes), stalling the whole sync
+// loop. With a bounded connect the loop moves on to the next bootnode and retries.
+constexpr int c_connectTimeoutMs = 5000;
+// I/O timeout for the blocking sendAll/recvFixed helpers. A peer that accepts the
+// TCP connection but then neither sends (auth handshake, frames) nor reads our
+// output would otherwise block the sync thread forever — the RLPx handshake and
+// download loop would stall on a single silent peer. Bounded I/O lets the sync
+// loop treat it as a failed peer and move on to the next bootnode.
+constexpr int c_ioTimeoutMs = 15000;
+Socket::Socket()
+{
+    m_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (m_fd < 0)
+    {
+        throw std::runtime_error("Socket: socket() failed: " + std::string(strerror(errno)));
+    }
+}
+
+Socket::Socket(int _fd) : m_fd(_fd) {}
+
+Socket::~Socket()
+{
+    close();
+}
+
+Socket::Socket(Socket&& _other) noexcept : m_fd(_other.m_fd)
+{
+    _other.m_fd = -1;
+}
+
+Socket& Socket::operator=(Socket&& _other) noexcept
+{
+    if (this != &_other)
+    {
+        close();
+        m_fd = _other.m_fd;
+        _other.m_fd = -1;
+    }
+    return *this;
+}
+
+void Socket::connect(std::string const& _host, uint16_t _port)
+{
+    struct addrinfo hints;
+    std::memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo* result = nullptr;
+    std::string portStr = std::to_string(_port);
+    int rc = ::getaddrinfo(_host.c_str(), portStr.c_str(), &hints, &result);
+    if (rc != 0 || result == nullptr)
+    {
+        throw std::runtime_error("Socket::connect: getaddrinfo failed for " + _host);
+    }
+
+    // Set the socket non-blocking so a black-holed peer makes connect() return
+    // EINPROGRESS instead of blocking for the kernel's TCP timeout; completion is
+    // then awaited with a bounded poll() below.
+    int flags = ::fcntl(m_fd, F_GETFL, 0);
+    if (flags >= 0)
+    {
+        ::fcntl(m_fd, F_SETFL, flags | O_NONBLOCK);
+    }
+
+    int connectRc = ::connect(m_fd, result->ai_addr, result->ai_addrlen);
+    ::freeaddrinfo(result);
+
+    if (connectRc != 0 && errno != EINPROGRESS)
+    {
+        throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
+                                 " failed: " + std::string(strerror(errno)));
+    }
+
+    if (connectRc != 0)
+    {
+        // Non-blocking connect in progress (EINPROGRESS): wait for completion with a
+        // bounded timeout. A black-holed peer would otherwise block here for the
+        // kernel's TCP retry budget.
+        struct pollfd pfd;
+        pfd.fd = m_fd;
+        pfd.events = POLLOUT;
+        pfd.revents = 0;
+        int pollRc = ::poll(&pfd, 1, c_connectTimeoutMs);
+        if (pollRc <= 0)
+        {
+            throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
+                                     " timed out after " + std::to_string(c_connectTimeoutMs) +
+                                     "ms");
+        }
+        // Distinguish an actual connection error from a spurious wakeup.
+        int soError = 0;
+        socklen_t soLen = sizeof(soError);
+        if (::getsockopt(m_fd, SOL_SOCKET, SO_ERROR, &soError, &soLen) != 0 || soError != 0)
+        {
+            throw std::runtime_error(
+                "Socket::connect: connect to " + _host + ":" + portStr +
+                " failed: " + std::string(strerror(soError != 0 ? soError : errno)));
+        }
+    }
+
+    // Restore the blocking mode the rest of the RLPx session relies on (sendAll /
+    // recvFixed are blocking full-read/full-write helpers).
+    int restoreFlags = ::fcntl(m_fd, F_GETFL, 0);
+    if (restoreFlags >= 0)
+    {
+        ::fcntl(m_fd, F_SETFL, restoreFlags & ~O_NONBLOCK);
+    }
+}
+
+void Socket::close()
+{
+    if (m_fd >= 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+}
+
+void Socket::sendAll(bytesConstRef _data)
+{
+    size_t sent = 0;
+    while (sent < _data.size())
+    {
+        // Wait for writability with a bounded timeout so a peer that never reads
+        // our output (full send buffer) cannot stall the sync loop forever.
+        struct pollfd pfd;
+        pfd.fd = m_fd;
+        pfd.events = POLLOUT;
+        pfd.revents = 0;
+        int pollRc = ::poll(&pfd, 1, c_ioTimeoutMs);
+        if (pollRc <= 0)
+        {
+            throw std::runtime_error(
+                "Socket::sendAll: write timed out after " + std::to_string(c_ioTimeoutMs) + "ms");
+        }
+        ssize_t n = ::send(m_fd, _data.data() + sent, _data.size() - sent, MSG_NOSIGNAL);
+        if (n < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            throw std::runtime_error(
+                "Socket::sendAll: send failed: " + std::string(strerror(errno)));
+        }
+        sent += static_cast<size_t>(n);
+    }
+}
+
+bcos::bytes Socket::recvFixed(size_t _size)
+{
+    bcos::bytes out(_size);
+    size_t received = 0;
+    while (received < _size)
+    {
+        // Wait for readability with a bounded timeout so a silent peer (accepts
+        // the connection but never sends) cannot block the sync thread forever.
+        struct pollfd pfd;
+        pfd.fd = m_fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+        int pollRc = ::poll(&pfd, 1, c_ioTimeoutMs);
+        if (pollRc <= 0)
+        {
+            throw std::runtime_error(
+                "Socket::recvFixed: read timed out after " + std::to_string(c_ioTimeoutMs) + "ms");
+        }
+        ssize_t n = ::recv(m_fd, out.data() + received, _size - received, 0);
+        if (n == 0)
+        {
+            throw std::runtime_error("Socket::recvFixed: connection closed by peer");
+        }
+        if (n < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            throw std::runtime_error(
+                "Socket::recvFixed: recv failed: " + std::string(strerror(errno)));
+        }
+        received += static_cast<size_t>(n);
+    }
+    return out;
+}
+
+TcpListener::TcpListener(uint16_t _port)
+{
+    m_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (m_fd < 0)
+    {
+        throw std::runtime_error("TcpListener: socket() failed");
+    }
+    int opt = 1;
+    ::setsockopt(m_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(_port);
+    if (::bind(m_fd, (struct sockaddr*)&addr, sizeof(addr)) != 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+        throw std::runtime_error("TcpListener: bind failed: " + std::string(strerror(errno)));
+    }
+    if (::listen(m_fd, 16) != 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+        throw std::runtime_error("TcpListener: listen failed: " + std::string(strerror(errno)));
+    }
+}
+
+TcpListener::~TcpListener()
+{
+    if (m_fd >= 0)
+    {
+        ::close(m_fd);
+    }
+}
+
+Socket TcpListener::accept()
+{
+    struct sockaddr_in addr;
+    socklen_t addrLen = sizeof(addr);
+    int fd = ::accept(m_fd, (struct sockaddr*)&addr, &addrLen);
+    if (fd < 0)
+    {
+        throw std::runtime_error(
+            "TcpListener::accept: accept failed: " + std::string(strerror(errno)));
+    }
+    return Socket(fd);
+}
+
+uint16_t TcpListener::port() const
+{
+    struct sockaddr_in addr;
+    socklen_t addrLen = sizeof(addr);
+    if (::getsockname(m_fd, (struct sockaddr*)&addr, &addrLen) != 0)
+    {
+        throw std::runtime_error("TcpListener::port: getsockname failed");
+    }
+    return ntohs(addr.sin_port);
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Socket.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Socket.h
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Socket.h
+ * @brief Minimal RAII blocking TCP socket used by the RLPx client/server.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <cstdint>
+#include <string>
+
+namespace bcos::devp2p::rlpx
+{
+// Blocking TCP socket with full-read/full-write helpers.
+class Socket
+{
+public:
+    Socket();
+    explicit Socket(int _fd);
+    ~Socket();
+    Socket(Socket const&) = delete;
+    Socket& operator=(Socket const&) = delete;
+    Socket(Socket&&) noexcept;
+    Socket& operator=(Socket&&) noexcept;
+
+    // Connect to a host (IP or DNS) and port. Throws on failure.
+    void connect(std::string const& _host, uint16_t _port);
+    void close();
+    // Write all bytes. Throws on error.
+    void sendAll(bytesConstRef _data);
+    // Read exactly _size bytes. Throws on EOF/error.
+    bcos::bytes recvFixed(size_t _size);
+
+    int fd() const { return m_fd; }
+    bool valid() const { return m_fd >= 0; }
+
+private:
+    int m_fd{-1};
+};
+
+// Blocking TCP listener (used by the server side and by loopback tests).
+class TcpListener
+{
+public:
+    explicit TcpListener(uint16_t _port);
+    ~TcpListener();
+    TcpListener(TcpListener const&) = delete;
+    TcpListener& operator=(TcpListener const&) = delete;
+
+    // Block until a connection arrives and return it.
+    Socket accept();
+
+    int fd() const { return m_fd; }
+    // The port this listener is bound to (useful when bound to port 0).
+    uint16_t port() const;
+
+private:
+    int m_fd{-1};
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/test/HandshakeTest.cpp
+++ b/bcos-devp2p/test/HandshakeTest.cpp
@@ -1,0 +1,99 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HandshakeTest.cpp
+ * @brief FramingCipher secret derivation + auth/ack message round trips.
+ * @date 2026/8/18
+ */
+#include <bcos-crypto/random/CryptoRandom.h>
+#include <bcos-devp2p/rlpx/Crypto.h>
+#include <bcos-devp2p/rlpx/Framing.h>
+#include <bcos-devp2p/rlpx/Handshake.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::devp2p::rlpx;
+
+BOOST_AUTO_TEST_SUITE(HandshakeTest)
+
+// geth TestHandshakeForwardCompatibility: aes-secret and mac-secret derived
+// from the (ephB, ephA) ECDH + nonces must match geth's authoritative values.
+BOOST_AUTO_TEST_CASE(secretsMatchGethVector)
+{
+    auto ephA = fromHex("869d6ecf5211f1cc60418a13b9d870b22959d0c16f02bec714c960dd2298a32d");
+    auto ephB = fromHex("e238eb8e04fee6511ab04c6dd3c89ce097b11f25d584863ac2b6d5b35b1847e4");
+    auto nonceA = fromHex("7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6");
+    auto nonceB = fromHex("559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd");
+
+    EccKeyPair ephAPair(ephA);
+    EccKeyPair ephBPair(ephB);
+
+    FramingCipher::KeyMaterial keyMaterial;
+    keyMaterial.ephemeralSharedSecret =
+        EciesCipher::computeSharedSecret(ref(ephAPair.publicKey()), ref(ephB));
+    keyMaterial.isInitiator = false;
+    keyMaterial.initiatorNonce = nonceA;
+    keyMaterial.recipientNonce = nonceB;
+    keyMaterial.initiatorFirstMessageData = {0x01, 0x02};
+    keyMaterial.recipientFirstMessageData = {0x03, 0x04};
+
+    bytes aesSecret;
+    bytes macSecret;
+    FramingCipher::deriveSecrets(keyMaterial, aesSecret, macSecret);
+
+    BOOST_CHECK_EQUAL(
+        toHex(aesSecret), "80e8632c05fed6fc2a13b0f8d31a3cf645366239170ea067065aba8e28bac487");
+    BOOST_CHECK_EQUAL(
+        toHex(macSecret), "2ea74ec5dae199227dff1af715362700e989d889d7a493cb0639691efb8e5f98");
+}
+
+// Auth message build + parse (initiator signs, recipient recovers).
+BOOST_AUTO_TEST_CASE(authMessageRoundTrip)
+{
+    EccKeyPair initiator;
+    EccKeyPair recipient;
+    EccKeyPair ephemeral;
+
+    AuthMessage built(initiator, ref(recipient.publicKey()), ephemeral);
+    auto wire = built.serialize();
+    // Strip the 2-byte size prefix; the parse constructor takes the ECIES body.
+    bytesConstRef wireRef(wire.data(), wire.size());
+    auto body = wireRef.getCroppedData(2);
+
+    AuthMessage parsed(body, ref(recipient.privateKey()));
+    BOOST_CHECK(parsed.initiatorPublicKey() == initiator.publicKey());
+    BOOST_CHECK(parsed.ephemeralPublicKey() == ephemeral.publicKey());
+    BOOST_CHECK(parsed.nonce().toBytes() == built.nonce().toBytes());
+}
+
+// Ack message round trip.
+BOOST_AUTO_TEST_CASE(ackMessageRoundTrip)
+{
+    EccKeyPair initiator;
+    EccKeyPair ephemeral;
+    auto recipientNonce = bcos::crypto::cryptoRandomBytes(32);
+
+    AuthAckMessage built(ephemeral, ref(initiator.publicKey()), ref(recipientNonce));
+    auto wire = built.serialize();
+    bytesConstRef wireRef(wire.data(), wire.size());
+    auto body = wireRef.getCroppedData(2);
+
+    AuthAckMessage parsed(body, ref(initiator.privateKey()));
+    BOOST_CHECK(parsed.ephemeralPublicKey() == ephemeral.publicKey());
+    BOOST_CHECK(parsed.nonce().toBytes() == built.nonce().toBytes());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 概述

从 eth_sync 分支拆分的 devp2p 子模块 PR:RLPx 传输层的阻塞 TCP Socket 与 ECIES 握手实现。

- `rlpx/Socket.{h,cpp}`:RAII 阻塞 TCP socket,提供 full-read/full-write 助手,供 RLPx client/server 使用
- `rlpx/Handshake.{h,cpp}`:RLPx ECIES 握手(auth/ack 交换、共享密钥推导),基于已合入的 `rlpx/Crypto.h`(#5507)
- `test/HandshakeTest.cpp`:握手单元测试

## 依赖

仅依赖 upstream 已合入代码(rlpx Crypto/Framing,#5507)与 bcos-utilities,与其他待提的 devp2p PR 无相互依赖,可独立合入。

## 验证

- `tools/.ci/check-commit.sh` 通过,有效行数 valid_insertions = 410
- `test-bcos-devp2p` 编译通过,测试 13/13 通过(Debug / gcc)