### PR TITLE
feat(rpc): map Engine API errors and add OP execution helpers

### DIFF
--- a/bcos-evm/bcos-evm/opstack/OpTransition.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.cpp
@@ -535,7 +535,7 @@ bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateVie
     if (const auto* err = std::get_if<std::error_code>(&props))
     {
         if (*err == evmone::state::make_error_code(evmone::state::GAS_LIMIT_REACHED))
-            throw std::runtime_error("op deposit: block gas limit reached (block error)");
+            throw OpDepositGasLimitReached("op deposit: block gas limit reached (block error)");
         // Processing-level failure (op-geth Regolith, state_transition.go:486-513):
         // mint is retained, nonce is force-incremented, gasUsed = gasLimit in full (:498).
         state.get(dep.from).nonce = preNonce + 1;

--- a/bcos-evm/bcos-evm/opstack/OpTransition.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.cpp
@@ -99,8 +99,8 @@ inline bcos::u256 intxToBcosU256(intx::uint256 const& val)
 /// bcos::protocol::OpStackReceiptMeta (the typed view over the tars opStackMeta hex-string
 /// fields). uint256 fields use intxToBcosU256 (full-width); uint64/uint32 scalar fields are
 /// assigned directly. Presence is preserved per-field. effective_gas_price is deliberately NOT
-/// carried here — it lands on the receipt's top-level effectiveGasPrice field (op-geth api.go:1775
-/// emits it at the top level, not inside the OP extension object).
+/// carried here — it lands on the receipt's top-level effectiveGasPrice field (op-geth
+/// internal/ethapi/api.go:1761 emits it at the top level, not inside the OP extension object).
 inline bcos::protocol::OpStackReceiptMeta toOpStackMeta(const OpReceiptMeta& meta)
 {
     bcos::protocol::OpStackReceiptMeta out;
@@ -360,7 +360,8 @@ bcos::protocol::TransactionReceipt::Ptr opTransition(const evmone::state::StateV
         bcos::bytesConstRef{outputBytes.data(), outputBytes.size()},
         !tx.to.has_value() ? toFiscoContractAddress(tx.sender, tx.nonce) : std::string{});
     out->setOpStackMeta(toOpStackMeta(meta));
-    // op-geth hexutil.Big: "0x" + lowercase hex, no leading zeros (api.go:1775, RPC top-level).
+    // op-geth hexutil.Big: "0x" + lowercase hex, no leading zeros (internal/ethapi/api.go:1761, RPC
+    // top-level).
     out->setEffectiveGasPrice("0x" + intx::to_string(effective_gas_price, 16));
     // out-param written last: an exception in the projection above must not leave a diff to apply.
     outStateDiff = std::move(receipt.state_diff);
@@ -506,6 +507,8 @@ bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateVie
     evmone::state::State state{view};
     auto& fromAcc = state.get_or_insert(dep.from);
     const uint64_t preNonce = fromAcc.nonce;
+    // op-geth AddBalance uses holiman/uint256 Add (state_object.go), which wraps
+    // mod 2^256. Rejecting mint overflow here would diverge from that EL.
     if (dep.mint.has_value())
         fromAcc.balance += *dep.mint;
 
@@ -521,8 +524,13 @@ bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateVie
     tx.max_priority_gas_price = 0;
     tx.nonce = preNonce;
 
-    // Deposit skips the fee cap validation; validate is used only to compute intrinsic gas / the
-    // EIP-7623 floor.
+    // Deposit skips the fee cap validation; validate is used to compute intrinsic gas / the
+    // EIP-7623 floor AND to enforce the block gas pool (GAS_LIMIT_REACHED is one of the two
+    // block-level deposit errors op-geth names in state_transition.go:486, the other being
+    // ErrSystemTxNotSupported, handled at the top of runDeposit). A deposit whose gas_limit
+    // exceeds the running block gas pool is a block error, not a processing-level failure —
+    // op-geth charges every transaction (including deposits) against gp.SubGas; only SYSTEM
+    // transactions are exempt, and dep.is_system_tx is already rejected above.
     evmone::state::BlockInfo validateBlock = block;
     validateBlock.base_fee = 0;
     const DepositValidationView maskedView{view, dep.from};

--- a/bcos-evm/bcos-evm/opstack/OpTransition.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.cpp
@@ -98,9 +98,8 @@ inline bcos::u256 intxToBcosU256(intx::uint256 const& val)
 /// Convert the execution layer's opstack::OpReceiptMeta into the framework layer's
 /// bcos::protocol::OpStackReceiptMeta (the typed view over the tars opStackMeta hex-string
 /// fields). uint256 fields use intxToBcosU256 (full-width); uint64/uint32 scalar fields are
-/// assigned directly. Presence is preserved per-field. effective_gas_price is deliberately NOT
-/// carried here — it lands on the receipt's top-level effectiveGasPrice field (op-geth
-/// internal/ethapi/api.go:1761 emits it at the top level, not inside the OP extension object).
+/// assigned directly. Presence is preserved per-field. effective_gas_price is
+/// written on the receipt top-level field, not in this OP extension object.
 inline bcos::protocol::OpStackReceiptMeta toOpStackMeta(const OpReceiptMeta& meta)
 {
     bcos::protocol::OpStackReceiptMeta out;
@@ -360,8 +359,7 @@ bcos::protocol::TransactionReceipt::Ptr opTransition(const evmone::state::StateV
         bcos::bytesConstRef{outputBytes.data(), outputBytes.size()},
         !tx.to.has_value() ? toFiscoContractAddress(tx.sender, tx.nonce) : std::string{});
     out->setOpStackMeta(toOpStackMeta(meta));
-    // op-geth hexutil.Big: "0x" + lowercase hex, no leading zeros (internal/ethapi/api.go:1761, RPC
-    // top-level).
+    // "0x" + lowercase hex, no leading zeros.
     out->setEffectiveGasPrice("0x" + intx::to_string(effective_gas_price, 16));
     // out-param written last: an exception in the projection above must not leave a diff to apply.
     outStateDiff = std::move(receipt.state_diff);
@@ -507,8 +505,7 @@ bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateVie
     evmone::state::State state{view};
     auto& fromAcc = state.get_or_insert(dep.from);
     const uint64_t preNonce = fromAcc.nonce;
-    // op-geth AddBalance uses holiman/uint256 Add (state_object.go), which wraps
-    // mod 2^256. Rejecting mint overflow here would diverge from that EL.
+    // Mint wraps mod 2^256, matching op-geth AddBalance.
     if (dep.mint.has_value())
         fromAcc.balance += *dep.mint;
 
@@ -524,13 +521,7 @@ bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateVie
     tx.max_priority_gas_price = 0;
     tx.nonce = preNonce;
 
-    // Deposit skips the fee cap validation; validate is used to compute intrinsic gas / the
-    // EIP-7623 floor AND to enforce the block gas pool (GAS_LIMIT_REACHED is one of the two
-    // block-level deposit errors op-geth names in state_transition.go:486, the other being
-    // ErrSystemTxNotSupported, handled at the top of runDeposit). A deposit whose gas_limit
-    // exceeds the running block gas pool is a block error, not a processing-level failure —
-    // op-geth charges every transaction (including deposits) against gp.SubGas; only SYSTEM
-    // transactions are exempt, and dep.is_system_tx is already rejected above.
+    // Skip fee-cap checks; still charge intrinsic gas and the block gas pool.
     evmone::state::BlockInfo validateBlock = block;
     validateBlock.base_fee = 0;
     const DepositValidationView maskedView{view, dep.from};

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -230,35 +230,15 @@ struct DepositTx
 /// OP 0x7E deposit transaction/receipt type (EIP-2718 typed envelope prefix).
 constexpr auto kDepositTxType = static_cast<evmone::state::Transaction::Type>(0x7e);
 
-// ---- L1-attributes deposit calldata layout (shared by synthesis and validation) ----
-// 176B with the Isthmus selector (0x098999be), 178B with the Jovian selector (0x3db6be2b).
-// Selectors mirror op-geth core/types (setL1BlockValues dispatch); the
-// pre-Isthmus Ecotone form (164B, 0x440a5e20) predates this chain's Isthmus baseline and
-// is never synthesized.
+// L1-attributes calldata: Isthmus 176B (0x098999be), Jovian 178B (0x3db6be2b).
 inline constexpr std::size_t IsthmusL1AttributesLen = 176;
 inline constexpr std::size_t JovianL1AttributesLen = 178;
 inline constexpr std::array<uint8_t, 4> IsthmusL1AttributesSelector = {0x09, 0x89, 0x99, 0xbe};
 inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6, 0xbe, 0x2b};
-/// Synthesized L1-attributes deposit gas limit. op-geth's core/types/deposit_tx.go
-/// defines no L1InfoDepositGas constant (only DepositTxType = 0x7E); deposit gas sizing
-/// lives on the op-node side. The built-in-CL synthesis keeps 1M — enough for the
-/// intrinsic gas + calldata the attributes deposit actually consumes; a normal 30M block
-/// pool accepts it. runDeposit DOES charge deposits against the running block gas pool
-/// (blockGasLeft) and raises the GAS_LIMIT_REACHED block error when a deposit's
-/// gas_limit exceeds it (op-geth state_transition.go:486 names ErrGasLimitReached as a
-/// block-level deposit error; only SYSTEM txs are exempt, and is_system_tx is rejected
-/// at the top of runDeposit).
+/// Gas limit used when synthesizing the L1-attributes deposit.
 inline constexpr int64_t c_l1InfoDepositGas = 1'000'000;
 
-/// L1 block information used to synthesize the L1-attributes deposit (mirrors op-geth
-/// core/types/rollup_cost.go L1BlockInfo). In production the deposit is derived by the
-/// op-node (L2 CL) and arrives inside payloadAttributes.transactions; this struct only
-/// feeds the built-in single-node CL's fallback synthesis, which runs when the CL did not
-/// supply a deposit. All-zero fields are the documented stand-in for an absent [op_l1]
-/// configuration (see NodeConfig::loadOpL1Config) — never a production L1 value. This
-/// folding is deliberate: an all-zero struct is indistinguishable from a genuine L1 block
-/// at height 0 with a zero hash, and the built-in-CL stand-in accepts that ambiguity
-/// because real op-node deposits always carry the actual L1 block info.
+/// L1 block fields for synthesizing the L1-attributes deposit (built-in CL fallback).
 struct L1BlockInfo
 {
     uint64_t number = 0;

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -238,7 +238,8 @@ inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6
 /// Gas limit used when synthesizing the L1-attributes deposit.
 inline constexpr int64_t c_l1InfoDepositGas = 1'000'000;
 
-/// L1 block fields for synthesizing the L1-attributes deposit (built-in CL fallback).
+/// L1 block fields for synthesizing the L1-attributes deposit.
+/// All-zero number/time/blockHash is the unset sentinel — production synthesize must refuse it.
 struct L1BlockInfo
 {
     uint64_t number = 0;
@@ -248,6 +249,11 @@ struct L1BlockInfo
     uint64_t sequenceNumber = 0;
     intx::uint256 blobBaseFee{0};
 };
+
+[[nodiscard]] inline bool isUnsetL1BlockInfo(L1BlockInfo const& info) noexcept
+{
+    return info.number == 0 && info.time == 0 && evmc::is_zero(info.blockHash);
+}
 
 /// Execute one 0x7E deposit: skip buyGas; add balance when mint has a value; still deduct
 /// intrinsic + the EIP-7623 floor; both failure paths retain the mint and force-increment the

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -11,6 +11,7 @@
 #include <intx/intx.hpp>
 #include <limits>
 #include <optional>
+#include <stdexcept>
 #include <system_error>
 #include <variant>
 
@@ -255,11 +256,18 @@ struct L1BlockInfo
     return info.number == 0 && info.time == 0 && evmc::is_zero(info.blockHash);
 }
 
+/// Deposit gas_limit exceeds remaining block gas (op-geth ErrGasLimitReached). Distinct
+/// from executor_v1::opstack::OpBlockGasPoolFull (prepare-time normal-tx pool full).
+struct OpDepositGasLimitReached : std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
 /// Execute one 0x7E deposit: skip buyGas; add balance when mint has a value; still deduct
 /// intrinsic + the EIP-7623 floor; both failure paths retain the mint and force-increment the
 /// nonce; is_system_tx==true throws std::runtime_error (block-level error); gas_limit
-/// exceeding blockGasLeft throws std::runtime_error (op-geth ErrGasLimitReached, block-level
-/// error). Returns a bcos::protocol::TransactionReceipt::Ptr
+/// exceeding blockGasLeft throws OpDepositGasLimitReached (op-geth ErrGasLimitReached,
+/// block-level error). Returns a bcos::protocol::TransactionReceipt::Ptr
 /// with the deposit_nonce/receipt_version carried via setOpStackMeta; the state diff is
 /// returned through `outStateDiff`.
 bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateView& view,

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -4,6 +4,7 @@
 #include <bcos-evm/opstack/OpForkSchedule.h>
 #include <bcos-framework/protocol/TransactionReceipt.h>
 #include <bcos-framework/protocol/TransactionReceiptFactory.h>
+#include <array>
 #include <bcos-evm/eth/state/state.hpp>
 #include <cstdint>
 #include <evmc/evmc.hpp>
@@ -229,12 +230,52 @@ struct DepositTx
 /// OP 0x7E deposit transaction/receipt type (EIP-2718 typed envelope prefix).
 constexpr auto kDepositTxType = static_cast<evmone::state::Transaction::Type>(0x7e);
 
+// ---- L1-attributes deposit calldata layout (shared by synthesis and validation) ----
+// 176B with the Isthmus selector (0x098999be), 178B with the Jovian selector (0x3db6be2b).
+// Selectors mirror op-geth core/types (setL1BlockValues dispatch); the
+// pre-Isthmus Ecotone form (164B, 0x440a5e20) predates this chain's Isthmus baseline and
+// is never synthesized.
+inline constexpr std::size_t IsthmusL1AttributesLen = 176;
+inline constexpr std::size_t JovianL1AttributesLen = 178;
+inline constexpr std::array<uint8_t, 4> IsthmusL1AttributesSelector = {0x09, 0x89, 0x99, 0xbe};
+inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6, 0xbe, 0x2b};
+/// Synthesized L1-attributes deposit gas limit. op-geth's core/types/deposit_tx.go
+/// defines no L1InfoDepositGas constant (only DepositTxType = 0x7E); deposit gas sizing
+/// lives on the op-node side. The built-in-CL synthesis keeps 1M — enough for the
+/// intrinsic gas + calldata the attributes deposit actually consumes; a normal 30M block
+/// pool accepts it. runDeposit DOES charge deposits against the running block gas pool
+/// (blockGasLeft) and raises the GAS_LIMIT_REACHED block error when a deposit's
+/// gas_limit exceeds it (op-geth state_transition.go:486 names ErrGasLimitReached as a
+/// block-level deposit error; only SYSTEM txs are exempt, and is_system_tx is rejected
+/// at the top of runDeposit).
+inline constexpr int64_t c_l1InfoDepositGas = 1'000'000;
+
+/// L1 block information used to synthesize the L1-attributes deposit (mirrors op-geth
+/// core/types/rollup_cost.go L1BlockInfo). In production the deposit is derived by the
+/// op-node (L2 CL) and arrives inside payloadAttributes.transactions; this struct only
+/// feeds the built-in single-node CL's fallback synthesis, which runs when the CL did not
+/// supply a deposit. All-zero fields are the documented stand-in for an absent [op_l1]
+/// configuration (see NodeConfig::loadOpL1Config) — never a production L1 value. This
+/// folding is deliberate: an all-zero struct is indistinguishable from a genuine L1 block
+/// at height 0 with a zero hash, and the built-in-CL stand-in accepts that ambiguity
+/// because real op-node deposits always carry the actual L1 block info.
+struct L1BlockInfo
+{
+    uint64_t number = 0;
+    uint64_t time = 0;
+    intx::uint256 baseFee{0};
+    evmc::bytes32 blockHash{};
+    uint64_t sequenceNumber = 0;
+    intx::uint256 blobBaseFee{0};
+};
+
 /// Execute one 0x7E deposit: skip buyGas; add balance when mint has a value; still deduct
 /// intrinsic + the EIP-7623 floor; both failure paths retain the mint and force-increment the
-/// nonce; is_system_tx==true throws std::runtime_error (block-level error). gas_limit exceeding
-/// blockGasLeft throws std::runtime_error (op-geth ErrGasLimitReached, block-level error).
-/// Returns a bcos::protocol::TransactionReceipt::Ptr with the deposit_nonce/receipt_version
-/// carried via setOpStackMeta; the state diff is returned through `outStateDiff`.
+/// nonce; is_system_tx==true throws std::runtime_error (block-level error); gas_limit
+/// exceeding blockGasLeft throws std::runtime_error (op-geth ErrGasLimitReached, block-level
+/// error). Returns a bcos::protocol::TransactionReceipt::Ptr
+/// with the deposit_nonce/receipt_version carried via setOpStackMeta; the state diff is
+/// returned through `outStateDiff`.
 bcos::protocol::TransactionReceipt::Ptr runDeposit(const evmone::state::StateView& view,
     const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
     const DepositTx& dep, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -240,7 +240,8 @@ inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6
 inline constexpr int64_t c_l1InfoDepositGas = 1'000'000;
 
 /// L1 block fields for synthesizing the L1-attributes deposit.
-/// All-zero number/time/blockHash is the unset sentinel — production synthesize must refuse it.
+/// All-zero number/time/blockHash is the unset snapshot sentinel.
+/// All-zero baseFeeScalar or batcherHash means SystemConfig was not supplied.
 struct L1BlockInfo
 {
     uint64_t number = 0;
@@ -249,11 +250,21 @@ struct L1BlockInfo
     evmc::bytes32 blockHash{};
     uint64_t sequenceNumber = 0;
     intx::uint256 blobBaseFee{0};
+    uint32_t baseFeeScalar = 0;
+    uint32_t blobBaseFeeScalar = 0;
+    evmc::bytes32 batcherHash{};
+    uint32_t operatorFeeScalar = 0;
+    uint64_t operatorFeeConstant = 0;
 };
 
 [[nodiscard]] inline bool isUnsetL1BlockInfo(L1BlockInfo const& info) noexcept
 {
     return info.number == 0 && info.time == 0 && evmc::is_zero(info.blockHash);
+}
+
+[[nodiscard]] inline bool isUnsetSystemConfig(L1BlockInfo const& info) noexcept
+{
+    return info.baseFeeScalar == 0 || evmc::is_zero(info.batcherHash);
 }
 
 /// Deposit gas_limit exceeds remaining block gas (op-geth ErrGasLimitReached). Distinct

--- a/bcos-evm/test/opstack/OpDepositTest.cpp
+++ b/bcos-evm/test/opstack/OpDepositTest.cpp
@@ -685,4 +685,30 @@ BOOST_AUTO_TEST_CASE(FailedCreateDepositStillBumpsNonceAndDeploysNothing)
     BOOST_CHECK_EQUAL(ts.count(evmone::state::compute_create_address(kFrom, 5)), 0u);
 }
 
+// R127: op-geth AddBalance uses uint256.Int.Add (wraps mod 2^256). A failed-deposit
+// reject on overflow would diverge from that EL.
+BOOST_AUTO_TEST_CASE(MintAdditionWrapsLikeOpGethUint256Add)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    test::TestState ts;
+    ts[kFrom] = {.nonce = 0, .balance = ~intx::uint256{0}, .storage = {}, .code = {}};
+    test::TestBlockHashes hashes;
+    DepositTx dep{.source_hash = 0x01_bytes32,
+        .from = kFrom,
+        .to = kFrom,
+        .mint = intx::uint256{2},
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {}};
+    evmone::state::StateDiff diff;
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
+    bcos::evm::applyStateDiffStrict(ts, diff);
+
+    BOOST_CHECK_EQUAL(r->status(), 0);
+    BOOST_CHECK_EQUAL(ts.at(kFrom).balance, intx::uint256{1});
+    BOOST_CHECK_EQUAL(ts.at(kFrom).nonce, 1u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-evm/test/opstack/OpDepositTest.cpp
+++ b/bcos-evm/test/opstack/OpDepositTest.cpp
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_CASE(GasLimitOverBlockBudgetIsBlockError)
     evmone::state::StateDiff diff;
     BOOST_CHECK_THROW(runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234,
                           /*blockGasLeft=*/50000, kOpTestReceiptFactory, diff),
-        std::runtime_error);
+        OpDepositGasLimitReached);
 }
 
 // D-04 边界（红队 F-6）：恰等于块剩余 gas 必须接受——">=" 作弊在此暴露

--- a/bcos-evm/test/opstack/OpDepositTest.cpp
+++ b/bcos-evm/test/opstack/OpDepositTest.cpp
@@ -685,8 +685,7 @@ BOOST_AUTO_TEST_CASE(FailedCreateDepositStillBumpsNonceAndDeploysNothing)
     BOOST_CHECK_EQUAL(ts.count(evmone::state::compute_create_address(kFrom, 5)), 0u);
 }
 
-// R127: op-geth AddBalance uses uint256.Int.Add (wraps mod 2^256). A failed-deposit
-// reject on overflow would diverge from that EL.
+// Mint wraps mod 2^256 (op-geth AddBalance).
 BOOST_AUTO_TEST_CASE(MintAdditionWrapsLikeOpGethUint256Add)
 {
     auto vm = evmc::VM{evmc_create_evmone()};

--- a/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
+++ b/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
@@ -71,6 +71,25 @@ public:
         call(std::move(tx), std::move(callback));
     }
 
+    // OP build path: adopt a verify=false probe execution as the verified pending block
+    // WITHOUT re-executing it. Only OpScheduler overrides this (the engine's buildOpPayload
+    // is the sole caller); every other scheduler keeps the default re-execution, which is
+    // correct because none of them is ever called this way. Defaulted (not pure) so existing
+    // implementations and fakes stay source-compatible — same pattern as callAtBlock above.
+    // Wiring contract with the engine: while the engine's OP build path
+    // (EngineServiceImpl::c_opMode) is active, the runtime m_delegate MUST be an OpScheduler —
+    // the only implementation overriding this method. Any other scheduler silently falls back
+    // to the defaulted verify=true re-execution: correct, but the build pays a second
+    // execution and loses the single-execution optimization. No RTTI dispatch is possible
+    // (OpScheduler is templated over its storage type), so this is a documented convention,
+    // not an enforced invariant.
+    virtual void adoptProbeAsPending(bcos::protocol::Block::Ptr block,
+        std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
+            callback)
+    {
+        executeBlock(std::move(block), true, std::move(callback));
+    }
+
     // clear all status
     virtual void reset(std::function<void(Error::Ptr)> callback) = 0;
     virtual void getCode(
@@ -86,7 +105,7 @@ public:
     virtual void preExecuteBlock(bcos::protocol::Block::Ptr block, bool verify,
         std::function<void(Error::Ptr)> callback) = 0;
 
-    virtual void stop() {};
-    virtual void setVersion(int version, ledger::LedgerConfig::Ptr ledgerConfig) {};
+    virtual void stop(){};
+    virtual void setVersion(int version, ledger::LedgerConfig::Ptr ledgerConfig){};
 };
 }  // namespace bcos::scheduler

--- a/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
+++ b/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
@@ -71,18 +71,8 @@ public:
         call(std::move(tx), std::move(callback));
     }
 
-    // OP build path: adopt a verify=false probe execution as the verified pending block
-    // WITHOUT re-executing it. Only OpScheduler overrides this (the engine's buildOpPayload
-    // is the sole caller); every other scheduler keeps the default re-execution, which is
-    // correct because none of them is ever called this way. Defaulted (not pure) so existing
-    // implementations and fakes stay source-compatible — same pattern as callAtBlock above.
-    // Wiring contract with the engine: while the engine's OP build path
-    // (EngineServiceImpl::c_opMode) is active, the runtime m_delegate MUST be an OpScheduler —
-    // the only implementation overriding this method. Any other scheduler silently falls back
-    // to the defaulted verify=true re-execution: correct, but the build pays a second
-    // execution and loses the single-execution optimization. No RTTI dispatch is possible
-    // (OpScheduler is templated over its storage type), so this is a documented convention,
-    // not an enforced invariant.
+    // Adopt a verify=false probe as the pending block without re-executing.
+    // Default re-runs executeBlock(verify=true); OpScheduler overrides this.
     virtual void adoptProbeAsPending(bcos::protocol::Block::Ptr block,
         std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
             callback)

--- a/bcos-framework/bcos-framework/engine/Errors.h
+++ b/bcos-framework/bcos-framework/engine/Errors.h
@@ -47,6 +47,7 @@ DERIVE_BCOS_EXCEPTION(UnsupportedFork);
 using OpCulpritTxHash = boost::error_info<struct OpCulpritTxHashTag, bcos::h256>;
 
 /// True when the reject is a block-gas-pool capacity fault (skip this build, do not evict).
-using OpBlockGasPoolFull = boost::error_info<struct OpBlockGasPoolFullTag, bool>;
+/// Named separately from executor_v1::opstack::OpBlockGasPoolFull (the prepare-time exception).
+using OpRejectIsCapacity = boost::error_info<struct OpRejectIsCapacityTag, bool>;
 
 }  // namespace bcos::engine

--- a/bcos-framework/bcos-framework/engine/Errors.h
+++ b/bcos-framework/bcos-framework/engine/Errors.h
@@ -46,11 +46,7 @@ DERIVE_BCOS_EXCEPTION(UnsupportedFork);
 /// opstack-executor/OpCommon.h. Never route this through the message text.
 using OpCulpritTxHash = boost::error_info<struct OpCulpritTxHashTag, bcos::h256>;
 
-/// Structured carrier marking an OP per-tx reject as a block-capacity fault (the block
-/// gas pool cannot fit the transaction) rather than a poisoned transaction: the build
-/// loop skips the tx for this build and must never remove it from the pool. Mirrors
-/// OpCulpritTxHash's error_info contract (attached by OpScheduler, read back by
-/// buildOpPayload). Never route this through the message text.
+/// True when the reject is a block-gas-pool capacity fault (skip this build, do not evict).
 using OpBlockGasPoolFull = boost::error_info<struct OpBlockGasPoolFullTag, bool>;
 
 }  // namespace bcos::engine

--- a/bcos-framework/bcos-framework/engine/Errors.h
+++ b/bcos-framework/bcos-framework/engine/Errors.h
@@ -46,4 +46,11 @@ DERIVE_BCOS_EXCEPTION(UnsupportedFork);
 /// opstack-executor/OpCommon.h. Never route this through the message text.
 using OpCulpritTxHash = boost::error_info<struct OpCulpritTxHashTag, bcos::h256>;
 
+/// Structured carrier marking an OP per-tx reject as a block-capacity fault (the block
+/// gas pool cannot fit the transaction) rather than a poisoned transaction: the build
+/// loop skips the tx for this build and must never remove it from the pool. Mirrors
+/// OpCulpritTxHash's error_info contract (attached by OpScheduler, read back by
+/// buildOpPayload). Never route this through the message text.
+using OpBlockGasPoolFull = boost::error_info<struct OpBlockGasPoolFullTag, bool>;
+
 }  // namespace bcos::engine

--- a/bcos-framework/bcos-framework/engine/OpBaseFee.h
+++ b/bcos-framework/bcos-framework/engine/OpBaseFee.h
@@ -14,9 +14,10 @@
  *  limitations under the License.
  *
  * @file OpBaseFee.h
