### PR TITLE
feat(devp2p): add rlpx session core

### DIFF
--- a/bcos-devp2p/bcos-devp2p/rlpx/Handshake.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Handshake.cpp
@@ -1,0 +1,319 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Handshake.cpp
+ * @brief RLPx v4 handshake implementation (port of silkworm auth messages).
+ * @date 2026/8/18
+ */
+#include "Handshake.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-crypto/random/CryptoRandom.h>
+#include <stdexcept>
+
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// 2-byte big-endian size prefix (EIP-8 auth-size).
+bcos::bytes serializeSizeImpl(size_t _size)
+{
+    bcos::bytes size(2, 0);
+    size[0] = static_cast<bcos::byte>((_size >> 8) & 0xff);
+    size[1] = static_cast<bcos::byte>(_size & 0xff);
+    return size;
+}
+
+size_t deserializeSize(bytesConstRef _data)
+{
+    if (_data.size() < 2)
+    {
+        throw std::runtime_error("handshake: size prefix too short");
+    }
+    return (static_cast<size_t>(_data[0]) << 8) | static_cast<size_t>(_data[1]);
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// AuthMessage
+// ---------------------------------------------------------------------------
+AuthMessage::AuthMessage(EccKeyPair const& _initiatorKeyPair, bytesConstRef _recipientPublicKey,
+    EccKeyPair const& _ephemeralKeyPair)
+  : m_initiatorPublicKey(_initiatorKeyPair.publicKey()),
+    m_recipientPublicKey(_recipientPublicKey.begin(), _recipientPublicKey.end()),
+    m_ephemeralPublicKey(_ephemeralKeyPair.publicKey())
+{
+    auto const& initiatorPrivateKey = _initiatorKeyPair.privateKey();
+    auto const& ephemeralPrivateKey = _ephemeralKeyPair.privateKey();
+    bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(_recipientPublicKey,
+        bytesConstRef(initiatorPrivateKey.data(), initiatorPrivateKey.size()));
+    m_nonce = bcos::crypto::cryptoRandomBytes(sharedSecret.size());
+    xorBytes(sharedSecret, bytesConstRef(m_nonce.data(), m_nonce.size()));
+    m_signature = signRecoverable(bytesConstRef(sharedSecret.data(), sharedSecret.size()),
+        bytesConstRef(ephemeralPrivateKey.data(), ephemeralPrivateKey.size()));
+}
+
+AuthMessage::AuthMessage(bytesConstRef _data, bytesConstRef _recipientPrivateKey)
+{
+    auto plainText = decryptBody(_data, _recipientPrivateKey);
+    initFromRlp(bytesConstRef(plainText.data(), plainText.size()));
+
+    bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(
+        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
+        _recipientPrivateKey);
+    if (sharedSecret.size() != m_nonce.size())
+    {
+        throw std::runtime_error("AuthMessage: invalid nonce size");
+    }
+    xorBytes(sharedSecret, bytesConstRef(m_nonce.data(), m_nonce.size()));
+    m_ephemeralPublicKey = recoverPublicKey(
+        bytesConstRef(sharedSecret.data(), sharedSecret.size()),
+        bytesConstRef(m_signature.data(), m_signature.size()));
+}
+
+bcos::bytes AuthMessage::bodyAsRlp() const
+{
+    bcos::bytes data;
+    bcos::codec::rlp::encode(data,
+        bytesConstRef(m_signature.data(), m_signature.size()),
+        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
+        bytesConstRef(m_nonce.data(), m_nonce.size()), static_cast<uint64_t>(kVersion));
+    return data;
+}
+
+void AuthMessage::initFromRlp(bytesConstRef _data)
+{
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto [listError, listHeader] = bcos::codec::rlp::decodeHeader(view);
+    if (listError || !listHeader.isList)
+    {
+        throw std::runtime_error("AuthMessage: auth body is not an RLP list");
+    }
+    bcos::bytesRef items(view.data(), listHeader.payloadLength);
+    auto decodeBytes = [&items](bcos::bytes& out) {
+        if (auto err = bcos::codec::rlp::decode(items, out))
+        {
+            throw std::runtime_error("AuthMessage: item decode failed");
+        }
+    };
+    decodeBytes(m_signature);
+    decodeBytes(m_initiatorPublicKey);
+    decodeBytes(m_nonce);
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("AuthMessage: version decode failed");
+    }
+    // Ignore trailing items (EIP-8 forward compatibility).
+    if (m_signature.size() != 65 || m_initiatorPublicKey.size() != 64 || m_nonce.size() != 32)
+    {
+        throw std::runtime_error("AuthMessage: invalid item sizes");
+    }
+}
+
+bcos::bytes AuthMessage::serializeSize(size_t _bodySize)
+{
+    return serializeSizeImpl(_bodySize);
+}
+
+bcos::bytes AuthMessage::decryptBody(bytesConstRef _data, bytesConstRef _recipientPrivateKey)
+{
+    auto size = serializeSizeImpl(_data.size());
+    return EciesCipher::decrypt(
+        _data, _recipientPrivateKey, bytesConstRef(size.data(), size.size()));
+}
+
+bcos::bytes AuthMessage::serialize() const
+{
+    bcos::bytes bodyRlp = bodyAsRlp();
+    bodyRlp.resize(EciesCipher::roundUpToBlockSize(bodyRlp.size()));
+    size_t bodySize = EciesCipher::estimateEncryptedSize(bodyRlp.size());
+
+    auto size = serializeSizeImpl(bodySize);
+    auto body = EciesCipher::encrypt(bytesConstRef(bodyRlp.data(), bodyRlp.size()),
+        bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()),
+        bytesConstRef(size.data(), size.size()));
+    body.insert(body.begin(), size.begin(), size.end());
+    return body;
+}
+
+// ---------------------------------------------------------------------------
+// AuthAckMessage
+// ---------------------------------------------------------------------------
+AuthAckMessage::AuthAckMessage(EccKeyPair const& _ephemeralKeyPair,
+    bytesConstRef _initiatorPublicKey, bytesConstRef _recipientNonce)
+  : m_ephemeralPublicKey(_ephemeralKeyPair.publicKey()),
+    m_initiatorPublicKey(_initiatorPublicKey.begin(), _initiatorPublicKey.end()),
+    m_nonce(_recipientNonce.begin(), _recipientNonce.end())
+{}
+
+AuthAckMessage::AuthAckMessage(bytesConstRef _data, bytesConstRef _initiatorPrivateKey)
+{
+    auto plainText = decryptBody(_data, _initiatorPrivateKey);
+    initFromRlp(bytesConstRef(plainText.data(), plainText.size()));
+}
+
+bcos::bytes AuthAckMessage::bodyAsRlp() const
+{
+    bcos::bytes data;
+    bcos::codec::rlp::encode(data,
+        bytesConstRef(m_ephemeralPublicKey.data(), m_ephemeralPublicKey.size()),
+        bytesConstRef(m_nonce.data(), m_nonce.size()), static_cast<uint64_t>(kVersion));
+    return data;
+}
+
+void AuthAckMessage::initFromRlp(bytesConstRef _data)
+{
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto [listError, listHeader] = bcos::codec::rlp::decodeHeader(view);
+    if (listError || !listHeader.isList)
+    {
+        throw std::runtime_error("AuthAckMessage: ack body is not an RLP list");
+    }
+    bcos::bytesRef items(view.data(), listHeader.payloadLength);
+    auto decodeBytes = [&items](bcos::bytes& out) {
+        if (auto err = bcos::codec::rlp::decode(items, out))
+        {
+            throw std::runtime_error("AuthAckMessage: item decode failed");
+        }
+    };
+    decodeBytes(m_ephemeralPublicKey);
+    decodeBytes(m_nonce);
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("AuthAckMessage: version decode failed");
+    }
+    if (m_ephemeralPublicKey.size() != 64 || m_nonce.size() != 32)
+    {
+        throw std::runtime_error("AuthAckMessage: invalid item sizes");
+    }
+}
+
+bcos::bytes AuthAckMessage::serializeSize(size_t _bodySize)
+{
+    return serializeSizeImpl(_bodySize);
+}
+
+bcos::bytes AuthAckMessage::decryptBody(bytesConstRef _data, bytesConstRef _initiatorPrivateKey)
+{
+    auto size = serializeSizeImpl(_data.size());
+    return EciesCipher::decrypt(
+        _data, _initiatorPrivateKey, bytesConstRef(size.data(), size.size()));
+}
+
+bcos::bytes AuthAckMessage::serialize() const
+{
+    bcos::bytes bodyRlp = bodyAsRlp();
+    bodyRlp.resize(EciesCipher::roundUpToBlockSize(bodyRlp.size()));
+    size_t bodySize = EciesCipher::estimateEncryptedSize(bodyRlp.size());
+
+    auto size = serializeSizeImpl(bodySize);
+    auto body = EciesCipher::encrypt(bytesConstRef(bodyRlp.data(), bodyRlp.size()),
+        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
+        bytesConstRef(size.data(), size.size()));
+    body.insert(body.begin(), size.begin(), size.end());
+    return body;
+}
+
+// ---------------------------------------------------------------------------
+// Handshake orchestration
+// ---------------------------------------------------------------------------
+AuthKeys Handshake::execute(Socket& _socket)
+{
+    if (m_isInitiator)
+    {
+        return authInitiator(_socket);
+    }
+    return authRecipient(_socket);
+}
+
+AuthKeys Handshake::authInitiator(Socket& _socket)
+{
+    if (m_recipientPublicKey.size() != 64)
+    {
+        throw std::invalid_argument("Handshake: initiator requires the recipient public key");
+    }
+    EccKeyPair ephemeralKeyPair;
+
+    AuthMessage authMessage(
+        m_keyPair, bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()),
+        ephemeralKeyPair);
+    auto authData = authMessage.serialize();
+    _socket.sendAll(bytesConstRef(authData.data(), authData.size()));
+
+    // Read the ack: 2-byte size || encrypted body.
+    auto sizeData = _socket.recvFixed(2);
+    size_t size = deserializeSize(bytesConstRef(sizeData.data(), sizeData.size()));
+    if (size > 2048)
+    {
+        throw std::runtime_error("Handshake: ack message too big");
+    }
+    auto ackData = _socket.recvFixed(size);
+
+    AuthAckMessage ackMessage(
+        bytesConstRef(ackData.data(), ackData.size()), ref(m_keyPair.privateKey()));
+
+    AuthKeys keys;
+    keys.peerEphemeralPublicKey = ackMessage.ephemeralPublicKey();
+    keys.ephemeralPrivateKey = ephemeralKeyPair.privateKey();
+    keys.initiatorNonce = authMessage.nonce().toBytes();
+    keys.recipientNonce = ackMessage.nonce().toBytes();
+    keys.initiatorFirstMessageData = authData;
+    // The MAC seed uses the FULL wire message, including the 2-byte size prefix.
+    keys.recipientFirstMessageData = sizeData;
+    keys.recipientFirstMessageData.insert(
+        keys.recipientFirstMessageData.end(), ackData.begin(), ackData.end());
+    return keys;
+}
+
+AuthKeys Handshake::authRecipient(Socket& _socket)
+{
+    // Read the auth: 2-byte size || encrypted body.
+    auto sizeData = _socket.recvFixed(2);
+    size_t size = deserializeSize(bytesConstRef(sizeData.data(), sizeData.size()));
+    if (size > 2048)
+    {
+        throw std::runtime_error("Handshake: auth message too big");
+    }
+    auto authData = _socket.recvFixed(size);
+
+    AuthMessage authMessage(
+        bytesConstRef(authData.data(), authData.size()), ref(m_keyPair.privateKey()));
+
+    EccKeyPair ephemeralKeyPair;
+    // The ack carries a fresh recipient nonce (independent of the initiator's).
+    auto recipientNonce = bcos::crypto::cryptoRandomBytes(32);
+    AuthAckMessage ackMessage(ephemeralKeyPair, ref(authMessage.initiatorPublicKey()),
+        bytesConstRef(recipientNonce.data(), recipientNonce.size()));
+    auto ackData = ackMessage.serialize();
+    _socket.sendAll(bytesConstRef(ackData.data(), ackData.size()));
+
+    AuthKeys keys;
+    keys.peerEphemeralPublicKey = authMessage.ephemeralPublicKey();
+    keys.ephemeralPrivateKey = ephemeralKeyPair.privateKey();
+    keys.initiatorNonce = authMessage.nonce().toBytes();
+    keys.recipientNonce = recipientNonce;
+    // The MAC seed uses the FULL wire message, including the 2-byte size prefix.
+    keys.initiatorFirstMessageData = sizeData;
+    keys.initiatorFirstMessageData.insert(
+        keys.initiatorFirstMessageData.end(), authData.begin(), authData.end());
+    keys.recipientFirstMessageData = ackData;
+    return keys;
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Handshake.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Handshake.cpp
@@ -46,6 +46,29 @@ size_t deserializeSize(bytesConstRef _data)
     }
     return (static_cast<size_t>(_data[0]) << 8) | static_cast<size_t>(_data[1]);
 }