- * @brief OP-Stack next-block baseFee (op-geth CalcBaseFee). Types-only in this
- * slice: the in-tree caller is CalcOpBaseFeeTest. EngineServiceImpl still has a
- * file-local decoder; #5538 should include this header and delete that copy.
+ * @brief OP-Stack next-block baseFee (op-geth CalcBaseFee) plus the shared Holocene/
+ * Jovian extraData shape gate. EngineServiceImpl aliases decodeEip1559Params and
+ * validateOpExtraDataShape from this header (the file-local copies were removed by
+ * #5538); calcOpBaseFee and the engine INVALID gates therefore share one rule set.
  */
 
 #pragma once
@@ -33,13 +34,19 @@
 namespace bcos::engine
 {
 
-/// Canyon EIP-1559 parameters (op-geth params/config.go). Mirrors the anonymous-namespace
-/// copies in EngineServiceImpl.cpp (these constants, decodeEip1559Params, and
-/// validateOptimismExtraDataShape) — #5538 consolidates all three copies onto this
-/// header so the engine INVALID gate and the next-base-fee calc share one decoder.
-/// Unused by calcOpBaseFee itself.
+/// Canyon EIP-1559 parameters (op-geth params/config.go).
 inline constexpr std::uint32_t c_eip1559DenominatorCanyon = 250;
 inline constexpr std::uint32_t c_eip1559ElasticityCanyon = 6;
+
+/// Holocene/Jovian extraData layout constants (version byte first): 9 bytes = Holocene
+/// 0x00 || denom(u32 BE) || elasticity(u32 BE); 17 bytes = Jovian 0x01 || same ||
+/// minBaseFee(u64 BE). Single home: the engine gate, the shape rule below and the
+/// next-base-fee calc all read from here.
+inline constexpr std::size_t c_holoceneExtraDataBytes = 9;
+inline constexpr std::size_t c_jovianExtraDataBytes = 17;
+inline constexpr bcos::byte c_holoceneExtraDataVersion = 0x00;
+inline constexpr bcos::byte c_jovianExtraDataVersion = 0x01;
+inline constexpr std::size_t c_eip1559ParamsBytes = 8;
 
 /// Decode the 8-byte Holocene eip1559Params / extraData[1:9] pair (u32 BE denom, u32 BE
 /// elasticity).
@@ -53,6 +60,41 @@ inline std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(
     auto denominator = bcos::fromBigEndian<std::uint32_t>(params.first(4));
     auto elasticity = bcos::fromBigEndian<std::uint32_t>(params.subspan(4, 4));
     return {denominator, elasticity};
+}
+
+/// Shared OP extraData shape gate (length/version/non-zero pair), single home for the
+/// rule the engine INVALID gates and calcOpBaseFee both enforce. Returns a
+/// context-free message body; callers prefix their own subject (the engine validators
+/// use "executionPayload.extraData ", calcOpBaseFee "OP parent extraData ") so each
+/// surface keeps its established wording. `allowEmpty` is true for payload validation
+/// (empty extraData is legal pre-Holocene); the base-fee calc only sees Holocene+
+/// parents and rejects it with the size message.
+inline std::optional<std::string> validateOpExtraDataShape(
+    const bcos::bytes& extraData, bool allowEmpty = true)
+{
+    if (extraData.empty())
+    {
+        return allowEmpty ? std::nullopt :
+                            std::optional<std::string>{"must be 9 (Holocene) or 17 (Jovian) bytes"};
+    }
+    if (extraData.size() != c_holoceneExtraDataBytes && extraData.size() != c_jovianExtraDataBytes)
+    {
+        return "must be 9 (Holocene) or 17 (Jovian) bytes, got " + std::to_string(extraData.size());
+    }
+    auto const expectedVersion = extraData.size() == c_jovianExtraDataBytes ?
+                                     c_jovianExtraDataVersion :
+                                     c_holoceneExtraDataVersion;
+    if (extraData[0] != expectedVersion)
+    {
+        return std::string("version byte does not match length");
+    }
+    auto [denominator, elasticity] = decodeEip1559Params(
+        std::span<const bcos::byte>(extraData).subspan(1, c_eip1559ParamsBytes));
+    if (denominator == 0 || elasticity == 0)
+    {
+        return std::string("must encode a non-zero EIP-1559 denominator and elasticity");
+    }
+    return std::nullopt;
 }
 
 /// Next-block baseFee (op-geth CalcBaseFee). Holocene-active and later only:
@@ -69,25 +111,15 @@ inline std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(
 /// is only read from exactly-17-byte extraData carrying 0x01.
 inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool parentIsJovian)
 {
-    auto const extra = parent.extraData();
-    if (extra.size() != 9 && extra.size() != 17)
+    // extraData() is a bytesConstRef; materialize the (<=17-byte) view so the shared
+    // shape rule and the span reads below share one value.
+    bcos::bytes const extra(parent.extraData().begin(), parent.extraData().end());
+    if (auto shapeError = validateOpExtraDataShape(extra, /*allowEmpty=*/false))
     {
-        throw std::invalid_argument(
-            "OP parent extraData must be 9 (Holocene) or 17 (Jovian) bytes");
+        throw std::invalid_argument("OP parent extraData " + *shapeError);
     }
-    auto const expectedVersion =
-        extra.size() == 17 ? static_cast<bcos::byte>(0x01) : static_cast<bcos::byte>(0x00);
-    if (extra[0] != expectedVersion)
-    {
-        throw std::invalid_argument("OP parent extraData version byte does not match length");
-    }
-    auto [denominator32, elasticity32] =
-        decodeEip1559Params(std::span<const bcos::byte>(extra.data(), extra.size()).subspan(1, 8));
-    if (denominator32 == 0 || elasticity32 == 0)
-    {
-        throw std::invalid_argument(
-            "OP parent extraData must encode a non-zero EIP-1559 denominator and elasticity");
-    }
+    auto [denominator32, elasticity32] = decodeEip1559Params(
+        std::span<const bcos::byte>(extra.data(), extra.size()).subspan(1, c_eip1559ParamsBytes));
     uint64_t const denominator = denominator32;
     uint64_t const elasticity = elasticity32;
 

--- a/bcos-framework/bcos-framework/engine/OpBaseFee.h
+++ b/bcos-framework/bcos-framework/engine/OpBaseFee.h
@@ -60,7 +60,7 @@ inline std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(
 /// Check extraData length, version byte, and non-zero EIP-1559 pair.
 /// Empty extraData is allowed when `allowEmpty` is true (pre-Holocene payloads).
 inline std::optional<std::string> validateOpExtraDataShape(
-    const bcos::bytes& extraData, bool allowEmpty = true)
+    std::span<const bcos::byte> extraData, bool allowEmpty = true)
 {
     if (extraData.empty())
     {
@@ -78,8 +78,8 @@ inline std::optional<std::string> validateOpExtraDataShape(
     {
         return std::string("version byte does not match length");
     }
-    auto [denominator, elasticity] = decodeEip1559Params(
-        std::span<const bcos::byte>(extraData).subspan(1, c_eip1559ParamsBytes));
+    auto [denominator, elasticity] =
+        decodeEip1559Params(extraData.subspan(1, c_eip1559ParamsBytes));
     if (denominator == 0 || elasticity == 0)
     {
         return std::string("must encode a non-zero EIP-1559 denominator and elasticity");
@@ -101,13 +101,14 @@ inline std::optional<std::string> validateOpExtraDataShape(
 /// is only read from exactly-17-byte extraData carrying 0x01.
 inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool parentIsJovian)
 {
-    bcos::bytes const extra(parent.extraData().begin(), parent.extraData().end());
+    auto extraView = parent.extraData();
+    std::span<const bcos::byte> extra{extraView.data(), extraView.size()};
     if (auto shapeError = validateOpExtraDataShape(extra, /*allowEmpty=*/false))
     {
         throw std::invalid_argument("OP parent extraData " + *shapeError);
     }
-    auto [denominator32, elasticity32] = decodeEip1559Params(
-        std::span<const bcos::byte>(extra.data(), extra.size()).subspan(1, c_eip1559ParamsBytes));
+    auto [denominator32, elasticity32] =
+        decodeEip1559Params(extra.subspan(1, c_eip1559ParamsBytes));
     uint64_t const denominator = denominator32;
     uint64_t const elasticity = elasticity32;
 
@@ -117,8 +118,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
     std::optional<bcos::u256> minBaseFee;
     if (parentIsJovian && extra.size() == 17 && extra[0] == 0x01)
     {
-        minBaseFee = bcos::u256(
-            bcos::fromBigEndian<std::uint64_t>(std::span<const bcos::byte>(extra).subspan(9, 8)));
+        minBaseFee = bcos::u256(bcos::fromBigEndian<std::uint64_t>(extra.subspan(9, 8)));
     }
 
     bcos::u256 const gasTarget = parent.gasLimit() / elasticity;

--- a/bcos-framework/bcos-framework/engine/OpBaseFee.h
+++ b/bcos-framework/bcos-framework/engine/OpBaseFee.h
@@ -14,10 +14,7 @@
  *  limitations under the License.
  *
  * @file OpBaseFee.h
- * @brief OP-Stack next-block baseFee (op-geth CalcBaseFee) plus the shared Holocene/
- * Jovian extraData shape gate. EngineServiceImpl aliases decodeEip1559Params and
- * validateOpExtraDataShape from this header (the file-local copies were removed by
- * #5538); calcOpBaseFee and the engine INVALID gates therefore share one rule set.
+ * @brief OP-Stack next-block baseFee (op-geth CalcBaseFee) and extraData shape checks.
  */
 
 #pragma once
@@ -38,10 +35,8 @@ namespace bcos::engine
 inline constexpr std::uint32_t c_eip1559DenominatorCanyon = 250;
 inline constexpr std::uint32_t c_eip1559ElasticityCanyon = 6;
 
-/// Holocene/Jovian extraData layout constants (version byte first): 9 bytes = Holocene
-/// 0x00 || denom(u32 BE) || elasticity(u32 BE); 17 bytes = Jovian 0x01 || same ||
-/// minBaseFee(u64 BE). Single home: the engine gate, the shape rule below and the
-/// next-base-fee calc all read from here.
+/// Holocene extraData is 9 bytes (0x00 || denom || elasticity);
+/// Jovian extraData is 17 bytes (0x01 || same || minBaseFee).
 inline constexpr std::size_t c_holoceneExtraDataBytes = 9;
 inline constexpr std::size_t c_jovianExtraDataBytes = 17;
 inline constexpr bcos::byte c_holoceneExtraDataVersion = 0x00;
@@ -62,13 +57,8 @@ inline std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(
     return {denominator, elasticity};
 }
 
-/// Shared OP extraData shape gate (length/version/non-zero pair), single home for the
-/// rule the engine INVALID gates and calcOpBaseFee both enforce. Returns a
-/// context-free message body; callers prefix their own subject (the engine validators
-/// use "executionPayload.extraData ", calcOpBaseFee "OP parent extraData ") so each
-/// surface keeps its established wording. `allowEmpty` is true for payload validation
-/// (empty extraData is legal pre-Holocene); the base-fee calc only sees Holocene+
-/// parents and rejects it with the size message.
+/// Check extraData length, version byte, and non-zero EIP-1559 pair.
+/// Empty extraData is allowed when `allowEmpty` is true (pre-Holocene payloads).
 inline std::optional<std::string> validateOpExtraDataShape(
     const bcos::bytes& extraData, bool allowEmpty = true)
 {
@@ -111,8 +101,6 @@ inline std::optional<std::string> validateOpExtraDataShape(
 /// is only read from exactly-17-byte extraData carrying 0x01.
 inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool parentIsJovian)
 {
-    // extraData() is a bytesConstRef; materialize the (<=17-byte) view so the shared
-    // shape rule and the span reads below share one value.
     bcos::bytes const extra(parent.extraData().begin(), parent.extraData().end());
     if (auto shapeError = validateOpExtraDataShape(extra, /*allowEmpty=*/false))
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -30,9 +30,7 @@ using namespace bcos::rpc;
 
 namespace
 {
-/// RAII release for the one-in-flight OP newPayload guard. The destructor must also run on
-/// exception unwind from the co_await below — a failed execution must not latch the flag
-/// shut and permanently answer SYNCING.
+/// Clears the OP newPayload in-flight flag, including on exception unwind.
 struct OpPayloadBusyReset
 {
     std::atomic<bool>& flag;
@@ -99,20 +97,7 @@ task::Task<void> EngineEndpoint::exchangeCapabilities(
 void EngineEndpoint::buildUnimplementedVersionError(
     std::string_view method, Json::Value& response) const
 {
-    // -38005 Unsupported fork for a method version this node does not implement at all
-    // (currently only forkchoiceUpdatedV4). isForkchoiceVersionSupported admits V4 when
-    // the instance was built with maxEngineVersion=V4 (OP mode); the RPC endpoint is the
-    // piece that refuses V4, because no engine mode implements a V4 forkchoiceUpdated
-    // request. This is NOT a declaration that older versions are incompatible: every
-    // version that IS implemented stays served, so a pre-Karst CL — the v1 Engine API
-    // harness kept alive by unsafe_allow_v1_executor, or a stock Lodestar driving V1-V3
-    // — keeps working.
-    //
-    // Built inline instead of through buildJsonError(request, ...) because a handler only
-    // ever receives the params array, never the request envelope: the JSON-RPC id is
-    // stamped onto the handler's response by the dispatcher
-    // (Web3JsonRpcImpl::handleRequest, `result["id"] = _request["id"]`), the same way it
-    // is for buildEngineNotAvailableError above and for every successful response.
+    // -38005: this method version is not implemented. The dispatcher stamps JSON-RPC id.
     Json::Value error(Json::objectValue);
     error["code"] = EngineError::UnsupportedFork;
     error["message"] = std::string(method) + " is not yet supported";
@@ -157,20 +142,7 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
 
     auto forkchoiceState = parseForkchoiceState(request);
     auto payloadAttrs = parsePayloadAttributes(request, version);
-    // Typed engine failures map onto the spec error codes here (the engine library cannot
-    // depend on the RPC layer's JsonRpcException). The mapped set:
-    //   -38003 InvalidPayloadAttributes — attribute faults (op-geth's
-    //   checkOptimismPayloadAttributes channel);
-    //   -38002 InvalidForkchoiceState — head known but finalizedBlockHash/safeBlockHash
-    //   not in chain;
-    //   -38005 UnsupportedFork — CL/chain fork-era mismatch.
-    // The exception's errinfo_comment is preserved via what() so the operator can tell
-    // which gate fired — e.g. the missing-revision case is a NODE-side misconfiguration,
-    // and a generic shape message would wrongly point at the CL. Anything else
-    // (OpExecutionInternalError and friends) propagates and answers the generic -32603,
-    // the correct classification for a genuine internal fault. (The buildOpPayload
-    // timestamp gate throws InvalidPayloadAttributes and is mapped to -38003 by this
-    // catch.)
+    // Map typed engine failures to spec codes; other exceptions stay -32603.
 
     engine::ForkchoiceUpdatedResult engineResult;
     try
@@ -185,13 +157,6 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
     }
     catch (engine::UnsupportedFork const& e)
     {
-        // The request's attribute shape cannot express the chain's fork era, or the chain
-        // lacks an on-chain EVM revision entirely. geth answers -38005 Unsupported fork
-        // for the same CL/chain mismatch; the service layer throws UnsupportedFork so this
-        // stays a diagnosable fork error instead of a generic -32603 InternalError. Keep
-        // the exception's errinfo_comment so the operator can tell which gate fired — the
-        // missing-revision case is a NODE-side misconfiguration and the generic shape
-        // message would wrongly point at the CL.
         BOOST_THROW_EXCEPTION(JsonRpcException(
             EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
     }
@@ -221,12 +186,6 @@ task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::
 
 task::Task<void> EngineEndpoint::getPayloadV4(const Json::Value& request, Json::Value& response)
 {
-    // Isthmus getPayload — a pre-Karst version, and served like every other one. The whole
-    // stack below already handles V4: isGetPayloadVersionSupported spans V1-V5,
-    // isGetPayloadVersionCompatible has its own V4 window, handleGetPayload fills
-    // executionRequests for V4+, and combineGetPayloadResponse renders the V4 shape.
-    // Refusing it here while serving newPayloadV4 would be the same fork-narrowing this
-    // node no longer does.
     co_await handleGetPayload(engine::ApiVersion::V4, request, response);
 }
 
@@ -264,15 +223,7 @@ task::Task<void> EngineEndpoint::handleGetPayload(
     }
     catch (engine::IncompatiblePayloadVersion const&)
     {
-        // The build behind this payloadId is outside the requested method's version
-        // window: either a version mismatch between the forkchoiceUpdated that built it
-        // and the getPayload asking for it, or a re-query AFTER the payload was committed
-        // through newPayload (a commit rewrites the cache entry with the newPayload
-        // version — PayloadEntry::version, EngineServiceImpl.h — so it no longer matches
-        // getPayloadV5's V3-build window). The mapping is -38005 to match op-geth, whose
-        // getPayload helper answers engine.UnsupportedFork when the payloadId's encoded
-        // build version is outside the method's allowed set (eth/catalyst/api.go:531-533,
-        // GetPayloadV5 allowing only PayloadV3).
+        // Payload was built under a different method version.
         BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
             "Unsupported fork: payload was built by a different method version"));
     }
@@ -317,10 +268,7 @@ task::Task<void> EngineEndpoint::handleNewPayload(
         co_return;
     }
 
-    // V4 (OP) execution runs a full block execution + commit per call. Bound it to one
-    // in-flight execution BEFORE parsing: a busy-rejected flood must not pay the full
-    // transaction hex decode; the concurrent request gets the spec-recognized SYNCING
-    // status (op-node retries) instead of queueing unbounded execution work behind a flood.
+    // One in-flight V4 newPayload; a second concurrent call answers SYNCING.
     const bool opExecution = version == engine::ApiVersion::V4;
     if (opExecution && m_opPayloadBusy.exchange(true, std::memory_order_acq_rel))
     {
@@ -331,17 +279,12 @@ task::Task<void> EngineEndpoint::handleNewPayload(
     OpPayloadBusyReset busyReset{m_opPayloadBusy, opExecution};
 
     auto newPayloadReq = parseNewPayloadRequest(request, version);
-    // TODO: engineService->newPayload() MUST throw JsonRpcException in these cases:
-    //   -32602 InvalidParams: wrong version of ExecutionPayload structure (V2)
     engine::PayloadStatus engineResult;
     try
     {
         engineResult =
             co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
     }
-    // handleOpNewPayload gates version != 4 with UnsupportedFork; the RPC must answer
-    // -38005 (op-geth unsupportedForkErr) rather than the generic -32603. Keep the
-    // errinfo_comment so the operator can tell which gate fired.
     catch (engine::UnsupportedFork const& e)
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -277,7 +277,8 @@ task::Task<void> EngineEndpoint::handleNewPayload(
     const bool opExecution = version == engine::ApiVersion::V4;
     if (opExecution && m_opPayloadBusy.exchange(true, std::memory_order_acq_rel))
     {
-        auto syncingStatus = serializePayloadStatus(engine::PayloadStatus{}, version);
+        auto syncingStatus = serializePayloadStatus(
+            engine::PayloadStatus{.status = engine::PayloadValidationStatus::Syncing}, version);
         buildJsonContent(syncingStatus, response);
         co_return;
     }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -273,6 +273,10 @@ task::Task<void> EngineEndpoint::handleNewPayload(
         co_return;
     }
 
+    // Parse before taking the latch so a malformed request still answers InvalidParams
+    // (-32602) while a V4 payload is in flight; the latch below only bounds execution.
+    auto newPayloadReq = parseNewPayloadRequest(request, version);
+
     // One in-flight V4 newPayload; a second concurrent call answers SYNCING.
     const bool opExecution = version == engine::ApiVersion::V4;
     if (opExecution && m_opPayloadBusy.exchange(true, std::memory_order_acq_rel))
@@ -289,7 +293,6 @@ task::Task<void> EngineEndpoint::handleNewPayload(
     }
     OpPayloadBusyReset busyReset{m_opPayloadBusy, opExecution};
 
-    auto newPayloadReq = parseNewPayloadRequest(request, version);
     engine::PayloadStatus engineResult;
     try
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -28,6 +28,24 @@
 using namespace bcos;
 using namespace bcos::rpc;
 
+namespace
+{
+/// RAII release for the one-in-flight OP newPayload guard. The destructor must also run on
+/// exception unwind from the co_await below — a failed execution must not latch the flag
+/// shut and permanently answer SYNCING.
+struct OpPayloadBusyReset
+{
+    std::atomic<bool>& flag;
+    bool owned;
+    ~OpPayloadBusyReset()
+    {
+        if (owned)
+        {
+            flag.store(false, std::memory_order_release);
+        }
+    }
+};
+}  // namespace
 
 EngineEndpoint::EngineEndpoint(NodeService::Ptr nodeService) : m_nodeService(std::move(nodeService))
 {}
@@ -82,11 +100,13 @@ void EngineEndpoint::buildUnimplementedVersionError(
     std::string_view method, Json::Value& response) const
 {
     // -38005 Unsupported fork for a method version this node does not implement at all
-    // (currently only forkchoiceUpdatedV4: the service layer's forkchoice window tops out
-    // at V3, see isForkchoiceVersionSupported). This is NOT a declaration that older
-    // versions are incompatible: every version that IS implemented stays served, so a
-    // pre-Karst CL — the v1 Engine API harness kept alive by unsafe_allow_v1_executor, or
-    // a stock Lodestar driving V1-V3 — keeps working.
+    // (currently only forkchoiceUpdatedV4). isForkchoiceVersionSupported admits V4 when
+    // the instance was built with maxEngineVersion=V4 (OP mode); the RPC endpoint is the
+    // piece that refuses V4, because no engine mode implements a V4 forkchoiceUpdated
+    // request. This is NOT a declaration that older versions are incompatible: every
+    // version that IS implemented stays served, so a pre-Karst CL — the v1 Engine API
+    // harness kept alive by unsafe_allow_v1_executor, or a stock Lodestar driving V1-V3
+    // — keeps working.
     //
     // Built inline instead of through buildJsonError(request, ...) because a handler only
     // ever receives the params array, never the request envelope: the JSON-RPC id is
@@ -137,16 +157,31 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
 
     auto forkchoiceState = parseForkchoiceState(request);
     auto payloadAttrs = parsePayloadAttributes(request, version);
-    // TODO: engineService->updateForkchoice() MUST throw JsonRpcException in these cases:
-    //   -38002 InvalidForkchoiceState: headBlockHash is VALID but finalizedBlockHash/safeBlockHash
-    //   not in chain -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <=
-    //   headBlockHash.timestamp -38005 UnsupportedFork: timestamp out of fork window (V2/V3
-    //   specific) -38006 TooDeepReorg: reorg depth exceeds limitation
+    // Typed engine failures map onto the spec error codes here (the engine library cannot
+    // depend on the RPC layer's JsonRpcException). The mapped set:
+    //   -38003 InvalidPayloadAttributes — attribute faults (op-geth's
+    //   checkOptimismPayloadAttributes channel);
+    //   -38002 InvalidForkchoiceState — head known but finalizedBlockHash/safeBlockHash
+    //   not in chain;
+    //   -38005 UnsupportedFork — CL/chain fork-era mismatch.
+    // The exception's errinfo_comment is preserved via what() so the operator can tell
+    // which gate fired — e.g. the missing-revision case is a NODE-side misconfiguration,
+    // and a generic shape message would wrongly point at the CL. Anything else
+    // (OpExecutionInternalError and friends) propagates and answers the generic -32603,
+    // the correct classification for a genuine internal fault. (The buildOpPayload
+    // timestamp gate throws InvalidPayloadAttributes and is mapped to -38003 by this
+    // catch.)
+
     engine::ForkchoiceUpdatedResult engineResult;
     try
     {
         engineResult = co_await engineService->updateForkchoice(forkchoiceState,
             payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    }
+    catch (engine::InvalidPayloadAttributes const& e)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::InvalidPayloadAttributes,
+            std::string("Invalid payload attributes: ") + e.what()));
     }
     catch (engine::UnsupportedFork const& e)
     {
@@ -157,8 +192,13 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
         // the exception's errinfo_comment so the operator can tell which gate fired — the
         // missing-revision case is a NODE-side misconfiguration and the generic shape
         // message would wrongly point at the CL.
-        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
-            std::string("Unsupported fork: ") + e.what()));
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
+    }
+    catch (engine::InvalidForkchoiceState const& e)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::InvalidForkchoiceState,
+            std::string("Invalid forkchoice state: ") + e.what()));
     }
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);
@@ -277,12 +317,41 @@ task::Task<void> EngineEndpoint::handleNewPayload(
         co_return;
     }
 
+    // V4 (OP) execution runs a full block execution + commit per call. Bound it to one
+    // in-flight execution BEFORE parsing: a busy-rejected flood must not pay the full
+    // transaction hex decode; the concurrent request gets the spec-recognized SYNCING
+    // status (op-node retries) instead of queueing unbounded execution work behind a flood.
+    const bool opExecution = version == engine::ApiVersion::V4;
+    if (opExecution && m_opPayloadBusy.exchange(true, std::memory_order_acq_rel))
+    {
+        auto syncingStatus = serializePayloadStatus(engine::PayloadStatus{}, version);
+        buildJsonContent(syncingStatus, response);
+        co_return;
+    }
+    OpPayloadBusyReset busyReset{m_opPayloadBusy, opExecution};
+
     auto newPayloadReq = parseNewPayloadRequest(request, version);
     // TODO: engineService->newPayload() MUST throw JsonRpcException in these cases:
     //   -32602 InvalidParams: wrong version of ExecutionPayload structure (V2)
-    //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3)
-    auto engineResult =
-        co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
+    engine::PayloadStatus engineResult;
+    try
+    {
+        engineResult =
+            co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
+    }
+    // handleOpNewPayload gates version != 4 with UnsupportedFork; the RPC must answer
+    // -38005 (op-geth unsupportedForkErr) rather than the generic -32603. Keep the
+    // errinfo_comment so the operator can tell which gate fired.
+    catch (engine::UnsupportedFork const& e)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
+    }
+    catch (engine::InvalidPayloadAttributes const& e)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::InvalidPayloadAttributes,
+            std::string("Invalid payload attributes: ") + e.what()));
+    }
     auto result = serializePayloadStatus(engineResult, version);
     buildJsonContent(result, response);
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -278,7 +278,12 @@ task::Task<void> EngineEndpoint::handleNewPayload(
     if (opExecution && m_opPayloadBusy.exchange(true, std::memory_order_acq_rel))
     {
         auto syncingStatus = serializePayloadStatus(
-            engine::PayloadStatus{.status = engine::PayloadValidationStatus::Syncing}, version);
+            engine::PayloadStatus{
+                .latestValidHash = std::nullopt,
+                .validationError = std::nullopt,
+                .status = engine::PayloadValidationStatus::Syncing,
+            },
+            version);
         buildJsonContent(syncingStatus, response);
         co_return;
     }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -35,6 +35,11 @@ struct OpPayloadBusyReset
 {
     std::atomic<bool>& flag;
     bool owned;
+    OpPayloadBusyReset(std::atomic<bool>& busy, bool owns) : flag(busy), owned(owns) {}
+    OpPayloadBusyReset(OpPayloadBusyReset const&) = delete;
+    OpPayloadBusyReset& operator=(OpPayloadBusyReset const&) = delete;
+    OpPayloadBusyReset(OpPayloadBusyReset&&) = delete;
+    OpPayloadBusyReset& operator=(OpPayloadBusyReset&&) = delete;
     ~OpPayloadBusyReset()
     {
         if (owned)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.h
@@ -23,6 +23,7 @@
 #include "bcos-rpc/groupmgr/NodeService.h"
 #include "bcos-task/Task.h"
 #include <json/json.h>
+#include <atomic>
 
 namespace bcos::rpc
 {
@@ -58,6 +59,11 @@ private:
 
     /// Build the -38005 answer for a method version this node does not implement.
     void buildUnimplementedVersionError(std::string_view method, Json::Value& response) const;
+
+    /// One-in-flight guard for OP (V4) newPayload executions: a second concurrent request is
+    /// answered with the spec-recognized SYNCING status instead of queueing another full
+    /// block execution + commit (CPU DoS bound; op-node retries).
+    std::atomic<bool> m_opPayloadBusy{false};
 
     NodeService::Ptr m_nodeService;
 };

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.h
@@ -60,9 +60,7 @@ private:
     /// Build the -38005 answer for a method version this node does not implement.
     void buildUnimplementedVersionError(std::string_view method, Json::Value& response) const;
 
-    /// One-in-flight guard for OP (V4) newPayload executions: a second concurrent request is
-    /// answered with the spec-recognized SYNCING status instead of queueing another full
-    /// block execution + commit (CPU DoS bound; op-node retries).
+    /// One in-flight V4 newPayload; a concurrent second call answers SYNCING.
     std::atomic<bool> m_opPayloadBusy{false};
 
     NodeService::Ptr m_nodeService;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -167,8 +167,9 @@ bcos::Address parseAddressField(Json::Value const& value, std::string_view field
     return bcos::rpc::parseAddress(value.asString());
 }
 
-/// Variable-length hex bytes (extraData, logsBloom, eip1559Params). Same isString() gate,
-/// plus fromHex's BadHexCharacter mapped to InvalidParams instead of InternalError.
+/// Variable-length hex bytes (extraData, logsBloom, eip1559Params, executionRequests).
+/// Same isString() gate, plus fromHex's BadHexCharacter mapped to InvalidParams
+/// instead of InternalError.
 bcos::bytes parseHexBytesField(Json::Value const& value, std::string_view field)
 {
     auto reject = [&]() -> bcos::bytes {
@@ -443,22 +444,10 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         // is a payload-validity question and is judged by the engine service, not here.
         std::vector<bytes> executionRequests;
         executionRequests.reserve(params[3].size());
-        for (auto const& item : params[3])
+        for (Json::ArrayIndex i = 0; i < params[3].size(); ++i)
         {
-            if (!item.isString())
-            {
-                BOOST_THROW_EXCEPTION(JsonRpcException(
-                    InvalidParams, "executionRequests entries must be hex strings"));
-            }
-            try
-            {
-                executionRequests.push_back(fromHex(item.asString()));
-            }
-            catch (bcos::BadHexCharacter const&)
-            {
-                BOOST_THROW_EXCEPTION(JsonRpcException(
-                    InvalidParams, "executionRequests entries must be hex strings"));
-            }
+            executionRequests.push_back(
+                parseHexBytesField(params[3][i], "executionRequests[" + std::to_string(i) + "]"));
         }
         request.executionRequests = std::move(executionRequests);
     }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -179,9 +179,16 @@ bcos::bytes parseHexBytesField(Json::Value const& value, std::string_view field)
     {
         return reject();
     }
+    auto const hex = value.asString();
+    // fromHex left-pads an odd nibble; require the same 0x + even-length contract as
+    // parseRawTransactionElement so extraData / logsBloom / eip1559Params stay verbatim.
+    if (hex.size() < 2 || hex.size() % 2 != 0 || hex[0] != '0' || (hex[1] != 'x' && hex[1] != 'X'))
+    {
+        return reject();
+    }
     try
     {
-        return bcos::fromHex(value.asString());
+        return bcos::fromHex(hex);
     }
     catch (bcos::BadHexCharacter const&)
     {
@@ -575,17 +582,21 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
     // forged value) and report malformed input as std::invalid_argument, which the RPC
     // entry point would surface as -32603 InternalError.
     //
-    // KNOWN GAP: gasLimit is parsed and carried on PayloadAttributes but buildPayload
-    // IGNORES it — the built block's gas limit always comes from this chain's own
-    // SystemConfig (EngineServiceImpl.h, ledgerConfig.gasLimit()). op-geth does the
-    // opposite: the attribute is mandatory on an OP chain (checkOptimismPayloadAttributes,
-    // eth/catalyst/api_optimism.go:41-43, else -38003) and sets header.GasLimit verbatim
-    // (miner/worker.go:362-363), and op-node always sends it from the L1 SystemConfig
-    // (op-node/rollup/derive/attributes.go:207-215). Honouring it changes what block this
-    // node produces, which belongs to the header-fields work rather than to this
-    // method-surface change.
+    // KNOWN GAP (generic path): the generic buildPayload IGNORES payloadAttributes.gasLimit —
+    // the built block's gas limit always comes from this chain's own SystemConfig
+    // (EngineServiceImpl.h, ledgerConfig.gasLimit()). The OP path (buildOpPayload) is the
+    // opposite: it prefers attrs.gasLimit and falls back to ledgerConfig, matching op-geth's
+    // mandatory-gasLimit semantics (checkOptimismPayloadAttributes, eth/catalyst/
+    // api_optimism.go:41-43, else -38003; miner/worker.go:362-363; op-node always sends it
+    // from the L1 SystemConfig, op-node/rollup/derive/attributes.go:207-215). Honouring it on
+    // the generic path changes what block this node produces, which belongs to the
+    // header-fields work rather than to this method-surface change.
     if (pa.isMember("gasLimit") && !pa["gasLimit"].isNull())
     {
+        // Interop note: parseQuantity (safeFromQuantity) is more lenient than op-geth's
+        // hexutil.Uint64 — it accepts a missing 0x prefix and leading zeros. The admitted
+        // set is deliberately wider than op-geth's; values decode identically, so there is
+        // no consensus impact (see parseBigQuantity's rationale above).
         attrs.gasLimit = parseQuantity(pa["gasLimit"], "payloadAttributes.gasLimit");
     }
     if (pa.isMember("eip1559Params") && !pa["eip1559Params"].isNull())
@@ -712,8 +723,6 @@ Json::Value bcos::rpc::serializeExecutionPayload(
     Json::Value transactions(Json::arrayValue);
     for (auto const& transaction : payload.transactions)
     {
-        // Raw EIP-2718 bytes out, exactly as carried — byte-for-byte what newPayload
-        // received or what buildPayload reassembled.
         transactions.append(toHexStringWithPrefix(transaction.raw));
     }
     ep["transactions"] = std::move(transactions);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -180,8 +180,7 @@ bcos::bytes parseHexBytesField(Json::Value const& value, std::string_view field)
         return reject();
     }
     auto const hex = value.asString();
-    // fromHex left-pads an odd nibble; require the same 0x + even-length contract as
-    // parseRawTransactionElement so extraData / logsBloom / eip1559Params stay verbatim.
+    // fromHex left-pads odd nibbles; require 0x and even length.
     if (hex.size() < 2 || hex.size() % 2 != 0 || hex[0] != '0' || (hex[1] != 'x' && hex[1] != 'X'))
     {
         return reject();
@@ -577,26 +576,9 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
         }
         attrs.noTxPool = pa["noTxPool"].asBool();
     }
-    // The three fields below go through the strict readers rather than a bare
-    // fromQuantity / fromHex: those stringify a JSON number before parsing it as hex (a
-    // forged value) and report malformed input as std::invalid_argument, which the RPC
-    // entry point would surface as -32603 InternalError.
-    //
-    // KNOWN GAP (generic path): the generic buildPayload IGNORES payloadAttributes.gasLimit —
-    // the built block's gas limit always comes from this chain's own SystemConfig
-    // (EngineServiceImpl.h, ledgerConfig.gasLimit()). The OP path (buildOpPayload) is the
-    // opposite: it prefers attrs.gasLimit and falls back to ledgerConfig, matching op-geth's
-    // mandatory-gasLimit semantics (checkOptimismPayloadAttributes, eth/catalyst/
-    // api_optimism.go:41-43, else -38003; miner/worker.go:362-363; op-node always sends it
-    // from the L1 SystemConfig, op-node/rollup/derive/attributes.go:207-215). Honouring it on
-    // the generic path changes what block this node produces, which belongs to the
-    // header-fields work rather than to this method-surface change.
+    // Strict readers: a bare fromQuantity/fromHex can turn a JSON number into -32603.
     if (pa.isMember("gasLimit") && !pa["gasLimit"].isNull())
     {
-        // Interop note: parseQuantity (safeFromQuantity) is more lenient than op-geth's
-        // hexutil.Uint64 — it accepts a missing 0x prefix and leading zeros. The admitted
-        // set is deliberately wider than op-geth's; values decode identically, so there is
-        // no consensus impact (see parseBigQuantity's rationale above).
         attrs.gasLimit = parseQuantity(pa["gasLimit"], "payloadAttributes.gasLimit");
     }
     if (pa.isMember("eip1559Params") && !pa["eip1559Params"].isNull())

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -204,8 +204,7 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV2)
     BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 2);
 }
 
-// UnsupportedFork from the FCU/newPayload version gates maps to -38005 — the permanent
-// wrong-version signal op-node does not retry — not the retryable generic -32603.
+// UnsupportedFork maps to -38005, not -32603.
 BOOST_AUTO_TEST_CASE(forkchoiceUpdatedWithAttrsUnsupportedForkMapsTo38005)
 {
     mockService.m_state->throwUnsupportedFork = true;
@@ -227,11 +226,7 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedWithAttrsUnsupportedForkMapsTo38005)
         [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
 }
 
-// Typed engine failures must map onto the spec error codes at the endpoint (R78):
-// InvalidPayloadAttributes -> -38003, UnsupportedFork -> -38005,
-// InvalidForkchoiceState -> -38002. Without the mapping every engine exception falls
-// into the dispatcher's catch(...) and answers the generic retryable -32603, which a
-// real op-node misclassifies as a transient server failure.
+// InvalidPayloadAttributes -> -38003, UnsupportedFork -> -38005, InvalidForkchoiceState -> -38002.
 BOOST_AUTO_TEST_CASE(forkchoiceUpdatedTypedFailuresMapToSpecErrorCodes)
 {
     Json::Value params(Json::arrayValue);
@@ -246,10 +241,6 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedTypedFailuresMapToSpecErrorCodes)
     attrs["suggestedFeeRecipient"] = "0x5555555555555555555555555555555555555555";
     params.append(attrs);
 
-    // CALL_ENGINE drives the endpoint directly (no dispatcher), so the mapped
-    // JsonRpcException surfaces here exactly as Web3JsonRpcImpl::handleRequest would see
-    // it: the dispatcher's catch(JsonRpcException) formats it into response["error"] with
-    // the same code.
     auto expectCode = [&](Json::Value params, int code) {
         Json::Value response;
         BOOST_CHECK_EXCEPTION(CALL_ENGINE(forkchoiceUpdatedV3, params, response), JsonRpcException,
@@ -298,9 +289,6 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV3)
     BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 3);
 }
 
-// The one method version this node really does not implement: forkchoiceUpdatedV4 is
-// refused at the RPC endpoint (-38005) before the engine service; OP mode constructs
-// maxEngineVersion=V4, so isForkchoiceVersionSupported would otherwise admit it.
 BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV4)
 {
     Json::Value params(Json::arrayValue);
@@ -662,8 +650,6 @@ BOOST_AUTO_TEST_CASE(newPayloadV4)
 
 BOOST_AUTO_TEST_CASE(newPayloadV4TypedVersionGateMapsToSpecErrorCode)
 {
-    // A fully shaped V4 request so parseNewPayloadRequest passes and the typed engine
-    // failure (not a -32602 shape error) is what reaches the endpoint's catch ladder.
     Json::Value params(Json::arrayValue);
     params.append(makeV4ExecutionPayloadJson());
     params.append(Json::Value(Json::arrayValue));  // expectedBlobVersionedHashes (empty)

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -108,6 +108,10 @@ public:
     {
         m_state->capturedNewPayloadRequest = request;
         m_state->capturedNewPayloadVersion = version;
+        if (m_state->throwInvalidPayloadAttributes)
+        {
+            BOOST_THROW_EXCEPTION(engine::InvalidPayloadAttributes{});
+        }
         if (m_state->throwUnsupportedFork)
         {
             BOOST_THROW_EXCEPTION(engine::UnsupportedFork{});
@@ -660,6 +664,22 @@ BOOST_AUTO_TEST_CASE(newPayloadV4TypedVersionGateMapsToSpecErrorCode)
     Json::Value response;
     BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV4, params, response), JsonRpcException,
         [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
+}
+
+BOOST_AUTO_TEST_CASE(newPayloadV4InvalidPayloadAttributesMapsTo38003)
+{
+    Json::Value params(Json::arrayValue);
+    params.append(makeV4ExecutionPayloadJson());
+    params.append(Json::Value(Json::arrayValue));
+    params.append(c_beaconRootHex);
+    params.append(Json::Value(Json::arrayValue));
+
+    mockService.m_state->throwInvalidPayloadAttributes = true;
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV4, params, response), JsonRpcException,
+        [](JsonRpcException const& e) {
+            return e.code() == EngineError::InvalidPayloadAttributes;
+        });
 }
 
 BOOST_AUTO_TEST_CASE(newPayloadV4MissingParams)

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -24,8 +24,8 @@
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/DataConvertUtility.h>
-#include <memory>
 #include <boost/test/unit_test.hpp>
+#include <memory>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -56,7 +56,9 @@ public:
         std::optional<engine::NewPayloadRequest> capturedNewPayloadRequest;
         std::optional<std::uint32_t> capturedNewPayloadVersion;
         bool throwUnknownPayload = false;
+        bool throwInvalidPayloadAttributes = false;
         bool throwUnsupportedFork = false;
+        bool throwInvalidForkchoiceState = false;
     };
     std::shared_ptr<State> m_state = std::make_shared<State>();
 
@@ -74,9 +76,17 @@ public:
     {
         m_state->capturedForkchoiceState = forkchoiceState;
         m_state->capturedForkchoiceVersion = static_cast<int>(version);
+        if (m_state->throwInvalidPayloadAttributes)
+        {
+            BOOST_THROW_EXCEPTION(engine::InvalidPayloadAttributes{});
+        }
         if (m_state->throwUnsupportedFork)
         {
             BOOST_THROW_EXCEPTION(engine::UnsupportedFork{});
+        }
+        if (m_state->throwInvalidForkchoiceState)
+        {
+            BOOST_THROW_EXCEPTION(engine::InvalidForkchoiceState{});
         }
         co_return m_state->forkchoiceUpdatedResult;
     }
@@ -98,6 +108,10 @@ public:
     {
         m_state->capturedNewPayloadRequest = request;
         m_state->capturedNewPayloadVersion = version;
+        if (m_state->throwUnsupportedFork)
+        {
+            BOOST_THROW_EXCEPTION(engine::UnsupportedFork{});
+        }
         co_return m_state->forkchoiceUpdatedResult.payloadStatus;
     }
 
@@ -190,6 +204,74 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV2)
     BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 2);
 }
 
+// UnsupportedFork from the FCU/newPayload version gates maps to -38005 — the permanent
+// wrong-version signal op-node does not retry — not the retryable generic -32603.
+BOOST_AUTO_TEST_CASE(forkchoiceUpdatedWithAttrsUnsupportedForkMapsTo38005)
+{
+    mockService.m_state->throwUnsupportedFork = true;
+
+    Json::Value params(Json::arrayValue);
+    Json::Value fc;
+    fc["headBlockHash"] = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    fc["safeBlockHash"] = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    fc["finalizedBlockHash"] = "0x3333333333333333333333333333333333333333333333333333333333333333";
+    params.append(fc);
+    Json::Value attrs;
+    attrs["timestamp"] = "0x1";
+    attrs["prevRandao"] = "0x4444444444444444444444444444444444444444444444444444444444444444";
+    attrs["suggestedFeeRecipient"] = "0x5555555555555555555555555555555555555555";
+    params.append(attrs);
+
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(forkchoiceUpdatedV2, params, response), JsonRpcException,
+        [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
+}
+
+// Typed engine failures must map onto the spec error codes at the endpoint (R78):
+// InvalidPayloadAttributes -> -38003, UnsupportedFork -> -38005,
+// InvalidForkchoiceState -> -38002. Without the mapping every engine exception falls
+// into the dispatcher's catch(...) and answers the generic retryable -32603, which a
+// real op-node misclassifies as a transient server failure.
+BOOST_AUTO_TEST_CASE(forkchoiceUpdatedTypedFailuresMapToSpecErrorCodes)
+{
+    Json::Value params(Json::arrayValue);
+    Json::Value fc;
+    fc["headBlockHash"] = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    fc["safeBlockHash"] = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    fc["finalizedBlockHash"] = "0x3333333333333333333333333333333333333333333333333333333333333333";
+    params.append(fc);
+    Json::Value attrs;
+    attrs["timestamp"] = "0x1";
+    attrs["prevRandao"] = "0x4444444444444444444444444444444444444444444444444444444444444444";
+    attrs["suggestedFeeRecipient"] = "0x5555555555555555555555555555555555555555";
+    params.append(attrs);
+
+    // CALL_ENGINE drives the endpoint directly (no dispatcher), so the mapped
+    // JsonRpcException surfaces here exactly as Web3JsonRpcImpl::handleRequest would see
+    // it: the dispatcher's catch(JsonRpcException) formats it into response["error"] with
+    // the same code.
+    auto expectCode = [&](Json::Value params, int code) {
+        Json::Value response;
+        BOOST_CHECK_EXCEPTION(CALL_ENGINE(forkchoiceUpdatedV3, params, response), JsonRpcException,
+            [code](JsonRpcException const& e) { return e.code() == code; });
+    };
+
+    mockService.m_state->throwInvalidPayloadAttributes = true;
+    expectCode(params, EngineError::InvalidPayloadAttributes);
+
+    mockService.m_state->throwInvalidPayloadAttributes = false;
+    mockService.m_state->throwUnsupportedFork = true;
+    expectCode(params, EngineError::UnsupportedFork);
+
+    mockService.m_state->throwUnsupportedFork = false;
+    mockService.m_state->throwInvalidForkchoiceState = true;
+    // The state-only shape (no attributes) exercises the same catch ladder.
+    Json::Value stateOnly(Json::arrayValue);
+    stateOnly.append(fc);
+    expectCode(stateOnly, EngineError::InvalidForkchoiceState);
+}
+
+
 BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV3)
 {
     Json::Value params(Json::arrayValue);
@@ -216,9 +298,9 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV3)
     BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 3);
 }
 
-// The one method version this node really does not implement: the service-layer forkchoice
-// window tops out at V3 (isForkchoiceVersionSupported), so V4 answers -38005 without
-// reaching the engine service.
+// The one method version this node really does not implement: forkchoiceUpdatedV4 is
+// refused at the RPC endpoint (-38005) before the engine service; OP mode constructs
+// maxEngineVersion=V4, so isForkchoiceVersionSupported would otherwise admit it.
 BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV4)
 {
     Json::Value params(Json::arrayValue);
@@ -433,6 +515,18 @@ Json::Value makeV1ExecutionPayloadJson()
 }
 }  // namespace
 
+BOOST_AUTO_TEST_CASE(newPayloadUnsupportedForkMapsTo38005)
+{
+    mockService.m_state->throwUnsupportedFork = true;
+
+    Json::Value params(Json::arrayValue);
+    params.append(makeV1ExecutionPayloadJson());
+
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV1, params, response), JsonRpcException,
+        [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
+}
+
 BOOST_AUTO_TEST_CASE(newPayloadV1)
 {
     Json::Value params(Json::arrayValue);
@@ -564,6 +658,22 @@ BOOST_AUTO_TEST_CASE(newPayloadV4)
     BOOST_CHECK(capturedReq.expectedBlobVersionedHashes.empty());
     BOOST_REQUIRE(capturedReq.executionRequests.has_value());
     BOOST_CHECK(capturedReq.executionRequests->empty());
+}
+
+BOOST_AUTO_TEST_CASE(newPayloadV4TypedVersionGateMapsToSpecErrorCode)
+{
+    // A fully shaped V4 request so parseNewPayloadRequest passes and the typed engine
+    // failure (not a -32602 shape error) is what reaches the endpoint's catch ladder.
+    Json::Value params(Json::arrayValue);
+    params.append(makeV4ExecutionPayloadJson());
+    params.append(Json::Value(Json::arrayValue));  // expectedBlobVersionedHashes (empty)
+    params.append(c_beaconRootHex);                // parentBeaconBlockRoot
+    params.append(Json::Value(Json::arrayValue));  // executionRequests (empty)
+
+    mockService.m_state->throwUnsupportedFork = true;
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV4, params, response), JsonRpcException,
+        [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
 }
 
 BOOST_AUTO_TEST_CASE(newPayloadV4MissingParams)

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -25,7 +25,10 @@
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <thread>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -59,6 +62,8 @@ public:
         bool throwInvalidPayloadAttributes = false;
         bool throwUnsupportedFork = false;
         bool throwInvalidForkchoiceState = false;
+        std::atomic<bool> hangNewPayload{false};
+        std::atomic<bool> enteredNewPayload{false};
     };
     std::shared_ptr<State> m_state = std::make_shared<State>();
 
@@ -106,6 +111,11 @@ public:
     task::Task<engine::PayloadStatus> newPayload(
         const engine::NewPayloadRequest& request, std::uint32_t version)
     {
+        m_state->enteredNewPayload.store(true);
+        while (m_state->hangNewPayload.load())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
         m_state->capturedNewPayloadRequest = request;
         m_state->capturedNewPayloadVersion = version;
         if (m_state->throwInvalidPayloadAttributes)
@@ -650,6 +660,41 @@ BOOST_AUTO_TEST_CASE(newPayloadV4)
     BOOST_CHECK(capturedReq.expectedBlobVersionedHashes.empty());
     BOOST_REQUIRE(capturedReq.executionRequests.has_value());
     BOOST_CHECK(capturedReq.executionRequests->empty());
+}
+
+BOOST_AUTO_TEST_CASE(newPayloadV4BusyReturnsSyncing)
+{
+    mockService.m_state->hangNewPayload.store(true);
+    mockService.m_state->enteredNewPayload.store(false);
+
+    Json::Value params(Json::arrayValue);
+    params.append(makeV4ExecutionPayloadJson());
+    params.append(Json::Value(Json::arrayValue));
+    params.append(c_beaconRootHex);
+    params.append(Json::Value(Json::arrayValue));
+
+    Json::Value firstResponse;
+    std::thread first([&] { CALL_ENGINE(newPayloadV4, params, firstResponse); });
+
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!mockService.m_state->enteredNewPayload.load() &&
+           std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    BOOST_REQUIRE_MESSAGE(mockService.m_state->enteredNewPayload.load(),
+        "first newPayloadV4 never entered the engine service");
+
+    Json::Value busyResponse;
+    CALL_ENGINE(newPayloadV4, params, busyResponse);
+    BOOST_REQUIRE(busyResponse.isMember("result"));
+    BOOST_CHECK_EQUAL(busyResponse["result"]["status"].asString(), "SYNCING");
+    BOOST_CHECK(!busyResponse["result"].isMember("latestValidHash"));
+
+    mockService.m_state->hangNewPayload.store(false);
+    first.join();
+    BOOST_REQUIRE(firstResponse.isMember("result"));
+    BOOST_CHECK_EQUAL(firstResponse["result"]["status"].asString(), "VALID");
 }
 
 BOOST_AUTO_TEST_CASE(newPayloadV4TypedVersionGateMapsToSpecErrorCode)

--- a/bcos-rpc/test/unittests/rpc/EngineTimestampBoundaryTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineTimestampBoundaryTest.cpp
@@ -142,5 +142,22 @@ BOOST_AUTO_TEST_CASE(int64BoundaryIsExact)
     BOOST_CHECK_EQUAL(ep["timestamp"].asString(), "0x20c49ba5e353f7");
 }
 
+BOOST_AUTO_TEST_CASE(oddNibbleExtraDataIsRejected)
+{
+    auto params = makeNewPayloadParams("0x64");
+    params[0]["extraData"] = "0x123";
+    try
+    {
+        parseNewPayloadRequest(params, engine::ApiVersion::V1);
+        BOOST_FAIL("expected JsonRpcException for odd-nibble extraData");
+    }
+    catch (JsonRpcException const& error)
+    {
+        std::string const what = error.what();
+        BOOST_CHECK_NE(what.find("executionPayload.extraData"), std::string::npos);
+        BOOST_CHECK_NE(what.find("hex string"), std::string::npos);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EngineTimestampBoundaryTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineTimestampBoundaryTest.cpp
@@ -21,6 +21,8 @@
 
 #include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <boost/test/unit_test.hpp>
+#include <string>
+#include <string_view>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -142,21 +144,59 @@ BOOST_AUTO_TEST_CASE(int64BoundaryIsExact)
     BOOST_CHECK_EQUAL(ep["timestamp"].asString(), "0x20c49ba5e353f7");
 }
 
-BOOST_AUTO_TEST_CASE(oddNibbleExtraDataIsRejected)
+void expectOddNibbleReject(auto const& parse, std::string_view field)
 {
-    auto params = makeNewPayloadParams("0x64");
-    params[0]["extraData"] = "0x123";
     try
     {
-        parseNewPayloadRequest(params, engine::ApiVersion::V1);
-        BOOST_FAIL("expected JsonRpcException for odd-nibble extraData");
+        parse();
+        BOOST_FAIL("expected JsonRpcException for odd-nibble hex");
     }
     catch (JsonRpcException const& error)
     {
         std::string const what = error.what();
-        BOOST_CHECK_NE(what.find("executionPayload.extraData"), std::string::npos);
+        BOOST_CHECK_NE(what.find(std::string(field)), std::string::npos);
         BOOST_CHECK_NE(what.find("hex string"), std::string::npos);
     }
+}
+
+BOOST_AUTO_TEST_CASE(oddNibbleExtraDataIsRejected)
+{
+    auto params = makeNewPayloadParams("0x64");
+    params[0]["extraData"] = "0x123";
+    expectOddNibbleReject([&] { parseNewPayloadRequest(params, engine::ApiVersion::V1); },
+        "executionPayload.extraData");
+}
+
+BOOST_AUTO_TEST_CASE(oddNibbleLogsBloomIsRejected)
+{
+    auto params = makeNewPayloadParams("0x64");
+    params[0]["logsBloom"] = "0x123";
+    expectOddNibbleReject([&] { parseNewPayloadRequest(params, engine::ApiVersion::V1); },
+        "executionPayload.logsBloom");
+}
+
+BOOST_AUTO_TEST_CASE(oddNibbleEip1559ParamsIsRejected)
+{
+    auto params = makeAttributesParams("0x64");
+    params[1]["eip1559Params"] = "0x123";
+    expectOddNibbleReject([&] { parsePayloadAttributes(params, engine::ApiVersion::V3); },
+        "payloadAttributes.eip1559Params");
+}
+
+BOOST_AUTO_TEST_CASE(oddNibbleExecutionRequestsIsRejected)
+{
+    auto params = makeNewPayloadParams("0x64");
+    params[0]["withdrawals"] = Json::Value(Json::arrayValue);
+    params[0]["blobGasUsed"] = "0x0";
+    params[0]["excessBlobGas"] = "0x0";
+    params[0]["withdrawalsRoot"] = h256Hex;
+    params.append(Json::Value(Json::arrayValue));
+    params.append(h256Hex);
+    Json::Value requests(Json::arrayValue);
+    requests.append("0x1");
+    params.append(requests);
+    expectOddNibbleReject(
+        [&] { parseNewPayloadRequest(params, engine::ApiVersion::V4); }, "executionRequests[0]");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,13 +19,13 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
-#include <boost/assert.hpp>
+#include <bcos-framework/engine/OpBaseFee.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <boost/throw_exception.hpp>
 #include <span>
 #include <stdexcept>
 #include <utility>
-#include <bcos-ledger/mpt/Constants.h>
-#include <bcos-rlp-protocol/EthBlockHeader.h>
 
 namespace
 {
@@ -141,106 +141,6 @@ std::optional<std::string> validateRawTransactionKind(
 }
 }  // namespace
 
-namespace
-{
-/// extraData version bytes (op-core/eip1559/eip1559.go:10-13). Note the Jovian version
-/// byte is 0x01, not 0x00: ValidateJovianExtraData (eip1559.go:167-176) rejects any
-/// other value on every post-Jovian block op-node reads back.
-constexpr bcos::byte c_holoceneExtraDataVersion = 0x00;
-constexpr bcos::byte c_jovianExtraDataVersion = 0x01;
-constexpr std::size_t c_holoceneExtraDataBytes = 9;
-constexpr std::size_t c_jovianExtraDataBytes = 17;
-
-/// Canyon EIP-1559 constants used to translate all-zero attribute params. op-node sends
-/// eip1559Params = 0,0 while the SystemConfig has not set the parameters, and expects
-/// the EL to translate them to the chain's Canyon constants (op-node/rollup/attributes/
-/// engine_consolidate.go checkExtraDataParamsMatch: "Translate 0,0 to the pre-Holocene
-/// protocol constants, like the EL does too", using ChainOpConfig
-/// .EIP1559DenominatorCanyon / .EIP1559Elasticity). This node has no rollup config to
-/// read them from, so they are pinned to the OP Stack defaults (250, 6) that our
-/// deployment's rollup.json chain_op_config carries (tools/opstack-genesis/
-/// gen_rollup_config.py defaults, emitted into tools/opnode-check/rollup.json).
-///
-/// DEPLOYMENT CONSTRAINT: a chain whose rollup.json sets different chain_op_config
-/// values would fail op-node's consolidation match and stall. Making these
-/// configurable is deliberately NOT done here: chain_op_config is a chain-level
-/// constant, so a per-node ini key would let two nodes stamp different extraData on
-/// the same height and split the chain. The correct home is a consensus-pinned
-/// value (the genesis config / SYS_CONFIG lane, alongside the eth genesis header),
-/// which changes the genesis artifact and belongs to that lane's PR.
-constexpr std::uint32_t c_eip1559DenominatorCanyon = 250;
-constexpr std::uint32_t c_eip1559ElasticityCanyon = 6;
-
-/// Width of the eip1559Params attribute field and of the parameter half of a
-/// non-empty extraData (op-service/eth/types.go:521 declares it as a Bytes8).
-constexpr std::size_t c_eip1559ParamsBytes = 8;
-
-/// Big-endian read of the two u32 halves of an 8-byte eip1559Params field
-/// (op-core/eip1559/eip1559.go DecodeHolocene1559Params: denominator [0:4],
-/// elasticity [4:8]).
-///
-/// Precondition: params.size() >= 8. std::span::first / ::subspan state that as a
-/// hard precondition ([span.sub]), so a shorter span is undefined behaviour here,
-/// NOT a std::out_of_range — every caller must establish the length first. The two
-/// callers that take CL-supplied bytes do: validatePayloadAttributes and
-/// validateOptimismExtraDataShape both check the length before decoding, and
-/// encodeOptimismExtraData rejects anything else at its entry.
-std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(std::span<const bcos::byte> params)
-{
-    BOOST_ASSERT(params.size() >= c_eip1559ParamsBytes);
-    auto denominator = bcos::fromBigEndian<std::uint32_t>(params.first(4));
-    auto elasticity = bcos::fromBigEndian<std::uint32_t>(params.subspan(4, 4));
-    return {denominator, elasticity};
-}
-
-/// OP-Stack header extraData shapes, as op-geth validates them on every block it
-/// imports — including the ones a CL hands back through newPayload
-/// (consensus/beacon/consensus.go:240-243 calls eip1559.ValidateOptimismExtraData,
-/// which picks the rule from the chain's fork schedule and skips only the genesis
-/// block). This service has no fork schedule to pick with, so it accepts any of the
-/// three legal shapes and rejects everything else: empty (pre-Holocene,
-/// eip1559.go:27-28), 9 bytes with version byte 0x00 (ValidateHoloceneExtraData,
-/// eip1559.go:119-127), 17 bytes with version byte 0x01 (ValidateJovianExtraData,
-/// eip1559.go:167-176). Both non-empty forms carry the denominator/elasticity pair
-/// in [1, 9), which must be non-zero on a header — unlike the attribute side, where
-/// 0,0 is legal and gets translated (validateHoloceneExtraDataPart,
-/// eip1559.go:105-113, and the note above ValidateHoloceneExtraData spelling out the
-/// difference).
-std::optional<std::string> validateOptimismExtraDataShape(const bcos::bytes& extraData)
-{
-    if (extraData.empty())
-    {
-        return std::nullopt;
-    }
-    if (extraData.size() != c_holoceneExtraDataBytes && extraData.size() != c_jovianExtraDataBytes)
-    {
-        return "executionPayload.extraData must be empty (pre-Holocene), " +
-               std::to_string(c_holoceneExtraDataBytes) + " bytes (Holocene) or " +
-               std::to_string(c_jovianExtraDataBytes) + " bytes (Jovian), got " +
-               std::to_string(extraData.size());
-    }
-    auto const expectedVersion = extraData.size() == c_jovianExtraDataBytes ?
-                                     c_jovianExtraDataVersion :
-                                     c_holoceneExtraDataVersion;
-    if (extraData[0] != expectedVersion)
-    {
-        return "executionPayload.extraData version byte must be " +
-               std::to_string(static_cast<unsigned>(expectedVersion)) + " for a " +
-               std::to_string(extraData.size()) + "-byte extraData, got " +
-               std::to_string(static_cast<unsigned>(extraData[0]));
-    }
-    auto [denominator, elasticity] = decodeEip1559Params(
-        std::span<const bcos::byte>(extraData).subspan(1, c_eip1559ParamsBytes));
-    if (denominator == 0 || elasticity == 0)
-    {
-        return std::string(
-            "executionPayload.extraData must encode a non-zero EIP-1559 denominator and "
-            "elasticity");
-    }
-    return std::nullopt;
-}
-}  // namespace
-
 bcos::bytes bcos::engine::detail::encodeOptimismExtraData(
     const PayloadAttributes& payloadAttributes)
 {
@@ -262,6 +162,12 @@ bcos::bytes bcos::engine::detail::encodeOptimismExtraData(
             "encodeOptimismExtraData requires exactly 8 bytes of eip1559Params"});
     }
     auto [denominator, elasticity] = decodeEip1559Params(*payloadAttributes.eip1559Params);
+    // Canyon translation of all-zero attribute params. op-node sends eip1559Params = 0,0
+    // while SystemConfig has not set the parameters, and expects the EL to translate them
+    // to the chain's Canyon constants (op-node engine_consolidate.go
+    // checkExtraDataParamsMatch). DEPLOYMENT CONSTRAINT: a chain whose rollup.json sets
+    // different chain_op_config values would fail consolidation; these stay pinned to the
+    // OP Stack defaults in OpBaseFee.h (250, 6).
     if (denominator == 0 && elasticity == 0)
     {
         denominator = c_eip1559DenominatorCanyon;
@@ -463,16 +369,18 @@ std::optional<std::string> bcos::engine::detail::validateExecutionPayload(
         auto expectedRoot = withdrawalsRootFor(executionPayload);
         if (*executionPayload.withdrawalsRoot != expectedRoot)
         {
-            return std::string("withdrawalsRoot does not match the value this node commits "
-                                "for the built header");
+            return std::string(
+                "withdrawalsRoot does not match the value this node commits "
+                "for the built header");
         }
     }
     // extraData is a V1-onwards field, so this applies at every newPayload version.
     // Since this PR makes extraData part of the block hash, an unchecked extraData is
-    // an unchecked block-hash input.
-    if (auto error = validateOptimismExtraDataShape(executionPayload.extraData))
+    // an unchecked block-hash input. Shape rules live in OpBaseFee.h (shared with
+    // calcOpBaseFee); prefix the helper's short reason for the INVALID channel.
+    if (auto error = validateOpExtraDataShape(executionPayload.extraData))
     {
-        return error;
+        return "executionPayload.extraData " + *error;
     }
     return std::nullopt;
 }
@@ -519,9 +427,10 @@ bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(evmc_re
         {
             return bcos::protocol::EthBlockVersion::LONDON;
         }
-        BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
-            "EngineService: unsupported EVM revision " + std::to_string(static_cast<int>(rev)) +
-            " for Eth header fork derivation"});
+        BOOST_THROW_EXCEPTION(
+            UnsupportedFork{} << bcos::errinfo_comment{"EngineService: unsupported EVM revision " +
+                                                       std::to_string(static_cast<int>(rev)) +
+                                                       " for Eth header fork derivation"});
     }
 }
 