+
+// Full wire message shared by auth and ack: pad the RLP body to a full ECIES
+// block, then emit 2-byte size prefix || ECIES(recipientPub, paddedBody). The
+// size prefix doubles as the ECIES MAC-extra-data (EIP-8).
+bcos::bytes buildEnvelope(bcos::bytes const& _bodyRlp, bytesConstRef _recipientPublicKey)
+{
+    bcos::bytes paddedBody = _bodyRlp;
+    paddedBody.resize(EciesCipher::roundUpToBlockSize(paddedBody.size()));
+    size_t bodySize = EciesCipher::estimateEncryptedSize(paddedBody.size());
+
+    auto size = serializeSizeImpl(bodySize);
+    auto body = EciesCipher::encrypt(bytesConstRef(paddedBody.data(), paddedBody.size()),
+        _recipientPublicKey, bytesConstRef(size.data(), size.size()));
+    body.insert(body.begin(), size.begin(), size.end());
+    return body;
+}
+
+// Decrypt a received size-prefixed ECIES body (shared by auth and ack).
+bcos::bytes decryptEnvelope(bytesConstRef _data, bytesConstRef _privateKey)
+{
+    auto size = serializeSizeImpl(_data.size());
+    return EciesCipher::decrypt(_data, _privateKey, bytesConstRef(size.data(), size.size()));
+}
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -59,8 +82,8 @@ AuthMessage::AuthMessage(EccKeyPair const& _initiatorKeyPair, bytesConstRef _rec
 {
     auto const& initiatorPrivateKey = _initiatorKeyPair.privateKey();
     auto const& ephemeralPrivateKey = _ephemeralKeyPair.privateKey();
-    bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(_recipientPublicKey,
-        bytesConstRef(initiatorPrivateKey.data(), initiatorPrivateKey.size()));
+    bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(
+        _recipientPublicKey, bytesConstRef(initiatorPrivateKey.data(), initiatorPrivateKey.size()));
     m_nonce = bcos::crypto::cryptoRandomBytes(sharedSecret.size());
     xorBytes(sharedSecret, bytesConstRef(m_nonce.data(), m_nonce.size()));
     m_signature = signRecoverable(bytesConstRef(sharedSecret.data(), sharedSecret.size()),
@@ -69,7 +92,7 @@ AuthMessage::AuthMessage(EccKeyPair const& _initiatorKeyPair, bytesConstRef _rec
 
 AuthMessage::AuthMessage(bytesConstRef _data, bytesConstRef _recipientPrivateKey)
 {
-    auto plainText = decryptBody(_data, _recipientPrivateKey);
+    auto plainText = decryptEnvelope(_data, _recipientPrivateKey);
     initFromRlp(bytesConstRef(plainText.data(), plainText.size()));
 
     bcos::bytes sharedSecret = EciesCipher::computeSharedSecret(
@@ -80,16 +103,14 @@ AuthMessage::AuthMessage(bytesConstRef _data, bytesConstRef _recipientPrivateKey
         throw std::runtime_error("AuthMessage: invalid nonce size");
     }
     xorBytes(sharedSecret, bytesConstRef(m_nonce.data(), m_nonce.size()));
-    m_ephemeralPublicKey = recoverPublicKey(
-        bytesConstRef(sharedSecret.data(), sharedSecret.size()),
+    m_ephemeralPublicKey = recoverPublicKey(bytesConstRef(sharedSecret.data(), sharedSecret.size()),
         bytesConstRef(m_signature.data(), m_signature.size()));
 }
 
 bcos::bytes AuthMessage::bodyAsRlp() const
 {
     bcos::bytes data;
-    bcos::codec::rlp::encode(data,
-        bytesConstRef(m_signature.data(), m_signature.size()),
+    bcos::codec::rlp::encode(data, bytesConstRef(m_signature.data(), m_signature.size()),
         bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
         bytesConstRef(m_nonce.data(), m_nonce.size()), static_cast<uint64_t>(kVersion));
     return data;
@@ -125,30 +146,11 @@ void AuthMessage::initFromRlp(bytesConstRef _data)
     }
 }
 
-bcos::bytes AuthMessage::serializeSize(size_t _bodySize)
-{
-    return serializeSizeImpl(_bodySize);
-}
-
-bcos::bytes AuthMessage::decryptBody(bytesConstRef _data, bytesConstRef _recipientPrivateKey)
-{
-    auto size = serializeSizeImpl(_data.size());
-    return EciesCipher::decrypt(
-        _data, _recipientPrivateKey, bytesConstRef(size.data(), size.size()));
-}
-
 bcos::bytes AuthMessage::serialize() const
 {
     bcos::bytes bodyRlp = bodyAsRlp();
-    bodyRlp.resize(EciesCipher::roundUpToBlockSize(bodyRlp.size()));
-    size_t bodySize = EciesCipher::estimateEncryptedSize(bodyRlp.size());
-
-    auto size = serializeSizeImpl(bodySize);
-    auto body = EciesCipher::encrypt(bytesConstRef(bodyRlp.data(), bodyRlp.size()),
-        bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()),
-        bytesConstRef(size.data(), size.size()));
-    body.insert(body.begin(), size.begin(), size.end());
-    return body;
+    return buildEnvelope(
+        bodyRlp, bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()));
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +165,7 @@ AuthAckMessage::AuthAckMessage(EccKeyPair const& _ephemeralKeyPair,
 
 AuthAckMessage::AuthAckMessage(bytesConstRef _data, bytesConstRef _initiatorPrivateKey)
 {
-    auto plainText = decryptBody(_data, _initiatorPrivateKey);
+    auto plainText = decryptEnvelope(_data, _initiatorPrivateKey);
     initFromRlp(bytesConstRef(plainText.data(), plainText.size()));
 }
 
@@ -204,30 +206,11 @@ void AuthAckMessage::initFromRlp(bytesConstRef _data)
     }
 }
 
-bcos::bytes AuthAckMessage::serializeSize(size_t _bodySize)
-{
-    return serializeSizeImpl(_bodySize);
-}
-
-bcos::bytes AuthAckMessage::decryptBody(bytesConstRef _data, bytesConstRef _initiatorPrivateKey)
-{
-    auto size = serializeSizeImpl(_data.size());
-    return EciesCipher::decrypt(
-        _data, _initiatorPrivateKey, bytesConstRef(size.data(), size.size()));
-}
-
 bcos::bytes AuthAckMessage::serialize() const
 {
     bcos::bytes bodyRlp = bodyAsRlp();
-    bodyRlp.resize(EciesCipher::roundUpToBlockSize(bodyRlp.size()));
-    size_t bodySize = EciesCipher::estimateEncryptedSize(bodyRlp.size());
-
-    auto size = serializeSizeImpl(bodySize);
-    auto body = EciesCipher::encrypt(bytesConstRef(bodyRlp.data(), bodyRlp.size()),
-        bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()),
-        bytesConstRef(size.data(), size.size()));
-    body.insert(body.begin(), size.begin(), size.end());
-    return body;
+    return buildEnvelope(
+        bodyRlp, bytesConstRef(m_initiatorPublicKey.data(), m_initiatorPublicKey.size()));
 }
 
 // ---------------------------------------------------------------------------
@@ -250,9 +233,8 @@ AuthKeys Handshake::authInitiator(Socket& _socket)
     }
     EccKeyPair ephemeralKeyPair;
 
-    AuthMessage authMessage(
-        m_keyPair, bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()),
-        ephemeralKeyPair);
+    AuthMessage authMessage(m_keyPair,
+        bytesConstRef(m_recipientPublicKey.data(), m_recipientPublicKey.size()), ephemeralKeyPair);
     auto authData = authMessage.serialize();
     _socket.sendAll(bytesConstRef(authData.data(), authData.size()));
 

--- a/bcos-devp2p/bcos-devp2p/rlpx/Handshake.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Handshake.h
@@ -1,0 +1,121 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Handshake.h
+ * @brief RLPx v4 encrypted handshake (EIP-8): Auth/Ack messages, ECIES
+ *        encapsulation, shared-secret derivation. Ported from silkworm
+ *        sentry/rlpx/auth; wire-compatible with geth p2p/rlpx.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Crypto.h"
+#include "Socket.h"
+
+namespace bcos::devp2p::rlpx
+{
+// RLPx v4 auth message: ECIES(recipientPub, rlp([sig, initiatorPub, nonce, 4])).
+class AuthMessage
+{
+public:
+    // Build as the initiator.
+    AuthMessage(EccKeyPair const& _initiatorKeyPair, bytesConstRef _recipientPublicKey,
+        EccKeyPair const& _ephemeralKeyPair);
+    // Parse + verify as the recipient.
+    AuthMessage(bytesConstRef _data, bytesConstRef _recipientPrivateKey);
+
+    // Wire bytes: 2-byte size || ECIES body.
+    bcos::bytes serialize() const;
+
+    PublicKey const& initiatorPublicKey() const { return m_initiatorPublicKey; }
+    PublicKey const& ephemeralPublicKey() const { return m_ephemeralPublicKey; }
+    bytesConstRef nonce() const { return bytesConstRef(m_nonce.data(), m_nonce.size()); }
+
+private:
+    bcos::bytes bodyAsRlp() const;
+    void initFromRlp(bytesConstRef _data);
+    static bcos::bytes serializeSize(size_t _bodySize);
+    static bcos::bytes decryptBody(bytesConstRef _data, bytesConstRef _recipientPrivateKey);
+
+    PublicKey m_initiatorPublicKey;
+    bcos::bytes m_recipientPublicKey;
+    PublicKey m_ephemeralPublicKey;
+    bcos::bytes m_nonce;
+    bcos::bytes m_signature;
+    static constexpr uint8_t kVersion{4};
+};
+
+// RLPx v4 ack message: ECIES(initiatorPub, rlp([ephemeralPub, nonce, 4])).
+class AuthAckMessage
+{
+public:
+    AuthAckMessage(EccKeyPair const& _ephemeralKeyPair, bytesConstRef _initiatorPublicKey,
+        bytesConstRef _recipientNonce);
+    // Parse as the initiator (we already know the recipient static key).
+    explicit AuthAckMessage(bytesConstRef _data, bytesConstRef _initiatorPrivateKey);
+
+    bcos::bytes serialize() const;
+
+    PublicKey const& ephemeralPublicKey() const { return m_ephemeralPublicKey; }
+    bytesConstRef nonce() const { return bytesConstRef(m_nonce.data(), m_nonce.size()); }
+
+private:
+    bcos::bytes bodyAsRlp() const;
+    void initFromRlp(bytesConstRef _data);
+    static bcos::bytes serializeSize(size_t _bodySize);
+    static bcos::bytes decryptBody(bytesConstRef _data, bytesConstRef _initiatorPrivateKey);
+
+    PublicKey m_ephemeralPublicKey;
+    bcos::bytes m_initiatorPublicKey;
+    bcos::bytes m_nonce;
+    static constexpr uint8_t kVersion{4};
+};
+
+// The keys derived from a completed handshake, plus the wire bytes of the
+// auth/ack messages (needed to seed the framing MACs).
+struct AuthKeys
+{
+    PublicKey peerEphemeralPublicKey;
+    PrivateKey ephemeralPrivateKey;
+    bcos::bytes initiatorNonce;
+    bcos::bytes recipientNonce;
+    bcos::bytes initiatorFirstMessageData;
+    bcos::bytes recipientFirstMessageData;
+};
+
+// Runs the encrypted handshake over a socket.
+//   initiator side: send auth, receive ack (needs the recipient static pubkey)
+//   recipient side: receive auth, send ack
+class Handshake
+{
+public:
+    Handshake(EccKeyPair const& _keyPair, bool _isInitiator,
+        bytesConstRef _recipientPublicKey = {})
+      : m_keyPair(_keyPair),
+        m_isInitiator(_isInitiator),
+        m_recipientPublicKey(_recipientPublicKey.begin(), _recipientPublicKey.end())
+    {}
+
+    AuthKeys execute(Socket& _socket);
+
+private:
+    AuthKeys authInitiator(Socket& _socket);
+    AuthKeys authRecipient(Socket& _socket);
+
+    EccKeyPair const& m_keyPair;
+    bool m_isInitiator;
+    bcos::bytes m_recipientPublicKey;  // set for the initiator side
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Handshake.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Handshake.h
@@ -46,8 +46,6 @@ public:
 private:
     bcos::bytes bodyAsRlp() const;
     void initFromRlp(bytesConstRef _data);
-    static bcos::bytes serializeSize(size_t _bodySize);
-    static bcos::bytes decryptBody(bytesConstRef _data, bytesConstRef _recipientPrivateKey);
 
     PublicKey m_initiatorPublicKey;
     bcos::bytes m_recipientPublicKey;
@@ -74,8 +72,6 @@ public:
 private:
     bcos::bytes bodyAsRlp() const;
     void initFromRlp(bytesConstRef _data);
-    static bcos::bytes serializeSize(size_t _bodySize);
-    static bcos::bytes decryptBody(bytesConstRef _data, bytesConstRef _initiatorPrivateKey);
 
     PublicKey m_ephemeralPublicKey;
     bcos::bytes m_initiatorPublicKey;
@@ -101,8 +97,7 @@ struct AuthKeys
 class Handshake
 {
 public:
-    Handshake(EccKeyPair const& _keyPair, bool _isInitiator,
-        bytesConstRef _recipientPublicKey = {})
+    Handshake(EccKeyPair const& _keyPair, bool _isInitiator, bytesConstRef _recipientPublicKey = {})
       : m_keyPair(_keyPair),
         m_isInitiator(_isInitiator),
         m_recipientPublicKey(_recipientPublicKey.begin(), _recipientPublicKey.end())
@@ -114,7 +109,7 @@ private:
     AuthKeys authInitiator(Socket& _socket);
     AuthKeys authRecipient(Socket& _socket);
 
-    EccKeyPair const& m_keyPair;
+    EccKeyPair m_keyPair;
     bool m_isInitiator;
     bcos::bytes m_recipientPublicKey;  // set for the initiator side
 };

--- a/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.cpp
@@ -1,0 +1,301 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MessageCodec.cpp
+ * @brief Message <-> frame payload codec implementation.
+ * @date 2026/8/18
+ */
+#include "MessageCodec.h"
+
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// --- Raw snappy (the wire format geth/erigon/reth/ethrex all use for devp2p
+// frame compression). The snappy "raw block" format is:
+//
+//   raw-block = uvarint(uncompressed-length) || sequence-of-tags
+//
+// Each tag byte is split as:  type = tag & 3   (LOW two bits)
+//                             data = tag >> 2  (high six bits)
+//   literal (type 0) : len = data + 1          (data < 60); if data in 60..63,
+//                      len = 1 + LE(data-59 length bytes), then the bytes.
+//   copy-1  (type 1) : len = (data & 7) + 4, offset = ((data >> 3) << 8) | next
+//   copy-2  (type 2) : len = data + 1,      offset = next 2 bytes LE
+//   copy-4  (type 3) : len = data + 1,      offset = next 4 bytes LE
+//
+// This is exactly what the vcpkg snappy port (RawCompress/RawUncompress), Go's
+// snappy.Decode (geth) and Rust snap::raw (ethrex) emit/consume.
+void appendUvarint(bcos::bytes& _out, uint64_t _value)
+{
+    while (_value >= 0x80)
+    {
+        _out.push_back(static_cast<bcos::byte>((_value & 0x7F) | 0x80));
+        _value >>= 7;
+    }
+    _out.push_back(static_cast<bcos::byte>(_value));
+}
+
+uint64_t readUvarint(bytesConstRef _data, size_t& _pos)
+{
+    uint64_t value = 0;
+    uint32_t shift = 0;
+    while (true)
+    {
+        if (_pos >= _data.size())
+        {
+            throw std::runtime_error("MessageCodec: truncated snappy varint");
+        }
+        uint8_t const b = _data[_pos++];
+        value |= static_cast<uint64_t>(b & 0x7F) << shift;
+        if ((b & 0x80) == 0)
+        {
+            return value;
+        }
+        shift += 7;
+        if (shift >= 64)
+        {
+            throw std::runtime_error("MessageCodec: snappy varint overflow");
+        }
+    }
+}
+
+bcos::bytes rawSnappyBlockCompress(bytesConstRef _data)
+{
+    // Literal-only encoding: always valid, trivially correct for any input. devp2p
+    // messages are small; skipping actual back-referencing costs nothing for sync.
+    bcos::bytes out;
+    size_t const n = _data.size();
+    if (n == 0)
+    {
+        return out;  // empty block
+    }
+    uint64_t const lenMinus1 = n - 1;
+    if (lenMinus1 < 60)
+    {
+        out.push_back(static_cast<bcos::byte>((lenMinus1 << 2)));  // literal tag
+    }
+    else
+    {
+        size_t lenBytes;
+        if (lenMinus1 <= 0xFF)
+        {
+            lenBytes = 1;
+        }
+        else if (lenMinus1 <= 0xFFFF)
+        {
+            lenBytes = 2;
+        }
+        else if (lenMinus1 <= 0xFFFFFF)
+        {
+            lenBytes = 3;
+        }
+        else
+        {
+            lenBytes = 4;
+        }
+        out.push_back(static_cast<bcos::byte>(((59 + lenBytes) << 2)));  // 60..63
+        for (size_t i = 0; i < lenBytes; ++i)
+        {
+            out.push_back(static_cast<bcos::byte>((lenMinus1 >> (8 * i)) & 0xFF));
+        }
+    }
+    out.insert(out.end(), _data.begin(), _data.end());
+    return out;
+}
+
+// Decodes one raw block starting at _pos; advances _pos to the end of the block.
+bcos::bytes rawSnappyDecompressBlock(bytesConstRef _data, size_t& _pos, size_t _maxOutput)
+{
+    bcos::bytes out;
+    size_t const n = _data.size();
+    auto need = [&](size_t k) {
+        if (_pos + k > n)
+        {
+            throw std::runtime_error("MessageCodec: truncated snappy data");
+        }
+    };
+    while (_pos < n)
+    {
+        uint8_t const tag = _data[_pos++];
+        uint8_t const type = tag & 0x3;       // LOW two bits select the element type
+        uint8_t const dataBits = tag >> 2;    // high six bits carry len/offset info
+        if (type == 0)  // literal
+        {
+            size_t len = dataBits + 1;
+            if (dataBits >= 60)
+            {
+                size_t const lenBytes = dataBits - 59;  // 60->1, 61->2, 62->3, 63->4
+                need(lenBytes);
+                uint64_t value = 0;
+                for (size_t i = 0; i < lenBytes; ++i)
+                {
+                    value |= static_cast<uint64_t>(_data[_pos + i]) << (8 * i);
+                }
+                _pos += lenBytes;
+                len = static_cast<size_t>(value) + 1;
+            }
+            if (out.size() + len > _maxOutput || _pos + len > n)
+            {
+                throw std::runtime_error("MessageCodec: snappy literal exceeds limits");
+            }
+            out.insert(out.end(), _data.begin() + _pos, _data.begin() + _pos + len);
+            _pos += len;
+        }
+        else
+        {
+            size_t len;
+            size_t offset;
+            if (type == 1)  // copy-1: 3-bit length + 5-bit offset
+            {
+                len = (dataBits & 0x7) + 4;
+                need(1);
+                offset = (static_cast<size_t>(dataBits >> 3) << 8) | _data[_pos++];
+            }
+            else if (type == 2)  // copy-2
+            {
+                len = dataBits + 1;
+                need(2);
+                offset = static_cast<size_t>(_data[_pos]) |
+                         (static_cast<size_t>(_data[_pos + 1]) << 8);
+                _pos += 2;
+            }
+            else  // copy-4
+            {
+                len = dataBits + 1;
+                need(4);
+                offset = static_cast<size_t>(_data[_pos]) |
+                         (static_cast<size_t>(_data[_pos + 1]) << 8) |
+                         (static_cast<size_t>(_data[_pos + 2]) << 16) |
+                         (static_cast<size_t>(_data[_pos + 3]) << 24);
+                _pos += 4;
+            }
+            if (offset == 0 || offset > out.size() || out.size() + len > _maxOutput)
+            {
+                throw std::runtime_error("MessageCodec: invalid snappy copy");
+            }
+            for (size_t i = 0; i < len; ++i)
+            {
+                out.push_back(out[out.size() - offset]);
+            }
+        }
+    }
+    return out;
+}
+
+bcos::bytes rawSnappyCompress(bytesConstRef _data)
+{
+    bcos::bytes block = rawSnappyBlockCompress(_data);
+    bcos::bytes out;
+    appendUvarint(out, _data.size());
+    out.insert(out.end(), block.begin(), block.end());
+    return out;
+}
+
+bcos::bytes rawSnappyDecompress(bytesConstRef _data, size_t _maxOutput)
+{
+    size_t pos = 0;
+    uint64_t const declared = readUvarint(_data, pos);
+    if (declared > _maxOutput)
+    {
+        throw std::runtime_error("MessageCodec: snappy declared length exceeds limits");
+    }
+    bcos::bytes out = rawSnappyDecompressBlock(_data, pos, _maxOutput);
+    if (out.size() != declared)
+    {
+        throw std::runtime_error("MessageCodec: snappy declared length mismatch");
+    }
+    return out;
+}
+}  // namespace
+
+bcos::bytes MessageCodec::encode(Message const& _message) const
+{
+    bcos::bytes frameData;
+    frameData.reserve(_message.data.size() + 1);
+    // Encode as a 64-bit value: RLP(uint8_t) hits a missing toCompactBigEndian(byte)
+    // overload, and the resulting encoding is identical for ids < 0x80.
+    bcos::codec::rlp::encode(frameData, static_cast<uint64_t>(_message.id));
+    if (!m_compressionEnabled)
+    {
+        frameData.insert(frameData.end(), _message.data.begin(), _message.data.end());
+    }
+    else
+    {
+        auto compressed = rawSnappyCompress(
+            bytesConstRef(_message.data.data(), _message.data.size()));
+        frameData.insert(frameData.end(), compressed.begin(), compressed.end());
+    }
+    std::cerr << "[codec] send id=" << static_cast<int>(_message.id)
+              << " compress=" << (m_compressionEnabled ? 1 : 0)
+              << " frame=" << bcos::toHexStringWithPrefix(frameData).substr(0, 120)
+              << std::endl;
+    return frameData;
+}
+
+Message MessageCodec::decode(bytesConstRef _frameData) const
+{
+    if (_frameData.empty())
+    {
+        throw std::runtime_error("MessageCodec: frame data too short");
+    }
+    std::cerr << "[codec] recv full=" << bcos::toHexStringWithPrefix(_frameData).substr(0, 200)
+              << " compress=" << (m_compressionEnabled ? 1 : 0) << std::endl;
+    Message message;
+    // The message id is RLP-encoded (RLP(0) == 0x80), so decode it properly.
+    {
+        bcos::bytesRef view(
+            const_cast<bcos::byte*>(_frameData.data()), _frameData.size());
+        if (auto err = bcos::codec::rlp::decode(view, message.id))
+        {
+            throw std::runtime_error("MessageCodec: failed to decode message id");
+        }
+        auto payload = _frameData.getCroppedData(_frameData.size() - view.size());
+        if (!m_compressionEnabled)
+        {
+            message.data.assign(payload.begin(), payload.end());
+        }
+        else
+        {
+            message.data = rawSnappyDecompress(payload, kMaxFrameSize);
+        }
+        // Diagnostics: dump complete BlockHeaders payloads to a file so the
+        // wire format can be analysed offline.
+        if (message.id == 20 && message.data.size() > 10000)
+        {
+            FILE* f = std::fopen("/home/more/tmp/blkheaders.bin", "wb");
+            if (f)
+            {
+                std::fwrite(message.data.data(), 1, message.data.size(), f);
+                std::fclose(f);
+                std::cerr << "[codec] WROTE blkheaders.bin size=" << message.data.size()
+                          << std::endl;
+            }
+        }
+        std::cerr << "[codec] recv id=" << static_cast<int>(message.id)
+                  << " compress=" << (m_compressionEnabled ? 1 : 0)
+                  << " raw=" << bcos::toHexStringWithPrefix(payload).substr(0, 96)
+                  << " data=" << bcos::toHexStringWithPrefix(message.data).substr(0, 96)
+                  << std::endl;
+    }
+    return message;
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.cpp
@@ -19,10 +19,8 @@
  */
 #include "MessageCodec.h"
 
+#include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-codec/rlp/RLPEncode.h>
-#include <bcos-utilities/DataConvertUtility.h>
-#include <cstring>
-#include <iostream>
 #include <stdexcept>
 namespace bcos::devp2p::rlpx
 {
@@ -135,9 +133,9 @@ bcos::bytes rawSnappyDecompressBlock(bytesConstRef _data, size_t& _pos, size_t _
     while (_pos < n)
     {
         uint8_t const tag = _data[_pos++];
-        uint8_t const type = tag & 0x3;       // LOW two bits select the element type
-        uint8_t const dataBits = tag >> 2;    // high six bits carry len/offset info
-        if (type == 0)  // literal
+        uint8_t const type = tag & 0x3;     // LOW two bits select the element type
+        uint8_t const dataBits = tag >> 2;  // high six bits carry len/offset info
+        if (type == 0)                      // literal
         {
             size_t len = dataBits + 1;
             if (dataBits >= 60)
@@ -173,8 +171,8 @@ bcos::bytes rawSnappyDecompressBlock(bytesConstRef _data, size_t& _pos, size_t _
             {
                 len = dataBits + 1;
                 need(2);
-                offset = static_cast<size_t>(_data[_pos]) |
-                         (static_cast<size_t>(_data[_pos + 1]) << 8);
+                offset =
+                    static_cast<size_t>(_data[_pos]) | (static_cast<size_t>(_data[_pos + 1]) << 8);
                 _pos += 2;
             }
             else  // copy-4
@@ -239,14 +237,10 @@ bcos::bytes MessageCodec::encode(Message const& _message) const
     }
     else
     {
-        auto compressed = rawSnappyCompress(
-            bytesConstRef(_message.data.data(), _message.data.size()));
+        auto compressed =
+            rawSnappyCompress(bytesConstRef(_message.data.data(), _message.data.size()));
         frameData.insert(frameData.end(), compressed.begin(), compressed.end());
     }
-    std::cerr << "[codec] send id=" << static_cast<int>(_message.id)
-              << " compress=" << (m_compressionEnabled ? 1 : 0)
-              << " frame=" << bcos::toHexStringWithPrefix(frameData).substr(0, 120)
-              << std::endl;
     return frameData;
 }
 
@@ -256,13 +250,10 @@ Message MessageCodec::decode(bytesConstRef _frameData) const
     {
         throw std::runtime_error("MessageCodec: frame data too short");
     }
-    std::cerr << "[codec] recv full=" << bcos::toHexStringWithPrefix(_frameData).substr(0, 200)
-              << " compress=" << (m_compressionEnabled ? 1 : 0) << std::endl;
     Message message;
     // The message id is RLP-encoded (RLP(0) == 0x80), so decode it properly.
     {
-        bcos::bytesRef view(
-            const_cast<bcos::byte*>(_frameData.data()), _frameData.size());
+        bcos::bytesRef view(const_cast<bcos::byte*>(_frameData.data()), _frameData.size());
         if (auto err = bcos::codec::rlp::decode(view, message.id))
         {
             throw std::runtime_error("MessageCodec: failed to decode message id");
@@ -276,24 +267,6 @@ Message MessageCodec::decode(bytesConstRef _frameData) const
         {
             message.data = rawSnappyDecompress(payload, kMaxFrameSize);
         }
-        // Diagnostics: dump complete BlockHeaders payloads to a file so the
-        // wire format can be analysed offline.
-        if (message.id == 20 && message.data.size() > 10000)
-        {
-            FILE* f = std::fopen("/home/more/tmp/blkheaders.bin", "wb");
-            if (f)
-            {
-                std::fwrite(message.data.data(), 1, message.data.size(), f);
-                std::fclose(f);
-                std::cerr << "[codec] WROTE blkheaders.bin size=" << message.data.size()
-                          << std::endl;
-            }
-        }
-        std::cerr << "[codec] recv id=" << static_cast<int>(message.id)
-                  << " compress=" << (m_compressionEnabled ? 1 : 0)
-                  << " raw=" << bcos::toHexStringWithPrefix(payload).substr(0, 96)
-                  << " data=" << bcos::toHexStringWithPrefix(message.data).substr(0, 96)
-                  << std::endl;
     }
     return message;
 }

--- a/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.h
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MessageCodec.h
+ * @brief RLPx message <-> frame payload codec (message id RLP + optional snappy),
+ *        ported from silkworm sentry/rlpx/framing/message_frame_codec.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+
+namespace bcos::devp2p::rlpx
+{
+// A decoded RLPx message.
+struct Message
+{
+    uint8_t id{0};       // message code
+    bcos::bytes data;    // RLP-encoded payload
+};
+
+// Encodes/decodes a Message into/from a frame payload:
+//   frame-data = RLP(id) || (snappy(data) | data)
+class MessageCodec
+{
+public:
+    static constexpr size_t kMaxFrameSize = 16 << 20;  // 16 MiB
+
+    bcos::bytes encode(Message const& _message) const;
+    Message decode(bytesConstRef _frameData) const;
+
+    void enableCompression() { m_compressionEnabled = true; }
+
+private:
+    bool m_compressionEnabled{false};
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
@@ -59,8 +59,8 @@ bcos::bytesRef takeListPayload(bcos::bytesRef& _view)
         throw std::runtime_error("rlpx: expected an RLP list");
     }
     bcos::bytesRef payload(_view.data(), header.payloadLength);
-    _view = bcos::bytesRef(
-        _view.data() + header.payloadLength, _view.size() - header.payloadLength);
+    _view =
+        bcos::bytesRef(_view.data() + header.payloadLength, _view.size() - header.payloadLength);
     return payload;
 }
 }  // namespace
@@ -71,17 +71,15 @@ bcos::bytes encodeHello(HelloMessage const& _msg)
     bcos::bytes capsPayload;
     for (auto const& cap : _msg.capabilities)
     {
-        bcos::codec::rlp::encode(
-            capsPayload, cap.name, static_cast<uint64_t>(cap.version));
+        bcos::codec::rlp::encode(capsPayload, cap.name, static_cast<uint64_t>(cap.version));
     }
     bcos::bytes capsList;
-    bcos::codec::rlp::encodeHeader(
-        capsList, {.isList = true, .payloadLength = capsPayload.size()});
+    bcos::codec::rlp::encodeHeader(capsList, {.isList = true, .payloadLength = capsPayload.size()});
     appendEncoded(capsList, capsPayload);
 
     bcos::bytes versionItem = encodeUint(_msg.version);
-    bcos::bytes nameItem = encodeString(bytesConstRef(
-        (const bcos::byte*)_msg.clientId.data(), _msg.clientId.size()));
+    bcos::bytes nameItem =
+        encodeString(bytesConstRef((const bcos::byte*)_msg.clientId.data(), _msg.clientId.size()));
     bcos::bytes portItem = encodeUint(_msg.listenPort);
     bcos::bytes idItem = encodeString(bytesConstRef(_msg.id.data(), _msg.id.size()));
 
@@ -130,6 +128,10 @@ HelloMessage decodeHello(bytesConstRef _data)
         {
             throw std::runtime_error("decodeHello: cap version decode failed");
         }
+        if (capVersion > 0xff)
+        {
+            throw std::runtime_error("decodeHello: capability version out of range");
+        }
         cap.version = static_cast<uint8_t>(capVersion);
         msg.capabilities.push_back(std::move(cap));
     }
@@ -150,10 +152,9 @@ HelloMessage decodeHello(bytesConstRef _data)
 
 bcos::bytes encodeDisconnect(DisconnectMessage const& _msg)
 {
-    // geth wire format: disconnectMsg = [reason] — a one-element RLP list, NOT a
-    // bare integer. (We encode/disconnect with a bare integer before this fix, which
-    // made real geth peers reject the message and made decodeDisconnect fail on
-    // real Disconnect frames.)
+    // geth wire format: disconnectMsg = [reason] — a one-element RLP list.
+    // (Some clients historically sent a bare integer; decodeDisconnect below
+    // accepts both forms, but the wire we emit is always the list form.)
     bcos::bytes out;
     bcos::codec::rlp::encode(out, std::vector<uint64_t>{static_cast<uint64_t>(_msg.reason)});
     return out;
@@ -184,8 +185,7 @@ DisconnectMessage decodeDisconnect(bytesConstRef _data)
         }
     }
     throw std::runtime_error("decodeDisconnect: reason decode failed payload=" +
-                             bcos::toHexStringWithPrefix(
-                                 bcos::bytes(_data.begin(), _data.end())));
+                             bcos::toHexStringWithPrefix(bcos::bytes(_data.begin(), _data.end())));
 }
 
 bcos::bytes encodePing()

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
@@ -1,0 +1,203 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Messages.cpp
+ * @brief devp2p base-protocol message RLP codecs.
+ * @date 2026/8/18
+ */
+#include "Messages.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <stdexcept>
+#include <vector>
+
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// Encode a pre-built payload as an RLP item (list or string).
+void appendEncoded(bcos::bytes& _to, bcos::bytes const& _item)
+{
+    _to.insert(_to.end(), _item.begin(), _item.end());
+}
+
+bcos::bytes encodeUint(uint64_t _value)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _value);
+    return out;
+}
+
+bcos::bytes encodeString(bytesConstRef _data)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _data);
+    return out;
+}
+
+// Expects a list at `_view` and returns a view over its payload.
+bcos::bytesRef takeListPayload(bcos::bytesRef& _view)
+{
+    auto [error, header] = bcos::codec::rlp::decodeHeader(_view);
+    if (error || !header.isList)
+    {
+        throw std::runtime_error("rlpx: expected an RLP list");
+    }
+    bcos::bytesRef payload(_view.data(), header.payloadLength);
+    _view = bcos::bytesRef(
+        _view.data() + header.payloadLength, _view.size() - header.payloadLength);
+    return payload;
+}
+}  // namespace
+
+bcos::bytes encodeHello(HelloMessage const& _msg)
+{
+    // caps payload: each cap = [name, version]
+    bcos::bytes capsPayload;
+    for (auto const& cap : _msg.capabilities)
+    {
+        bcos::codec::rlp::encode(
+            capsPayload, cap.name, static_cast<uint64_t>(cap.version));
+    }
+    bcos::bytes capsList;
+    bcos::codec::rlp::encodeHeader(
+        capsList, {.isList = true, .payloadLength = capsPayload.size()});
+    appendEncoded(capsList, capsPayload);
+
+    bcos::bytes versionItem = encodeUint(_msg.version);
+    bcos::bytes nameItem = encodeString(bytesConstRef(
+        (const bcos::byte*)_msg.clientId.data(), _msg.clientId.size()));
+    bcos::bytes portItem = encodeUint(_msg.listenPort);
+    bcos::bytes idItem = encodeString(bytesConstRef(_msg.id.data(), _msg.id.size()));
+
+    size_t payloadLength =
+        versionItem.size() + nameItem.size() + capsList.size() + portItem.size() + idItem.size();
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payloadLength});
+    appendEncoded(out, versionItem);
+    appendEncoded(out, nameItem);
+    appendEncoded(out, capsList);
+    appendEncoded(out, portItem);
+    appendEncoded(out, idItem);
+    return out;
+}
+
+HelloMessage decodeHello(bytesConstRef _data)
+{
+    HelloMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("decodeHello: version decode failed");
+    }
+    msg.version = version;
+
+    if (auto err = bcos::codec::rlp::decode(items, msg.clientId))
+    {
+        throw std::runtime_error("decodeHello: clientId decode failed");
+    }
+
+    // caps list
+    auto capsPayload = takeListPayload(items);
+    while (!capsPayload.empty())
+    {
+        auto capItems = takeListPayload(capsPayload);
+        Capability cap;
+        if (auto err = bcos::codec::rlp::decode(capItems, cap.name))
+        {
+            throw std::runtime_error("decodeHello: cap name decode failed");
+        }
+        uint64_t capVersion = 0;
+        if (auto err = bcos::codec::rlp::decode(capItems, capVersion))
+        {
+            throw std::runtime_error("decodeHello: cap version decode failed");
+        }
+        cap.version = static_cast<uint8_t>(capVersion);
+        msg.capabilities.push_back(std::move(cap));
+    }
+
+    uint64_t listenPort = 0;
+    if (auto err = bcos::codec::rlp::decode(items, listenPort))
+    {
+        throw std::runtime_error("decodeHello: listenPort decode failed");
+    }
+    msg.listenPort = listenPort;
+
+    if (auto err = bcos::codec::rlp::decode(items, msg.id))
+    {
+        throw std::runtime_error("decodeHello: id decode failed");
+    }
+    return msg;
+}
+
+bcos::bytes encodeDisconnect(DisconnectMessage const& _msg)
+{
+    // geth wire format: disconnectMsg = [reason] — a one-element RLP list, NOT a
+    // bare integer. (We encode/disconnect with a bare integer before this fix, which
+    // made real geth peers reject the message and made decodeDisconnect fail on
+    // real Disconnect frames.)
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, std::vector<uint64_t>{static_cast<uint64_t>(_msg.reason)});
+    return out;
+}
+
+DisconnectMessage decodeDisconnect(bytesConstRef _data)
+{
+    DisconnectMessage msg;
+    // Wire format varies by client: geth/erigon send the EIP-8 list form [reason],
+    // while some clients (e.g. ethrex) send a bare integer. Accept both.
+    {
+        bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+        std::vector<uint64_t> reasons;
+        if (auto err = bcos::codec::rlp::decode(view, reasons); err == nullptr)
+        {
+            msg.reason = reasons.empty() ? DisconnectReason::DisconnectRequested :
+                                           static_cast<DisconnectReason>(reasons[0]);
+            return msg;
+        }
+    }
+    {
+        bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+        uint64_t reason = 0;
+        if (auto err = bcos::codec::rlp::decode(view, reason); err == nullptr)
+        {
+            msg.reason = static_cast<DisconnectReason>(reason);
+            return msg;
+        }
+    }
+    throw std::runtime_error("decodeDisconnect: reason decode failed payload=" +
+                             bcos::toHexStringWithPrefix(
+                                 bcos::bytes(_data.begin(), _data.end())));
+}
+
+bcos::bytes encodePing()
+{
+    // Ping payload is the empty list: 0xc0.
+    return bcos::bytes{0xc0};
+}
+
+bcos::bytes encodePong()
+{
+    // Pong payload is the empty list: 0xc0.
+    return bcos::bytes{0xc0};
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
@@ -49,7 +49,8 @@ enum class DisconnectReason : uint8_t
     UnexpectedIdentity = 0x09,
     LocalIdentity = 0x0a,
     PingTimeout = 0x0b,
-    Unknown = 0x10,
+    // 0x10 is the spec's "subprotocol-specific reason" sentinel.
+    SubprotocolReason = 0x10,
 };
 
 struct Capability

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
@@ -1,0 +1,86 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Messages.h
+ * @brief devp2p base-protocol messages: Hello, Disconnect, Ping, Pong.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <string>
+#include <vector>
+
+namespace bcos::devp2p::rlpx
+{
+// devp2p base-protocol message codes (shared by every capability).
+namespace baseMsg
+{
+constexpr uint8_t Hello = 0x00;
+constexpr uint8_t Disconnect = 0x01;
+constexpr uint8_t Ping = 0x02;
+constexpr uint8_t Pong = 0x03;
+}  // namespace baseMsg
+
+// Reason codes of the Disconnect message (EIP-8 / devp2p).
+enum class DisconnectReason : uint8_t
+{
+    DisconnectRequested = 0x00,
+    TcpSubsystemError = 0x01,
+    ProtocolBreach = 0x02,
+    UselessPeer = 0x03,
+    TooManyPeers = 0x04,
+    AlreadyConnected = 0x05,
+    IncompatibleP2pProtocolVersion = 0x06,
+    NullNodeIdentity = 0x07,
+    ClientQuitting = 0x08,
+    UnexpectedIdentity = 0x09,
+    LocalIdentity = 0x0a,
+    PingTimeout = 0x0b,
+    Unknown = 0x10,
+};
+
+struct Capability
+{
+    std::string name;
+    uint8_t version{0};
+};
+
+// RLP: [version, name, [[name, version], ...], listenPort, id]
+struct HelloMessage
+{
+    uint64_t version{5};
+    std::string clientId;
+    std::vector<Capability> capabilities;
+    uint64_t listenPort{0};
+    bcos::bytes id;  // 64-byte secp256k1 public key
+};
+
+bcos::bytes encodeHello(HelloMessage const& _msg);
+HelloMessage decodeHello(bytesConstRef _data);
+
+// RLP: [reason]
+struct DisconnectMessage
+{
+    DisconnectReason reason{DisconnectReason::DisconnectRequested};
+};
+
+bcos::bytes encodeDisconnect(DisconnectMessage const& _msg);
+DisconnectMessage decodeDisconnect(bytesConstRef _data);
+
+// Ping/Pong are the empty list RLP: 0xc0.
+bcos::bytes encodePing();
+bcos::bytes encodePong();
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Session.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Session.cpp
@@ -1,0 +1,52 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Session.cpp
+ * @brief RLPx session implementation.
+ * @date 2026/8/18
+ */
+#include "Session.h"
+
+#include <stdexcept>
+
+namespace bcos::devp2p::rlpx
+{
+Session::Session(Socket&& _socket, FramingCipher _cipher)
+  : m_socket(std::move(_socket)), m_cipher(std::move(_cipher))
+{}
+
+void Session::sendMessage(Message const& _message)
+{
+    auto frameData = m_codec.encode(_message);
+    auto encrypted = m_cipher.encryptFrame(std::move(frameData));
+    m_socket.sendAll(bytesConstRef(encrypted.data(), encrypted.size()));
+}
+
+Message Session::recvMessage()
+{
+    auto header = m_socket.recvFixed(FramingCipher::headerSize());
+    size_t frameSize = m_cipher.decryptHeader(bytesConstRef(header.data(), header.size()));
+    if (frameSize > MessageCodec::kMaxFrameSize)
+    {
+        throw std::runtime_error("Session: frame too large");
+    }
+
+    auto encrypted = m_socket.recvFixed(FramingCipher::frameSize(frameSize));
+    auto frameData = m_cipher.decryptFrame(
+        bytesConstRef(encrypted.data(), encrypted.size()), frameSize);
+    return m_codec.decode(bytesConstRef(frameData.data(), frameData.size()));
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Session.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Session.h
@@ -1,0 +1,46 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Session.h
+ * @brief An established RLPx session: framed, encrypted message exchange over a
+ *        socket (port of silkworm MessageStream over geth-compatible framing).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Framing.h"
+#include "MessageCodec.h"
+#include "Socket.h"
+
+namespace bcos::devp2p::rlpx
+{
+// Sends/receives framed + encrypted messages over a connected socket.
+// Owns the socket so that the session can outlive the connection setup scope.
+class Session
+{
+public:
+    Session(Socket&& _socket, FramingCipher _cipher);
+
+    void sendMessage(Message const& _message);
+    Message recvMessage();
+
+    void enableCompression() { m_codec.enableCompression(); }
+
+private:
+    Socket m_socket;
+    FramingCipher m_cipher;
+    MessageCodec m_codec;
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
@@ -19,6 +19,11 @@
  */
 #include "Socket.h"
 
+// The blocking RLPx socket is built on the POSIX socket API (arpa/inet.h,
+// poll.h, sys/socket.h, ...), which does not exist on Windows. Compile the
+// implementation only off Windows; nothing links the RLPx sync client there.
+#if !defined(_WIN32)
+
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -332,3 +337,5 @@ uint16_t TcpListener::port() const
 }
 
 }  // namespace bcos::devp2p::rlpx
+
+#endif  // !defined(_WIN32)

--- a/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
@@ -27,11 +27,75 @@
 #include <sys/socket.h>
 #include <unistd.h>
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <stdexcept>
 
 namespace bcos::devp2p::rlpx
 {
+namespace
+{
+// Send flags: Linux suppresses SIGPIPE per-send with MSG_NOSIGNAL, while Darwin
+// and the BSDs do not define MSG_NOSIGNAL and only offer the SO_NOSIGPIPE socket
+// option. Without either, send() to a closed peer raises SIGPIPE and kills the
+// process.
+#if defined(MSG_NOSIGNAL)
+constexpr int c_sendFlags = MSG_NOSIGNAL;
+#else
+constexpr int c_sendFlags = 0;
+#endif
+
+// Silence SIGPIPE on the platforms that only expose the SO_NOSIGPIPE socket
+// option (Darwin/BSD); a no-op elsewhere.
+void applyNoSigpipe(int _fd)
+{
+#if defined(SO_NOSIGPIPE)
+    int one = 1;
+    ::setsockopt(_fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#endif
+}
+
+// One poll() bounded by the time remaining until `_deadline`. Retries EINTR
+// against the remaining budget and throws when the poll itself fails or the
+// deadline expires, so the whole read/write is bounded by the caller's total
+// timeout instead of by each individual poll() gap.
+void pollWithRemaining(int _fd, short _events,
+    std::chrono::steady_clock::time_point const& _deadline, int _totalTimeoutMs,
+    std::string const& _what)
+{
+    while (true)
+    {
+        auto const now = std::chrono::steady_clock::now();
+        auto const remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(_deadline - now).count();
+        if (remaining <= 0)
+        {
+            throw std::runtime_error(
+                _what + " timed out after " + std::to_string(_totalTimeoutMs) + "ms");
+        }
+        struct pollfd pfd;
+        pfd.fd = _fd;
+        pfd.events = _events;
+        pfd.revents = 0;
+        int const pollRc = ::poll(&pfd, 1, static_cast<int>(remaining));
+        if (pollRc > 0)
+        {
+            return;
+        }
+        if (pollRc < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            throw std::runtime_error(_what + " failed: " + std::string(strerror(errno)));
+        }
+        throw std::runtime_error(
+            _what + " timed out after " + std::to_string(_totalTimeoutMs) + "ms");
+    }
+}
+}  // namespace
+
 // Connect timeout for outbound RLPx dials. A bootnode behind a black-hole firewall
 // (packets silently dropped) would otherwise make the blocking connect() hang for
 // the kernel's TCP timeout (tens of seconds to minutes), stalling the whole sync
@@ -50,9 +114,13 @@ Socket::Socket()
     {
         throw std::runtime_error("Socket: socket() failed: " + std::string(strerror(errno)));
     }
+    applyNoSigpipe(m_fd);
 }
 
-Socket::Socket(int _fd) : m_fd(_fd) {}
+Socket::Socket(int _fd) : m_fd(_fd)
+{
+    applyNoSigpipe(m_fd);
+}
 
 Socket::~Socket()
 {
@@ -100,13 +168,14 @@ void Socket::connect(std::string const& _host, uint16_t _port)
     }
 
     int connectRc = ::connect(m_fd, result->ai_addr, result->ai_addrlen);
+    // freeaddrinfo is not required to preserve errno, so snapshot it first.
+    int const connectErrno = errno;
     ::freeaddrinfo(result);
 
-    if (connectRc != 0 && errno != EINPROGRESS)
+    if (connectRc != 0 && connectErrno != EINPROGRESS)
     {
-        throw std::runtime_error(
-            "Socket::connect: connect to " + _host + ":" + portStr + " failed: " +
-            std::string(strerror(errno)));
+        throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
+                                 " failed: " + std::string(strerror(connectErrno)));
     }
 
     if (connectRc != 0)
@@ -114,25 +183,18 @@ void Socket::connect(std::string const& _host, uint16_t _port)
         // Non-blocking connect in progress (EINPROGRESS): wait for completion with a
         // bounded timeout. A black-holed peer would otherwise block here for the
         // kernel's TCP retry budget.
-        struct pollfd pfd;
-        pfd.fd = m_fd;
-        pfd.events = POLLOUT;
-        pfd.revents = 0;
-        int pollRc = ::poll(&pfd, 1, c_connectTimeoutMs);
-        if (pollRc <= 0)
-        {
-            throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
-                                     " timed out after " + std::to_string(c_connectTimeoutMs) +
-                                     "ms");
-        }
+        auto const deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(c_connectTimeoutMs);
+        pollWithRemaining(m_fd, POLLOUT, deadline, c_connectTimeoutMs,
+            "Socket::connect: connect to " + _host + ":" + portStr);
         // Distinguish an actual connection error from a spurious wakeup.
         int soError = 0;
         socklen_t soLen = sizeof(soError);
         if (::getsockopt(m_fd, SOL_SOCKET, SO_ERROR, &soError, &soLen) != 0 || soError != 0)
         {
-            throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
-                                     " failed: " + std::string(strerror(soError != 0 ? soError :
-                                                                                       errno)));
+            throw std::runtime_error(
+                "Socket::connect: connect to " + _host + ":" + portStr +
+                " failed: " + std::string(strerror(soError != 0 ? soError : connectErrno)));
         }
     }
 