--- a/opstack-executor/OpBlockExecute.h
+++ b/opstack-executor/OpBlockExecute.h
@@ -82,11 +82,8 @@ OpBlockResult processOpBlock(const evmone::state::StateView& view,
 
 
 // ---- Jovian L1-attributes block shape ----
-// The L1-attributes deposit's calldata is 176B on the Jovian activation block, 178B with the
-// Jovian selector thereafter.
-inline constexpr std::size_t IsthmusL1AttributesLen = 176;
-inline constexpr std::size_t JovianL1AttributesLen = 178;
-inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6, 0xbe, 0x2b};
+// Lengths/selectors live in OpTransition.h (already included). Duplicating them here
+// redefines IsthmusL1AttributesLen / JovianL1AttributesLen / JovianL1AttributesSelector.
 
 /// Shared Jovian L1-attributes shape (selector/length + activation deposits-only).
 /// `lastTxIsDeposit` is the path-specific last-tx probe: processOpBlock uses the DepositTx

--- a/opstack-executor/OpCommon.h
+++ b/opstack-executor/OpCommon.h
@@ -31,11 +31,20 @@ namespace bcos::evm
 /// namespaces (and the code that references it from either) resolve it by outer-scope lookup.
 struct OpConsensusError : std::runtime_error
 {
-    using std::runtime_error::runtime_error;
-    /// Offending tx (when the rejection is per-tx). Downstream pool eviction reads this
-    /// field, never the message text — a string-format contract would silently break the
-    /// moment anyone rewords the message.
     std::optional<bcos::h256> txHash;
+    /// True when the reject is a block-capacity fault (the block gas pool cannot fit the
+    /// transaction), not a poisoned transaction: the build loop skips the tx for this
+    /// build and must never evict it from the pool. OpScheduler forwards it across the
+    /// boundary `bcos::Error` as `OpBlockGasPoolFull`.
+    bool capacity = false;
+
+    explicit OpConsensusError(std::string const& what_arg) : std::runtime_error(what_arg) {}
+
+    /// Per-tx reject. The hash is a structured member; OpScheduler attaches it to the
+    /// boundary `bcos::Error` as `OpCulpritTxHash`. Never encode it into `what()`.
+    OpConsensusError(std::string what_arg, bcos::h256 hash, bool _capacity = false)
+      : std::runtime_error(std::move(what_arg)), txHash(hash), capacity(_capacity)
+    {}
 };
 }  // namespace bcos::evm
 

--- a/opstack-executor/OpCommon.h
+++ b/opstack-executor/OpCommon.h
@@ -32,16 +32,12 @@ namespace bcos::evm
 struct OpConsensusError : std::runtime_error
 {
     std::optional<bcos::h256> txHash;
-    /// True when the reject is a block-capacity fault (the block gas pool cannot fit the
-    /// transaction), not a poisoned transaction: the build loop skips the tx for this
-    /// build and must never evict it from the pool. OpScheduler forwards it across the
-    /// boundary `bcos::Error` as `OpBlockGasPoolFull`.
+    /// True when the block gas pool cannot fit this tx (skip this build, do not evict).
     bool capacity = false;
 
     explicit OpConsensusError(std::string const& what_arg) : std::runtime_error(what_arg) {}
 
-    /// Per-tx reject. The hash is a structured member; OpScheduler attaches it to the
-    /// boundary `bcos::Error` as `OpCulpritTxHash`. Never encode it into `what()`.
+    /// Per-tx reject. `txHash` is structured; do not encode it into `what()`.
     OpConsensusError(std::string what_arg, bcos::h256 hash, bool _capacity = false)
       : std::runtime_error(std::move(what_arg)), txHash(hash), capacity(_capacity)
     {}

--- a/opstack-executor/OpDepositEncode.h
+++ b/opstack-executor/OpDepositEncode.h
@@ -77,25 +77,10 @@ inline bcos::bytes encodeDepositEnvelope(const bcos::evm::opstack::DepositTx& d)
     return out;
 }
 
-/// Synthesize the L1-attributes deposit envelope (op-geth l1AttributesDeposited /
-/// deriveL1InfoDepositHash, with the Isthmus/Jovian calldata layout mirrored by
-/// opt8n-ref's l1AttributesLayout and op-geth's rollup_cost.go extractors):
-/// sourceHash = keccak256(bytes32(1) || keccak256(l1BlockHash || bytes32(seq))),
-/// matching specs.optimism.io L1 attributes deposited (domain 1).
-/// calldata = selector || packed fields ([4:8] baseFeeScalar, [8:12] blobBaseFeeScalar,
-/// [12:20] seq, [20:28] l1 time, [28:36] l1 number, [36:68] l1 baseFee, [68:100] l1
-/// blobBaseFee, [100:132] l1 blockHash, [132:164] batcherHash, Isthmus+ [164:168]
-/// opFeeScalar, [168:176] opFeeConstant, Jovian [176:178] DA-footprint gas scalar).
-/// The scalar/operator-fee fields have no producer in this chain yet and are zero.
-/// Production deposits are derived by the op-node and arrive via
-/// payloadAttributes.transactions; this path only serves the built-in single-node CL.
-/// l2BlockTime is unused: the spec sourceHash does not bind L2 time.
-/// FISCO selects Jovian by genesis feature flag (OpForkFlags::jovianActive), not by
-/// an activation height. The synthesizer therefore emits 178B whenever the flag is
-/// on — there is no built-in-CL "activation block" that must be 176B. The read side
-/// still accepts both forms: 176B is treated as the op-geth activation (deposits-only)
-/// shape so an external op-node can send that block; 178B with the Jovian selector is
-/// the post-activation form this path produces. Production deposits come from op-node.
+/// Build the L1-attributes deposit envelope (0x7e).
+/// sourceHash = keccak256(bytes32(1) || keccak256(l1BlockHash || bytes32(seq))).
+/// Calldata is Isthmus 176B or Jovian 178B; unused scalar fields are zero.
+/// `l2BlockTime` is unused (sourceHash does not bind L2 time).
 inline bcos::bytes synthesizeL1AttributesDeposit(
     const L1BlockInfo& l1Info, bool jovianActive, [[maybe_unused]] uint64_t l2BlockTime)
 {

--- a/opstack-executor/OpDepositEncode.h
+++ b/opstack-executor/OpDepositEncode.h
@@ -84,23 +84,6 @@ inline bcos::bytes encodeDepositEnvelope(const bcos::evm::opstack::DepositTx& d)
 inline bcos::bytes synthesizeL1AttributesDeposit(
     const L1BlockInfo& l1Info, bool jovianActive, [[maybe_unused]] uint64_t l2BlockTime)
 {
-    bcos::bytes data(jovianActive ? JovianL1AttributesLen : IsthmusL1AttributesLen, 0);
-    const auto& selector = jovianActive ? JovianL1AttributesSelector :
-                                          IsthmusL1AttributesSelector;
-    std::copy(selector.begin(), selector.end(), data.begin());
-    auto dataSpan = std::span(data);
-    auto seqField = dataSpan.subspan(12, 8);
-    bcos::toBigEndian(l1Info.sequenceNumber, seqField);
-    auto timeField = dataSpan.subspan(20, 8);
-    bcos::toBigEndian(l1Info.time, timeField);
-    auto numberField = dataSpan.subspan(28, 8);
-    bcos::toBigEndian(l1Info.number, numberField);
-    intx::be::store(
-        std::span<uint8_t, 32>(dataSpan.subspan(36, 32).data(), 32), l1Info.baseFee);
-    intx::be::store(
-        std::span<uint8_t, 32>(dataSpan.subspan(68, 32).data(), 32), l1Info.blobBaseFee);
-    std::copy_n(l1Info.blockHash.bytes, sizeof(evmc::bytes32), data.begin() + 100);
-
     // op-node L1InfoDepositSource: inner = keccak(l1Hash[32] || bytes32(seq)),
     // sourceHash = keccak(bytes32(domain=1) || inner).
     std::array<uint8_t, 64> innerInput{};
@@ -125,7 +108,22 @@ inline bcos::bytes synthesizeL1AttributesDeposit(
         .value = intx::uint256{0},
         .gas_limit = c_l1InfoDepositGas,
         .is_system_tx = false,
-        .data = evmc::bytes(data.begin(), data.end())};
+        .data = {}};
+    deposit.data.resize(jovianActive ? JovianL1AttributesLen : IsthmusL1AttributesLen, 0);
+    const auto& selector =
+        jovianActive ? JovianL1AttributesSelector : IsthmusL1AttributesSelector;
+    std::copy(selector.begin(), selector.end(), deposit.data.begin());
+    auto dataSpan = std::span(deposit.data);
+    auto seqField = dataSpan.subspan(12, 8);
+    bcos::toBigEndian(l1Info.sequenceNumber, seqField);
+    auto timeField = dataSpan.subspan(20, 8);
+    bcos::toBigEndian(l1Info.time, timeField);
+    auto numberField = dataSpan.subspan(28, 8);
+    bcos::toBigEndian(l1Info.number, numberField);
+    intx::be::store(std::span<uint8_t, 32>(dataSpan.subspan(36, 32).data(), 32), l1Info.baseFee);
+    intx::be::store(
+        std::span<uint8_t, 32>(dataSpan.subspan(68, 32).data(), 32), l1Info.blobBaseFee);
+    std::copy_n(l1Info.blockHash.bytes, sizeof(evmc::bytes32), deposit.data.begin() + 100);
     return encodeDepositEnvelope(deposit);
 }
 }  // namespace bcos::evm::opstack

--- a/opstack-executor/OpDepositEncode.h
+++ b/opstack-executor/OpDepositEncode.h
@@ -8,11 +8,11 @@
 #include <bcos-evm/opstack/OpTransition.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
-#include <evmc/evmc.hpp>
-#include <intx/intx.hpp>
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
 #include <span>
 
 namespace bcos::evm::opstack::detail
@@ -77,12 +77,43 @@ inline bcos::bytes encodeDepositEnvelope(const bcos::evm::opstack::DepositTx& d)
     return out;
 }
 
+// Field offsets into the setL1BlockValues calldata laid out below (op-node L1BlockInfo
+// binary layout: uint32 baseFeeScalar/blobBaseFeeScalar, uint32 operatorFeeScalar,
+// uint64 operatorFeeConstant; Jovian appends a uint16 DA-footprint scalar).
+inline constexpr std::size_t c_l1AttributesBaseFeeScalarOffset = 4;
+inline constexpr std::size_t c_l1AttributesBlobBaseFeeScalarOffset = 8;
+inline constexpr std::size_t c_l1AttributesSeqOffset = 12;
+inline constexpr std::size_t c_l1AttributesTimeOffset = 20;
+inline constexpr std::size_t c_l1AttributesNumberOffset = 28;
+inline constexpr std::size_t c_l1AttributesBaseFeeOffset = 36;
+inline constexpr std::size_t c_l1AttributesBlobBaseFeeOffset = 68;
+inline constexpr std::size_t c_l1AttributesBlockHashOffset = 100;
+inline constexpr std::size_t c_l1AttributesBatcherHashOffset = 132;
+inline constexpr std::size_t c_l1AttributesOperatorFeeScalarOffset = 164;
+inline constexpr std::size_t c_l1AttributesOperatorFeeConstantOffset = 168;
+
+inline void storeU32BE(std::span<uint8_t> dst, uint32_t value)
+{
+    dst[0] = static_cast<uint8_t>(value >> 24);
+    dst[1] = static_cast<uint8_t>(value >> 16);
+    dst[2] = static_cast<uint8_t>(value >> 8);
+    dst[3] = static_cast<uint8_t>(value);
+}
+
 /// Build the L1-attributes deposit envelope (0x7e).
-/// sourceHash = keccak256(bytes32(1) || keccak256(l1BlockHash || bytes32(seq))).
-/// Calldata is Isthmus 176B or Jovian 178B; unused scalar fields are zero.
-/// `l2BlockTime` is unused (sourceHash does not bind L2 time).
-inline bcos::bytes synthesizeL1AttributesDeposit(
-    const L1BlockInfo& l1Info, bool jovianActive, [[maybe_unused]] uint64_t l2BlockTime)
+/// sourceHash = keccak256(bytes32(1) || keccak256(l1BlockHash || bytes32(seq))) — L2 time is
+/// deliberately not bound into the sourceHash, so the builder takes no L2 time.
+/// Calldata is the setL1BlockValues* layout — Isthmus 176B, Jovian 178B (op-node
+/// L1BlockInfo marshalBinaryIsthmus/Jovian):
+///   [0:4] selector | [4:8] baseFeeScalar | [8:12] blobBaseFeeScalar
+///   [12:20] sequenceNumber | [20:28] timestamp | [28:36] number
+///   [36:68] baseFee | [68:100] blobBaseFee | [100:132] blockHash
+///   [132:164] batcherHash | [164:168] operatorFeeScalar | [168:176] operatorFeeConstant
+///   (Jovian only) [176:178] DA-footprint scalar
+/// The Jovian DA-footprint scalar is zero here (op-node decodes zero as its default).
+/// The production seam refuses to synthesize from an L1BlockInfo without SystemConfig
+/// fields (see isUnsetSystemConfig).
+inline bcos::bytes synthesizeL1AttributesDeposit(const L1BlockInfo& l1Info, bool jovianActive)
 {
     // op-node L1InfoDepositSource: inner = keccak(l1Hash[32] || bytes32(seq)),
     // sourceHash = keccak(bytes32(domain=1) || inner).
@@ -91,13 +122,13 @@ inline bcos::bytes synthesizeL1AttributesDeposit(
     std::array<uint8_t, 8> seqBe{};
     bcos::toBigEndian(l1Info.sequenceNumber, seqBe);
     std::copy(seqBe.begin(), seqBe.end(), innerInput.begin() + 56);
-    const auto inner = bcos::crypto::keccak256Hash(
-        bcos::bytesConstRef(innerInput.data(), innerInput.size()));
+    const auto inner =
+        bcos::crypto::keccak256Hash(bcos::bytesConstRef(innerInput.data(), innerInput.size()));
     std::array<uint8_t, 64> domainInput{};
     domainInput[31] = 1;  // bytes32(uint256(1)) — L1InfoDepositSourceDomain
     std::copy(inner.begin(), inner.end(), domainInput.begin() + 32);
-    const auto keccak = bcos::crypto::keccak256Hash(
-        bcos::bytesConstRef(domainInput.data(), domainInput.size()));
+    const auto keccak =
+        bcos::crypto::keccak256Hash(bcos::bytesConstRef(domainInput.data(), domainInput.size()));
     evmc::bytes32 sourceHash{};
     std::copy_n(keccak.begin(), sizeof(evmc::bytes32), sourceHash.bytes);
 
@@ -110,20 +141,32 @@ inline bcos::bytes synthesizeL1AttributesDeposit(
         .is_system_tx = false,
         .data = {}};
     deposit.data.resize(jovianActive ? JovianL1AttributesLen : IsthmusL1AttributesLen, 0);
-    const auto& selector =
-        jovianActive ? JovianL1AttributesSelector : IsthmusL1AttributesSelector;
+    const auto& selector = jovianActive ? JovianL1AttributesSelector : IsthmusL1AttributesSelector;
     std::copy(selector.begin(), selector.end(), deposit.data.begin());
     auto dataSpan = std::span(deposit.data);
-    auto seqField = dataSpan.subspan(12, 8);
+    storeU32BE(dataSpan.subspan(c_l1AttributesBaseFeeScalarOffset, 4), l1Info.baseFeeScalar);
+    storeU32BE(
+        dataSpan.subspan(c_l1AttributesBlobBaseFeeScalarOffset, 4), l1Info.blobBaseFeeScalar);
+    auto seqField = dataSpan.subspan(c_l1AttributesSeqOffset, 8);
     bcos::toBigEndian(l1Info.sequenceNumber, seqField);
-    auto timeField = dataSpan.subspan(20, 8);
+    auto timeField = dataSpan.subspan(c_l1AttributesTimeOffset, 8);
     bcos::toBigEndian(l1Info.time, timeField);
-    auto numberField = dataSpan.subspan(28, 8);
+    auto numberField = dataSpan.subspan(c_l1AttributesNumberOffset, 8);
     bcos::toBigEndian(l1Info.number, numberField);
-    intx::be::store(std::span<uint8_t, 32>(dataSpan.subspan(36, 32).data(), 32), l1Info.baseFee);
     intx::be::store(
-        std::span<uint8_t, 32>(dataSpan.subspan(68, 32).data(), 32), l1Info.blobBaseFee);
-    std::copy_n(l1Info.blockHash.bytes, sizeof(evmc::bytes32), deposit.data.begin() + 100);
+        std::span<uint8_t, 32>(dataSpan.subspan(c_l1AttributesBaseFeeOffset, 32).data(), 32),
+        l1Info.baseFee);
+    intx::be::store(
+        std::span<uint8_t, 32>(dataSpan.subspan(c_l1AttributesBlobBaseFeeOffset, 32).data(), 32),
+        l1Info.blobBaseFee);
+    std::copy_n(l1Info.blockHash.bytes, sizeof(evmc::bytes32),
+        deposit.data.begin() + c_l1AttributesBlockHashOffset);
+    std::copy_n(l1Info.batcherHash.bytes, sizeof(evmc::bytes32),
+        deposit.data.begin() + c_l1AttributesBatcherHashOffset);
+    storeU32BE(
+        dataSpan.subspan(c_l1AttributesOperatorFeeScalarOffset, 4), l1Info.operatorFeeScalar);
+    auto opFeeConstantField = dataSpan.subspan(c_l1AttributesOperatorFeeConstantOffset, 8);
+    bcos::toBigEndian(l1Info.operatorFeeConstant, opFeeConstantField);
     return encodeDepositEnvelope(deposit);
 }
 }  // namespace bcos::evm::opstack

--- a/opstack-executor/OpDepositEncode.h
+++ b/opstack-executor/OpDepositEncode.h
@@ -3,10 +3,17 @@
 // set (bytes32 / address / uint256 / uint64); the shared encodeTuple helper
 // lives in a later EngineService slice.
 #include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
 #include <bcos-evm/opstack/OpTransition.h>
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <span>
 
 namespace bcos::evm::opstack::detail
 {
@@ -68,5 +75,72 @@ inline bcos::bytes encodeDepositEnvelope(const bcos::evm::opstack::DepositTx& d)
     out.push_back(0x7e);
     out.insert(out.end(), body.begin(), body.end());
     return out;
+}
+
+/// Synthesize the L1-attributes deposit envelope (op-geth l1AttributesDeposited /
+/// deriveL1InfoDepositHash, with the Isthmus/Jovian calldata layout mirrored by
+/// opt8n-ref's l1AttributesLayout and op-geth's rollup_cost.go extractors):
+/// sourceHash = keccak256(bytes32(1) || keccak256(l1BlockHash || bytes32(seq))),
+/// matching specs.optimism.io L1 attributes deposited (domain 1).
+/// calldata = selector || packed fields ([4:8] baseFeeScalar, [8:12] blobBaseFeeScalar,
+/// [12:20] seq, [20:28] l1 time, [28:36] l1 number, [36:68] l1 baseFee, [68:100] l1
+/// blobBaseFee, [100:132] l1 blockHash, [132:164] batcherHash, Isthmus+ [164:168]
+/// opFeeScalar, [168:176] opFeeConstant, Jovian [176:178] DA-footprint gas scalar).
+/// The scalar/operator-fee fields have no producer in this chain yet and are zero.
+/// Production deposits are derived by the op-node and arrive via
+/// payloadAttributes.transactions; this path only serves the built-in single-node CL.
+/// l2BlockTime is unused: the spec sourceHash does not bind L2 time.
+/// FISCO selects Jovian by genesis feature flag (OpForkFlags::jovianActive), not by
+/// an activation height. The synthesizer therefore emits 178B whenever the flag is
+/// on — there is no built-in-CL "activation block" that must be 176B. The read side
+/// still accepts both forms: 176B is treated as the op-geth activation (deposits-only)
+/// shape so an external op-node can send that block; 178B with the Jovian selector is
+/// the post-activation form this path produces. Production deposits come from op-node.
+inline bcos::bytes synthesizeL1AttributesDeposit(
+    const L1BlockInfo& l1Info, bool jovianActive, [[maybe_unused]] uint64_t l2BlockTime)
+{
+    bcos::bytes data(jovianActive ? JovianL1AttributesLen : IsthmusL1AttributesLen, 0);
+    const auto& selector = jovianActive ? JovianL1AttributesSelector :
+                                          IsthmusL1AttributesSelector;
+    std::copy(selector.begin(), selector.end(), data.begin());
+    auto dataSpan = std::span(data);
+    auto seqField = dataSpan.subspan(12, 8);
+    bcos::toBigEndian(l1Info.sequenceNumber, seqField);
+    auto timeField = dataSpan.subspan(20, 8);
+    bcos::toBigEndian(l1Info.time, timeField);
+    auto numberField = dataSpan.subspan(28, 8);
+    bcos::toBigEndian(l1Info.number, numberField);
+    intx::be::store(
+        std::span<uint8_t, 32>(dataSpan.subspan(36, 32).data(), 32), l1Info.baseFee);
+    intx::be::store(
+        std::span<uint8_t, 32>(dataSpan.subspan(68, 32).data(), 32), l1Info.blobBaseFee);
+    std::copy_n(l1Info.blockHash.bytes, sizeof(evmc::bytes32), data.begin() + 100);
+
+    // op-node L1InfoDepositSource: inner = keccak(l1Hash[32] || bytes32(seq)),
+    // sourceHash = keccak(bytes32(domain=1) || inner).
+    std::array<uint8_t, 64> innerInput{};
+    std::copy_n(l1Info.blockHash.bytes, sizeof(evmc::bytes32), innerInput.begin());
+    std::array<uint8_t, 8> seqBe{};
+    bcos::toBigEndian(l1Info.sequenceNumber, seqBe);
+    std::copy(seqBe.begin(), seqBe.end(), innerInput.begin() + 56);
+    const auto inner = bcos::crypto::keccak256Hash(
+        bcos::bytesConstRef(innerInput.data(), innerInput.size()));
+    std::array<uint8_t, 64> domainInput{};
+    domainInput[31] = 1;  // bytes32(uint256(1)) — L1InfoDepositSourceDomain
+    std::copy(inner.begin(), inner.end(), domainInput.begin() + 32);
+    const auto keccak = bcos::crypto::keccak256Hash(
+        bcos::bytesConstRef(domainInput.data(), domainInput.size()));
+    evmc::bytes32 sourceHash{};
+    std::copy_n(keccak.begin(), sizeof(evmc::bytes32), sourceHash.bytes);
+
+    DepositTx deposit{.source_hash = sourceHash,
+        .from = OP_DEPOSITOR,
+        .to = OP_L1_BLOCK,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = c_l1InfoDepositGas,
+        .is_system_tx = false,
+        .data = evmc::bytes(data.begin(), data.end())};
+    return encodeDepositEnvelope(deposit);
 }
 }  // namespace bcos::evm::opstack

--- a/opstack-executor/OpScheduler.h
+++ b/opstack-executor/OpScheduler.h
@@ -103,6 +103,21 @@ public:
         bcos::crypto::HashType announcedBlockHash;
     };
 
+    /// Retained probe (verify=false) execution, adopted by adoptProbeAsPending. The view's
+    /// top mutable layer is exactly this block's delta; adopt will pushView it. Un-adopted
+    /// retained views are private until pushView (forkCommitted views carry no storage
+    /// layers), so a stale slot is bounded extra retention, never state corruption — but
+    /// the clears in reset(), at probe start, and on adopt keep it empty across builds.
+    /// Single-writer discipline: all accesses hold m_executeMutex (probe write; adopt
+    /// read/write under execute+commit; reset holds all three). Deliberately not under
+    /// m_pendingMutex — the slot outlives m_pending on the probe path.
+    struct ProbeSlot
+    {
+        ViewType view;  // forkCommitted()+newMutable execution view
+        bcos::evm::engine::OpExecuteBlockResult result;  // commitments + receipts
+        protocol::BlockHeader::Ptr executedHeader;       // commitment-filled header
+    };
+
     // ---- SchedulerInterface overrides ----
 
     /// Engine newPayload drives this; PBFT/sync do not.
@@ -110,21 +125,38 @@ public:
         std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
             callback) override
     {
-        // Capturing lambda would hold this/block/cb in the closure, which task::wait destroys at
-        // the end of this full-expression; a coroutine that genuinely suspends would then read a
-        // freed closure (BaselineScheduler-tpp.h uses this parameter form for the same reason).
-        task::wait([](decltype(this) self, bcos::protocol::Block::Ptr block, bool verify,
-                       std::function<void(
-                           bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
-                           callback) -> task::Task<void> {
+        // Parameter-form task so a genuine suspend does not read a destroyed capturing
+        // lambda (BaselineScheduler-tpp.h). syncWait: EngineServiceImpl treats execute
+        // as finished when this returns (task::wait is fire-and-forget).
+        task::syncWait([](decltype(this) self, bcos::protocol::Block::Ptr block, bool verify,
+                           std::function<void(
+                               bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
+                               callback) -> task::Task<void> {
             std::apply(callback, co_await self->coExecuteBlock(std::move(block), verify));
         }(this, std::move(block), verify, std::move(callback)));
+    }
+
+    /// Adopt the retained probe (verify=false) as the verified pending block WITHOUT
+    /// re-executing. Only the OP build path calls this. The commitment check is deterministic
+    /// for a build (the final header was rebuilt from the probe's commitments) but is kept to
+    /// preserve the verify=true invariant and surface future regressions. Holds both delegate
+    /// locks across pushView — identical pairing to coExecuteBlock's pushView.
+    void adoptProbeAsPending(bcos::protocol::Block::Ptr block,
+        std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
+            callback) override
+    {
+        task::syncWait([](decltype(this) self, bcos::protocol::Block::Ptr block,
+                           std::function<void(
+                               bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
+                               callback) -> task::Task<void> {
+            std::apply(callback, co_await self->coAdoptProbe(std::move(block)));
+        }(this, std::move(block), std::move(callback)));
     }
 
     void commitBlock(bcos::protocol::BlockHeader::Ptr header,
         std::function<void(bcos::Error::Ptr, bcos::ledger::LedgerConfig::Ptr)> callback) override
     {
-        task::wait(
+        task::syncWait(
             [](decltype(this) self, bcos::protocol::BlockHeader::Ptr header,
                 std::function<void(bcos::Error::Ptr, bcos::ledger::LedgerConfig::Ptr)> callback)
                 -> task::Task<void> {
@@ -154,6 +186,10 @@ public:
             // lastCommitted is set. Restore the watermark to the committed tip.
             m_lastExecutedBlockNumber.store(m_lastCommittedBlockNumber.load());
         }
+        // Unconditional clear: the probe path leaves m_pending EMPTY with a retained slot,
+        // so a clear inside `if (m_pending)` would never fire and a stale probe would leak
+        // across aborted builds.
+        m_lastProbe.reset();
         callback(nullptr);
     }
 
@@ -435,12 +471,10 @@ private:
 
             // One execute at a time. Also take m_commitMutex so pushView / popFrontStorage
             // cannot race mergeBackStorage (reset() already takes all three). NOTE: these
-            // std::unique_lock objects span the co_awaits below, which is safe ONLY while the
-            // whole task::wait chain runs synchronously to completion on the calling thread
-            // (bcos::task's symmetric transfer: Wait.h starts an AsyncTask and returns at the
-            // first real suspension). If a future awaitable genuinely suspends, the closure
-            // fix above (parameter-form task::wait) is not enough here — the locks must be
-            // narrowed or replaced with a coroutine-aware lock.
+            // std::unique_lock objects span the co_awaits below. executeBlock/commitBlock
+            // now use task::syncWait, so the EngineServiceImpl caller does not proceed
+            // until this task finishes. If a future awaitable resumes on another thread,
+            // these locks must be narrowed or replaced with a coroutine-aware lock.
             std::unique_lock executeLock(m_executeMutex, std::try_to_lock);
             if (!executeLock.owns_lock())
             {
@@ -456,6 +490,13 @@ private:
                 OP_SCHEDULER_LOG(INFO) << message;
                 co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidStatus, message),
                     nullptr, false};
+            }
+
+            // Clear any stale slot before executing a probe: a failed probe must not leave
+            // the previous build's retained view behind (covers the ledgerGas re-probe too).
+            if (!verify)
+            {
+                m_lastProbe.reset();
             }
 
             // One pending slot: refuse another height, replace only verify=true at this height.
@@ -557,9 +598,18 @@ private:
 
             auto ledgerConfig = co_await loadLedgerConfig(view, number);
 
-            // Persist trie nodes only on verify=true + feature_l2_ethereum_compat.
+            // Persist trie nodes whenever the L2-compat feature is on, regardless of verify:
+            // the OP build path's probe (verify=false) is adopted via adoptProbeAsPending, so
+            // its retained view must already carry this block's persisted MPT nodes and the
+            // incremental root. Safe on the probe path: buildAndCollect only runs after a
+            // successful full-block execution (a poisoned tx throws in the per-tx loop before
+            // finalize), so eviction-failed probes never persist; un-adopted retained views
+            // (ledgerGas re-probe, aborted builds) are private until pushView and their
+            // persisted nodes are dropped with the view, never merged.
+            // Behavior note: on an L2-compat chain missing parent trie nodes, a probe now
+            // fails at buildAndCollect (MPTInvariantViolation) where it previously succeeded
+            // and the canonical pass failed — same net outcome (build aborts), earlier surface.
             bool const persistTrieNodes =
-                verify &&
                 ledgerConfig->features().get(ledger::Features::Flag::feature_l2_ethereum_compat);
             auto outcome =
                 co_await execute(view, *blockHeader, transactions, *ledgerConfig, persistTrieNodes);
@@ -598,6 +648,13 @@ private:
                 }
                 m_lastExecutedBlockNumber.store(number);
             }
+            else
+            {
+                // Retain the probe for adoptProbeAsPending: adopt pushes this view and stashes
+                // the result, so no second (canonical) execution is needed. Overwrites any
+                // stale slot from an earlier failed probe.
+                m_lastProbe = ProbeSlot{std::move(view), std::move(outcome.result), executedHeader};
+            }
 
             co_return {nullptr, std::move(executedHeader), sysBlock};
         }
@@ -606,12 +663,155 @@ private:
             auto message =
                 fmt::format("Execute block failed! {}", boost::diagnostic_information(e));
             OP_SCHEDULER_LOG(ERROR) << message;
+            auto error = BCOS_ERROR_PTR(classifyException(std::current_exception()), message);
+            if (auto const* opErr = dynamic_cast<bcos::evm::OpConsensusError const*>(&e);
+                opErr && opErr->txHash.has_value())
+            {
+                *error << bcos::engine::OpCulpritTxHash(*opErr->txHash);
+                if (opErr->capacity)
+                {
+                    *error << bcos::engine::OpBlockGasPoolFull{true};
+                }
+            }
+            co_return {std::move(error), nullptr, false};
+        }
+        catch (...)
+        {
+            auto message = std::string{"Execute block failed! ("} +
+                           describeException(std::current_exception()) + ")";
+            OP_SCHEDULER_LOG(ERROR) << message;
+            co_return {BCOS_ERROR_UNIQUE_PTR(classifyException(std::current_exception()), message),
+                nullptr, false};
+        }
+    }
+
+    task::Task<std::tuple<Error::Ptr, protocol::BlockHeader::Ptr, bool>> coAdoptProbe(
+        protocol::Block::Ptr block)
+    {
+        try
+        {
+            auto blockHeader = block->blockHeader();
+            auto const number = blockHeader->number();
+            OP_SCHEDULER_LOG(INFO) << "Adopt probe: " << number;
+
+            // Same double-lock as coExecuteBlock: pushView must not race mergeBackStorage.
+            std::unique_lock executeLock(m_executeMutex, std::try_to_lock);
+            if (!executeLock.owns_lock())
+            {
+                auto message = std::string{"Another block is executing!"};
+                OP_SCHEDULER_LOG(INFO) << message;
+                co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidStatus, message),
+                    nullptr, false};
+            }
+            std::unique_lock commitLock(m_commitMutex, std::try_to_lock);
+            if (!commitLock.owns_lock())
+            {
+                auto message = std::string{"Another block is committing!"};
+                OP_SCHEDULER_LOG(INFO) << message;
+                co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidStatus, message),
+                    nullptr, false};
+            }
+            if (!m_lastProbe)
+            {
+                auto message = std::string{"adoptProbeAsPending: no retained probe"};
+                OP_SCHEDULER_LOG(INFO) << message;
+                co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::UnknownError, message),
+                    nullptr, false};
+            }
+            if (m_lastProbe->executedHeader->number() != number)
+            {
+                auto message = fmt::format(
+                    "adoptProbeAsPending: retained probe is at height {}, "
+                    "adopt input is at height {}",
+                    m_lastProbe->executedHeader->number(), number);
+                OP_SCHEDULER_LOG(INFO) << message;
+                // Refusal is terminal for this build's adopt; drop the retained probe so a
+                // stale slot does not outlive the refused build.
+                m_lastProbe.reset();
+                co_return {
+                    BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidBlockNumber, message),
+                    nullptr, false};
+            }
+
+            // Error-surface parity with coExecuteBlock: refuse discontinuous or
+            // already-committed heights at build time instead of letting them fail later at
+            // commitContinuityCheck, and refuse to clobber any live pending (defensive reuse
+            // of the one-pending-slot discipline; unreachable via buildOpPayload, which resets
+            // before the probe, but the adopt method must not assume its caller).
+            auto const lastExecuted = m_lastExecutedBlockNumber.load();
+            auto const lastCommitted = m_lastCommittedBlockNumber.load();
+            if (number > 0 && number == lastCommitted)
+            {
+                auto message =
+                    std::string{"adoptProbeAsPending: block is already the committed tip"};
+                OP_SCHEDULER_LOG(INFO) << message;
+                m_lastProbe.reset();
+                co_return {
+                    BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidBlockNumber, message),
+                    nullptr, false};
+            }
+            if (lastExecuted != -1 && number - lastExecuted != 1)
+            {
+                auto message = fmt::format(
+                    "Discontinuous adopt! expect: {} input: {}", lastExecuted + 1, number);
+                OP_SCHEDULER_LOG(INFO) << message;
+                m_lastProbe.reset();
+                co_return {
+                    BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidBlockNumber, message),
+                    nullptr, false};
+            }
+            {
+                std::lock_guard<std::mutex> lock(m_pendingMutex);
+                if (m_pending)
+                {
+                    auto message =
+                        fmt::format("adoptProbeAsPending: unexpected live pending block at {}",
+                            m_pending->executedHeader->number());
+                    OP_SCHEDULER_LOG(INFO) << message;
+                    m_lastProbe.reset();
+                    co_return {
+                        BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidStatus, message),
+                        nullptr, false};
+                }
+            }
+
+            namespace engine = bcos::evm::engine;
+            if (auto mismatch =
+                    engine::mismatchedFieldOf(headerCommitments(*m_lastProbe->executedHeader),
+                        headerCommitments(*blockHeader)))
+            {
+                auto message =
+                    fmt::format("adoptProbeAsPending: commitment mismatch on field {}", *mismatch);
+                OP_SCHEDULER_LOG(INFO) << message;
+                m_lastProbe.reset();
+                co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::UnknownError, message),
+                    nullptr, false};
+            }
+
+            auto const announcedBlockHash =
+                bcos::protocol::EthBlockHeader::computeHash(*blockHeader);
+            m_multiLayerStorage->pushView(std::move(m_lastProbe->view));
+            auto executedHeader = m_lastProbe->executedHeader;
+            {
+                std::lock_guard<std::mutex> lock(m_pendingMutex);
+                m_pending = PendingBlock{std::move(block), std::move(m_lastProbe->result),
+                    announcedBlockHash, executedHeader, true};
+            }
+            m_lastExecutedBlockNumber.store(number);
+            m_lastProbe.reset();
+            OP_SCHEDULER_LOG(INFO) << "Adopted probe as pending: " << number;
+            co_return {nullptr, std::move(executedHeader), false};
+        }
+        catch (std::exception& e)
+        {
+            auto message = fmt::format("Adopt probe failed! {}", boost::diagnostic_information(e));
+            OP_SCHEDULER_LOG(ERROR) << message;
             co_return {BCOS_ERROR_UNIQUE_PTR(classifyException(std::current_exception()), message),
                 nullptr, false};
         }
         catch (...)
         {
-            auto message = std::string{"Execute block failed! ("} +
+            auto message = std::string{"Adopt probe failed! ("} +
                            describeException(std::current_exception()) + ")";
             OP_SCHEDULER_LOG(ERROR) << message;
             co_return {BCOS_ERROR_UNIQUE_PTR(classifyException(std::current_exception()), message),
@@ -794,8 +994,11 @@ private:
             for (std::size_t i = 0; i < rawTxBytes.size(); ++i)
             {
                 auto const& raw = rawTxBytes[i];
+                auto const culprit = transactions[i]->hash();
                 if (raw.empty())  // empty envelope: raw[0] would be out of bounds
-                    throw bcos::evm::OpConsensusError("OpScheduler: empty envelope");
+                {
+                    throw bcos::evm::OpConsensusError("OpScheduler: empty envelope", culprit);
+                }
                 auto const typeByte = raw[0];
                 if (op::classifyTxType(typeByte) == static_cast<uint8_t>(op::kDepositTxType))
                 {
@@ -807,15 +1010,18 @@ private:
                     catch (const OpTxValidationFailed& e)
                     {
                         throw bcos::evm::OpConsensusError(
-                            std::string("OpScheduler: malformed deposit: ") + e.what());
+                            std::string("OpScheduler: malformed deposit: ") + e.what(), culprit);
                     }
                 }
                 // Reject blob (0x03) and 0x7d type bytes.
                 else if (typeByte < 0xc0 && typeByte != 0x01 && typeByte != 0x02 &&
                          typeByte != 0x04)
+                {
                     throw bcos::evm::OpConsensusError(
                         fmt::format("OpScheduler: unsupported tx type byte 0x{:02x}",
-                            static_cast<unsigned>(typeByte)));
+                            static_cast<unsigned>(typeByte)),
+                        culprit);
+                }
             }
 
             bcos::ledger::LedgerConfig execLedgerConfig;
@@ -1395,6 +1601,7 @@ private:
     std::atomic<int64_t> m_lastCommittedBlockNumber{-1};
     std::mutex m_pendingMutex;
     std::optional<PendingBlock> m_pending;
+    std::optional<ProbeSlot> m_lastProbe;
 };
 
 

--- a/opstack-executor/OpScheduler.h
+++ b/opstack-executor/OpScheduler.h
@@ -750,9 +750,19 @@ private:
                 co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::UnknownError, message),
                     nullptr, false};
             }
-
             auto const announcedBlockHash =
                 bcos::protocol::EthBlockHeader::computeHash(*blockHeader);
+            auto const probeHash =
+                bcos::protocol::EthBlockHeader::computeHash(*m_lastProbe->executedHeader);
+            if (probeHash != announcedBlockHash)
+            {
+                auto message = std::string{
+                    "adoptProbeAsPending: executed header hash does not match the announced hash"};
+                OP_SCHEDULER_LOG(INFO) << message;
+                m_lastProbe.reset();
+                co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::UnknownError, message),
+                    nullptr, false};
+            }
             m_multiLayerStorage->pushView(std::move(m_lastProbe->view));
             auto executedHeader = m_lastProbe->executedHeader;
             {
@@ -957,10 +967,10 @@ private:
             for (std::size_t i = 0; i < rawTxBytes.size(); ++i)
             {
                 auto const& raw = rawTxBytes[i];
-                auto const culprit = transactions[i]->hash();
                 if (raw.empty())  // empty envelope: raw[0] would be out of bounds
                 {
-                    throw bcos::evm::OpConsensusError("OpScheduler: empty envelope", culprit);
+                    throw bcos::evm::OpConsensusError(
+                        "OpScheduler: empty envelope", transactions[i]->hash());
                 }
                 auto const typeByte = raw[0];
                 if (op::classifyTxType(typeByte) == static_cast<uint8_t>(op::kDepositTxType))
@@ -973,7 +983,8 @@ private:
                     catch (const OpTxValidationFailed& e)
                     {
                         throw bcos::evm::OpConsensusError(
-                            std::string("OpScheduler: malformed deposit: ") + e.what(), culprit);
+                            std::string("OpScheduler: malformed deposit: ") + e.what(),
+                            transactions[i]->hash());
                     }
                 }
                 // Reject blob (0x03) and 0x7d type bytes.
@@ -983,7 +994,7 @@ private:
                     throw bcos::evm::OpConsensusError(
                         fmt::format("OpScheduler: unsupported tx type byte 0x{:02x}",
                             static_cast<unsigned>(typeByte)),
-                        culprit);
+                        transactions[i]->hash());
                 }
             }
 
@@ -1294,7 +1305,7 @@ private:
             }
             if (opErr.capacity)
             {
-                error << bcos::engine::OpBlockGasPoolFull{true};
+                error << bcos::engine::OpRejectIsCapacity{true};
             }
         }
         catch (...)

--- a/opstack-executor/OpScheduler.h
+++ b/opstack-executor/OpScheduler.h
@@ -1284,9 +1284,9 @@ private:
         co_return ledgerConfig;
     }
 
-    /// Recover culprit / capacity tags via exception_ptr. A cross-TU typed
-    /// `catch (std::exception)` can miss OpConsensusError (RTTI / static-lib boundary);
-    /// rethrow from exception_ptr still sees the complete object.
+    /// Recover culprit / capacity tags via exception_ptr. The surrounding catch sites
+    /// only see std::exception (catch (std::exception&) / catch (...)); rethrow from the
+    /// exception_ptr to recover OpConsensusError and its structured fields.
     static void attachOpRejectInfo(Error& error, std::exception_ptr eptr)
     {
         if (!eptr)

--- a/opstack-executor/OpScheduler.h
+++ b/opstack-executor/OpScheduler.h
@@ -103,14 +103,7 @@ public:
         bcos::crypto::HashType announcedBlockHash;
     };
 
-    /// Retained probe (verify=false) execution, adopted by adoptProbeAsPending. The view's
-    /// top mutable layer is exactly this block's delta; adopt will pushView it. Un-adopted
-    /// retained views are private until pushView (forkCommitted views carry no storage
-    /// layers), so a stale slot is bounded extra retention, never state corruption — but
-    /// the clears in reset(), at probe start, and on adopt keep it empty across builds.
-    /// Single-writer discipline: all accesses hold m_executeMutex (probe write; adopt
-    /// read/write under execute+commit; reset holds all three). Deliberately not under
-    /// m_pendingMutex — the slot outlives m_pending on the probe path.
+    /// verify=false probe retained for adoptProbeAsPending.
     struct ProbeSlot
     {
         ViewType view;  // forkCommitted()+newMutable execution view
@@ -136,11 +129,7 @@ public:
         }(this, std::move(block), verify, std::move(callback)));
     }
 
-    /// Adopt the retained probe (verify=false) as the verified pending block WITHOUT
-    /// re-executing. Only the OP build path calls this. The commitment check is deterministic
-    /// for a build (the final header was rebuilt from the probe's commitments) but is kept to
-    /// preserve the verify=true invariant and surface future regressions. Holds both delegate
-    /// locks across pushView — identical pairing to coExecuteBlock's pushView.
+    /// Adopt the retained verify=false probe as the pending block without re-executing.
     void adoptProbeAsPending(bcos::protocol::Block::Ptr block,
         std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool _sysBlock)>
             callback) override
@@ -186,9 +175,7 @@ public:
             // lastCommitted is set. Restore the watermark to the committed tip.
             m_lastExecutedBlockNumber.store(m_lastCommittedBlockNumber.load());
         }
-        // Unconditional clear: the probe path leaves m_pending EMPTY with a retained slot,
-        // so a clear inside `if (m_pending)` would never fire and a stale probe would leak
-        // across aborted builds.
+        // Always drop a leftover probe; verify=false does not populate m_pending.
         m_lastProbe.reset();
         callback(nullptr);
     }
@@ -598,17 +585,7 @@ private:
 
             auto ledgerConfig = co_await loadLedgerConfig(view, number);
 
-            // Persist trie nodes whenever the L2-compat feature is on, regardless of verify:
-            // the OP build path's probe (verify=false) is adopted via adoptProbeAsPending, so
-            // its retained view must already carry this block's persisted MPT nodes and the
-            // incremental root. Safe on the probe path: buildAndCollect only runs after a
-            // successful full-block execution (a poisoned tx throws in the per-tx loop before
-            // finalize), so eviction-failed probes never persist; un-adopted retained views
-            // (ledgerGas re-probe, aborted builds) are private until pushView and their
-            // persisted nodes are dropped with the view, never merged.
-            // Behavior note: on an L2-compat chain missing parent trie nodes, a probe now
-            // fails at buildAndCollect (MPTInvariantViolation) where it previously succeeded
-            // and the canonical pass failed — same net outcome (build aborts), earlier surface.
+            // Persist trie nodes on L2-compat even for verify=false; adopt reuses this view.
             bool const persistTrieNodes =
                 ledgerConfig->features().get(ledger::Features::Flag::feature_l2_ethereum_compat);
             auto outcome =
@@ -650,9 +627,7 @@ private:
             }
             else
             {
-                // Retain the probe for adoptProbeAsPending: adopt pushes this view and stashes
-                // the result, so no second (canonical) execution is needed. Overwrites any
-                // stale slot from an earlier failed probe.
+                // Keep the probe so adoptProbeAsPending can push this view.
                 m_lastProbe = ProbeSlot{std::move(view), std::move(outcome.result), executedHeader};
             }
 
@@ -725,19 +700,12 @@ private:
                     "adopt input is at height {}",
                     m_lastProbe->executedHeader->number(), number);
                 OP_SCHEDULER_LOG(INFO) << message;
-                // Refusal is terminal for this build's adopt; drop the retained probe so a
-                // stale slot does not outlive the refused build.
                 m_lastProbe.reset();
                 co_return {
                     BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidBlockNumber, message),
                     nullptr, false};
             }
 
-            // Error-surface parity with coExecuteBlock: refuse discontinuous or
-            // already-committed heights at build time instead of letting them fail later at
-            // commitContinuityCheck, and refuse to clobber any live pending (defensive reuse
-            // of the one-pending-slot discipline; unreachable via buildOpPayload, which resets
-            // before the probe, but the adopt method must not assume its caller).
             auto const lastExecuted = m_lastExecutedBlockNumber.load();
             auto const lastCommitted = m_lastCommittedBlockNumber.load();
             if (number > 0 && number == lastCommitted)

--- a/opstack-executor/OpScheduler.h
+++ b/opstack-executor/OpScheduler.h
@@ -624,6 +624,7 @@ private:
                         outcome.announcedBlockHash, executedHeader, true};
                 }
                 m_lastExecutedBlockNumber.store(number);
+                m_lastProbe.reset();
             }
             else
             {
@@ -639,15 +640,7 @@ private:
                 fmt::format("Execute block failed! {}", boost::diagnostic_information(e));
             OP_SCHEDULER_LOG(ERROR) << message;
             auto error = BCOS_ERROR_PTR(classifyException(std::current_exception()), message);
-            if (auto const* opErr = dynamic_cast<bcos::evm::OpConsensusError const*>(&e);
-                opErr && opErr->txHash.has_value())
-            {
-                *error << bcos::engine::OpCulpritTxHash(*opErr->txHash);
-                if (opErr->capacity)
-                {
-                    *error << bcos::engine::OpBlockGasPoolFull{true};
-                }
-            }
+            attachOpRejectInfo(*error, std::current_exception());
             co_return {std::move(error), nullptr, false};
         }
         catch (...)
@@ -655,8 +648,10 @@ private:
             auto message = std::string{"Execute block failed! ("} +
                            describeException(std::current_exception()) + ")";
             OP_SCHEDULER_LOG(ERROR) << message;
-            co_return {BCOS_ERROR_UNIQUE_PTR(classifyException(std::current_exception()), message),
-                nullptr, false};
+            auto error =
+                BCOS_ERROR_UNIQUE_PTR(classifyException(std::current_exception()), message);
+            attachOpRejectInfo(*error, std::current_exception());
+            co_return {std::move(error), nullptr, false};
         }
     }
 
@@ -1276,6 +1271,34 @@ private:
         ledgerConfig->setBlockNumber(header->number());
         ledgerConfig->setTimestamp(header->timestamp());
         co_return ledgerConfig;
+    }
+
+    /// Recover culprit / capacity tags via exception_ptr. A cross-TU typed
+    /// `catch (std::exception)` can miss OpConsensusError (RTTI / static-lib boundary);
+    /// rethrow from exception_ptr still sees the complete object.
+    static void attachOpRejectInfo(Error& error, std::exception_ptr eptr)
+    {
+        if (!eptr)
+        {
+            return;
+        }
+        try
+        {
+            std::rethrow_exception(std::move(eptr));
+        }
+        catch (const bcos::evm::OpConsensusError& opErr)
+        {
+            if (opErr.txHash.has_value())
+            {
+                error << bcos::engine::OpCulpritTxHash(*opErr.txHash);
+            }
+            if (opErr.capacity)
+            {
+                error << bcos::engine::OpBlockGasPoolFull{true};
+            }
+        }
+        catch (...)
+        {}
     }
 
 public:

--- a/opstack-executor/OpSchedulerSeam.h
+++ b/opstack-executor/OpSchedulerSeam.h
@@ -33,7 +33,7 @@ class OpSchedulerSeam
 {
 public:
     explicit OpSchedulerSeam(
-        bcos::evm::opstack::OpForkFlags forkFlags, bcos::evm::opstack::L1BlockInfo l1BlockInfo = {})
+        bcos::evm::opstack::OpForkFlags forkFlags, bcos::evm::opstack::L1BlockInfo l1BlockInfo)
       : m_forkFlags(forkFlags), m_l1BlockInfo(std::move(l1BlockInfo))
     {}
 
@@ -73,8 +73,16 @@ public:
     [[nodiscard]] bool isJovianActive() const noexcept { return m_forkFlags.jovianActive; }
 
     /// Synthesize the L1-attributes deposit envelope from the configured L1 info.
+    /// Refuses the unset sentinel (number/time/hash all zero) so a missing CL snapshot
+    /// cannot mint a plausible all-zero L1-attributes deposit.
     [[nodiscard]] bcos::bytes synthesizeL1AttributesEnvelope(uint64_t l2BlockTime) const
     {
+        if (bcos::evm::opstack::isUnsetL1BlockInfo(m_l1BlockInfo))
+        {
+            throw std::invalid_argument(
+                "OpSchedulerSeam: refuse to synthesize L1-attributes from an unset "
+                "L1BlockInfo (number, time, and blockHash are all zero)");
+        }
         return bcos::evm::opstack::synthesizeL1AttributesDeposit(
             m_l1BlockInfo, m_forkFlags.jovianActive, l2BlockTime);
     }

--- a/opstack-executor/OpSchedulerSeam.h
+++ b/opstack-executor/OpSchedulerSeam.h
@@ -5,6 +5,7 @@
 // Engine-facing OP seam. executeBlock exists only for the scheduler concept check.
 
 #include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-framework/engine/Types.h>
 #include <bcos-framework/ledger/LedgerConfig.h>
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-framework/protocol/TransactionReceipt.h>
@@ -14,11 +15,13 @@
 #include <opstack-executor/OpBlockExecute.h>
 #include <opstack-executor/OpCommitments.h>
 #include <opstack-executor/OpCommon.h>
+#include <opstack-executor/OpDepositEncode.h>
 #include <cstdint>
 #include <optional>
 #include <range/v3/range/concepts.hpp>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace bcos::evm::engine
@@ -29,7 +32,10 @@ template <class Storage>
 class OpSchedulerSeam
 {
 public:
-    explicit OpSchedulerSeam(bcos::evm::opstack::OpForkFlags forkFlags) : m_forkFlags(forkFlags) {}
+    explicit OpSchedulerSeam(
+        bcos::evm::opstack::OpForkFlags forkFlags, bcos::evm::opstack::L1BlockInfo l1BlockInfo = {})
+      : m_forkFlags(forkFlags), m_l1BlockInfo(std::move(l1BlockInfo))
+    {}
 
     using BlockEnv = bcos::protocol::BlockHeader;
     using ExecuteResult = OpExecuteBlockResult;
@@ -66,6 +72,18 @@ public:
     /// Jovian is active (blobGasUsed is DA footprint; Isthmus keeps it 0).
     [[nodiscard]] bool isJovianActive() const noexcept { return m_forkFlags.jovianActive; }
 
+    /// L1-attributes deposit envelope for the block's forced-transaction set, synthesized
+    /// from the configured L1 info (op-geth l1AttributesDeposited semantics). In production
+    /// the op-node (L2 CL) supplies this deposit inside payloadAttributes.transactions, so
+    /// this member only serves the built-in single-node CL's fallback. An all-zero
+    /// L1BlockInfo (no [op_l1] config) is the documented stand-in, never a production L1
+    /// value — see L1BlockInfo.
+    [[nodiscard]] bcos::bytes synthesizeL1AttributesEnvelope(uint64_t l2BlockTime) const
+    {
+        return bcos::evm::opstack::synthesizeL1AttributesDeposit(
+            m_l1BlockInfo, m_forkFlags.jovianActive, l2BlockTime);
+    }
+
     OpSchedulerSeam(const OpSchedulerSeam&) = delete;
     OpSchedulerSeam(OpSchedulerSeam&&) = delete;
     OpSchedulerSeam& operator=(const OpSchedulerSeam&) = delete;
@@ -85,6 +103,7 @@ public:
 
 private:
     bcos::evm::opstack::OpForkFlags m_forkFlags;
+    bcos::evm::opstack::L1BlockInfo m_l1BlockInfo;
 };
 
 }  // namespace bcos::evm::engine

--- a/opstack-executor/OpSchedulerSeam.h
+++ b/opstack-executor/OpSchedulerSeam.h
@@ -73,9 +73,10 @@ public:
     [[nodiscard]] bool isJovianActive() const noexcept { return m_forkFlags.jovianActive; }
 
     /// Synthesize the L1-attributes deposit envelope from the configured L1 info.
-    /// Refuses the unset sentinel (number/time/hash all zero) so a missing CL snapshot
-    /// cannot mint a plausible all-zero L1-attributes deposit.
-    [[nodiscard]] bcos::bytes synthesizeL1AttributesEnvelope(uint64_t l2BlockTime) const
+    /// Refuses the unset snapshot sentinel (number/time/hash all zero) and an unset
+    /// SystemConfig (zero baseFeeScalar or batcherHash) so a missing CL snapshot cannot
+    /// mint a plausible L1-attributes deposit.
+    [[nodiscard]] bcos::bytes synthesizeL1AttributesEnvelope() const
     {
         if (bcos::evm::opstack::isUnsetL1BlockInfo(m_l1BlockInfo))
         {
@@ -83,8 +84,14 @@ public:
                 "OpSchedulerSeam: refuse to synthesize L1-attributes from an unset "
                 "L1BlockInfo (number, time, and blockHash are all zero)");
         }