@@ -156,30 +218,23 @@ void Socket::close()
 
 void Socket::sendAll(bytesConstRef _data)
 {
+    // Bound the WHOLE write by one deadline (not each poll) so a peer that
+    // dribbles out a byte every so often cannot hold the sync loop forever.
+    auto const deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(c_ioTimeoutMs);
     size_t sent = 0;
     while (sent < _data.size())
     {
-        // Wait for writability with a bounded timeout so a peer that never reads
-        // our output (full send buffer) cannot stall the sync loop forever.
-        struct pollfd pfd;
-        pfd.fd = m_fd;
-        pfd.events = POLLOUT;
-        pfd.revents = 0;
-        int pollRc = ::poll(&pfd, 1, c_ioTimeoutMs);
-        if (pollRc <= 0)
-        {
-            throw std::runtime_error(
-                "Socket::sendAll: write timed out after " + std::to_string(c_ioTimeoutMs) +
-                "ms");
-        }
-        ssize_t n = ::send(m_fd, _data.data() + sent, _data.size() - sent, MSG_NOSIGNAL);
+        pollWithRemaining(m_fd, POLLOUT, deadline, c_ioTimeoutMs, "Socket::sendAll: write");
+        ssize_t n = ::send(m_fd, _data.data() + sent, _data.size() - sent, c_sendFlags);
         if (n < 0)
         {
             if (errno == EINTR)
             {
                 continue;
             }
-            throw std::runtime_error("Socket::sendAll: send failed: " + std::string(strerror(errno)));
+            throw std::runtime_error(
+                "Socket::sendAll: send failed: " + std::string(strerror(errno)));
         }
         sent += static_cast<size_t>(n);
     }
@@ -188,22 +243,14 @@ void Socket::sendAll(bytesConstRef _data)
 bcos::bytes Socket::recvFixed(size_t _size)
 {
     bcos::bytes out(_size);
+    // One deadline for the whole read: a peer that sends one byte per poll gap
+    // must not be able to stall the caller past c_ioTimeoutMs in total.
+    auto const deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(c_ioTimeoutMs);
     size_t received = 0;
     while (received < _size)
     {
-        // Wait for readability with a bounded timeout so a silent peer (accepts
-        // the connection but never sends) cannot block the sync thread forever.
-        struct pollfd pfd;
-        pfd.fd = m_fd;
-        pfd.events = POLLIN;
-        pfd.revents = 0;
-        int pollRc = ::poll(&pfd, 1, c_ioTimeoutMs);
-        if (pollRc <= 0)
-        {
-            throw std::runtime_error(
-                "Socket::recvFixed: read timed out after " + std::to_string(c_ioTimeoutMs) +
-                "ms");
-        }
+        pollWithRemaining(m_fd, POLLIN, deadline, c_ioTimeoutMs, "Socket::recvFixed: read");
         ssize_t n = ::recv(m_fd, out.data() + received, _size - received, 0);
         if (n == 0)
         {
@@ -215,7 +262,8 @@ bcos::bytes Socket::recvFixed(size_t _size)
             {
                 continue;
             }
-            throw std::runtime_error("Socket::recvFixed: recv failed: " + std::string(strerror(errno)));
+            throw std::runtime_error(
+                "Socket::recvFixed: recv failed: " + std::string(strerror(errno)));
         }
         received += static_cast<size_t>(n);
     }
@@ -241,15 +289,13 @@ TcpListener::TcpListener(uint16_t _port)
     {
         ::close(m_fd);
         m_fd = -1;
-        throw std::runtime_error(
-            "TcpListener: bind failed: " + std::string(strerror(errno)));
+        throw std::runtime_error("TcpListener: bind failed: " + std::string(strerror(errno)));
     }
     if (::listen(m_fd, 16) != 0)
     {
         ::close(m_fd);
         m_fd = -1;
-        throw std::runtime_error(
-            "TcpListener: listen failed: " + std::string(strerror(errno)));
+        throw std::runtime_error("TcpListener: listen failed: " + std::string(strerror(errno)));
     }
 }
 
@@ -268,7 +314,8 @@ Socket TcpListener::accept()
     int fd = ::accept(m_fd, (struct sockaddr*)&addr, &addrLen);
     if (fd < 0)
     {
-        throw std::runtime_error("TcpListener::accept: accept failed: " + std::string(strerror(errno)));
+        throw std::runtime_error(
+            "TcpListener::accept: accept failed: " + std::string(strerror(errno)));
     }
     return Socket(fd);
 }