+        if (bcos::evm::opstack::isUnsetSystemConfig(m_l1BlockInfo))
+        {
+            throw std::invalid_argument(
+                "OpSchedulerSeam: refuse to synthesize L1-attributes with an unset "
+                "SystemConfig (baseFeeScalar and batcherHash must be non-zero)");
+        }
         return bcos::evm::opstack::synthesizeL1AttributesDeposit(
-            m_l1BlockInfo, m_forkFlags.jovianActive, l2BlockTime);
+            m_l1BlockInfo, m_forkFlags.jovianActive);
     }
 
     OpSchedulerSeam(const OpSchedulerSeam&) = delete;

--- a/opstack-executor/OpSchedulerSeam.h
+++ b/opstack-executor/OpSchedulerSeam.h
@@ -72,12 +72,7 @@ public:
     /// Jovian is active (blobGasUsed is DA footprint; Isthmus keeps it 0).
     [[nodiscard]] bool isJovianActive() const noexcept { return m_forkFlags.jovianActive; }
 
-    /// L1-attributes deposit envelope for the block's forced-transaction set, synthesized
-    /// from the configured L1 info (op-geth l1AttributesDeposited semantics). In production
-    /// the op-node (L2 CL) supplies this deposit inside payloadAttributes.transactions, so
-    /// this member only serves the built-in single-node CL's fallback. An all-zero
-    /// L1BlockInfo (no [op_l1] config) is the documented stand-in, never a production L1
-    /// value — see L1BlockInfo.
+    /// Synthesize the L1-attributes deposit envelope from the configured L1 info.
     [[nodiscard]] bcos::bytes synthesizeL1AttributesEnvelope(uint64_t l2BlockTime) const
     {
         return bcos::evm::opstack::synthesizeL1AttributesDeposit(

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -1125,6 +1125,14 @@ public:
             props = co_await m_prepare(stateView, blockHeader, transaction, ledgerConfig, fee,
                 blockGasLeft, call ? std::optional<uint64_t>{} : chainId, &blockInfo, call);
         }
+        catch (const OpBlockGasPoolFull& e)
+        {
+            // Same conversion as ExecuteContext::prepare: on the block path a full pool is a
+            // capacity fault (keep the transaction), not a poisoned-tx reject.
+            throw bcos::evm::OpConsensusError(
+                std::string("OpScheduler: block gas pool full: ") + e.what(), transaction.hash(),
+                /*capacity=*/true);
+        }
         catch (const OpTxValidationFailed& e)
         {
             throw bcos::evm::OpConsensusError(

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -243,9 +243,7 @@ namespace bcos::executor_v1::opstack
 DERIVE_BCOS_EXCEPTION(OpEvmcRevisionNotConfigured);
 DERIVE_BCOS_EXCEPTION(OpForkRevisionMismatch);
 DERIVE_BCOS_EXCEPTION(OpTxValidationFailed);
-/// Block gas pool cannot fit the transaction (evmone GAS_LIMIT_REACHED). Distinct from
-/// OpTxValidationFailed so the engine can treat capacity as skip-for-this-build instead
-/// of pool eviction (op-geth's miner gasPool prefix stop never removes pool txs).
+/// Block gas pool cannot fit the transaction (skip this build, do not evict).
 DERIVE_BCOS_EXCEPTION(OpBlockGasPoolFull);
 
 using bcos::evm::evmstate::SharedErrorSlot;  // Storage2State.h
@@ -918,8 +916,6 @@ public:
             }
             catch (const OpBlockGasPoolFull& e)
             {
-                // Capacity fault (block gas pool full): skip-for-this-build semantics —
-                // the engine must never evict this tx from the pool (F2).
                 throw bcos::evm::OpConsensusError(
                     std::string("OpScheduler: block gas pool full: ") + e.what(),
                     transaction.hash(), /*capacity=*/true);
@@ -1387,19 +1383,10 @@ private:
                                     blockGasLeft);
         if (auto const* err = std::get_if<std::error_code>(&validated))
         {
-            // Block path only: a tx that does not fit the block gas pool is a capacity
-            // fault (F2 skip-not-evict). eth_call/estimateGas (call=true) simulate against
-            // their own throwaway pool — there the pool is a per-call bound, not a block
-            // property, so GAS_LIMIT_REACHED stays an ordinary validation failure
-            // (OpTxValidationFailed, which the call wrapper classifies) and must not
-            // escape as OpBlockGasPoolFull.
+            // On the block path, a full gas pool is a capacity fault, not a poisoned tx.
+            // eth_call / estimateGas keep GAS_LIMIT_REACHED as ordinary validation.
             if (*err == evmone::state::make_error_code(evmone::state::GAS_LIMIT_REACHED) && !call)
             {
-                // Block gas pool full: the tx does not fit this block — a capacity fault,
-                // not a poisoned transaction. The engine's gas-aware prefix assembly keeps
-                // this unreachable for sealed txs; if it still fires (forced-tx overflow or
-                // accounting drift), the engine skips the tx for this build and never
-                // removes it from the pool (F2).
                 BOOST_THROW_EXCEPTION(
                     OpBlockGasPoolFull{} << bcos::errinfo_comment(err->message()));
             }

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -243,6 +243,10 @@ namespace bcos::executor_v1::opstack
 DERIVE_BCOS_EXCEPTION(OpEvmcRevisionNotConfigured);
 DERIVE_BCOS_EXCEPTION(OpForkRevisionMismatch);
 DERIVE_BCOS_EXCEPTION(OpTxValidationFailed);
+/// Block gas pool cannot fit the transaction (evmone GAS_LIMIT_REACHED). Distinct from
+/// OpTxValidationFailed so the engine can treat capacity as skip-for-this-build instead
+/// of pool eviction (op-geth's miner gasPool prefix stop never removes pool txs).
+DERIVE_BCOS_EXCEPTION(OpBlockGasPoolFull);
 
 using bcos::evm::evmstate::SharedErrorSlot;  // Storage2State.h
 
@@ -912,16 +916,19 @@ public:
                     call ? std::optional<uint64_t>{} : std::optional<uint64_t>(m_ctx->chainId),
                     &*m_blockInfo, call);
             }
+            catch (const OpBlockGasPoolFull& e)
+            {
+                // Capacity fault (block gas pool full): skip-for-this-build semantics —
+                // the engine must never evict this tx from the pool (F2).
+                throw bcos::evm::OpConsensusError(
+                    std::string("OpScheduler: block gas pool full: ") + e.what(),
+                    transaction.hash(), /*capacity=*/true);
+            }
             catch (const OpTxValidationFailed& e)
             {
-                // The offending tx's hash rides in a structured member (bcos::Error carries a
-                // string only across the delegate boundary): the engine's OP build loop reads
-                // e.txHash to evict the culprit from the pool instead of failing every
-                // subsequent build — never parse the message text.
-                bcos::evm::OpConsensusError err(
-                    std::string("OpScheduler: normal tx validation failed: ") + e.what());
-                err.txHash = transaction.hash();
-                throw err;
+                throw bcos::evm::OpConsensusError(
+                    std::string("OpScheduler: normal tx validation failed: ") + e.what(),
+                    transaction.hash());
             }
             // Only after a successful prepare: a rejected normal tx must not flip the
             // deposit-after-non-deposit warn path for a later deposit in the same block.
@@ -1124,13 +1131,9 @@ public:
         }
         catch (const OpTxValidationFailed& e)
         {
-            // Mirror the ExecuteContext::prepare catch: the offending tx's hash rides in a
-            // structured member so the engine's OP build loop can evict the culprit by hash —
-            // never parse the message text.
-            bcos::evm::OpConsensusError err(
-                std::string("OpScheduler: normal tx validation failed: ") + e.what());
-            err.txHash = transaction.hash();
-            throw err;
+            throw bcos::evm::OpConsensusError(
+                std::string("OpScheduler: normal tx validation failed: ") + e.what(),
+                transaction.hash());
         }
         evmone::state::StateDiff diff;
         auto receipt = co_await m_execute(stateView, blockHeader, transaction, ledgerConfig, props,
@@ -1384,6 +1387,22 @@ private:
                                     blockGasLeft);
         if (auto const* err = std::get_if<std::error_code>(&validated))
         {
+            // Block path only: a tx that does not fit the block gas pool is a capacity
+            // fault (F2 skip-not-evict). eth_call/estimateGas (call=true) simulate against
+            // their own throwaway pool — there the pool is a per-call bound, not a block
+            // property, so GAS_LIMIT_REACHED stays an ordinary validation failure
+            // (OpTxValidationFailed, which the call wrapper classifies) and must not
+            // escape as OpBlockGasPoolFull.
+            if (*err == evmone::state::make_error_code(evmone::state::GAS_LIMIT_REACHED) && !call)
+            {
+                // Block gas pool full: the tx does not fit this block — a capacity fault,
+                // not a poisoned transaction. The engine's gas-aware prefix assembly keeps
+                // this unreachable for sealed txs; if it still fires (forced-tx overflow or
+                // accounting drift), the engine skips the tx for this build and never
+                // removes it from the pool (F2).
+                BOOST_THROW_EXCEPTION(
+                    OpBlockGasPoolFull{} << bcos::errinfo_comment(err->message()));
+            }
             // DEBUG not WARNING: this path is reachable from unauthenticated eth_call /
             // estimateGas, where any caller can trigger validation failures at will — a
             // WARNING here would be a log-amplification vector.

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -1251,7 +1251,7 @@ private:
         {
             throw;
         }
-        catch (const OpBlockGasPoolFull& e)
+        catch (const bcos::evm::opstack::OpDepositGasLimitReached& e)
         {
             bcos::evm::OpConsensusError err("OpScheduler: " + what + " failed: " + e.what());
             err.capacity = true;
@@ -1259,10 +1259,7 @@ private:
         }
         catch (const std::exception& e)
         {
-            std::string const msg = e.what();
-            bcos::evm::OpConsensusError err("OpScheduler: " + what + " failed: " + msg);
-            err.capacity = msg.find("block gas limit reached") != std::string::npos;
-            throw err;
+            throw bcos::evm::OpConsensusError("OpScheduler: " + what + " failed: " + e.what());
         }
         catch (...)
         {

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -1251,9 +1251,18 @@ private:
         {
             throw;
         }
+        catch (const OpBlockGasPoolFull& e)
+        {
+            bcos::evm::OpConsensusError err("OpScheduler: " + what + " failed: " + e.what());
+            err.capacity = true;
+            throw err;
+        }
         catch (const std::exception& e)
         {
-            throw bcos::evm::OpConsensusError("OpScheduler: " + what + " failed: " + e.what());
+            std::string const msg = e.what();
+            bcos::evm::OpConsensusError err("OpScheduler: " + what + " failed: " + msg);
+            err.capacity = msg.find("block gas limit reached") != std::string::npos;
+            throw err;
         }
         catch (...)
         {

--- a/opstack-executor/tests/OpCommonTest.cpp
+++ b/opstack-executor/tests/OpCommonTest.cpp
@@ -121,4 +121,13 @@ BOOST_AUTO_TEST_CASE(ClassifyTxTypeMapping)
     BOOST_CHECK_EQUAL(op::classifyTxType(0x05), 0x05);
 }
 
+BOOST_AUTO_TEST_CASE(PerTxCtorEmbedsCulpritTag)
+{
+    bcos::h256 const hash(std::string(64, 'e'), bcos::h256::FromHex);
+    OpConsensusError const err("OpScheduler: normal tx validation failed: nonce too low", hash);
+    BOOST_REQUIRE(err.txHash.has_value());
+    BOOST_CHECK_EQUAL(err.txHash->hex(), hash.hex());
+    BOOST_CHECK_EQUAL(std::string_view(err.what()).find("[tx="), std::string_view::npos);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
+++ b/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
@@ -10,14 +10,18 @@
 //      (The block-pre shape checks live in PreBlockOpStepsTest; the seam itself no longer
 //      executes blocks — see the note at the end of this file.)
 #include "OpSchedulerSeamTestHelpers.h"
-#include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/OpTransition.h>
 #include <bcos-framework/storage2/MemoryStorage.h>
 #include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <opstack-executor/OpSchedulerSeam.h>
+#include <opstack-executor/OpstackExecutor.h>
 #include <boost/test/unit_test.hpp>
+#include <algorithm>
 #include <array>
+#include <span>
 #include <stdexcept>
 #include <vector>
 
@@ -78,15 +82,15 @@ BOOST_AUTO_TEST_CASE(ConstructAndSeamSurface)
     auto view = multiLayerStorage.fork();
     view.newMutable();
 
-    // The ctor takes only fork flags (feature-driven fork selection; this is a pure seam shim —
-    // no receipt factory / chain id / VM).
+    // L1BlockInfo is required (no silent default). Construction with the unset sentinel is
+    // allowed; synthesizeL1AttributesEnvelope is what refuses it.
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
-        bcos::evm::opstack::OpForkFlags{.jovianActive = false});
+        bcos::evm::opstack::OpForkFlags{.jovianActive = false}, {});
 
     // Fork predicate: feature-driven (feature_op_jovian), constant across blocks — no timestamps.
     BOOST_CHECK(!scheduler.isJovianActive());
     bcos::evm::engine::OpSchedulerSeam<ViewType> jovianScheduler(
-        bcos::evm::opstack::OpForkFlags{.jovianActive = true});
+        bcos::evm::opstack::OpForkFlags{.jovianActive = true}, {});
     BOOST_CHECK(jovianScheduler.isJovianActive());
 
     // computeTxRoot over the empty range: the standard empty-trie root (0x56e81f...), which
@@ -122,36 +126,33 @@ BOOST_AUTO_TEST_CASE(SynthesizeL1AttributesIsDepositEnvelope)
     BOOST_CHECK_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
 }
 
-BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
+BOOST_AUTO_TEST_CASE(SynthesizeRefusesUnsetL1BlockInfo)
 {
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
-        bcos::evm::opstack::OpForkFlags{.jovianActive = false});
+        bcos::evm::opstack::OpForkFlags{.jovianActive = false}, {});
+    BOOST_CHECK_THROW((void)scheduler.synthesizeL1AttributesEnvelope(1000), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
+{
+    // All-zero L1 is a test-only fixture: call the encoder, not the production seam.
     constexpr uint64_t kL2Time = 0x123456789abcdef0ull;
-    const auto env = scheduler.synthesizeL1AttributesEnvelope(kL2Time);
+    const auto env = bcos::evm::opstack::synthesizeL1AttributesDeposit(
+        bcos::evm::opstack::L1BlockInfo{}, false, kL2Time);
     BOOST_REQUIRE_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
+    auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
+        bcos::bytesConstRef(env.data(), env.size()));
 
-    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
-    std::vector<bcos::bytes> fields;
-    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
-    BOOST_REQUIRE_EQUAL(fields.size(), 8);
-
-    BOOST_CHECK_EQUAL(fields[0].size(), 32);  // sourceHash
-    const std::array<uint8_t, 20> kDepositor{0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde,
-        0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0x00, 0x01};
-    const std::array<uint8_t, 20> kL1Block{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15};
+    BOOST_CHECK(dep.from == bcos::evm::opstack::OP_DEPOSITOR);
+    BOOST_REQUIRE(dep.to.has_value());
+    BOOST_CHECK(*dep.to == bcos::evm::opstack::OP_L1_BLOCK);
+    BOOST_CHECK(!dep.mint.has_value());
+    BOOST_CHECK(dep.value == intx::uint256{0});
+    BOOST_CHECK_EQUAL(dep.gas_limit, bcos::evm::opstack::c_l1InfoDepositGas);
+    BOOST_CHECK(!dep.is_system_tx);
+    BOOST_REQUIRE_EQUAL(dep.data.size(), bcos::evm::opstack::IsthmusL1AttributesLen);
     BOOST_CHECK_EQUAL_COLLECTIONS(
-        fields[1].begin(), fields[1].end(), kDepositor.begin(), kDepositor.end());
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-        fields[2].begin(), fields[2].end(), kL1Block.begin(), kL1Block.end());
-    // mint / value / isSystemTx encode as empty RLP items.
-    BOOST_CHECK(fields[3].empty());
-    BOOST_CHECK(fields[4].empty());
-    BOOST_CHECK_EQUAL(fields[5], (bcos::bytes{0x0f, 0x42, 0x40}));  // gas 1'000'000, payload only
-    BOOST_CHECK(fields[6].empty());
-    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::IsthmusL1AttributesLen);
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-        fields[7].begin(), fields[7].begin() + 4, kIsthmusSelector.begin(), kIsthmusSelector.end());
+        dep.data.begin(), dep.data.begin() + 4, kIsthmusSelector.begin(), kIsthmusSelector.end());
 
     // sourceHash = keccak(bytes32(1) || keccak(l1Hash || bytes32(seq))).
     std::array<uint8_t, 64> innerInput{};
@@ -162,8 +163,8 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
     std::copy(inner.begin(), inner.end(), domainInput.begin() + 32);
     const auto expectedHash =
         bcos::crypto::keccak256Hash(bcos::bytesConstRef(domainInput.data(), domainInput.size()));
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-        fields[0].begin(), fields[0].end(), expectedHash.begin(), expectedHash.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(dep.source_hash.bytes, dep.source_hash.bytes + 32,
+        expectedHash.begin(), expectedHash.end());
 }
 
 BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
@@ -184,11 +185,10 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
         bcos::evm::opstack::OpForkFlags{.jovianActive = true}, l1Info);
     const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
-    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
-    std::vector<bcos::bytes> fields;
-    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
-    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::JovianL1AttributesLen);
-    auto const& calldata = fields[7];
+    auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
+        bcos::bytesConstRef(env.data(), env.size()));
+    BOOST_REQUIRE_EQUAL(dep.data.size(), bcos::evm::opstack::JovianL1AttributesLen);
+    auto const& calldata = dep.data;
 
     auto checkBE = [&](size_t offset, uint64_t value) {
         std::array<uint8_t, 8> be{};
@@ -232,11 +232,10 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
         bcos::evm::opstack::OpForkFlags{.jovianActive = false}, l1Info);
     const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
-    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
-    std::vector<bcos::bytes> fields;
-    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
-    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::IsthmusL1AttributesLen);
-    auto const& calldata = fields[7];
+    auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
+        bcos::bytesConstRef(env.data(), env.size()));
+    BOOST_REQUIRE_EQUAL(dep.data.size(), bcos::evm::opstack::IsthmusL1AttributesLen);
+    auto const& calldata = dep.data;
 
     auto checkBE = [&](size_t offset, uint64_t value) {
         std::array<uint8_t, 8> be{};
@@ -263,22 +262,19 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
 
 BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayoutAndUniqueness)
 {
-    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
-        bcos::evm::opstack::OpForkFlags{.jovianActive = true});
-    const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
+    bcos::evm::opstack::L1BlockInfo const unset{};
+    const auto env = bcos::evm::opstack::synthesizeL1AttributesDeposit(unset, true, 1000);
     BOOST_REQUIRE_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
-    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
-    std::vector<bcos::bytes> fields;
-    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
-    BOOST_REQUIRE_EQUAL(fields.size(), 8);
-    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::JovianL1AttributesLen);
+    auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
+        bcos::bytesConstRef(env.data(), env.size()));
+    BOOST_REQUIRE_EQUAL(dep.data.size(), bcos::evm::opstack::JovianL1AttributesLen);
     BOOST_CHECK_EQUAL_COLLECTIONS(
-        fields[7].begin(), fields[7].begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
+        dep.data.begin(), dep.data.begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
     // [176:178] DA-footprint scalar is zero.
-    BOOST_CHECK_EQUAL(fields[7][176], 0);
-    BOOST_CHECK_EQUAL(fields[7][177], 0);
+    BOOST_CHECK_EQUAL(dep.data[176], 0);
+    BOOST_CHECK_EQUAL(dep.data[177], 0);
 
-    const auto envLater = scheduler.synthesizeL1AttributesEnvelope(1001);
+    const auto envLater = bcos::evm::opstack::synthesizeL1AttributesDeposit(unset, true, 1001);
     BOOST_CHECK(env == envLater);  // sourceHash is domain-1(l1Hash, seq), not L2 time
 }
 

--- a/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
+++ b/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
@@ -10,11 +10,14 @@
 //      (The block-pre shape checks live in PreBlockOpStepsTest; the seam itself no longer
 //      executes blocks — see the note at the end of this file.)
 #include "OpSchedulerSeamTestHelpers.h"
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-framework/storage2/MemoryStorage.h>
 #include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <opstack-executor/OpSchedulerSeam.h>
 #include <boost/test/unit_test.hpp>
+#include <array>
 #include <stdexcept>
 #include <vector>
 
@@ -58,6 +61,12 @@ using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
 using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
 using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
 using ViewType = typename MLS::ViewType;
+
+// Independent golden selectors (not the production constants). Two temporary
+// std::array instances in BOOST_CHECK_EQUAL_COLLECTIONS would dangle both
+// iterators, so these live as named constants.
+constexpr std::array<uint8_t, 4> kIsthmusSelector{0x09, 0x89, 0x99, 0xbe};
+constexpr std::array<uint8_t, 4> kJovianSelector{0x3d, 0xb6, 0xbe, 0x2b};
 
 }  // namespace
 
@@ -113,6 +122,184 @@ BOOST_AUTO_TEST_CASE(SynthesizeL1AttributesIsDepositEnvelope)
     auto const env = bcos::evm::engine::testutil::synthesizeL1AttributesEnvelope(false);
     BOOST_REQUIRE(!env.empty());
     BOOST_CHECK_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
+}
+
+// Production-synthesis layout anchor: the seam's synthesizeL1AttributesEnvelope must produce
+// a 0x7e envelope whose rlp fields carry the op-geth L1-attributes deposit shape — from ==
+// OP_DEPOSITOR, to == OP_L1_BLOCK, gas == c_l1InfoDepositGas, data == Isthmus 176B with the
+// Isthmus selector, and sourceHash == keccak256(bytes32(1) || keccak256(l1Hash || bytes32(seq))).
+// The fixture helper (testutil) is NOT the anchor: this decodes the seam's own output.
+BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
+{
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = false});
+    constexpr uint64_t kL2Time = 0x123456789abcdef0ull;
+    const auto env = scheduler.synthesizeL1AttributesEnvelope(kL2Time);
+    BOOST_REQUIRE_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
+
+    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
+    std::vector<bcos::bytes> fields;
+    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
+    BOOST_REQUIRE_EQUAL(fields.size(), 8);
+
+    BOOST_CHECK_EQUAL(fields[0].size(), 32);  // sourceHash
+    // Independent golden bytes (not the production constants): a corrupted
+    // OP_DEPOSITOR / OP_L1_BLOCK / selector constant must fail this anchor.
+    // OP_DEPOSITOR = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001
+    const std::array<uint8_t, 20> kDepositor{0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde,
+        0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0x00, 0x01};
+    // OP_L1_BLOCK = 0x4200000000000000000000000000000000000015
+    const std::array<uint8_t, 20> kL1Block{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15};
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        fields[1].begin(), fields[1].end(), kDepositor.begin(), kDepositor.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        fields[2].begin(), fields[2].end(), kL1Block.begin(), kL1Block.end());
+    // mint absent / value 0 / isSystemTx false all RLP-encode as the empty string and
+    // decode back to an empty byte vector.
+    BOOST_CHECK(fields[3].empty());
+    BOOST_CHECK(fields[4].empty());
+    BOOST_CHECK_EQUAL(fields[5], (bcos::bytes{0x0f, 0x42, 0x40}));  // gas 1'000'000, payload only
+    BOOST_CHECK(fields[6].empty());
+    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::IsthmusL1AttributesLen);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        fields[7].begin(), fields[7].begin() + 4, kIsthmusSelector.begin(), kIsthmusSelector.end());
+
+    // sourceHash = keccak(bytes32(1) || keccak(l1Hash[32] || bytes32(seq))) for zero L1 info.
+    // l2Time is not part of the spec preimage.
+    std::array<uint8_t, 64> innerInput{};
+    const auto inner =
+        bcos::crypto::keccak256Hash(bcos::bytesConstRef(innerInput.data(), innerInput.size()));
+    std::array<uint8_t, 64> domainInput{};
+    domainInput[31] = 1;
+    std::copy(inner.begin(), inner.end(), domainInput.begin() + 32);
+    const auto expectedHash =
+        bcos::crypto::keccak256Hash(bcos::bytesConstRef(domainInput.data(), domainInput.size()));
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        fields[0].begin(), fields[0].end(), expectedHash.begin(), expectedHash.end());
+}
+
+// Non-zero L1 info with pairwise-distinct fields: every packed calldata offset must carry
+// exactly its own field, so a mis-offset synthesis (e.g. seq written at [20:28]) fails.
+BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
+{
+    bcos::evm::opstack::L1BlockInfo l1Info;
+    l1Info.sequenceNumber = 0x1122334455667788ull;
+    l1Info.time = 0x2233445566778899ull;
+    l1Info.number = 0x33445566778899aaull;
+    l1Info.baseFee = intx::uint256{0x445566778899aabbull};
+    l1Info.blobBaseFee = intx::uint256{0x5566778899aabbccull};
+    std::array<uint8_t, 32> hashBytes{};
+    for (size_t i = 0; i < hashBytes.size(); ++i)
+    {
+        hashBytes[i] = static_cast<uint8_t>(0x60 + i);
+    }
+    std::copy(hashBytes.begin(), hashBytes.end(), l1Info.blockHash.bytes);
+
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = true}, l1Info);
+    const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
+    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
+    std::vector<bcos::bytes> fields;
+    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
+    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::JovianL1AttributesLen);
+    auto const& calldata = fields[7];
+
+    auto checkBE = [&](size_t offset, uint64_t value) {
+        std::array<uint8_t, 8> be{};
+        bcos::toBigEndian(value, be);
+        BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
+            calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
+    };
+    auto checkBE256 = [&](size_t offset, intx::uint256 const& value) {
+        std::array<uint8_t, 32> be{};
+        intx::be::store(std::span<uint8_t, 32>(be.data(), be.size()), value);
+        BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
+            calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
+    };
+    // Selector [0:4] — independent golden bytes (Jovian).
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        calldata.begin(), calldata.begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
+    checkBE(12, l1Info.sequenceNumber);  // seq
+    checkBE(20, l1Info.time);            // l1 time
+    checkBE(28, l1Info.number);          // l1 number
+    checkBE256(36, l1Info.baseFee);      // l1 baseFee
+    checkBE256(68, l1Info.blobBaseFee);  // l1 blobBaseFee
+    BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + 100, calldata.begin() + 132, hashBytes.begin(),
+        hashBytes.end());  // l1 blockHash
+}
+
+// Same non-zero L1 grid on the Isthmus (176B) form. The Jovian case above does not
+// cover [12:176] when jovianActive is false; an all-zero default L1BlockInfo would
+// hide a swapped seq/time/number store.
+BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
+{
+    bcos::evm::opstack::L1BlockInfo l1Info;
+    l1Info.sequenceNumber = 0x1122334455667788ull;
+    l1Info.time = 0x2233445566778899ull;
+    l1Info.number = 0x33445566778899aaull;
+    l1Info.baseFee = intx::uint256{0x445566778899aabbull};
+    l1Info.blobBaseFee = intx::uint256{0x5566778899aabbccull};
+    std::array<uint8_t, 32> hashBytes{};
+    for (size_t i = 0; i < hashBytes.size(); ++i)
+    {
+        hashBytes[i] = static_cast<uint8_t>(0x60 + i);
+    }
+    std::copy(hashBytes.begin(), hashBytes.end(), l1Info.blockHash.bytes);
+
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = false}, l1Info);
+    const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
+    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
+    std::vector<bcos::bytes> fields;
+    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
+    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::IsthmusL1AttributesLen);
+    auto const& calldata = fields[7];
+
+    auto checkBE = [&](size_t offset, uint64_t value) {
+        std::array<uint8_t, 8> be{};
+        bcos::toBigEndian(value, be);
+        BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
+            calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
+    };
+    auto checkBE256 = [&](size_t offset, intx::uint256 const& value) {
+        std::array<uint8_t, 32> be{};
+        intx::be::store(std::span<uint8_t, 32>(be.data(), be.size()), value);
+        BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
+            calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
+    };
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        calldata.begin(), calldata.begin() + 4, kIsthmusSelector.begin(), kIsthmusSelector.end());
+    checkBE(12, l1Info.sequenceNumber);
+    checkBE(20, l1Info.time);
+    checkBE(28, l1Info.number);
+    checkBE256(36, l1Info.baseFee);
+    checkBE256(68, l1Info.blobBaseFee);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        calldata.begin() + 100, calldata.begin() + 132, hashBytes.begin(), hashBytes.end());
+}
+
+// Jovian: the synthesized deposit carries the Jovian selector and 178B data (with the
+// zero DA-footprint scalar). sourceHash does not bind L2 time.
+BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayoutAndUniqueness)
+{
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = true});
+    const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
+    BOOST_REQUIRE_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
+    bcos::bytesRef cursor(const_cast<bcos::byte*>(env.data() + 1), env.size() - 1);
+    std::vector<bcos::bytes> fields;
+    BOOST_REQUIRE(bcos::codec::rlp::decode(cursor, fields) == nullptr);
+    BOOST_REQUIRE_EQUAL(fields.size(), 8);
+    BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::JovianL1AttributesLen);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        fields[7].begin(), fields[7].begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
+    // [176:178] DA-footprint scalar is zero for the stand-in.
+    BOOST_CHECK_EQUAL(fields[7][176], 0);
+    BOOST_CHECK_EQUAL(fields[7][177], 0);
+
+    const auto envLater = scheduler.synthesizeL1AttributesEnvelope(1001);
+    BOOST_CHECK(env == envLater);  // sourceHash is domain-1(l1Hash, seq), not L2 time
 }
 
 // Note: the empty-block rejection test lives in PreBlockOpStepsTest (RejectsEmptyBlock).

--- a/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
+++ b/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
@@ -70,6 +70,27 @@ using ViewType = typename MLS::ViewType;
 constexpr std::array<uint8_t, 4> kIsthmusSelector{0x09, 0x89, 0x99, 0xbe};
 constexpr std::array<uint8_t, 4> kJovianSelector{0x3d, 0xb6, 0xbe, 0x2b};
 
+/// Fully populated L1 info (snapshot + SystemConfig) for the offset pins.
+bcos::evm::opstack::L1BlockInfo filledL1Info()
+{
+    bcos::evm::opstack::L1BlockInfo l1Info;
+    l1Info.sequenceNumber = 0x1122334455667788ull;
+    l1Info.time = 0x2233445566778899ull;
+    l1Info.number = 0x33445566778899aaull;
+    l1Info.baseFee = intx::uint256{0x445566778899aabbull};
+    l1Info.blobBaseFee = intx::uint256{0x5566778899aabbccull};
+    l1Info.baseFeeScalar = 0xa1b2c3d4u;
+    l1Info.blobBaseFeeScalar = 0x11223344u;
+    l1Info.operatorFeeScalar = 0x55667788u;
+    l1Info.operatorFeeConstant = 0x99aabbccddeeff00ull;
+    for (size_t i = 0; i < sizeof(l1Info.blockHash.bytes); ++i)
+    {
+        l1Info.blockHash.bytes[i] = static_cast<uint8_t>(0x60 + i);
+        l1Info.batcherHash.bytes[i] = static_cast<uint8_t>(0x90 + i);
+    }
+    return l1Info;
+}
+
 }  // namespace
 
 BOOST_AUTO_TEST_SUITE(OpSchedulerSeamSmokeSuite)
@@ -130,15 +151,24 @@ BOOST_AUTO_TEST_CASE(SynthesizeRefusesUnsetL1BlockInfo)
 {
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
         bcos::evm::opstack::OpForkFlags{.jovianActive = false}, {});
-    BOOST_CHECK_THROW((void)scheduler.synthesizeL1AttributesEnvelope(1000), std::invalid_argument);
+    BOOST_CHECK_THROW((void)scheduler.synthesizeL1AttributesEnvelope(), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(SynthesizeRefusesZeroSystemConfig)
+{
+    auto l1Info = filledL1Info();
+    l1Info.baseFeeScalar = 0;
+    std::fill(l1Info.batcherHash.bytes, l1Info.batcherHash.bytes + 32, 0);
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = false}, l1Info);
+    BOOST_CHECK_THROW((void)scheduler.synthesizeL1AttributesEnvelope(), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
 {
     // All-zero L1 is a test-only fixture: call the encoder, not the production seam.
-    constexpr uint64_t kL2Time = 0x123456789abcdef0ull;
-    const auto env = bcos::evm::opstack::synthesizeL1AttributesDeposit(
-        bcos::evm::opstack::L1BlockInfo{}, false, kL2Time);
+    const auto env =
+        bcos::evm::opstack::synthesizeL1AttributesDeposit(bcos::evm::opstack::L1BlockInfo{}, false);
     BOOST_REQUIRE_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
     auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
         bcos::bytesConstRef(env.data(), env.size()));
@@ -169,22 +199,15 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
 
 BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
 {
-    bcos::evm::opstack::L1BlockInfo l1Info;
-    l1Info.sequenceNumber = 0x1122334455667788ull;
-    l1Info.time = 0x2233445566778899ull;
-    l1Info.number = 0x33445566778899aaull;
-    l1Info.baseFee = intx::uint256{0x445566778899aabbull};
-    l1Info.blobBaseFee = intx::uint256{0x5566778899aabbccull};
+    auto const l1Info = filledL1Info();
     std::array<uint8_t, 32> hashBytes{};
-    for (size_t i = 0; i < hashBytes.size(); ++i)
-    {
-        hashBytes[i] = static_cast<uint8_t>(0x60 + i);
-    }
-    std::copy(hashBytes.begin(), hashBytes.end(), l1Info.blockHash.bytes);
+    std::array<uint8_t, 32> batcherBytes{};
+    std::copy_n(l1Info.blockHash.bytes, 32, hashBytes.begin());
+    std::copy_n(l1Info.batcherHash.bytes, 32, batcherBytes.begin());
 
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
         bcos::evm::opstack::OpForkFlags{.jovianActive = true}, l1Info);
-    const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
+    const auto env = scheduler.synthesizeL1AttributesEnvelope();
     auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
         bcos::bytesConstRef(env.data(), env.size()));
     BOOST_REQUIRE_EQUAL(dep.data.size(), bcos::evm::opstack::JovianL1AttributesLen);
@@ -202,9 +225,18 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
         BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
             calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
     };
+    auto checkU32 = [&](size_t offset, uint32_t value) {
+        std::array<uint8_t, 4> be{static_cast<uint8_t>(value >> 24),
+            static_cast<uint8_t>(value >> 16), static_cast<uint8_t>(value >> 8),
+            static_cast<uint8_t>(value)};
+        BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
+            calldata.begin() + static_cast<ptrdiff_t>(offset + 4), be.begin(), be.end());
+    };
     // Selector [0:4].
     BOOST_CHECK_EQUAL_COLLECTIONS(
         calldata.begin(), calldata.begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
+    checkU32(4, l1Info.baseFeeScalar);
+    checkU32(8, l1Info.blobBaseFeeScalar);
     checkBE(12, l1Info.sequenceNumber);  // seq
     checkBE(20, l1Info.time);            // l1 time
     checkBE(28, l1Info.number);          // l1 number
@@ -212,26 +244,23 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
     checkBE256(68, l1Info.blobBaseFee);  // l1 blobBaseFee
     BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + 100, calldata.begin() + 132, hashBytes.begin(),
         hashBytes.end());  // l1 blockHash
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        calldata.begin() + 132, calldata.begin() + 164, batcherBytes.begin(), batcherBytes.end());
+    checkU32(164, l1Info.operatorFeeScalar);
+    checkBE(168, l1Info.operatorFeeConstant);
 }
 
 BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
 {
-    bcos::evm::opstack::L1BlockInfo l1Info;
-    l1Info.sequenceNumber = 0x1122334455667788ull;
-    l1Info.time = 0x2233445566778899ull;
-    l1Info.number = 0x33445566778899aaull;
-    l1Info.baseFee = intx::uint256{0x445566778899aabbull};
-    l1Info.blobBaseFee = intx::uint256{0x5566778899aabbccull};
+    auto const l1Info = filledL1Info();
     std::array<uint8_t, 32> hashBytes{};
-    for (size_t i = 0; i < hashBytes.size(); ++i)
-    {
-        hashBytes[i] = static_cast<uint8_t>(0x60 + i);
-    }
-    std::copy(hashBytes.begin(), hashBytes.end(), l1Info.blockHash.bytes);
+    std::array<uint8_t, 32> batcherBytes{};
+    std::copy_n(l1Info.blockHash.bytes, 32, hashBytes.begin());
+    std::copy_n(l1Info.batcherHash.bytes, 32, batcherBytes.begin());
 
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
         bcos::evm::opstack::OpForkFlags{.jovianActive = false}, l1Info);
-    const auto env = scheduler.synthesizeL1AttributesEnvelope(1000);
+    const auto env = scheduler.synthesizeL1AttributesEnvelope();
     auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
         bcos::bytesConstRef(env.data(), env.size()));
     BOOST_REQUIRE_EQUAL(dep.data.size(), bcos::evm::opstack::IsthmusL1AttributesLen);
@@ -249,8 +278,17 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
         BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
             calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
     };
+    auto checkU32 = [&](size_t offset, uint32_t value) {
+        std::array<uint8_t, 4> be{static_cast<uint8_t>(value >> 24),
+            static_cast<uint8_t>(value >> 16), static_cast<uint8_t>(value >> 8),
+            static_cast<uint8_t>(value)};
+        BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
+            calldata.begin() + static_cast<ptrdiff_t>(offset + 4), be.begin(), be.end());
+    };
     BOOST_CHECK_EQUAL_COLLECTIONS(
         calldata.begin(), calldata.begin() + 4, kIsthmusSelector.begin(), kIsthmusSelector.end());
+    checkU32(4, l1Info.baseFeeScalar);
+    checkU32(8, l1Info.blobBaseFeeScalar);
     checkBE(12, l1Info.sequenceNumber);
     checkBE(20, l1Info.time);
     checkBE(28, l1Info.number);
@@ -258,12 +296,18 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
     checkBE256(68, l1Info.blobBaseFee);
     BOOST_CHECK_EQUAL_COLLECTIONS(
         calldata.begin() + 100, calldata.begin() + 132, hashBytes.begin(), hashBytes.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        calldata.begin() + 132, calldata.begin() + 164, batcherBytes.begin(), batcherBytes.end());
+    checkU32(164, l1Info.operatorFeeScalar);
+    checkBE(168, l1Info.operatorFeeConstant);
 }
 
-BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayoutAndUniqueness)
+BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayout)
 {
+    // The sourceHash is domain-1(l1Hash, seq) — L2 time is deliberately not bound, so the
+    // builder takes no L2-time argument a caller could vary.
     bcos::evm::opstack::L1BlockInfo const unset{};
-    const auto env = bcos::evm::opstack::synthesizeL1AttributesDeposit(unset, true, 1000);
+    const auto env = bcos::evm::opstack::synthesizeL1AttributesDeposit(unset, true);
     BOOST_REQUIRE_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
     auto const dep = bcos::executor_v1::opstack::decodeDepositEnvelope(
         bcos::bytesConstRef(env.data(), env.size()));
@@ -273,9 +317,6 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayoutAndUniqueness)
     // [176:178] DA-footprint scalar is zero.
     BOOST_CHECK_EQUAL(dep.data[176], 0);
     BOOST_CHECK_EQUAL(dep.data[177], 0);
-
-    const auto envLater = bcos::evm::opstack::synthesizeL1AttributesDeposit(unset, true, 1001);
-    BOOST_CHECK(env == envLater);  // sourceHash is domain-1(l1Hash, seq), not L2 time
 }
 
 // Note: the empty-block rejection test lives in PreBlockOpStepsTest (RejectsEmptyBlock).

--- a/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
+++ b/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
@@ -62,9 +62,7 @@ using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, Backend
 using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
 using ViewType = typename MLS::ViewType;
 
-// Independent golden selectors (not the production constants). Two temporary
-// std::array instances in BOOST_CHECK_EQUAL_COLLECTIONS would dangle both
-// iterators, so these live as named constants.
+// Named selectors so BOOST_CHECK_EQUAL_COLLECTIONS does not dangle temporaries.
 constexpr std::array<uint8_t, 4> kIsthmusSelector{0x09, 0x89, 0x99, 0xbe};
 constexpr std::array<uint8_t, 4> kJovianSelector{0x3d, 0xb6, 0xbe, 0x2b};
 
@@ -124,11 +122,6 @@ BOOST_AUTO_TEST_CASE(SynthesizeL1AttributesIsDepositEnvelope)
     BOOST_CHECK_EQUAL(env.front(), static_cast<bcos::byte>(0x7e));
 }
 
-// Production-synthesis layout anchor: the seam's synthesizeL1AttributesEnvelope must produce
-// a 0x7e envelope whose rlp fields carry the op-geth L1-attributes deposit shape — from ==
-// OP_DEPOSITOR, to == OP_L1_BLOCK, gas == c_l1InfoDepositGas, data == Isthmus 176B with the
-// Isthmus selector, and sourceHash == keccak256(bytes32(1) || keccak256(l1Hash || bytes32(seq))).
-// The fixture helper (testutil) is NOT the anchor: this decodes the seam's own output.
 BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
 {
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
@@ -143,20 +136,15 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
     BOOST_REQUIRE_EQUAL(fields.size(), 8);
 
     BOOST_CHECK_EQUAL(fields[0].size(), 32);  // sourceHash
-    // Independent golden bytes (not the production constants): a corrupted
-    // OP_DEPOSITOR / OP_L1_BLOCK / selector constant must fail this anchor.
-    // OP_DEPOSITOR = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001
     const std::array<uint8_t, 20> kDepositor{0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde,
         0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0xde, 0xad, 0x00, 0x01};
-    // OP_L1_BLOCK = 0x4200000000000000000000000000000000000015
     const std::array<uint8_t, 20> kL1Block{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15};
     BOOST_CHECK_EQUAL_COLLECTIONS(
         fields[1].begin(), fields[1].end(), kDepositor.begin(), kDepositor.end());
     BOOST_CHECK_EQUAL_COLLECTIONS(
         fields[2].begin(), fields[2].end(), kL1Block.begin(), kL1Block.end());
-    // mint absent / value 0 / isSystemTx false all RLP-encode as the empty string and
-    // decode back to an empty byte vector.
+    // mint / value / isSystemTx encode as empty RLP items.
     BOOST_CHECK(fields[3].empty());
     BOOST_CHECK(fields[4].empty());
     BOOST_CHECK_EQUAL(fields[5], (bcos::bytes{0x0f, 0x42, 0x40}));  // gas 1'000'000, payload only
@@ -165,8 +153,7 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
     BOOST_CHECK_EQUAL_COLLECTIONS(
         fields[7].begin(), fields[7].begin() + 4, kIsthmusSelector.begin(), kIsthmusSelector.end());
 
-    // sourceHash = keccak(bytes32(1) || keccak(l1Hash[32] || bytes32(seq))) for zero L1 info.
-    // l2Time is not part of the spec preimage.
+    // sourceHash = keccak(bytes32(1) || keccak(l1Hash || bytes32(seq))).
     std::array<uint8_t, 64> innerInput{};
     const auto inner =
         bcos::crypto::keccak256Hash(bcos::bytesConstRef(innerInput.data(), innerInput.size()));
@@ -179,8 +166,6 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositMatchesIsthmusLayout)
         fields[0].begin(), fields[0].end(), expectedHash.begin(), expectedHash.end());
 }
 
-// Non-zero L1 info with pairwise-distinct fields: every packed calldata offset must carry
-// exactly its own field, so a mis-offset synthesis (e.g. seq written at [20:28]) fails.
 BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
 {
     bcos::evm::opstack::L1BlockInfo l1Info;
@@ -217,7 +202,7 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
         BOOST_CHECK_EQUAL_COLLECTIONS(calldata.begin() + static_cast<ptrdiff_t>(offset),
             calldata.begin() + static_cast<ptrdiff_t>(offset + be.size()), be.begin(), be.end());
     };
-    // Selector [0:4] — independent golden bytes (Jovian).
+    // Selector [0:4].
     BOOST_CHECK_EQUAL_COLLECTIONS(
         calldata.begin(), calldata.begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
     checkBE(12, l1Info.sequenceNumber);  // seq
@@ -229,9 +214,6 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsCalldataFieldOffsets)
         hashBytes.end());  // l1 blockHash
 }
 
-// Same non-zero L1 grid on the Isthmus (176B) form. The Jovian case above does not
-// cover [12:176] when jovianActive is false; an all-zero default L1BlockInfo would
-// hide a swapped seq/time/number store.
 BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
 {
     bcos::evm::opstack::L1BlockInfo l1Info;
@@ -279,8 +261,6 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositPinsIsthmusCalldataFieldOffsets)
         calldata.begin() + 100, calldata.begin() + 132, hashBytes.begin(), hashBytes.end());
 }
 
-// Jovian: the synthesized deposit carries the Jovian selector and 178B data (with the
-// zero DA-footprint scalar). sourceHash does not bind L2 time.
 BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayoutAndUniqueness)
 {
     bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
@@ -294,7 +274,7 @@ BOOST_AUTO_TEST_CASE(SynthesizedDepositJovianLayoutAndUniqueness)
     BOOST_REQUIRE_EQUAL(fields[7].size(), bcos::evm::opstack::JovianL1AttributesLen);
     BOOST_CHECK_EQUAL_COLLECTIONS(
         fields[7].begin(), fields[7].begin() + 4, kJovianSelector.begin(), kJovianSelector.end());
-    // [176:178] DA-footprint scalar is zero for the stand-in.
+    // [176:178] DA-footprint scalar is zero.
     BOOST_CHECK_EQUAL(fields[7][176], 0);
     BOOST_CHECK_EQUAL(fields[7][177], 0);
 

--- a/opstack-executor/tests/OpSchedulerTest.cpp
+++ b/opstack-executor/tests/OpSchedulerTest.cpp
@@ -260,6 +260,12 @@ bcos::protocol::Transaction::Ptr buildUnsupportedTypeTx()
 {
     bcostars::Transaction tars;
     tars.extraTransactionBytes.push_back(0x03);
+    // The per-tx type gate attaches transactions[i]->hash() as the culprit; a hash-less
+    // carrier makes TransactionImpl::hash() throw EmptyTransactionHash before the gate
+    // (author commit 4f1144ef1 regression) — carry a synthetic hash like every real
+    // envelope carrier does.
+    bcos::bytes hashBytes(32, 0x03);
+    tars.extraTransactionHash.assign(hashBytes.begin(), hashBytes.end());
     auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
         [tars = std::move(tars)]() mutable { return &tars; });
     return tx;
@@ -1202,6 +1208,32 @@ BOOST_AUTO_TEST_CASE(CallInvalidReturnsError)
             const auto msg = err->errorMessage();
             BOOST_CHECK_MESSAGE(msg.find("consensus rejection") != std::string::npos,
                 "invalid call must not return a status-0 receipt, got: " << msg);
+        });
+    BOOST_REQUIRE(called);
+}
+
+// F10 pin: eth_call with a declared gas above the call context's block gas pool must
+// classify as a consensus rejection (base behaviour, "consensus rejection" wire reason) —
+// the F2 capacity type (OpBlockGasPoolFull) must not escape the public call path as an
+// UnknownError.
+BOOST_AUTO_TEST_CASE(CallGasAboveBlockPoolClassifiesAsConsensusRejected)
+{
+    Fixture f;
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader());
+    auto tx = buildWeb3Tx(/*maxFeePerGas=*/2'000'000'000, /*maxPriorityFeePerGas=*/0);
+    auto* fakeTx = dynamic_cast<FakeCallTx*>(tx.get());
+    BOOST_REQUIRE(fakeTx != nullptr);
+    fakeTx->m_gasLimit = 30'000'001;  // above the call context's 30M block gas pool
+    bool called = false;
+    f.scheduler->call(
+        std::move(tx), [&](bcos::Error::Ptr err, bcos::protocol::TransactionReceipt::Ptr) {
+            called = true;
+            BOOST_REQUIRE(err != nullptr);
+            BOOST_CHECK_EQUAL(
+                err->errorCode(), (int)bcos::scheduler::SchedulerError::OpConsensusRejected);
+            const auto msg = err->errorMessage();
+            BOOST_CHECK_MESSAGE(msg.find("consensus rejection") != std::string::npos,
+                "over-gas call must classify as a consensus rejection, got: " << msg);
         });
     BOOST_REQUIRE(called);
 }
@@ -2199,6 +2231,235 @@ BOOST_AUTO_TEST_CASE(ExecutedHeaderMirrorsAnnouncedEthMetadataFields)
     BOOST_REQUIRE_MESSAGE(executed.parentBeaconBlockRoot().has_value(),
         "parentBeaconBlockRoot presence must survive");
     BOOST_CHECK(*executed.parentBeaconBlockRoot() == *announced->parentBeaconBlockRoot());