--- a/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Socket.cpp
@@ -1,0 +1,287 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Socket.cpp
+ * @brief Blocking TCP socket implementation (POSIX sockets).
+ * @date 2026/8/18
+ */
+#include "Socket.h"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+
+namespace bcos::devp2p::rlpx
+{
+// Connect timeout for outbound RLPx dials. A bootnode behind a black-hole firewall
+// (packets silently dropped) would otherwise make the blocking connect() hang for
+// the kernel's TCP timeout (tens of seconds to minutes), stalling the whole sync
+// loop. With a bounded connect the loop moves on to the next bootnode and retries.
+constexpr int c_connectTimeoutMs = 5000;
+// I/O timeout for the blocking sendAll/recvFixed helpers. A peer that accepts the
+// TCP connection but then neither sends (auth handshake, frames) nor reads our
+// output would otherwise block the sync thread forever — the RLPx handshake and
+// download loop would stall on a single silent peer. Bounded I/O lets the sync
+// loop treat it as a failed peer and move on to the next bootnode.
+constexpr int c_ioTimeoutMs = 15000;
+Socket::Socket()
+{
+    m_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (m_fd < 0)
+    {
+        throw std::runtime_error("Socket: socket() failed: " + std::string(strerror(errno)));
+    }
+}
+
+Socket::Socket(int _fd) : m_fd(_fd) {}
+
+Socket::~Socket()
+{
+    close();
+}
+
+Socket::Socket(Socket&& _other) noexcept : m_fd(_other.m_fd)
+{
+    _other.m_fd = -1;
+}
+
+Socket& Socket::operator=(Socket&& _other) noexcept
+{
+    if (this != &_other)
+    {
+        close();
+        m_fd = _other.m_fd;
+        _other.m_fd = -1;
+    }
+    return *this;
+}
+
+void Socket::connect(std::string const& _host, uint16_t _port)
+{
+    struct addrinfo hints;
+    std::memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo* result = nullptr;
+    std::string portStr = std::to_string(_port);
+    int rc = ::getaddrinfo(_host.c_str(), portStr.c_str(), &hints, &result);
+    if (rc != 0 || result == nullptr)
+    {
+        throw std::runtime_error("Socket::connect: getaddrinfo failed for " + _host);
+    }
+
+    // Set the socket non-blocking so a black-holed peer makes connect() return
+    // EINPROGRESS instead of blocking for the kernel's TCP timeout; completion is
+    // then awaited with a bounded poll() below.
+    int flags = ::fcntl(m_fd, F_GETFL, 0);
+    if (flags >= 0)
+    {
+        ::fcntl(m_fd, F_SETFL, flags | O_NONBLOCK);
+    }
+
+    int connectRc = ::connect(m_fd, result->ai_addr, result->ai_addrlen);
+    ::freeaddrinfo(result);
+
+    if (connectRc != 0 && errno != EINPROGRESS)
+    {
+        throw std::runtime_error(
+            "Socket::connect: connect to " + _host + ":" + portStr + " failed: " +
+            std::string(strerror(errno)));
+    }
+
+    if (connectRc != 0)
+    {
+        // Non-blocking connect in progress (EINPROGRESS): wait for completion with a
+        // bounded timeout. A black-holed peer would otherwise block here for the
+        // kernel's TCP retry budget.
+        struct pollfd pfd;
+        pfd.fd = m_fd;
+        pfd.events = POLLOUT;
+        pfd.revents = 0;
+        int pollRc = ::poll(&pfd, 1, c_connectTimeoutMs);
+        if (pollRc <= 0)
+        {
+            throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
+                                     " timed out after " + std::to_string(c_connectTimeoutMs) +
+                                     "ms");
+        }
+        // Distinguish an actual connection error from a spurious wakeup.
+        int soError = 0;
+        socklen_t soLen = sizeof(soError);
+        if (::getsockopt(m_fd, SOL_SOCKET, SO_ERROR, &soError, &soLen) != 0 || soError != 0)
+        {
+            throw std::runtime_error("Socket::connect: connect to " + _host + ":" + portStr +
+                                     " failed: " + std::string(strerror(soError != 0 ? soError :
+                                                                                       errno)));
+        }
+    }
+
+    // Restore the blocking mode the rest of the RLPx session relies on (sendAll /
+    // recvFixed are blocking full-read/full-write helpers).
+    int restoreFlags = ::fcntl(m_fd, F_GETFL, 0);
+    if (restoreFlags >= 0)
+    {
+        ::fcntl(m_fd, F_SETFL, restoreFlags & ~O_NONBLOCK);
+    }
+}
+
+void Socket::close()
+{
+    if (m_fd >= 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+}
+
+void Socket::sendAll(bytesConstRef _data)
+{
+    size_t sent = 0;
+    while (sent < _data.size())
+    {
+        // Wait for writability with a bounded timeout so a peer that never reads
+        // our output (full send buffer) cannot stall the sync loop forever.
+        struct pollfd pfd;
+        pfd.fd = m_fd;
+        pfd.events = POLLOUT;
+        pfd.revents = 0;
+        int pollRc = ::poll(&pfd, 1, c_ioTimeoutMs);
+        if (pollRc <= 0)
+        {
+            throw std::runtime_error(
+                "Socket::sendAll: write timed out after " + std::to_string(c_ioTimeoutMs) +
+                "ms");
+        }
+        ssize_t n = ::send(m_fd, _data.data() + sent, _data.size() - sent, MSG_NOSIGNAL);
+        if (n < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            throw std::runtime_error("Socket::sendAll: send failed: " + std::string(strerror(errno)));
+        }
+        sent += static_cast<size_t>(n);
+    }
+}
+
+bcos::bytes Socket::recvFixed(size_t _size)
+{
+    bcos::bytes out(_size);
+    size_t received = 0;
+    while (received < _size)
+    {
+        // Wait for readability with a bounded timeout so a silent peer (accepts
+        // the connection but never sends) cannot block the sync thread forever.
+        struct pollfd pfd;
+        pfd.fd = m_fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+        int pollRc = ::poll(&pfd, 1, c_ioTimeoutMs);
+        if (pollRc <= 0)
+        {
+            throw std::runtime_error(
+                "Socket::recvFixed: read timed out after " + std::to_string(c_ioTimeoutMs) +
+                "ms");
+        }
+        ssize_t n = ::recv(m_fd, out.data() + received, _size - received, 0);
+        if (n == 0)
+        {
+            throw std::runtime_error("Socket::recvFixed: connection closed by peer");
+        }
+        if (n < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            throw std::runtime_error("Socket::recvFixed: recv failed: " + std::string(strerror(errno)));
+        }
+        received += static_cast<size_t>(n);
+    }
+    return out;
+}
+
+TcpListener::TcpListener(uint16_t _port)
+{
+    m_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (m_fd < 0)
+    {
+        throw std::runtime_error("TcpListener: socket() failed");
+    }
+    int opt = 1;
+    ::setsockopt(m_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(_port);
+    if (::bind(m_fd, (struct sockaddr*)&addr, sizeof(addr)) != 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+        throw std::runtime_error(
+            "TcpListener: bind failed: " + std::string(strerror(errno)));
+    }
+    if (::listen(m_fd, 16) != 0)
+    {
+        ::close(m_fd);
+        m_fd = -1;
+        throw std::runtime_error(
+            "TcpListener: listen failed: " + std::string(strerror(errno)));
+    }
+}
+
+TcpListener::~TcpListener()
+{
+    if (m_fd >= 0)
+    {
+        ::close(m_fd);
+    }
+}
+
+Socket TcpListener::accept()
+{
+    struct sockaddr_in addr;
+    socklen_t addrLen = sizeof(addr);
+    int fd = ::accept(m_fd, (struct sockaddr*)&addr, &addrLen);
+    if (fd < 0)
+    {
+        throw std::runtime_error("TcpListener::accept: accept failed: " + std::string(strerror(errno)));
+    }
+    return Socket(fd);
+}
+
+uint16_t TcpListener::port() const
+{
+    struct sockaddr_in addr;
+    socklen_t addrLen = sizeof(addr);
+    if (::getsockname(m_fd, (struct sockaddr*)&addr, &addrLen) != 0)
+    {
+        throw std::runtime_error("TcpListener::port: getsockname failed");
+    }
+    return ntohs(addr.sin_port);
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Socket.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Socket.h
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Socket.h
+ * @brief Minimal RAII blocking TCP socket used by the RLPx client/server.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <cstdint>
+#include <string>
+
+namespace bcos::devp2p::rlpx
+{
+// Blocking TCP socket with full-read/full-write helpers.
+class Socket
+{
+public:
+    Socket();
+    explicit Socket(int _fd);
+    ~Socket();
+    Socket(Socket const&) = delete;
+    Socket& operator=(Socket const&) = delete;
+    Socket(Socket&&) noexcept;
+    Socket& operator=(Socket&&) noexcept;
+
+    // Connect to a host (IP or DNS) and port. Throws on failure.
+    void connect(std::string const& _host, uint16_t _port);
+    void close();
+    // Write all bytes. Throws on error.
+    void sendAll(bytesConstRef _data);
+    // Read exactly _size bytes. Throws on EOF/error.
+    bcos::bytes recvFixed(size_t _size);
+
+    int fd() const { return m_fd; }
+    bool valid() const { return m_fd >= 0; }
+
+private:
+    int m_fd{-1};
+};
+
+// Blocking TCP listener (used by the server side and by loopback tests).
+class TcpListener
+{
+public:
+    explicit TcpListener(uint16_t _port);
+    ~TcpListener();
+    TcpListener(TcpListener const&) = delete;
+    TcpListener& operator=(TcpListener const&) = delete;
+
+    // Block until a connection arrives and return it.
+    Socket accept();
+
+    int fd() const { return m_fd; }
+    // The port this listener is bound to (useful when bound to port 0).
+    uint16_t port() const;
+
+private:
+    int m_fd{-1};
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/test/HandshakeTest.cpp
+++ b/bcos-devp2p/test/HandshakeTest.cpp
@@ -17,10 +17,10 @@
  * @brief FramingCipher secret derivation + auth/ack message round trips.
  * @date 2026/8/18
  */
+#include <bcos-crypto/random/CryptoRandom.h>
 #include <bcos-devp2p/rlpx/Crypto.h>
 #include <bcos-devp2p/rlpx/Framing.h>
 #include <bcos-devp2p/rlpx/Handshake.h>
-#include <bcos-crypto/random/CryptoRandom.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <boost/test/unit_test.hpp>
 
@@ -54,10 +54,10 @@ BOOST_AUTO_TEST_CASE(secretsMatchGethVector)
     bytes macSecret;
     FramingCipher::deriveSecrets(keyMaterial, aesSecret, macSecret);
 
-    BOOST_CHECK_EQUAL(toHex(aesSecret),
-        "80e8632c05fed6fc2a13b0f8d31a3cf645366239170ea067065aba8e28bac487");
-    BOOST_CHECK_EQUAL(toHex(macSecret),
-        "2ea74ec5dae199227dff1af715362700e989d889d7a493cb0639691efb8e5f98");
+    BOOST_CHECK_EQUAL(
+        toHex(aesSecret), "80e8632c05fed6fc2a13b0f8d31a3cf645366239170ea067065aba8e28bac487");
+    BOOST_CHECK_EQUAL(
+        toHex(macSecret), "2ea74ec5dae199227dff1af715362700e989d889d7a493cb0639691efb8e5f98");
 }
 
 // Auth message build + parse (initiator signs, recipient recovers).
@@ -86,8 +86,7 @@ BOOST_AUTO_TEST_CASE(ackMessageRoundTrip)
     EccKeyPair ephemeral;
     auto recipientNonce = bcos::crypto::cryptoRandomBytes(32);
 
-    AuthAckMessage built(
-        ephemeral, ref(initiator.publicKey()), ref(recipientNonce));
+    AuthAckMessage built(ephemeral, ref(initiator.publicKey()), ref(recipientNonce));
     auto wire = built.serialize();
     bytesConstRef wireRef(wire.data(), wire.size());
     auto body = wireRef.getCroppedData(2);
@@ -95,6 +94,67 @@ BOOST_AUTO_TEST_CASE(ackMessageRoundTrip)
     AuthAckMessage parsed(body, ref(initiator.privateKey()));
     BOOST_CHECK(parsed.ephemeralPublicKey() == ephemeral.publicKey());
     BOOST_CHECK(parsed.nonce().toBytes() == built.nonce().toBytes());
+}
+
+// geth's EIP-8 forward-compatibility vectors: decrypt the Auth2/Ack2
+// ciphertexts with geth's static keys and check the recovered initiator /
+// ephemeral public keys and nonces against geth's expected values. This proves
+// the handshake ECIES envelope + RLP parsing is wire-compatible with geth, not
+// merely self-consistent.
+BOOST_AUTO_TEST_CASE(eip8AuthAckCiphertextDecode)
+{
+    auto const keyA = fromHex("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee");
+    auto const keyB = fromHex("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291");
+    auto const ephA = fromHex("869d6ecf5211f1cc60418a13b9d870b22959d0c16f02bec714c960dd2298a32d");
+    auto const ephB = fromHex("e238eb8e04fee6511ab04c6dd3c89ce097b11f25d584863ac2b6d5b35b1847e4");
+    auto const nonceA = fromHex("7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6");
+    auto const nonceB = fromHex("559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd");
+
+    EccKeyPair keyAPair(keyA);
+    EccKeyPair keyBPair(keyB);
+    EccKeyPair ephAPair(ephA);
+    EccKeyPair ephBPair(ephB);
+
+    // Auth2 (geth eip8HandshakeAuthTests[0]): initiator A -> recipient B.
+    auto const authWireHex =
+        "01b304ab7578555167be8154d5cc456f567d5ba302662433674222360f08d5f1534499d3678b513b0fca474f"
+        "3a514b18e75683032eb63fccb16c156dc6eb2c0b1593f0d84ac74f6e475f1b8d56116b849634a8c458705bf8"
+        "3a626ea0384d4d7341aae591fae42ce6bd5c850bfe0b999a694a49bbbaf3ef6cda61110601d3b4c02ab6c304"
+        "37257a6e0117792631a4b47c1d52fc0f8f89caadeb7d02770bf999cc147d2df3b62e1ffb2c9d8c125a398486"
+        "5356266bca11ce7d3a688663a51d82defaa8aad69da39ab6d5470e81ec5f2a7a47fb865ff7cca21516f9299a"
+        "07b1bc63ba56c7a1a892112841ca44b6e0034dee70c9adabc15d76a54f443593fafdc3b27af8059703f88928"
+        "e199cb122362a4b35f62386da7caad09c001edaeb5f8a06d2b26fb6cb93c52a9fca51853b68193916982358f"
+        "e1e5369e249875bb8d0d0ec36f917bc5e1eafd5896d46bd61ff23f1a863a8a8dcd54c7b109b771c8e61ec9c8"
+        "908c733c0263440e2aa067241aaa433f0bb053c7b31a838504b148f570c0ad62837129e547678c5190341e4f"
+        "1693956c3bf7678318e2d5b5340c9e488eefea198576344afbdf66db5f51204a6961a63ce072c8926c";
+    auto authWire = fromHex(authWireHex);
+    bytesConstRef authWireRef(authWire.data(), authWire.size());
+    BOOST_REQUIRE_EQUAL(authWire.size(), 437);  // 2-byte size prefix + 435 B body
+    AuthMessage auth(authWireRef.getCroppedData(2), ref(keyB));
+    BOOST_CHECK(auth.initiatorPublicKey() == keyAPair.publicKey());
+    BOOST_CHECK(auth.ephemeralPublicKey() == ephAPair.publicKey());
+    BOOST_CHECK(auth.nonce().toBytes() == nonceA);
+
+    // Ack2 (geth eip8HandshakeRespTests[0]): recipient B -> initiator A.
+    auto const ackWireHex =
+        "01ea0451958701280a56482929d3b0757da8f7fbe5286784beead59d95089c217c9b917788989470b0e330cc"
+        "6e4fb383c0340ed85fab836ec9fb8a49672712aeabbdfd1e837c1ff4cace34311cd7f4de05d59279e3524ab2"
+        "6ef753a0095637ac88f2b499b9914b5f64e143eae548a1066e14cd2f4bd7f814c4652f11b254f8a2d0191e2f"
+        "5546fae6055694aed14d906df79ad3b407d94692694e259191cde171ad542fc588fa2b7333313d82a9f88733"
+        "2f1dfc36cea03f831cb9a23fea05b33deb999e85489e645f6aab1872475d488d7bd6c7c120caf28dbfc5d683"
+        "3888155ed69d34dbdc39c1f299be1057810f34fbe754d021bfca14dc989753d61c413d261934e1a9c67ee060"
+        "a25eefb54e81a4d14baff922180c395d3f998d70f46f6b58306f969627ae364497e73fc27f6d17ae45a413d3"
+        "22cb8814276be6ddd13b885b201b943213656cde498fa0e9ddc8e0b8f8a53824fbd82254f3e2c17e8eaea009"
+        "c38b4aa0a3f306e8797db43c25d68e86f262e564086f59a2fc60511c42abfb3057c247a8a8fe4fb3ccbadde1"
+        "7514b7ac8000cdb6a912778426260c47f38919a91f25f4b5ffb455d6aaaf150f7e5529c100ce62d6d92826a7"
+        "1778d809bdf60232ae21ce8a437eca8223f45ac37f6487452ce626f549b3b5fdee26afd2072e4bc75833c246"
+        "4c805246155289f4";
+    auto ackWire = fromHex(ackWireHex);
+    bytesConstRef ackWireRef(ackWire.data(), ackWire.size());
+    BOOST_REQUIRE_EQUAL(ackWire.size(), 492);  // 2-byte size prefix + 490 B body
+    AuthAckMessage ack(ackWireRef.getCroppedData(2), ref(keyA));
+    BOOST_CHECK(ack.ephemeralPublicKey() == ephBPair.publicKey());
+    BOOST_CHECK(ack.nonce().toBytes() == nonceB);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-devp2p/test/HandshakeTest.cpp
+++ b/bcos-devp2p/test/HandshakeTest.cpp
@@ -1,0 +1,100 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HandshakeTest.cpp
+ * @brief FramingCipher secret derivation + auth/ack message round trips.
+ * @date 2026/8/18
+ */
+#include <bcos-devp2p/rlpx/Crypto.h>
+#include <bcos-devp2p/rlpx/Framing.h>
+#include <bcos-devp2p/rlpx/Handshake.h>
+#include <bcos-crypto/random/CryptoRandom.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::devp2p::rlpx;
+
+BOOST_AUTO_TEST_SUITE(HandshakeTest)
+
+// geth TestHandshakeForwardCompatibility: aes-secret and mac-secret derived
+// from the (ephB, ephA) ECDH + nonces must match geth's authoritative values.
+BOOST_AUTO_TEST_CASE(secretsMatchGethVector)
+{
+    auto ephA = fromHex("869d6ecf5211f1cc60418a13b9d870b22959d0c16f02bec714c960dd2298a32d");
+    auto ephB = fromHex("e238eb8e04fee6511ab04c6dd3c89ce097b11f25d584863ac2b6d5b35b1847e4");
+    auto nonceA = fromHex("7e968bba13b6c50e2c4cd7f241cc0d64d1ac25c7f5952df231ac6a2bda8ee5d6");
+    auto nonceB = fromHex("559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd");
+
+    EccKeyPair ephAPair(ephA);
+    EccKeyPair ephBPair(ephB);
+
+    FramingCipher::KeyMaterial keyMaterial;
+    keyMaterial.ephemeralSharedSecret =
+        EciesCipher::computeSharedSecret(ref(ephAPair.publicKey()), ref(ephB));
+    keyMaterial.isInitiator = false;
+    keyMaterial.initiatorNonce = nonceA;
+    keyMaterial.recipientNonce = nonceB;
+    keyMaterial.initiatorFirstMessageData = {0x01, 0x02};
+    keyMaterial.recipientFirstMessageData = {0x03, 0x04};
+
+    bytes aesSecret;
+    bytes macSecret;
+    FramingCipher::deriveSecrets(keyMaterial, aesSecret, macSecret);
+
+    BOOST_CHECK_EQUAL(toHex(aesSecret),
+        "80e8632c05fed6fc2a13b0f8d31a3cf645366239170ea067065aba8e28bac487");
+    BOOST_CHECK_EQUAL(toHex(macSecret),
+        "2ea74ec5dae199227dff1af715362700e989d889d7a493cb0639691efb8e5f98");
+}
+
+// Auth message build + parse (initiator signs, recipient recovers).
+BOOST_AUTO_TEST_CASE(authMessageRoundTrip)
+{
+    EccKeyPair initiator;
+    EccKeyPair recipient;
+    EccKeyPair ephemeral;
+
+    AuthMessage built(initiator, ref(recipient.publicKey()), ephemeral);
+    auto wire = built.serialize();
+    // Strip the 2-byte size prefix; the parse constructor takes the ECIES body.
+    bytesConstRef wireRef(wire.data(), wire.size());
+    auto body = wireRef.getCroppedData(2);
+
+    AuthMessage parsed(body, ref(recipient.privateKey()));
+    BOOST_CHECK(parsed.initiatorPublicKey() == initiator.publicKey());
+    BOOST_CHECK(parsed.ephemeralPublicKey() == ephemeral.publicKey());
+    BOOST_CHECK(parsed.nonce().toBytes() == built.nonce().toBytes());
+}
+
+// Ack message round trip.
+BOOST_AUTO_TEST_CASE(ackMessageRoundTrip)
+{
+    EccKeyPair initiator;
+    EccKeyPair ephemeral;
+    auto recipientNonce = bcos::crypto::cryptoRandomBytes(32);
+
+    AuthAckMessage built(
+        ephemeral, ref(initiator.publicKey()), ref(recipientNonce));
+    auto wire = built.serialize();
+    bytesConstRef wireRef(wire.data(), wire.size());
+    auto body = wireRef.getCroppedData(2);
+
+    AuthAckMessage parsed(body, ref(initiator.privateKey()));
+    BOOST_CHECK(parsed.ephemeralPublicKey() == ephemeral.publicKey());
+    BOOST_CHECK(parsed.nonce().toBytes() == built.nonce().toBytes());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-devp2p/test/MessageCodecTest.cpp
+++ b/bcos-devp2p/test/MessageCodecTest.cpp
@@ -1,0 +1,215 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MessageCodecTest.cpp
+ * @brief MessageCodec frame-payload codec + raw-snappy tests.
+ * @date 2026/9/2
+ */
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-devp2p/rlpx/MessageCodec.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::devp2p::rlpx;
+
+namespace
+{
+// RLP-encode the message id the same way MessageCodec::encode does.
+bytes rlpMessageId(uint8_t _id)
+{
+    bytes out;
+    bcos::codec::rlp::encode(out, static_cast<uint64_t>(_id));
+    return out;
+}
+
+// Compressed frame payload: RLP(id) || uvarint(declared) || snappy block.
+bytes makeCompressedFrame(uint8_t _id, uint64_t _declared, bytes const& _block)
+{
+    bytes out = rlpMessageId(_id);
+    uint64_t value = _declared;
+    while (value >= 0x80)
+    {
+        out.push_back(static_cast<byte>((value & 0x7F) | 0x80));
+        value >>= 7;
+    }
+    out.push_back(static_cast<byte>(value));
+    out.insert(out.end(), _block.begin(), _block.end());
+    return out;
+}
+
+// Append an snappy literal element (len < 60) for `_data` to `_block`.
+void appendLiteral(bytes& _block, std::string const& _data)
+{
+    BOOST_REQUIRE(_data.size() > 0 && _data.size() < 60);
+    _block.push_back(static_cast<byte>((_data.size() - 1) << 2));
+    _block.insert(_block.end(), _data.begin(), _data.end());
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(MessageCodecTest)
+
+// Uncompressed encode/decode round trips across message ids and payload sizes.
+BOOST_AUTO_TEST_CASE(roundTripUncompressed)
+{
+    MessageCodec codec;
+    std::vector<uint8_t> const ids = {0, 1, 0x7f, 0x80, 0xff};
+    std::vector<size_t> const sizes = {0, 1, 16, 100, 4096, 100000};
+    for (auto id : ids)
+    {
+        for (auto size : sizes)
+        {
+            Message msg;
+            msg.id = id;
+            msg.data.resize(size);
+            for (size_t i = 0; i < size; ++i)
+            {
+                msg.data[i] = static_cast<byte>((i * 31 + id) & 0xff);
+            }
+            auto frame = codec.encode(msg);
+            Message decoded = codec.decode(bytesConstRef(frame.data(), frame.size()));
+            BOOST_CHECK_EQUAL(decoded.id, id);
+            BOOST_CHECK(decoded.data == msg.data);
+        }
+    }
+}
+
+// Compressed round trips. Sizes straddle the raw-snappy literal length-extension
+// branches: <60 (single tag), 61..256 (1 length byte), 257..65536 (2 bytes) and
+// >65536 (3 bytes).
+BOOST_AUTO_TEST_CASE(roundTripCompressed)
+{
+    MessageCodec codec;
+    codec.enableCompression();
+    std::vector<size_t> const sizes = {0, 1, 59, 60, 61, 256, 257, 1000, 65536, 65537};
+    for (auto size : sizes)
+    {
+        Message msg;
+        msg.id = 0x11;
+        msg.data.resize(size);
+        for (size_t i = 0; i < size; ++i)
+        {
+            msg.data[i] = static_cast<byte>((i * 7 + 3) & 0xff);
+        }
+        auto frame = codec.encode(msg);
+        Message decoded = codec.decode(bytesConstRef(frame.data(), frame.size()));
+        BOOST_CHECK_EQUAL(decoded.id, 0x11);
+        BOOST_CHECK(decoded.data == msg.data);
+    }
+}
+
+// A compressed stream using every copy element type (copy-1/2/4), including an
+// overlapping back-reference, must decompress exactly as geth/snappy would.
+BOOST_AUTO_TEST_CASE(decodeCopyElements)
+{
+    MessageCodec codec;
+    codec.enableCompression();
+
+    // copy-1: literal "abcde" then copy-1 len=5 offset=5 (tag 0x05 0x05).
+    {
+        bytes block;
+        appendLiteral(block, "abcde");
+        block.push_back(0x05);  // copy-1 tag: len=5 (dataBits 1), offset hi 0
+        block.push_back(0x05);  // offset lo
+        auto frame = makeCompressedFrame(1, 10, block);
+        Message decoded = codec.decode(bytesConstRef(frame.data(), frame.size()));
+        BOOST_CHECK_EQUAL(std::string(decoded.data.begin(), decoded.data.end()), "abcdeabcde");
+    }
+    // copy-2: literal "abcd" then copy-2 len=8 offset=4 (tag 0x1e, LE offset).
+    {
+        bytes block;
+        appendLiteral(block, "abcd");
+        block.push_back(0x1e);  // copy-2 tag: len = 7 + 1 = 8
+        block.push_back(0x04);  // offset LE
+        block.push_back(0x00);
+        auto frame = makeCompressedFrame(2, 12, block);
+        Message decoded = codec.decode(bytesConstRef(frame.data(), frame.size()));
+        BOOST_CHECK_EQUAL(std::string(decoded.data.begin(), decoded.data.end()), "abcdabcdabcd");
+    }
+    // copy-4: literal "abcd" then copy-4 len=1 offset=4 (tag 0x03, 4-byte LE).
+    {
+        bytes block;
+        appendLiteral(block, "abcd");
+        block.push_back(0x03);  // copy-4 tag: len = 0 + 1 = 1
+        block.push_back(0x04);  // offset LE (4 bytes)
+        block.push_back(0x00);
+        block.push_back(0x00);
+        block.push_back(0x00);
+        auto frame = makeCompressedFrame(3, 5, block);
+        Message decoded = codec.decode(bytesConstRef(frame.data(), frame.size()));
+        BOOST_CHECK_EQUAL(std::string(decoded.data.begin(), decoded.data.end()), "abcda");
+    }
+}
+
+// Malformed inputs must fail closed instead of over-allocating or looping.
+BOOST_AUTO_TEST_CASE(decodeFailsClosed)
+{
+    MessageCodec codec;
+    codec.enableCompression();
+
+    // Empty frame data.
+    bytes empty;
+    BOOST_CHECK_THROW(codec.decode(bytesConstRef(empty.data(), empty.size())), std::runtime_error);
+
+    // Truncated RLP message id (0x81 claims a 1-byte string, none follows).
+    bytes badId = {0x81};
+    BOOST_CHECK_THROW(codec.decode(bytesConstRef(badId.data(), badId.size())), std::runtime_error);
+
+    // Truncated snappy varint (0x80 has the continuation bit set, nothing follows).
+    bytes truncatedVarint = rlpMessageId(1);
+    truncatedVarint.push_back(0x80);
+    BOOST_CHECK_THROW(codec.decode(bytesConstRef(truncatedVarint.data(), truncatedVarint.size())),
+        std::runtime_error);
+
+    // Declared length over the 16 MiB limit.
+    auto tooLarge = makeCompressedFrame(1, MessageCodec::kMaxFrameSize + 1, {});
+    BOOST_CHECK_THROW(
+        codec.decode(bytesConstRef(tooLarge.data(), tooLarge.size())), std::runtime_error);
+
+    // Declared length does not match the decompressed size.
+    bytes shortBlock;
+    appendLiteral(shortBlock, "abc");
+    auto mismatch = makeCompressedFrame(1, 10, shortBlock);
+    BOOST_CHECK_THROW(
+        codec.decode(bytesConstRef(mismatch.data(), mismatch.size())), std::runtime_error);
+
+    // Block truncated: literal claims 10 bytes, only 3 are present.
+    bytes truncatedBlock = {static_cast<byte>((10 - 1) << 2), 'a', 'b', 'c'};
+    auto truncated = makeCompressedFrame(1, 10, truncatedBlock);
+    BOOST_CHECK_THROW(
+        codec.decode(bytesConstRef(truncated.data(), truncated.size())), std::runtime_error);
+
+    // Copy with offset 0 is invalid.
+    bytes zeroOffset;
+    appendLiteral(zeroOffset, "abc");
+    zeroOffset.push_back(0x01);  // copy-1 len=4
+    zeroOffset.push_back(0x00);  // offset 0
+    auto badOffset = makeCompressedFrame(1, 4, zeroOffset);
+    BOOST_CHECK_THROW(
+        codec.decode(bytesConstRef(badOffset.data(), badOffset.size())), std::runtime_error);
+
+    // Copy with an offset past the already-decompressed output is invalid.
+    bytes pastOffset;
+    appendLiteral(pastOffset, "abc");
+    pastOffset.push_back(0x01);  // copy-1 len=4
+    pastOffset.push_back(0x05);  // offset 5 > 3
+    auto badPast = makeCompressedFrame(1, 4, pastOffset);
+    BOOST_CHECK_THROW(
+        codec.decode(bytesConstRef(badPast.data(), badPast.size())), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-devp2p/test/MessagesTest.cpp
+++ b/bcos-devp2p/test/MessagesTest.cpp
@@ -1,0 +1,143 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MessagesTest.cpp
+ * @brief devp2p base-protocol Hello/Disconnect/Ping codec tests.
+ * @date 2026/9/2
+ */
+#include <bcos-devp2p/rlpx/Messages.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::devp2p::rlpx;
+
+namespace
+{
+HelloMessage makeHello()
+{
+    HelloMessage msg;
+    msg.version = 5;
+    msg.clientId = "FISCO-BCOS";
+    msg.capabilities = {{"eth", 68}, {"les", 2}};
+    msg.listenPort = 30303;
+    msg.id.assign(64, 0x11);
+    return msg;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(MessagesTest)
+
+// Hello encode/decode round trip preserves every field.
+BOOST_AUTO_TEST_CASE(helloRoundTrip)
+{
+    auto msg = makeHello();
+    // Capability version 255 must round-trip (upper bound of the uint8 range).
+    msg.capabilities = {{"eth", 68}, {"snap", 1}, {"edge", 255}};
+
+    auto wire = encodeHello(msg);
+    HelloMessage decoded = decodeHello(bytesConstRef(wire.data(), wire.size()));
+
+    BOOST_CHECK_EQUAL(decoded.version, msg.version);
+    BOOST_CHECK(decoded.clientId == msg.clientId);
+    BOOST_CHECK_EQUAL(decoded.capabilities.size(), msg.capabilities.size());
+    for (size_t i = 0; i < msg.capabilities.size(); ++i)
+    {
+        BOOST_CHECK(decoded.capabilities[i].name == msg.capabilities[i].name);
+        BOOST_CHECK_EQUAL(decoded.capabilities[i].version, msg.capabilities[i].version);
+    }
+    BOOST_CHECK_EQUAL(decoded.listenPort, msg.listenPort);
+    BOOST_CHECK(decoded.id == msg.id);
+}
+
+// Golden Hello bytes, independently hand-RLP-encoded:
+//   [version=5, "FISCO-BCOS", [], listenPort=30303, id = 64 x 0x11]
+// pins the exact wire format (empty capability list).
+BOOST_AUTO_TEST_CASE(helloGoldenWireFormat)
+{
+    HelloMessage msg;
+    msg.version = 5;
+    msg.clientId = "FISCO-BCOS";
+    msg.capabilities = {};
+    msg.listenPort = 30303;
+    msg.id.assign(64, 0x11);
+
+    auto wire = encodeHello(msg);
+    BOOST_CHECK_EQUAL(toHex(wire),
+        "f852058a464953434f2d42434f53c082765fb840111111111111111111111111"
+        "1111111111111111111111111111111111111111111111111111111111111111"
+        "1111111111111111111111111111111111111111");
+
+    // And the golden decodes back to the same message.
+    HelloMessage decoded = decodeHello(bytesConstRef(wire.data(), wire.size()));
+    BOOST_CHECK_EQUAL(decoded.version, 5);
+    BOOST_CHECK(decoded.clientId == "FISCO-BCOS");
+    BOOST_CHECK(decoded.capabilities.empty());
+    BOOST_CHECK_EQUAL(decoded.listenPort, 30303);
+    BOOST_CHECK(decoded.id == msg.id);
+}
+
+// A capability version > 0xff (256 here) must be rejected, not silently wrapped.
+BOOST_AUTO_TEST_CASE(helloRejectsOversizedCapVersion)
+{
+    // [5, "FISCO-BCOS", [["eth", 256]], 30303, 64 x 0x11]
+    auto wire = fromHex(
+        "f85a058a464953434f2d42434f53c8c78365746882010082765fb84011111111"
+        "1111111111111111111111111111111111111111111111111111111111111111"
+        "11111111111111111111111111111111111111111111111111111111");
+    BOOST_CHECK_THROW(decodeHello(bytesConstRef(wire.data(), wire.size())), std::runtime_error);
+}
+
+// Disconnect is always emitted in the geth list form [reason] and both the list
+// form and the legacy bare-integer form are accepted on decode.
+BOOST_AUTO_TEST_CASE(disconnectCodecs)
+{
+    // [0x00] (DisconnectRequested)
+    DisconnectMessage msg;
+    msg.reason = DisconnectReason::DisconnectRequested;
+    auto wire = encodeDisconnect(msg);
+    BOOST_CHECK(wire == (bytes{0xc1, 0x80}));
+
+    // [0x02] (ProtocolBreach)
+    msg.reason = DisconnectReason::ProtocolBreach;
+    wire = encodeDisconnect(msg);
+    BOOST_CHECK(wire == (bytes{0xc1, 0x02}));
+
+    // Decode the list form.
+    auto listForm = fromHex("c180");
+    auto decoded = decodeDisconnect(bytesConstRef(listForm.data(), listForm.size()));
+    BOOST_CHECK(decoded.reason == DisconnectReason::DisconnectRequested);
+
+    // Decode the legacy bare-integer form (as sent by some clients).
+    auto bareForm = fromHex("02");
+    decoded = decodeDisconnect(bytesConstRef(bareForm.data(), bareForm.size()));
+    BOOST_CHECK(decoded.reason == DisconnectReason::ProtocolBreach);
+
+    // 0x10 is the spec's subprotocol-specific reason.
+    auto subreason = fromHex("10");
+    decoded = decodeDisconnect(bytesConstRef(subreason.data(), subreason.size()));
+    BOOST_CHECK(decoded.reason == DisconnectReason::SubprotocolReason);
+}
+
+// Ping/Pong payloads are the empty list.
+BOOST_AUTO_TEST_CASE(pingPongEmptyList)
+{
+    BOOST_CHECK(encodePing() == (bytes{0xc0}));
+    BOOST_CHECK(encodePong() == (bytes{0xc0}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## 概述

RLPx 加密会话核心层（自包含，无其他 devp2p 模块依赖），是 devp2p 改造（rlpx → eth → sync）的第一部分。

## 变更内容

### `bcos-devp2p/bcos-devp2p/rlpx/`（10 个文件，新增）
- **Socket**：TCP 连接/监听封装（connect、accept、recv/send、超时）
- **MessageCodec**：RLPx 帧编码/解码 + raw-snappy 块压缩（与 geth/erigon/reth/ethrex 线格式一致，手写实现，无新增第三方依赖）
- **Messages**：Hello/Disconnect 基础消息编解码
- **Handshake**：RLPx ECIES 握手（auth/ack 消息构造与解析、密钥派生）
- **Session**：加密会话封装（帧加密、压缩、消息收发）

### 单元测试（1 个文件）
- `HandshakeTest.cpp`：密钥派生 geth 权威向量比对、auth/ack 往返

## 说明

- 构建配置无需改动（`GLOB_RECURSE`）
- 已本地验证独立编译 + 全部单测通过（No errors detected）
- 依赖 eth 的 `Client` 及 eth/68 协议在后续 PR #5536 中提交