+}
+
+// ── adoptProbeAsPending (the OP build path: ONE verify=false probe → adopt, no re-execution) ──
+
+namespace
+{
+/// Drive one block through the engine's OP build slice: a local probe back-fills the announced
+/// header's commitments (production: buildOpPayload rebuilds the final header from the probe
+/// result), then executeBlock(verify=false) runs the scheduler's retained probe,
+/// adoptProbeAsPending pushViews the probe's view WITHOUT re-execution, and commitBlock lands
+/// it. Returns the executed (commitment-filled) header and the local probe's full-rebuild root.
+std::pair<bcos::protocol::BlockHeader::Ptr, bcos::h256> probeAdoptCommit(Fixture& f,
+    std::shared_ptr<bcostars::protocol::BlockHeaderImpl> header,
+    std::vector<bcos::bytes> const& rawTxBytes)
+{
+    auto view = f.multiLayerStorage.forkCommitted();
+    view.newMutable();
+    auto const result = runExecutionProbe(f, view, *header, rawTxBytes);
+    BOOST_REQUIRE_EQUAL(result.receipts.size(), rawTxBytes.size());
+    fillAnnouncedHeader(header, result);
+    auto block = assembleBlock(f, header, rawTxBytes);
+
+    // The scheduler's own probe (verify=false): retains m_lastProbe.
+    auto probeCb = invokeExecute(f, block, /*verify=*/false);
+    BOOST_REQUIRE_MESSAGE(probeCb.err == nullptr,
+        "probe executeBlock " << header->number()
+                              << " failed: " << (probeCb.err ? probeCb.err->errorMessage() : ""));
+    BOOST_REQUIRE(probeCb.header != nullptr);
+
+    ExecuteCb adoptCb;
+    bool called = false;
+    f.scheduler->adoptProbeAsPending(
+        block, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr h, bool) {
+            called = true;
+            adoptCb.err = std::move(e);
+            adoptCb.header = std::move(h);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(adoptCb.err == nullptr,
+        "adoptProbeAsPending " << header->number()
+                               << " failed: " << (adoptCb.err ? adoptCb.err->errorMessage() : ""));
+    BOOST_REQUIRE(adoptCb.header != nullptr);
+    // The adopted header's stateRoot (the scheduler probe's incremental buildAndCollect root)
+    // must equal the local probe's full-rebuild root — the ①a contract pinned by
+    // IncrementalMPTRootMatchesFullRebuild, re-checked here because adopt relies on it.
+    BOOST_REQUIRE_MESSAGE(adoptCb.header->stateRoot() == result.stateRoot,
+        "adopted header stateRoot " << adoptCb.header->stateRoot().hex()
+                                    << " must equal the probe's full-rebuild root "
+                                    << result.stateRoot.hex());
+
+    bcos::Error::Ptr commitErr;
+    called = false;
+    f.scheduler->commitBlock(
+        adoptCb.header, [&](bcos::Error::Ptr e, bcos::ledger::LedgerConfig::Ptr) {
+            called = true;
+            commitErr = std::move(e);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(commitErr == nullptr,
+        "commitBlock " << header->number()
+                       << " failed: " << (commitErr ? commitErr->errorMessage() : ""));
+    return {std::move(adoptCb.header), result.stateRoot};
+}
+
+/// The committed state must carry the block's root trie-node row after an adopt-driven commit.
+/// This is the direct pin on "the probe's retained view already carries the block's persisted
+/// MPT nodes": under the regression (persistTrieNodes re-coupled to verify) the probe runs a
+/// root-only full rebuild, never flushes nodes, and the row is missing.
+void requireCommittedRootNodeRow(Fixture& f, bcos::h256 const& stateRoot, int number)
+{
+    auto view = f.multiLayerStorage.fork();
+    auto nodeRow = bcos::task::syncWait(
+        bcos::storage2::readOne(view, bcos::storage2::mptNodeStateKey(stateRoot)));
+    BOOST_REQUIRE_MESSAGE(nodeRow.has_value(),
+        "block " << number
+                 << "'s adopted probe must persist trie nodes into committed storage "
+                    "(root node row missing for stateRoot "
+                 << stateRoot.hex() << " — persistTrieNodes was likely re-coupled to verify)");
+}
+}  // namespace
+
+/// Task 6b core regression: the adopt path must preserve L2-compat trie persistence across
+/// CONSECUTIVE blocks. The engine executes ONE verify=false probe whose retained view must
+/// already carry the block's persisted MPT nodes + incremental root (OpScheduler decouples
+/// persistTrieNodes from verify). If it were re-coupled (persistTrieNodes = verify && flag),
+/// the probe never flushes nodes; the adopt pushes a node-less view; block 2's probe then
+/// finds no persisted nodes under block 1's root and aborts with an MPTInvariantViolation-
+/// flavored storage fault, and the chain silently loses historical-call service. Pins, per
+/// block: probe → adopt → commit all succeed; the block's root node row is in COMMITTED
+/// storage; block 2's root is block 1's state updated by block 2's writes (equal to the
+/// full-rebuild root); and a historical call at block 1 is served through block 1's persisted
+/// trie answering the PRE-block-2 value.
+BOOST_AUTO_TEST_CASE(adoptPreservesTriePersistenceForNextBlock)
+{
+    const bcos::Address kContract{"0x3000000000000000000000000000000000000000"};
+    const bcos::h256 kV1{"0x00000000000000000000000000000000000000000000000000000000000000a1"};
+    const bcos::h256 kV2{"0x00000000000000000000000000000000000000000000000000000000000000b2"};
+
+    Fixture f;
+    seedL2CompatFeature(f.multiLayerStorage);
+    fundCallAccount(f.multiLayerStorage, kCallSender, f.hashImpl, bcos::u256(1) << 200);
+    seedContractWithSlot(f.multiLayerStorage, kContract, kV1, f.hashImpl);
+    auto const genesisRoot = computeAndPersistGenesisTrie(f.multiLayerStorage);
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader(genesisRoot));
+
+    auto depEnv = encodeDepositEnvelope(makeDeposit());
+    auto eipEvmcBytes = evmc::from_hex(kEip1559EnvelopeHex).value();
+    bcos::bytes eipEnvBytes(eipEvmcBytes.begin(), eipEvmcBytes.end());
+    // Block 2 flips the contract's slot 0 INSIDE the block delta, so block 2's root and trie
+    // nodes differ from block 1's (a no-op block would make the block-2 checks vacuous).
+    bcos::bytes setterEnv = makeSetterDepositEnvelope(kContract, kV2);
+
+    // Block 1: probe → adopt → commit, all succeeding.
+    auto [block1Header, block1Root] =
+        probeAdoptCommit(f, makeHeaderAt(1, bcos::u256(1'000'000'000)), {depEnv, eipEnvBytes});
+    BOOST_CHECK_EQUAL(block1Header->number(), 1);
+    BOOST_CHECK_MESSAGE(block1Root != bcos::h256{}, "block 1 must have a non-zero state root");
+    requireCommittedRootNodeRow(f, block1Root, 1);
+
+    // Block 2 chains on block 1: same probe → adopt → commit flow. The adopted view carries
+    // block 2's own persisted nodes; block 2's root is block 1's state updated by the setter
+    // write (probeAdoptCommit asserts it equals the full-rebuild root over that state).
+    auto [block2Header, block2Root] =
+        probeAdoptCommit(f, makeHeaderAt(2, bcos::u256(2'000'000'000)), {depEnv, setterEnv});
+    BOOST_CHECK_EQUAL(block2Header->number(), 2);
+    BOOST_CHECK_MESSAGE(block2Root != block1Root,
+        "block 2 must advance the state root (the setter deposit changed slot 0)");
+    requireCommittedRootNodeRow(f, block2Root, 2);
+
+    // End-to-end behavioral pin: block 1 is now a HISTORICAL height. Its call must be served
+    // through block 1's persisted trie (the M5 gate) and answer the PRE-block-2 value kV1 —
+    // missing node rows would refuse the call ("no persisted MPT nodes"), and a latest-state
+    // pass-through would answer kV2.
+    auto [err, receipt] =
+        callAt(f, buildWeb3Tx(bcos::u256(30'000'000'000ULL), bcos::u256(0), kContract), 1);
+    BOOST_REQUIRE_MESSAGE(err == nullptr,
+        "historical call at block 1 must be served through its persisted trie, got: "
+            << (err ? err->errorMessage() : ""));
+    BOOST_REQUIRE(receipt != nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);  // FISCO receipt status: 0 = success
+    auto const out = receipt->output();
+    bcos::bytes const outBytes(out.begin(), out.end());
+    bcos::bytes const v1Bytes(kV1.data(), kV1.data() + bcos::h256::SIZE);
+    BOOST_CHECK_MESSAGE(outBytes == v1Bytes, "block-1 call must read slot=V1");
+}
+
+/// Lifecycle guard: adoptProbeAsPending without a retained probe (no prior verify=false
+/// executeBlock — e.g. a double adopt, or an adopt after an aborted build's reset) must refuse
+/// loudly with "no retained probe", never fabricate a pending block.
+BOOST_AUTO_TEST_CASE(adoptRejectsWithoutRetainedProbe)
+{
+    Fixture f;
+    auto block = f.blockFactory->createBlock();
+    block->setBlockHeader(makeHeader());
+
+    bcos::Error::Ptr err;
+    bcos::protocol::BlockHeader::Ptr executedHeader;
+    bool called = false;
+    f.scheduler->adoptProbeAsPending(
+        block, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr h, bool) {
+            called = true;
+            err = std::move(e);
+            executedHeader = std::move(h);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(err != nullptr,
+        "adopt without a retained probe must be refused, not fabricate a pending block");
+    BOOST_TEST_CONTEXT("err message: " << err->errorMessage())
+    {
+        BOOST_CHECK_EQUAL(err->errorCode(), (int)bcos::scheduler::SchedulerError::UnknownError);
+        BOOST_CHECK(err->errorMessage().find("adoptProbeAsPending: no retained probe") !=
+                    std::string::npos);
+    }
+    BOOST_CHECK(executedHeader == nullptr);
+}
+
+/// Deterministic commitment check: adopt must reject a block whose announced header commitments
+/// differ from the retained probe's executed header ("commitment mismatch on field stateRoot"),
+/// never stash a divergent pending. The adopt-side mirror of
+/// VerifyRejectsMismatchedAnnouncedCommitments.
+BOOST_AUTO_TEST_CASE(adoptRejectsCommitmentMismatch)
+{
+    Fixture f;
+    seedL2CompatFeature(f.multiLayerStorage);
+    fundCallAccount(f.multiLayerStorage, kCallSender, f.hashImpl, bcos::u256(1) << 200);
+    auto const genesisRoot = computeAndPersistGenesisTrie(f.multiLayerStorage);
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader(genesisRoot));
+
+    std::vector<bcos::bytes> const rawTxBytes{encodeDepositEnvelope(makeDeposit())};
+
+    // Local probe back-fills the announced header's true commitments, then exactly ONE field is
+    // corrupted. The scheduler probe (verify=false) performs no commitment comparison — it
+    // retains its executed header with the TRUE commitments — so the divergence only surfaces
+    // at adopt. (Mutate before assembly: bcostars setBlockHeader deep-copies the tars inner.)
+    auto header = makeHeaderAt(1, bcos::u256(1'000'000'000));
+    {
+        auto view = f.multiLayerStorage.forkCommitted();
+        view.newMutable();
+        auto const result = runExecutionProbe(f, view, *header, rawTxBytes);
+        BOOST_REQUIRE_EQUAL(result.receipts.size(), rawTxBytes.size());
+        fillAnnouncedHeader(header, result);
+    }
+    header->setStateRoot(commitmentCorruption(0xb7));
+
+    auto block = assembleBlock(f, header, rawTxBytes);
+    auto probeCb = invokeExecute(f, block, /*verify=*/false);
+    BOOST_REQUIRE_MESSAGE(probeCb.err == nullptr,
+        "probe executeBlock failed: " << (probeCb.err ? probeCb.err->errorMessage() : ""));
+
+    bcos::Error::Ptr err;
+    bcos::protocol::BlockHeader::Ptr executedHeader;
+    bool called = false;
+    f.scheduler->adoptProbeAsPending(
+        block, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr h, bool) {
+            called = true;
+            err = std::move(e);
+            executedHeader = std::move(h);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(
+        err != nullptr, "adopt with a divergent announced commitment must be refused");
+    BOOST_TEST_CONTEXT("err message: " << err->errorMessage())
+    {
+        BOOST_CHECK_EQUAL(err->errorCode(), (int)bcos::scheduler::SchedulerError::UnknownError);
+        BOOST_CHECK(err->errorMessage().find(
+                        "adoptProbeAsPending: commitment mismatch on field stateRoot") !=
+                    std::string::npos);
+    }
+    BOOST_CHECK(executedHeader == nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpSchedulerTest.cpp
+++ b/opstack-executor/tests/OpSchedulerTest.cpp
@@ -1231,14 +1231,14 @@ BOOST_AUTO_TEST_CASE(CallGasAboveBlockPoolClassifiesAsConsensusRejected)
             BOOST_CHECK_MESSAGE(msg.find("consensus rejection") != std::string::npos,
                 "over-gas call must classify as a consensus rejection, got: " << msg);
             BOOST_CHECK_MESSAGE(
-                boost::get_error_info<bcos::engine::OpBlockGasPoolFull>(*err) == nullptr,
-                "eth_call must not tag OpBlockGasPoolFull / capacity");
+                boost::get_error_info<bcos::engine::OpRejectIsCapacity>(*err) == nullptr,
+                "eth_call must not tag OpRejectIsCapacity / capacity");
         });
     BOOST_REQUIRE(called);
 }
 
 /// executeBlock: a normal tx that does not fit the remaining pool is a capacity fault
-/// (OpBlockGasPoolFull + no-evict), not the eth_call classification above.
+/// (OpRejectIsCapacity + no-evict), not the eth_call classification above.
 BOOST_AUTO_TEST_CASE(ExecuteBlockGasPoolFullTagsCapacity)
 {
     Fixture f;
@@ -1259,10 +1259,35 @@ BOOST_AUTO_TEST_CASE(ExecuteBlockGasPoolFullTagsCapacity)
     BOOST_CHECK_MESSAGE(out.err->errorMessage().find("block gas pool full") != std::string::npos ||
                             out.err->errorMessage().find("gas limit reached") != std::string::npos,
         "block-path pool full must name the capacity fault, got: " << out.err->errorMessage());
-    auto const* capacity = boost::get_error_info<bcos::engine::OpBlockGasPoolFull>(*out.err);
+    auto const* capacity = boost::get_error_info<bcos::engine::OpRejectIsCapacity>(*out.err);
     BOOST_REQUIRE_MESSAGE(capacity != nullptr && *capacity,
-        "executeBlock pool-full must tag OpBlockGasPoolFull=true (no-evict)");
+        "executeBlock pool-full must tag OpRejectIsCapacity=true (no-evict)");
     BOOST_CHECK(boost::get_error_info<bcos::engine::OpCulpritTxHash>(*out.err) != nullptr);
+    BOOST_CHECK(out.header == nullptr);
+}
+
+/// Deposit gas_limit above the remaining block pool is a capacity fault via the typed
+/// OpDepositGasLimitReached exception (not a message-text match in rethrowExecError).
+BOOST_AUTO_TEST_CASE(ExecuteBlockDepositOverBudgetTagsCapacity)
+{
+    Fixture f;
+    auto dep = makeDeposit();
+    dep.gas_limit = 50'000;
+    auto const depEnv = encodeDepositEnvelope(dep);
+
+    auto header = makeHeader();
+    header->setGasLimit(bcos::u256(30'000));
+
+    auto out = invokeExecute(f, assembleBlock(f, header, {depEnv}), /*verify=*/false);
+    BOOST_REQUIRE(out.err != nullptr);
+    BOOST_CHECK_EQUAL(
+        out.err->errorCode(), (int)bcos::scheduler::SchedulerError::OpConsensusRejected);
+    BOOST_CHECK_MESSAGE(
+        out.err->errorMessage().find("block gas limit reached") != std::string::npos,
+        "deposit over budget must name ErrGasLimitReached, got: " << out.err->errorMessage());
+    auto const* capacity = boost::get_error_info<bcos::engine::OpRejectIsCapacity>(*out.err);
+    BOOST_REQUIRE_MESSAGE(capacity != nullptr && *capacity,
+        "deposit over-budget must tag OpRejectIsCapacity=true (no-evict)");
     BOOST_CHECK(out.header == nullptr);
 }
 
@@ -2474,6 +2499,49 @@ BOOST_AUTO_TEST_CASE(adoptRejectsCommitmentMismatch)
                     std::string::npos);
     }
     BOOST_CHECK(executedHeader == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(adoptRejectsHashMismatchWhenCommitmentsMatch)
+{
+    Fixture f;
+    seedL2CompatFeature(f.multiLayerStorage);
+    fundCallAccount(f.multiLayerStorage, kCallSender, f.hashImpl, bcos::u256(1) << 200);
+    auto const genesisRoot = computeAndPersistGenesisTrie(f.multiLayerStorage);
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader(genesisRoot));
+
+    std::vector<bcos::bytes> const rawTxBytes{encodeDepositEnvelope(makeDeposit())};
+
+    auto header = makeHeaderAt(1, bcos::u256(1'000'000'000));
+    {
+        auto view = f.multiLayerStorage.forkCommitted();
+        view.newMutable();
+        auto const result = runExecutionProbe(f, view, *header, rawTxBytes);
+        BOOST_REQUIRE_EQUAL(result.receipts.size(), rawTxBytes.size());
+        fillAnnouncedHeader(header, result);
+    }
+
+    auto probeBlock = assembleBlock(f, header, rawTxBytes);
+    auto probeCb = invokeExecute(f, probeBlock, /*verify=*/false);
+    BOOST_REQUIRE_MESSAGE(probeCb.err == nullptr,
+        "probe executeBlock failed: " << (probeCb.err ? probeCb.err->errorMessage() : ""));
+
+    // Timestamp is outside headerCommitments; changing it after the probe keeps
+    // commitment equality and must still fail the hash-identity gate.
+    header->setTimestamp(header->timestamp() + 1000);
+    auto adoptBlock = assembleBlock(f, header, rawTxBytes);
+
+    bcos::Error::Ptr err;
+    bool called = false;
+    f.scheduler->adoptProbeAsPending(
+        adoptBlock, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr, bool) {
+            called = true;
+            err = std::move(e);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(err != nullptr, "adopt with a hash-only divergence must be refused");
+    BOOST_CHECK_EQUAL(err->errorCode(), (int)bcos::scheduler::SchedulerError::UnknownError);
+    BOOST_CHECK(
+        err->errorMessage().find("executed header hash does not match") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpSchedulerTest.cpp
+++ b/opstack-executor/tests/OpSchedulerTest.cpp
@@ -260,10 +260,7 @@ bcos::protocol::Transaction::Ptr buildUnsupportedTypeTx()
 {
     bcostars::Transaction tars;
     tars.extraTransactionBytes.push_back(0x03);
-    // The per-tx type gate attaches transactions[i]->hash() as the culprit; a hash-less
-    // carrier makes TransactionImpl::hash() throw EmptyTransactionHash before the gate
-    // (author commit 4f1144ef1 regression) — carry a synthetic hash like every real
-    // envelope carrier does.
+    // hash() must be populated; an empty hash throws before the type gate.
     bcos::bytes hashBytes(32, 0x03);
     tars.extraTransactionHash.assign(hashBytes.begin(), hashBytes.end());
     auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
@@ -1212,10 +1209,7 @@ BOOST_AUTO_TEST_CASE(CallInvalidReturnsError)
     BOOST_REQUIRE(called);
 }
 
-// F10 pin: eth_call with a declared gas above the call context's block gas pool must
-// classify as a consensus rejection (base behaviour, "consensus rejection" wire reason) —
-// the F2 capacity type (OpBlockGasPoolFull) must not escape the public call path as an
-// UnknownError.
+// eth_call over the block gas pool is a consensus rejection, not OpBlockGasPoolFull.
 BOOST_AUTO_TEST_CASE(CallGasAboveBlockPoolClassifiesAsConsensusRejected)
 {
     Fixture f;
@@ -2233,15 +2227,11 @@ BOOST_AUTO_TEST_CASE(ExecutedHeaderMirrorsAnnouncedEthMetadataFields)
     BOOST_CHECK(*executed.parentBeaconBlockRoot() == *announced->parentBeaconBlockRoot());
 }
 
-// ── adoptProbeAsPending (the OP build path: ONE verify=false probe → adopt, no re-execution) ──
+// adoptProbeAsPending: probe (verify=false) then adopt, no second execution.
 
 namespace
 {
-/// Drive one block through the engine's OP build slice: a local probe back-fills the announced
-/// header's commitments (production: buildOpPayload rebuilds the final header from the probe
-/// result), then executeBlock(verify=false) runs the scheduler's retained probe,
-/// adoptProbeAsPending pushViews the probe's view WITHOUT re-execution, and commitBlock lands
-/// it. Returns the executed (commitment-filled) header and the local probe's full-rebuild root.
+/// Probe, adopt, and commit one block. Returns the executed header and the probe state root.
 std::pair<bcos::protocol::BlockHeader::Ptr, bcos::h256> probeAdoptCommit(Fixture& f,
     std::shared_ptr<bcostars::protocol::BlockHeaderImpl> header,
     std::vector<bcos::bytes> const& rawTxBytes)
@@ -2253,7 +2243,6 @@ std::pair<bcos::protocol::BlockHeader::Ptr, bcos::h256> probeAdoptCommit(Fixture
     fillAnnouncedHeader(header, result);
     auto block = assembleBlock(f, header, rawTxBytes);
 
-    // The scheduler's own probe (verify=false): retains m_lastProbe.
     auto probeCb = invokeExecute(f, block, /*verify=*/false);
     BOOST_REQUIRE_MESSAGE(probeCb.err == nullptr,
         "probe executeBlock " << header->number()
@@ -2273,9 +2262,6 @@ std::pair<bcos::protocol::BlockHeader::Ptr, bcos::h256> probeAdoptCommit(Fixture
         "adoptProbeAsPending " << header->number()
                                << " failed: " << (adoptCb.err ? adoptCb.err->errorMessage() : ""));
     BOOST_REQUIRE(adoptCb.header != nullptr);
-    // The adopted header's stateRoot (the scheduler probe's incremental buildAndCollect root)
-    // must equal the local probe's full-rebuild root — the ①a contract pinned by
-    // IncrementalMPTRootMatchesFullRebuild, re-checked here because adopt relies on it.
     BOOST_REQUIRE_MESSAGE(adoptCb.header->stateRoot() == result.stateRoot,
         "adopted header stateRoot " << adoptCb.header->stateRoot().hex()
                                     << " must equal the probe's full-rebuild root "
@@ -2295,10 +2281,7 @@ std::pair<bcos::protocol::BlockHeader::Ptr, bcos::h256> probeAdoptCommit(Fixture
     return {std::move(adoptCb.header), result.stateRoot};
 }
 
-/// The committed state must carry the block's root trie-node row after an adopt-driven commit.
-/// This is the direct pin on "the probe's retained view already carries the block's persisted
-/// MPT nodes": under the regression (persistTrieNodes re-coupled to verify) the probe runs a
-/// root-only full rebuild, never flushes nodes, and the row is missing.
+/// After adopt+commit, the block's root trie node must be in committed storage.
 void requireCommittedRootNodeRow(Fixture& f, bcos::h256 const& stateRoot, int number)
 {
     auto view = f.multiLayerStorage.fork();
@@ -2312,17 +2295,7 @@ void requireCommittedRootNodeRow(Fixture& f, bcos::h256 const& stateRoot, int nu
 }
 }  // namespace
 
-/// Task 6b core regression: the adopt path must preserve L2-compat trie persistence across
-/// CONSECUTIVE blocks. The engine executes ONE verify=false probe whose retained view must
-/// already carry the block's persisted MPT nodes + incremental root (OpScheduler decouples
-/// persistTrieNodes from verify). If it were re-coupled (persistTrieNodes = verify && flag),
-/// the probe never flushes nodes; the adopt pushes a node-less view; block 2's probe then
-/// finds no persisted nodes under block 1's root and aborts with an MPTInvariantViolation-
-/// flavored storage fault, and the chain silently loses historical-call service. Pins, per
-/// block: probe → adopt → commit all succeed; the block's root node row is in COMMITTED
-/// storage; block 2's root is block 1's state updated by block 2's writes (equal to the
-/// full-rebuild root); and a historical call at block 1 is served through block 1's persisted
-/// trie answering the PRE-block-2 value.
+// Consecutive adopt+commit blocks keep trie nodes so a historical call at block 1 still works.
 BOOST_AUTO_TEST_CASE(adoptPreservesTriePersistenceForNextBlock)
 {
     const bcos::Address kContract{"0x3000000000000000000000000000000000000000"};
@@ -2339,20 +2312,15 @@ BOOST_AUTO_TEST_CASE(adoptPreservesTriePersistenceForNextBlock)
     auto depEnv = encodeDepositEnvelope(makeDeposit());
     auto eipEvmcBytes = evmc::from_hex(kEip1559EnvelopeHex).value();
     bcos::bytes eipEnvBytes(eipEvmcBytes.begin(), eipEvmcBytes.end());
-    // Block 2 flips the contract's slot 0 INSIDE the block delta, so block 2's root and trie
-    // nodes differ from block 1's (a no-op block would make the block-2 checks vacuous).
     bcos::bytes setterEnv = makeSetterDepositEnvelope(kContract, kV2);
 
-    // Block 1: probe → adopt → commit, all succeeding.
+    // Block 1.
     auto [block1Header, block1Root] =
         probeAdoptCommit(f, makeHeaderAt(1, bcos::u256(1'000'000'000)), {depEnv, eipEnvBytes});
     BOOST_CHECK_EQUAL(block1Header->number(), 1);
     BOOST_CHECK_MESSAGE(block1Root != bcos::h256{}, "block 1 must have a non-zero state root");
     requireCommittedRootNodeRow(f, block1Root, 1);
 
-    // Block 2 chains on block 1: same probe → adopt → commit flow. The adopted view carries
-    // block 2's own persisted nodes; block 2's root is block 1's state updated by the setter
-    // write (probeAdoptCommit asserts it equals the full-rebuild root over that state).
     auto [block2Header, block2Root] =
         probeAdoptCommit(f, makeHeaderAt(2, bcos::u256(2'000'000'000)), {depEnv, setterEnv});
     BOOST_CHECK_EQUAL(block2Header->number(), 2);
@@ -2360,10 +2328,6 @@ BOOST_AUTO_TEST_CASE(adoptPreservesTriePersistenceForNextBlock)
         "block 2 must advance the state root (the setter deposit changed slot 0)");
     requireCommittedRootNodeRow(f, block2Root, 2);
 
-    // End-to-end behavioral pin: block 1 is now a HISTORICAL height. Its call must be served
-    // through block 1's persisted trie (the M5 gate) and answer the PRE-block-2 value kV1 —
-    // missing node rows would refuse the call ("no persisted MPT nodes"), and a latest-state
-    // pass-through would answer kV2.
     auto [err, receipt] =
         callAt(f, buildWeb3Tx(bcos::u256(30'000'000'000ULL), bcos::u256(0), kContract), 1);
     BOOST_REQUIRE_MESSAGE(err == nullptr,
@@ -2377,9 +2341,6 @@ BOOST_AUTO_TEST_CASE(adoptPreservesTriePersistenceForNextBlock)
     BOOST_CHECK_MESSAGE(outBytes == v1Bytes, "block-1 call must read slot=V1");
 }
 
-/// Lifecycle guard: adoptProbeAsPending without a retained probe (no prior verify=false
-/// executeBlock — e.g. a double adopt, or an adopt after an aborted build's reset) must refuse
-/// loudly with "no retained probe", never fabricate a pending block.
 BOOST_AUTO_TEST_CASE(adoptRejectsWithoutRetainedProbe)
 {
     Fixture f;
@@ -2407,10 +2368,6 @@ BOOST_AUTO_TEST_CASE(adoptRejectsWithoutRetainedProbe)
     BOOST_CHECK(executedHeader == nullptr);
 }
 
-/// Deterministic commitment check: adopt must reject a block whose announced header commitments
-/// differ from the retained probe's executed header ("commitment mismatch on field stateRoot"),
-/// never stash a divergent pending. The adopt-side mirror of
-/// VerifyRejectsMismatchedAnnouncedCommitments.
 BOOST_AUTO_TEST_CASE(adoptRejectsCommitmentMismatch)
 {
     Fixture f;
@@ -2421,10 +2378,6 @@ BOOST_AUTO_TEST_CASE(adoptRejectsCommitmentMismatch)
 
     std::vector<bcos::bytes> const rawTxBytes{encodeDepositEnvelope(makeDeposit())};
 
-    // Local probe back-fills the announced header's true commitments, then exactly ONE field is
-    // corrupted. The scheduler probe (verify=false) performs no commitment comparison — it
-    // retains its executed header with the TRUE commitments — so the divergence only surfaces
-    // at adopt. (Mutate before assembly: bcostars setBlockHeader deep-copies the tars inner.)
     auto header = makeHeaderAt(1, bcos::u256(1'000'000'000));
     {
         auto view = f.multiLayerStorage.forkCommitted();

--- a/opstack-executor/tests/OpSchedulerTest.cpp
+++ b/opstack-executor/tests/OpSchedulerTest.cpp
@@ -20,6 +20,7 @@
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
 #include <bcos-evm/adapter/StateRootCompute.h>
+#include <bcos-framework/engine/Errors.h>
 #include <bcos-framework/ledger/FeaturesStorage.h>  // writeToStorage (seedL2CompatFeature)
 #include <bcos-framework/ledger/LedgerConfig.h>
 #include <bcos-framework/protocol/Transaction.h>
@@ -40,6 +41,7 @@
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/Error.h>
+#include <boost/exception/get_error_info.hpp>
 #include <boost/test/unit_test.hpp>
 #include <bcos-evm/eth/state/hash_utils.hpp>
 #include <evmc/evmc.hpp>
@@ -1228,8 +1230,40 @@ BOOST_AUTO_TEST_CASE(CallGasAboveBlockPoolClassifiesAsConsensusRejected)
             const auto msg = err->errorMessage();
             BOOST_CHECK_MESSAGE(msg.find("consensus rejection") != std::string::npos,
                 "over-gas call must classify as a consensus rejection, got: " << msg);
+            BOOST_CHECK_MESSAGE(
+                boost::get_error_info<bcos::engine::OpBlockGasPoolFull>(*err) == nullptr,
+                "eth_call must not tag OpBlockGasPoolFull / capacity");
         });
     BOOST_REQUIRE(called);
+}
+
+/// executeBlock: a normal tx that does not fit the remaining pool is a capacity fault
+/// (OpBlockGasPoolFull + no-evict), not the eth_call classification above.
+BOOST_AUTO_TEST_CASE(ExecuteBlockGasPoolFullTagsCapacity)
+{
+    Fixture f;
+    auto dep = makeDeposit();
+    dep.gas_limit = 25'000;
+    auto const depEnv = encodeDepositEnvelope(dep);
+    auto const eipEvmcBytes = evmc::from_hex(kEip1559EnvelopeHex).value();
+    bcos::bytes const eipEnvBytes(eipEvmcBytes.begin(), eipEvmcBytes.end());
+
+    auto header = makeHeader();
+    // 30k admits the 25k deposit; leftover after deposit used-gas is < eip1559's 21k.
+    header->setGasLimit(bcos::u256(30'000));
+
+    auto out = invokeExecute(f, assembleBlock(f, header, {depEnv, eipEnvBytes}), /*verify=*/false);
+    BOOST_REQUIRE(out.err != nullptr);
+    BOOST_CHECK_EQUAL(
+        out.err->errorCode(), (int)bcos::scheduler::SchedulerError::OpConsensusRejected);
+    BOOST_CHECK_MESSAGE(out.err->errorMessage().find("block gas pool full") != std::string::npos ||
+                            out.err->errorMessage().find("gas limit reached") != std::string::npos,
+        "block-path pool full must name the capacity fault, got: " << out.err->errorMessage());
+    auto const* capacity = boost::get_error_info<bcos::engine::OpBlockGasPoolFull>(*out.err);
+    BOOST_REQUIRE_MESSAGE(capacity != nullptr && *capacity,
+        "executeBlock pool-full must tag OpBlockGasPoolFull=true (no-evict)");
+    BOOST_CHECK(boost::get_error_info<bcos::engine::OpCulpritTxHash>(*out.err) != nullptr);
+    BOOST_CHECK(out.header == nullptr);
 }
 
 /// Scheduler-level call-chain (OpScheduler::call → coCallLatest → buildOpBlockInfo) baseFee
@@ -2366,6 +2400,33 @@ BOOST_AUTO_TEST_CASE(adoptRejectsWithoutRetainedProbe)
                     std::string::npos);
     }
     BOOST_CHECK(executedHeader == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(verifyTrueClearsRetainedProbe)
+{
+    Fixture f;
+    auto depEnv = encodeDepositEnvelope(makeDeposit());
+    auto probe = executeOpBlock(f, makeHeader(), {depEnv}, /*verify=*/false);
+    BOOST_REQUIRE_MESSAGE(
+        probe.err == nullptr, "probe: " << (probe.err ? probe.err->errorMessage() : ""));
+    auto verified = executeOpBlock(f, makeHeader(), {depEnv}, /*verify=*/true);
+    BOOST_REQUIRE_MESSAGE(verified.err == nullptr,
+        "verify=true: " << (verified.err ? verified.err->errorMessage() : ""));
+
+    auto block = f.blockFactory->createBlock();
+    block->setBlockHeader(makeHeader());
+    bcos::Error::Ptr err;
+    bool called = false;
+    f.scheduler->adoptProbeAsPending(
+        block, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr, bool) {
+            called = true;
+            err = std::move(e);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK_EQUAL(err->errorCode(), (int)bcos::scheduler::SchedulerError::UnknownError);
+    BOOST_CHECK(
+        err->errorMessage().find("adoptProbeAsPending: no retained probe") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(adoptRejectsCommitmentMismatch)

--- a/opstack-executor/tests/PreBlockOpStepsTest.cpp
+++ b/opstack-executor/tests/PreBlockOpStepsTest.cpp
@@ -257,6 +257,19 @@ BOOST_AUTO_TEST_CASE(JovianRejectsBadSelector)
     BOOST_CHECK_THROW(f.run(op::jovianConfig(), {kDepositEnvelope}, {dep}), OpConsensusError);
 }
 
+BOOST_AUTO_TEST_CASE(AcceptsFirstDepositThatIsNotL1Attributes)
+{
+    // R128: op-geth EL only requires txs[0].IsDepositTx (rollup_cost.go CalcDAFootprint).
+    // A user deposit in slot 0 is a CL derivation miss; rejecting it here would diverge.
+    Fixture f;
+    auto dep = depositWithData(l1AttributesData(op::IsthmusL1AttributesLen));
+    dep.from = evmc::address{};
+    dep.to = evmc::address{};
+    BOOST_REQUIRE(!op::isL1AttributesTx(dep));
+    BOOST_CHECK_NO_THROW(f.run(op::isthmusConfig(), {kDepositEnvelope}, {dep}));
+    BOOST_CHECK(f.hashes.has_value());
+}
+
 BOOST_AUTO_TEST_CASE(IsthmusAcceptsAndLeavesScalarEmpty)
 {
     Fixture f;

--- a/opstack-executor/tests/PreBlockOpStepsTest.cpp
+++ b/opstack-executor/tests/PreBlockOpStepsTest.cpp
@@ -259,8 +259,7 @@ BOOST_AUTO_TEST_CASE(JovianRejectsBadSelector)
 
 BOOST_AUTO_TEST_CASE(AcceptsFirstDepositThatIsNotL1Attributes)
 {
-    // R128: op-geth EL only requires txs[0].IsDepositTx (rollup_cost.go CalcDAFootprint).
-    // A user deposit in slot 0 is a CL derivation miss; rejecting it here would diverge.
+    // First tx must be a deposit; it does not have to be the L1-attributes deposit.
     Fixture f;
     auto dep = depositWithData(l1AttributesData(op::IsthmusL1AttributesLen));
     dep.from = evmc::address{};


### PR DESCRIPTION
## Summary
- Map typed Engine failures at the RPC endpoint: `InvalidPayloadAttributes` → `-38003`, `InvalidForkchoiceState` → `-38002`, `UnsupportedFork` → `-38005`.
- Bound concurrent OP `engine_newPayloadV4` to one in-flight execution. A second V4 call answers `SYNCING` with an explicit `PayloadStatus{status=Syncing, latestValidHash=nullopt, validationError=nullopt}` (not a default-constructed status).
- Why only V4 is gated: this latch is the OP Isthmus execution face (`executionRequests` / OP `newPayloadV4`). Concurrent V1–V3 calls are not that face; they still serialize through OpScheduler's try-lock and surface as an error rather than `SYNCING`.
- Reject odd-nibble hex on Engine DATA (`extraData`, `logsBloom`, `eip1559Params`, `executionRequests`).
- OP execution helpers: L1-attributes deposit synthesis (SystemConfig scalars, `batcherHash` and the operator-fee pair carried by `L1BlockInfo` and encoded at the op-node Isthmus/Jovian offsets; the seam refuses an unset SystemConfig), `OpScheduler::adoptProbeAsPending` (commitment match plus executed vs announced header hash), and block-gas-pool capacity via typed `OpDepositGasLimitReached` / `OpRejectIsCapacity`. Culprit `hash()` runs only on reject paths.
- `EngineServiceImpl` uses the shared `OpBaseFee.h` extraData / eip1559 helpers; the file-local copies are gone.

## Follow-up
- The synthesized L1-attributes deposit now encodes SystemConfig scalars, `batcherHash` and the operator-fee pair; `synthesizeL1AttributesEnvelope` refuses an unset SystemConfig (zero `baseFeeScalar` or zero `batcherHash`) — fail-closed in code, not by promise. The Jovian DA-footprint scalar at `[176:178]` stays zero (op-node decodes zero as its default).
- `gasLimit` is still parsed on the Engine path and ignored by `buildPayload` (outside this diff). That gap is unchanged; this PR only dropped the in-code note.

## Test plan
- [x] `EngineRpcTest` (`newPayloadV4`, `newPayloadV4BusyReturnsSyncing`, `newPayloadV4InvalidPayloadAttributesMapsTo38003`)
- [x] `EngineTimestampBoundaryTest`
- [x] `OpSchedulerTest` (capacity tags, adopt commitment/hash mismatch, `verifyTrueClearsRetainedProbe`)
- [x] `OpDepositTest` (`GasLimitOverBlockBudgetIsBlockError`)
- [x] `JovianExtraDataTest`
- [x] `OpSchedulerSeamSmokeTest`, `OpCommonTest`
