### PR TITLE
Refactor gateway/AMOP network path to coroutine-based interfaces

### DIFF
--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -61,6 +61,9 @@ public:
      * @brief: get nodeIDs from gateway
      * @param: _groupID
      * @return {error, groupNodeInfo}: error is nullptr on success
+     * @note coroutine: _groupID is passed by reference and the coroutine frame holds the
+     *       reference (not a copy) across suspensions — the caller must keep it alive until the
+     *       returned task completes (e.g. own it in a task::wait frame); do not pass a temporary.
      */
     virtual task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo(
         const std::string& _groupID) = 0;
@@ -115,11 +118,17 @@ public:
     /**
      * @brief: send message to a random node subscribed to _topic
      * @return {error, responseType, responseData}: error is nullptr on success
+     * @note coroutine: _topic is passed by reference and the coroutine frame holds the reference
+     *       (not a copy) across suspensions — the caller must keep it alive until the returned
+     *       task completes (e.g. own it in a task::wait frame); do not pass a temporary.
      */
     virtual task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) = 0;
     /**
      * @brief: broadcast message to all nodes subscribed to _topic
+     * @note coroutine: _topic is passed by reference and the coroutine frame holds the reference
+     *       (not a copy) across suspensions — the caller must keep it alive until the returned
+     *       task completes (e.g. own it in a task::wait frame); do not pass a temporary.
      */
     virtual task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) = 0;

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -30,6 +30,7 @@
 #include <bcos-utilities/Error.h>
 #include <memory>
 #include <range/v3/view/any_view.hpp>
+#include <tuple>
 
 namespace bcos
 {
@@ -59,18 +60,15 @@ public:
     /**
      * @brief: get nodeIDs from gateway
      * @param: _groupID
-     * @param _getGroupNodeInfoFunc: get nodeIDs callback
-     * @return void
+     * @return {error, groupNodeInfo}: error is nullptr on success
      */
-    virtual void asyncGetGroupNodeInfo(
-        const std::string& _groupID, GetGroupNodeInfoFunc _getGroupNodeInfoFunc) = 0;
+    virtual task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo(
+        const std::string& _groupID) = 0;
     /**
      * @brief: get connected peers
-     * @param _callback:
-     * @return void
+     * @return {error, localGatewayInfo, peerGatewayInfos}: error is nullptr on success
      */
-    virtual void asyncGetPeers(
-        std::function<void(Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr)> _callback) = 0;
+    virtual task::Task<std::tuple<Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr>> getPeers() = 0;
     /**
      * @brief: send message to a single node
      * @param _groupID: groupID
@@ -113,9 +111,17 @@ public:
         bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(Error::Ptr&&)>) = 0;
 
     /// for AMOP
-    virtual void asyncSendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc) = 0;
-    virtual void asyncSendBroadcastMessageByTopic(
+
+    /**
+     * @brief: send message to a random node subscribed to _topic
+     * @return {error, responseType, responseData}: error is nullptr on success
+     */
+    virtual task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
+        const std::string& _topic, bcos::bytesConstRef _data) = 0;
+    /**
+     * @brief: broadcast message to all nodes subscribed to _topic
+     */
+    virtual task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) = 0;
 
     virtual void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,

--- a/bcos-framework/bcos-framework/rpc/RPCInterface.h
+++ b/bcos-framework/bcos-framework/rpc/RPCInterface.h
@@ -70,6 +70,9 @@ public:
      *
      * @param _requestData the AMOP data
      * @return {error, responseData}: error is nullptr on success
+     * @note coroutine: _topic is passed by reference and the coroutine frame holds the reference
+     *       (not a copy) across suspensions — the caller must keep it alive until the returned
+     *       task completes (e.g. own it in a task::wait frame); do not pass a temporary.
      */
     virtual task::Task<std::tuple<Error::Ptr, bytesPointer>> notifyAMOPMessage(
         int16_t _type, std::string const& _topic, bytesConstRef _requestData) = 0;

--- a/bcos-framework/bcos-framework/rpc/RPCInterface.h
+++ b/bcos-framework/bcos-framework/rpc/RPCInterface.h
@@ -21,7 +21,9 @@
 
 #include "bcos-framework/multigroup/GroupInfo.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
+#include <bcos-task/Task.h>
 #include <bcos-utilities/Error.h>
+#include <tuple>
 
 namespace bcos
 {
@@ -67,11 +69,10 @@ public:
      * @brief receive the amop message from the gateway
      *
      * @param _requestData the AMOP data
-     * @param _callback the callback
+     * @return {error, responseData}: error is nullptr on success
      */
-    virtual void asyncNotifyAMOPMessage(int16_t _type, std::string const& _topic,
-        bytesConstRef _requestData,
-        std::function<void(Error::Ptr&& _error, bytesPointer _responseData)> _callback) = 0;
+    virtual task::Task<std::tuple<Error::Ptr, bytesPointer>> notifyAMOPMessage(
+        int16_t _type, std::string const& _topic, bytesConstRef _requestData) = 0;
 
     // the gateway notify the rpc to re-subscribe the topic when the gateway set-up
     virtual void asyncNotifySubscribeTopic(

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -261,13 +261,18 @@ public:
             _id, _moduleId, std::move(_nodeID), _responseData, _receiveCallback);
     }
 
-    void asyncGetGroupNodeInfo(
-        const std::string& _groupID, GetGroupNodeInfoFunc _getGroupNodeInfoFunc) override
-    {}
-    void asyncGetPeers(
-        std::function<void(Error::Ptr, gateway::GatewayInfo::Ptr, gateway::GatewayInfosPtr)>
-            _callback) override
-    {}
+    task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo(
+        const std::string& /*_groupID*/) override
+    {
+        co_return std::make_tuple(
+            Error::Ptr(nullptr), bcos::gateway::GroupNodeInfo::Ptr(nullptr));
+    }
+    task::Task<std::tuple<Error::Ptr, gateway::GatewayInfo::Ptr, gateway::GatewayInfosPtr>>
+    getPeers() override
+    {
+        co_return std::make_tuple(Error::Ptr(nullptr), gateway::GatewayInfo::Ptr(nullptr),
+            gateway::GatewayInfosPtr(nullptr));
+    }
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override
@@ -277,12 +282,16 @@ public:
     void asyncNotifyGroupInfo(
         bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(Error::Ptr&&)> function) override
     {}
-    void asyncSendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc) override
-    {}
-    void asyncSendBroadcastMessageByTopic(
-        const std::string& _topic, bcos::bytesConstRef _data) override
-    {}
+    task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
+        const std::string& /*_topic*/, bcos::bytesConstRef /*_data*/) override
+    {
+        co_return std::make_tuple(Error::Ptr(nullptr), int16_t(0), bcos::bytes{});
+    }
+    task::Task<void> sendBroadcastMessageByTopic(
+        const std::string& /*_topic*/, bcos::bytesConstRef /*_data*/) override
+    {
+        co_return;
+    }
     void asyncSubscribeTopic(const std::string& _clientID, const std::string& _topicInfo,
         std::function<void(Error::Ptr&&)> _callback) override
     {}

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -251,25 +251,26 @@ void FrontService::start()
     // try to getNodeIDs from gateway
     auto self = std::weak_ptr<FrontService>(
         std::static_pointer_cast<FrontService>(shared_from_this()));
-    m_gatewayInterface->asyncGetGroupNodeInfo(m_groupID,
-        [self](const Error::Ptr& _error, const bcos::gateway::GroupNodeInfo::Ptr& _groupNodeInfo) {
-            if (_error)
-            {
-                FRONT_LOG(ERROR) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo failed")
-                                 << LOG_KV("code", _error->errorCode())
-                                 << LOG_KV("message", _error->errorMessage());
-                return;
-            }
+    task::wait([](std::weak_ptr<FrontService> self,
+                   bcos::gateway::GatewayInterface::Ptr gateway,
+                   std::string groupID) -> bcos::task::Task<void> {
+        auto [error, groupNodeInfo] = co_await gateway->getGroupNodeInfo(groupID);
+        if (error)
+        {
+            FRONT_LOG(ERROR) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo failed")
+                             << LOG_KV("code", error->errorCode())
+                             << LOG_KV("message", error->errorMessage());
+            co_return;
+        }
+        auto frontService = self.lock();
+        if (frontService && groupNodeInfo)
+        {
             FRONT_LOG(INFO) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo callback")
-                            << LOG_KV("node size",
-                                   _groupNodeInfo ? _groupNodeInfo->nodeIDList().size() : 0);
-            auto frontService = self.lock();
-            if (frontService)
-            {
-                frontService->onReceiveGroupNodeInfo(
-                    frontService->groupID(), _groupNodeInfo, nullptr);
-            }
-        });
+                            << LOG_KV("node size", groupNodeInfo->nodeIDList().size());
+            frontService->onReceiveGroupNodeInfo(
+                frontService->groupID(), groupNodeInfo, nullptr);
+        }
+    }(self, m_gatewayInterface, m_groupID));
 
     FRONT_LOG(INFO) << LOG_DESC("start") << LOG_KV("nodeID", m_nodeID->hex())
                     << LOG_KV("groupID", m_groupID);

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -52,19 +52,24 @@ public:
      */
     void start() override {}
     void stop() override {}
-    void asyncGetPeers(std::function<void(
-            Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>) override
-    {}
+    task::Task<std::tuple<Error::Ptr, bcos::gateway::GatewayInfo::Ptr,
+        bcos::gateway::GatewayInfosPtr>>
+    getPeers() override
+    {
+        co_return std::make_tuple(Error::Ptr(nullptr),
+            bcos::gateway::GatewayInfo::Ptr(nullptr), bcos::gateway::GatewayInfosPtr(nullptr));
+    }
     /**
      * @brief: get nodeIDs from gateway
      * @param _groupID:
-     * @param _onGetGroupNodeInfo: get nodeIDs callback
-     * @return void
+     * @return {error, groupNodeInfo}: error is nullptr on success
      */
-    void asyncGetGroupNodeInfo(
-        const std::string& _groupID, GetGroupNodeInfoFunc _onGetGroupNodeInfo) override
+    task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo(
+        const std::string& _groupID) override
     {
-        boost::ignore_unused(_groupID, _onGetGroupNodeInfo);
+        boost::ignore_unused(_groupID);
+        co_return std::make_tuple(
+            Error::Ptr(nullptr), bcos::gateway::GroupNodeInfo::Ptr(nullptr));
     }
 
     /**
@@ -88,10 +93,15 @@ public:
         bcos::group::GroupInfo::Ptr, std::function<void(Error::Ptr&&)>) override
     {}
 
-    void asyncSendMessageByTopic(const std::string&, bcos::bytesConstRef,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)>) override
-    {}
-    void asyncSendBroadcastMessageByTopic(const std::string&, bcos::bytesConstRef) override {}
+    task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
+        const std::string&, bcos::bytesConstRef) override
+    {
+        co_return std::make_tuple(Error::Ptr(nullptr), int16_t(0), bcos::bytes{});
+    }
+    task::Task<void> sendBroadcastMessageByTopic(const std::string&, bcos::bytesConstRef) override
+    {
+        co_return;
+    }
 
     void asyncSubscribeTopic(
         std::string const&, std::string const&, std::function<void(Error::Ptr&&)>) override

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -89,13 +89,8 @@ void Gateway::stop()
     GATEWAY_LOG(INFO) << LOG_DESC("stop end.");
 }
 
-void Gateway::asyncGetPeers(
-    std::function<void(Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr)> _onGetPeers)
+bcos::task::Task<std::tuple<Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr>> Gateway::getPeers()
 {
-    if (!_onGetPeers)
-    {
-        return;
-    }
     auto sessionInfos = m_p2pInterface->sessionInfos();
     auto peersNodeIDList = m_gatewayNodeManager->peersRouterTable()->getAllPeers();
     GatewayInfosPtr peerGatewayInfos = std::make_shared<GatewayInfos>();
@@ -122,20 +117,19 @@ void Gateway::asyncGetPeers(
     auto localGatewayInfo = std::make_shared<GatewayInfo>(localP2pInfo);
     auto localNodeInfo = m_gatewayNodeManager->localRouterTable()->nodeListInfo();
     localGatewayInfo->setNodeIDInfo(std::move(localNodeInfo));
-    _onGetPeers(nullptr, localGatewayInfo, peerGatewayInfos);
+    co_return std::make_tuple(nullptr, std::move(localGatewayInfo), std::move(peerGatewayInfos));
 }
 
 /**
  * @brief: get nodeIDs from gateway
  * @param _groupID:
- * @param _onGetGroupNodeInfo: get nodeIDs callback
- * @return void
+ * @return {error, groupNodeInfo}: error is nullptr on success
  */
-void Gateway::asyncGetGroupNodeInfo(
-    const std::string& _groupID, GetGroupNodeInfoFunc _onGetGroupNodeInfo)
+bcos::task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+Gateway::getGroupNodeInfo(const std::string& _groupID)
 {
     auto groupNodeInfo = m_gatewayNodeManager->getGroupNodeInfoList(_groupID);
-    _onGetGroupNodeInfo(nullptr, groupNodeInfo);
+    co_return std::make_tuple(nullptr, std::move(groupNodeInfo));
 }
 
 
@@ -623,24 +617,24 @@ bcos::gateway::GatewayNodeManager::Ptr bcos::gateway::Gateway::gatewayNodeManage
 {
     return m_gatewayNodeManager;
 }
-void bcos::gateway::Gateway::asyncSendMessageByTopic(const std::string& _topic,
-    bcos::bytesConstRef _data,
-    std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>>
+bcos::gateway::Gateway::sendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data)
 {
     if (m_amop)
     {
-        m_amop->asyncSendMessageByTopic(_topic, _data, std::move(_respFunc));
-        return;
+        co_return co_await m_amop->sendMessageByTopic(_topic, _data);
     }
-    _respFunc(BCOS_ERROR_PTR(-1, "AMOP is not initialized"), 0, {});
+    co_return std::make_tuple(BCOS_ERROR_PTR(-1, "AMOP is not initialized"), (int16_t)0,
+        bcos::bytes{});
 }
-void bcos::gateway::Gateway::asyncSendBroadcastMessageByTopic(
+bcos::task::Task<void> bcos::gateway::Gateway::sendBroadcastMessageByTopic(
     const std::string& _topic, bcos::bytesConstRef _data)
 {
     if (m_amop)
     {
-        m_amop->asyncSendBroadcastMessageByTopic(_topic, _data);
+        co_await m_amop->sendBroadcastMessageByTopic(_topic, _data);
     }
+    co_return;
 }
 void bcos::gateway::Gateway::asyncSubscribeTopic(std::string const& _clientID,
     std::string const& _topicInfo, std::function<void(Error::Ptr&&)> _callback)

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -51,18 +51,16 @@ public:
 
     /**
      * @brief: get connected peers
-     * @return void
+     * @return {error, localGatewayInfo, peerGatewayInfos}: error is nullptr on success
      */
-    void asyncGetPeers(
-        std::function<void(Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr)> _onGetPeers) override;
+    task::Task<std::tuple<Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr>> getPeers() override;
     /**
      * @brief: get nodeIDs from gateway
      * @param _groupID:
-     * @param _onGetGroupNodeInfo: get nodeIDs callback
-     * @return void
+     * @return {error, groupNodeInfo}: error is nullptr on success
      */
-    void asyncGetGroupNodeInfo(
-        const std::string& _groupID, GetGroupNodeInfoFunc _onGetGroupNodeInfo) override;
+    task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo(
+        const std::string& _groupID) override;
     /**
      * @brief: send message to multiple nodes
      * @param _groupID: groupID
@@ -110,9 +108,9 @@ public:
         bcos::group::GroupInfo::Ptr, std::function<void(Error::Ptr&&)>) override;
 
     /// for AMOP
-    void asyncSendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc) override;
-    void asyncSendBroadcastMessageByTopic(
+    task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
+        const std::string& _topic, bcos::bytesConstRef _data) override;
+    task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) override;
 
     void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -230,18 +230,18 @@ void AMOPImpl::onReceiveRequestTopicMessage(P2pID const& _nodeID, AMOPMessage::P
 }
 
 // receive AMOP request message from the given node
-void AMOPImpl::onReceiveAMOPMessage(P2pID const& _nodeID, AMOPMessage::Ptr _msg,
-    std::function<void(bytesPointer, int16_t)> const& _responseCallback)
+bcos::task::Task<std::tuple<bytesPointer, int16_t>> AMOPImpl::onReceiveAMOPMessage(
+    P2pID const& _nodeID, AMOPMessage::Ptr _msg)
 {
     // AMOPRequest
     auto request = m_requestFactory->buildRequest(_msg->data());
-    // message seq
+    // message topic
     std::string topic = request->topic();
-    onReceiveAMOPMessage(_nodeID, topic, _msg->data(), _responseCallback);
+    co_return co_await onReceiveAMOPMessage(_nodeID, topic, _msg->data());
 }
 
-void AMOPImpl::onReceiveAMOPMessage(P2pID const& _nodeID, std::string const& _topic,
-    bytesConstRef _data, std::function<void(bytesPointer, int16_t)> const& _responseCallback)
+bcos::task::Task<std::tuple<bytesPointer, int16_t>> AMOPImpl::onReceiveAMOPMessage(
+    P2pID const& _nodeID, std::string const& _topic, bytesConstRef _data)
 {
     std::vector<std::string> clients;
     m_topicManager->queryClientsByTopic(_topic, clients);
@@ -261,37 +261,31 @@ void AMOPImpl::onReceiveAMOPMessage(P2pID const& _nodeID, std::string const& _to
         std::string errorMessage = "NotFoundClientByTopicDispatchMsg";
         amopMsg->setData(bytesConstRef((bcos::byte*)errorMessage.c_str(), errorMessage.size()));
         amopMsg->encode(*buffer);
-        m_strand.post([buffer, _responseCallback]() {
-            _responseCallback(buffer, GatewayMessageType::AMOPMessageType);
-        });
         AMOP_LOG(WARNING) << LOG_BADGE("onRecvAMOPMessage")
                           << LOG_DESC("no client subscribe the topic") << LOG_KV("topic", _topic)
                           << LOG_KV("nodeID", printShortP2pID(_nodeID));
-        return;
+        co_return std::make_tuple(buffer, (int16_t)GatewayMessageType::AMOPMessageType);
     }
 
     AMOP_LOG(INFO) << LOG_DESC("onRecvAMOPMessage") << LOG_KV("topic", _topic)
                    << LOG_KV("from", printShortP2pID(_nodeID))
                    << LOG_KV("choosedClient", choosedClient);
-    clientService->asyncNotifyAMOPMessage(bcos::rpc::AMOPNotifyMessageType::Unicast, _topic, _data,
-        [this, _responseCallback](Error::Ptr&& _error, bytesPointer _responseData) {
-            if (!_error || _error->errorCode() == CommonError::SUCCESS)
-            {
-                _responseCallback(_responseData, GatewayMessageType::WSMessageType);
-                return;
-            }
-            auto amopMsg = m_messageFactory->buildMessage();
-            amopMsg->setStatus(_error->errorCode());
-            amopMsg->setType(AMOPMessage::Type::AMOPResponse);
-            auto const& errorMessage = _error->errorMessage();
-            amopMsg->setData(bytesConstRef((bcos::byte*)errorMessage.c_str(), errorMessage.size()));
-            auto buffer = std::make_shared<bcos::bytes>();
-            amopMsg->encode(*buffer);
-            _responseCallback(buffer, GatewayMessageType::AMOPMessageType);
-            AMOP_LOG(WARNING) << LOG_DESC("asyncNotifyAMOPMessage failed")
-                              << LOG_KV("code", _error->errorCode())
-                              << LOG_KV("msg", _error->errorMessage());
-        });
+    auto [error, responseData] = co_await clientService->notifyAMOPMessage(
+        bcos::rpc::AMOPNotifyMessageType::Unicast, _topic, _data);
+    if (!error || error->errorCode() == CommonError::SUCCESS)
+    {
+        co_return std::make_tuple(responseData, (int16_t)GatewayMessageType::WSMessageType);
+    }
+    auto amopMsg = m_messageFactory->buildMessage();
+    amopMsg->setStatus(error->errorCode());
+    amopMsg->setType(AMOPMessage::Type::AMOPResponse);
+    auto const& errorMessage = error->errorMessage();
+    amopMsg->setData(bytesConstRef((bcos::byte*)errorMessage.c_str(), errorMessage.size()));
+    auto buffer = std::make_shared<bcos::bytes>();
+    amopMsg->encode(*buffer);
+    AMOP_LOG(WARNING) << LOG_DESC("notifyAMOPMessage failed")
+                      << LOG_KV("code", error->errorCode()) << LOG_KV("msg", error->errorMessage());
+    co_return std::make_tuple(buffer, (int16_t)GatewayMessageType::AMOPMessageType);
 }
 
 // receive the AMOP broadcast message from given node
@@ -320,25 +314,28 @@ void AMOPImpl::onReceiveAMOPBroadcastMessage(P2pID const& _nodeID, AMOPMessage::
         AMOP_LOG(DEBUG) << LOG_BADGE("onRecvAMOPBroadcastMessage")
                         << LOG_DESC("push message to client") << LOG_KV("topic", topic)
                         << LOG_KV("client", client);
-        clientService->asyncNotifyAMOPMessage(bcos::rpc::AMOPNotifyMessageType::Broadcast, topic,
-            _msg->data(), [client](Error::Ptr&& _error, bytesPointer) {
-                if (_error)
-                {
-                    AMOP_LOG(WARNING)
-                        << LOG_BADGE("onRecvAMOPBroadcastMessage")
-                        << LOG_DESC("asyncNotifyAMOPMessage failed") << LOG_KV("client", client)
-                        << LOG_KV("code", _error->errorCode())
-                        << LOG_KV("msg", _error->errorMessage());
-                }
-            });
+        // one detached coroutine per client: the notifies run concurrently and each only logs
+        // its own failure. The payload is copied into the coroutine frame (task::wait is
+        // fire-and-forget, _msg does not outlive this function).
+        task::wait([](bcos::rpc::RPCInterface::Ptr _clientService, std::string _topic,
+                       bcos::bytes _data, std::string _client) -> task::Task<void> {
+            auto [error, responseData] = co_await _clientService->notifyAMOPMessage(
+                bcos::rpc::AMOPNotifyMessageType::Broadcast, _topic, bcos::ref(_data));
+            if (error)
+            {
+                AMOP_LOG(WARNING) << LOG_BADGE("onRecvAMOPBroadcastMessage")
+                                  << LOG_DESC("notifyAMOPMessage failed")
+                                  << LOG_KV("client", _client) << LOG_KV("code", error->errorCode())
+                                  << LOG_KV("msg", error->errorMessage());
+            }
+        }(clientService, topic, bcos::bytes(_msg->data().begin(), _msg->data().end()), client));
     }
     AMOP_LOG(DEBUG) << LOG_DESC("onReceiveAMOPBroadcastMessage")
                     << LOG_KV("nodeID", printShortP2pID(_nodeID));
 }
 
-bool AMOPImpl::trySendTopicMessageToLocalClient(const std::string& _topic,
-    bcos::bytesConstRef _data,
-    std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc)
+bcos::task::Task<std::optional<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>>>
+AMOPImpl::trySendTopicMessageToLocalClient(const std::string& _topic, bcos::bytesConstRef _data)
 {
     std::vector<std::string> clients;
     m_topicManager->queryClientsByTopic(_topic, clients);
@@ -346,209 +343,20 @@ bool AMOPImpl::trySendTopicMessageToLocalClient(const std::string& _topic,
     {
         AMOP_LOG(INFO) << LOG_DESC("trySendTopicMessageToLocalClient failed for empty client")
                        << LOG_KV("topic", _topic);
-        return false;
+        co_return std::nullopt;
     }
     AMOP_LOG(INFO) << LOG_DESC("trySendTopicMessageToLocalClient") << LOG_KV("topic", _topic)
                    << LOG_KV("clientsSubscribeTopic", clients.size());
-    auto self = shared_from_this();
-    onReceiveAMOPMessage(m_p2pNodeID, _topic, _data,
-        [self, _topic, _respFunc](bytesPointer _response, int16_t _type) {
-            self->onRecvAMOPResponse(_type, _response, _respFunc);
-            AMOP_LOG(INFO) << LOG_DESC("trySendTopicMessageToLocalClient: receive response")
-                           << LOG_KV("topic", _topic);
-        });
-
-    return true;
-}
-
-// asyncSendMessage to the given topic
-void AMOPImpl::asyncSendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data,
-    std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc)
-{
-    std::vector<P2pID> nodeIDs;
-    m_topicManager->queryNodeIDsByTopic(_topic, nodeIDs);
-    if (nodeIDs.empty())
-    {
-        if (trySendTopicMessageToLocalClient(_topic, _data, _respFunc))
-        {
-            return;
-        }
-        auto errorPtr = BCOS_ERROR_PTR(CommonError::NotFoundPeerByTopicSendMsg,
-            "there has no node subscribe this topic, topic: " + _topic);
-        if (_respFunc)
-        {
-            _respFunc(std::move(errorPtr), 0, {});
-        }
-
-        AMOP_LOG(WARNING) << LOG_BADGE("asyncSendMessage")
-                          << LOG_DESC("there has no node subscribe the topic")
-                          << LOG_KV("topic", _topic);
-        return;
-    }
-    AMOP_LOG(INFO) << LOG_DESC("asyncSendMessageByTopic") << LOG_KV("topic", _topic)
-                   << LOG_KV("nodeIDsSize", nodeIDs.size());
-    auto buffer = buildAndEncodeMessage(AMOPMessage::Type::AMOPRequest, _data);
-
-    auto self = shared_from_this();
-    // try to send the message to a random node and retry with the remaining nodes on failure.
-    // The retry loop (a coroutine launched fire-and-forget) replaces the old recursive
-    // RetrySender callback chain. All state is passed as coroutine parameters so it is copied
-    // into the frame and stays alive for the whole (possibly deferred) send.
-    task::wait([](std::shared_ptr<AMOPImpl> _self, bcos::bytes _payload,
-                   std::vector<P2pID> _nodeIDs,
-                   std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _callback)
-                   -> task::Task<void> {
-        auto network = _self->m_network;
-        auto messageFactory = _self->m_messageFactory;
-        // finite response timeout: Options{0, true} waits forever (Session registers no timer
-        // for a zero timeout), so a peer that accepts the request but never answers would suspend
-        // this detached coroutine indefinitely — the remaining candidates would never be tried
-        // and the caller would never see the terminal AMOPSendMsgFailed. Tradeoff: a subscriber
-        // that answers slower than this timeout makes the gateway retry the NEXT subscriber while
-        // the first may still be processing, so one request can be delivered to (and handled by)
-        // two subscribers — delivery is possibly-duplicated, not at-most-once. If deployments
-        // need a different value this should become a gateway config option.
-        constexpr uint32_t c_amopResponseTimeoutMs = 30000;
-        // shuffle the candidate list once, then take-and-erase the front per attempt: the node
-        // attempted is always the one removed, so a dead node is never retried while a live one
-        // is dropped untried (randomChoose+erase(begin()) removed a different node than tried).
-        auto seed = std::chrono::system_clock::now().time_since_epoch().count();
-        std::shuffle(_nodeIDs.begin(), _nodeIDs.end(), std::default_random_engine(seed));
-        // build the message once and re-stamp only the seq per attempt (each attempt is a fresh
-        // request on another session); the payload is moved in once instead of being lvalue-copied
-        // into a rebuilt message every iteration.
-        auto message = std::static_pointer_cast<P2PMessage>(
-            network->messageFactory()->buildMessage());
-        message->setPacketType(GatewayMessageType::AMOPMessageType);
-        message->setPayload(std::move(_payload));
-        while (!_nodeIDs.empty())
-        {
-            auto choosedNodeID = _nodeIDs.front();
-            _nodeIDs.erase(_nodeIDs.begin());
-            AMOP_LOG(INFO) << LOG_DESC("asyncSendMessageByTopic")
-                           << LOG_KV("choosedNodeID", printShortP2pID(choosedNodeID));
-            message->setSeq(network->messageFactory()->newSeq());
-            try
-            {
-                auto resp = co_await network->sendMessageByNodeID(choosedNodeID, *message,
-                    ::ranges::views::single(message->payload()),
-                    Options{c_amopResponseTimeoutMs, true});
-                auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
-                if (!respMessage)
-                {
-                    // self-id sends and sessions expiring before the write co_return a null
-                    // response: treat it as a (retryable) send failure, not a silent success
-                    AMOP_LOG(INFO)
-                        << LOG_DESC("asyncSendMessageByTopic: no response, retry next node")
-                        << LOG_KV("nodeID", printShortP2pID(choosedNodeID));
-                    continue;
-                }
-                auto packetType = respMessage->packetType();
-                auto responseData = respMessage->payload();
-                bcos::Error::Ptr error = nullptr;
-                if (packetType == bcos::gateway::GatewayMessageType::AMOPMessageType)
-                {
-                    // zero copy overhead
-                    auto amopMsg = messageFactory->buildMessage();
-                    if (amopMsg->decode(responseData) < 0)
-                    {
-                        // the peer answered, so the request was DELIVERED and its handler ran —
-                        // retrying the next subscriber would replay the same payload (instant
-                        // at-least-once, worse than the documented 30s-timeout duplicate). Fail
-                        // the caller instead; retry is reserved for sends that never reached a
-                        // peer (null response / send exception).
-                        AMOP_LOG(WARNING)
-                            << LOG_DESC("asyncSendMessageByTopic: decode response failed")
-                            << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
-                            << LOG_KV("size", responseData.size());
-                        error = BCOS_ERROR_PTR(CommonError::AMOPSendMsgFailed,
-                            "unable to decode the AMOP response from the peer");
-                        responseData = bytesConstRef();
-                    }
-                    else
-                    {
-                        auto errorMessage =
-                            std::string(amopMsg->data().begin(), amopMsg->data().end());
-                        auto errorCode = amopMsg->status();
-                        // tars error
-                        if (amopMsg->status() == (uint16_t)(-8) ||
-                            amopMsg->status() == (uint16_t)(-7))
-                        {
-                            errorMessage =
-                                "Access to the remote RPC service timed out, please make sure it "
-                                "is online";
-                            errorCode = -1;
-                        }
-                        error = BCOS_ERROR_PTR(errorCode, errorMessage);
-
-                        AMOP_LOG(INFO)
-                            << LOG_DESC("asyncSendMessageByTopic error: receive responseData")
-                            << LOG_KV("status", amopMsg->status()) << LOG_KV("msg", errorMessage);
-                    }
-                }
-                if (_callback)
-                {
-                    AMOP_LOG(INFO)
-                        << LOG_DESC("asyncSendMessageByTopic: receive responseData")
-                        << LOG_KV("size", responseData.size()) << LOG_KV("type", packetType);
-                    try
-                    {
-                        _callback(std::move(error), packetType, responseData);
-                    }
-                    catch (std::exception const& e)
-                    {
-                        AMOP_LOG(WARNING)
-                            << LOG_DESC("asyncSendMessageByTopic: response callback exception")
-                            << LOG_KV("msg", boost::diagnostic_information(e));
-                    }
-                }
-                co_return;
-            }
-            catch (NetworkException const& e)
-            {
-                AMOP_LOG(DEBUG) << LOG_BADGE("asyncSendMessageByTopic")
-                                << LOG_DESC("send failed, retry next node")
-                                << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
-                                << LOG_KV("code", e.errorCode()) << LOG_KV("msg", e.what());
-            }
-            catch (std::exception const& e)
-            {
-                // a non-network throw must not escape onto the io thread that resumed this
-                // detached coroutine (aborting the process and losing the terminal callback):
-                // log it and fall through to the next candidate
-                AMOP_LOG(WARNING) << LOG_BADGE("asyncSendMessageByTopic")
-                                  << LOG_DESC("unexpected exception, retry next node")
-                                  << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
-                                  << LOG_KV("msg", boost::diagnostic_information(e));
-            }
-        }
-        // all candidate nodes failed
-        auto errorPtr = BCOS_ERROR_PTR(
-            CommonError::AMOPSendMsgFailed, "unable to send message to peer by topic");
-        if (_callback)
-        {
-            try
-            {
-                _callback(std::move(errorPtr), 0, {});
-            }
-            catch (std::exception const& e)
-            {
-                AMOP_LOG(WARNING)
-                    << LOG_DESC("asyncSendMessageByTopic: failure callback exception")
-                    << LOG_KV("msg", boost::diagnostic_information(e));
-            }
-        }
-    }(self, std::move(buffer), nodeIDs, _respFunc));
-}
-
-void AMOPImpl::onRecvAMOPResponse(int16_t _type, bytesPointer _responseData,
-    std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _callback)
-{
+    auto [response, type] = co_await onReceiveAMOPMessage(m_p2pNodeID, _topic, _data);
+    AMOP_LOG(INFO) << LOG_DESC("trySendTopicMessageToLocalClient: receive response")
+                   << LOG_KV("topic", _topic);
+    // decode the AMOP response (the former onRecvAMOPResponse): an AMOPMessageType response
+    // carries an encoded AMOPMessage whose status is the real error code
     bcos::Error::Ptr error = nullptr;
-    if (_type == bcos::gateway::GatewayMessageType::AMOPMessageType)
+    if (type == bcos::gateway::GatewayMessageType::AMOPMessageType)
     {
         // zero copy overhead
-        auto amopMsg = m_messageFactory->buildMessage(ref(*_responseData));
+        auto amopMsg = m_messageFactory->buildMessage(ref(*response));
         auto errorMessage = std::string(amopMsg->data().begin(), amopMsg->data().end());
         auto errorCode = amopMsg->status();
         // tars error
@@ -561,20 +369,163 @@ void AMOPImpl::onRecvAMOPResponse(int16_t _type, bytesPointer _responseData,
         }
         error = BCOS_ERROR_PTR(errorCode, errorMessage);
 
-        AMOP_LOG(INFO) << LOG_DESC("asyncSendMessageByTopic error: receive responseData")
+        AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic error: receive responseData")
                        << LOG_KV("status", amopMsg->status()) << LOG_KV("msg", errorMessage);
     }
-    if (_callback)
-    {
-        AMOP_LOG(INFO) << LOG_DESC("asyncSendMessageByTopic: receive responseData")
-                       << LOG_KV("size", _responseData->size()) << LOG_KV("type", _type);
-        _callback(std::move(error), _type, bcos::ref(*_responseData));
-    }
+    AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic: receive responseData")
+                   << LOG_KV("size", response->size()) << LOG_KV("type", type);
+    co_return std::make_optional(std::make_tuple(std::move(error), type, *response));
 }
 
-void AMOPImpl::asyncSendBroadcastMessageByTopic(
+// send message to the given topic
+bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> AMOPImpl::sendMessageByTopic(
     const std::string& _topic, bcos::bytesConstRef _data)
 {
+    // keep this alive for the whole (possibly deferred) send — callers may launch the coroutine
+    // detached via task::wait
+    auto self = shared_from_this();
+    std::vector<P2pID> nodeIDs;
+    m_topicManager->queryNodeIDsByTopic(_topic, nodeIDs);
+    if (nodeIDs.empty())
+    {
+        // no remote subscriber: try the local clients
+        auto result = co_await trySendTopicMessageToLocalClient(_topic, _data);
+        if (result)
+        {
+            co_return std::move(*result);
+        }
+        AMOP_LOG(WARNING) << LOG_BADGE("asyncSendMessage")
+                          << LOG_DESC("there has no node subscribe the topic")
+                          << LOG_KV("topic", _topic);
+        co_return std::make_tuple(BCOS_ERROR_PTR(CommonError::NotFoundPeerByTopicSendMsg,
+                                      "there has no node subscribe this topic, topic: " + _topic),
+            (int16_t)0, bcos::bytes{});
+    }
+    AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic") << LOG_KV("topic", _topic)
+                   << LOG_KV("nodeIDsSize", nodeIDs.size());
+    auto buffer = buildAndEncodeMessage(AMOPMessage::Type::AMOPRequest, _data);
+
+    // try to send the message to a random node and retry with the remaining nodes on failure.
+    // All state lives in this coroutine frame so it stays alive for the whole (possibly
+    // deferred) send.
+    auto network = m_network;
+    auto messageFactory = m_messageFactory;
+    // finite response timeout: Options{0, true} waits forever (Session registers no timer
+    // for a zero timeout), so a peer that accepts the request but never answers would suspend
+    // this coroutine indefinitely — the remaining candidates would never be tried
+    // and the caller would never see the terminal AMOPSendMsgFailed. Tradeoff: a subscriber
+    // that answers slower than this timeout makes the gateway retry the NEXT subscriber while
+    // the first may still be processing, so one request can be delivered to (and handled by)
+    // two subscribers — delivery is possibly-duplicated, not at-most-once. If deployments
+    // need a different value this should become a gateway config option.
+    constexpr uint32_t c_amopResponseTimeoutMs = 30000;
+    // shuffle the candidate list once, then take-and-erase the front per attempt: the node
+    // attempted is always the one removed, so a dead node is never retried while a live one
+    // is dropped untried (randomChoose+erase(begin()) removed a different node than tried).
+    auto seed = std::chrono::system_clock::now().time_since_epoch().count();
+    std::shuffle(nodeIDs.begin(), nodeIDs.end(), std::default_random_engine(seed));
+    // build the message once and re-stamp only the seq per attempt (each attempt is a fresh
+    // request on another session); the payload is moved in once instead of being lvalue-copied
+    // into a rebuilt message every iteration.
+    auto message =
+        std::static_pointer_cast<P2PMessage>(network->messageFactory()->buildMessage());
+    message->setPacketType(GatewayMessageType::AMOPMessageType);
+    message->setPayload(std::move(buffer));
+    while (!nodeIDs.empty())
+    {
+        auto choosedNodeID = nodeIDs.front();
+        nodeIDs.erase(nodeIDs.begin());
+        AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic")
+                       << LOG_KV("choosedNodeID", printShortP2pID(choosedNodeID));
+        message->setSeq(network->messageFactory()->newSeq());
+        try
+        {
+            auto resp = co_await network->sendMessageByNodeID(choosedNodeID, *message,
+                ::ranges::views::single(message->payload()), Options{c_amopResponseTimeoutMs, true});
+            auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
+            if (!respMessage)
+            {
+                // self-id sends and sessions expiring before the write co_return a null
+                // response: treat it as a (retryable) send failure, not a silent success
+                AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic: no response, retry next node")
+                               << LOG_KV("nodeID", printShortP2pID(choosedNodeID));
+                continue;
+            }
+            auto packetType = respMessage->packetType();
+            auto responseData = respMessage->payload();
+            bcos::Error::Ptr error = nullptr;
+            if (packetType == bcos::gateway::GatewayMessageType::AMOPMessageType)
+            {
+                // zero copy overhead
+                auto amopMsg = messageFactory->buildMessage();
+                if (amopMsg->decode(responseData) < 0)
+                {
+                    // the peer answered, so the request was DELIVERED and its handler ran —
+                    // retrying the next subscriber would replay the same payload (instant
+                    // at-least-once, worse than the documented 30s-timeout duplicate). Fail
+                    // the caller instead; retry is reserved for sends that never reached a
+                    // peer (null response / send exception).
+                    AMOP_LOG(WARNING)
+                        << LOG_DESC("sendMessageByTopic: decode response failed")
+                        << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
+                        << LOG_KV("size", responseData.size());
+                    error = BCOS_ERROR_PTR(CommonError::AMOPSendMsgFailed,
+                        "unable to decode the AMOP response from the peer");
+                    responseData = bytesConstRef();
+                }
+                else
+                {
+                    auto errorMessage = std::string(amopMsg->data().begin(), amopMsg->data().end());
+                    auto errorCode = amopMsg->status();
+                    // tars error
+                    if (amopMsg->status() == (uint16_t)(-8) || amopMsg->status() == (uint16_t)(-7))
+                    {
+                        errorMessage =
+                            "Access to the remote RPC service timed out, please make sure it "
+                            "is online";
+                        errorCode = -1;
+                    }
+                    error = BCOS_ERROR_PTR(errorCode, errorMessage);
+
+                    AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic error: receive responseData")
+                                   << LOG_KV("status", amopMsg->status())
+                                   << LOG_KV("msg", errorMessage);
+                }
+            }
+            AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic: receive responseData")
+                           << LOG_KV("size", responseData.size()) << LOG_KV("type", packetType);
+            co_return std::make_tuple(
+                std::move(error), packetType, responseData.toBytes());
+        }
+        catch (NetworkException const& e)
+        {
+            AMOP_LOG(DEBUG) << LOG_BADGE("sendMessageByTopic")
+                            << LOG_DESC("send failed, retry next node")
+                            << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
+                            << LOG_KV("code", e.errorCode()) << LOG_KV("msg", e.what());
+        }
+        catch (std::exception const& e)
+        {
+            // a non-network throw must not escape onto the io thread that resumed this
+            // coroutine: log it and fall through to the next candidate
+            AMOP_LOG(WARNING) << LOG_BADGE("sendMessageByTopic")
+                              << LOG_DESC("unexpected exception, retry next node")
+                              << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
+                              << LOG_KV("msg", boost::diagnostic_information(e));
+        }
+    }
+    // all candidate nodes failed
+    co_return std::make_tuple(
+        BCOS_ERROR_PTR(CommonError::AMOPSendMsgFailed, "unable to send message to peer by topic"),
+        (int16_t)0, bcos::bytes{});
+}
+
+bcos::task::Task<void> AMOPImpl::sendBroadcastMessageByTopic(
+    const std::string& _topic, bcos::bytesConstRef _data)
+{
+    // keep this alive for the whole (possibly deferred) send — callers may launch the coroutine
+    // detached via task::wait
+    auto self = shared_from_this();
     std::vector<std::string> nodeIDs;
     m_topicManager->queryNodeIDsByTopic(_topic, nodeIDs);
     if (nodeIDs.empty())
@@ -582,19 +533,15 @@ void AMOPImpl::asyncSendBroadcastMessageByTopic(
         AMOP_LOG(WARNING) << LOG_BADGE("asyncSendBroadbastMessage")
                           << LOG_DESC("there no node subscribe this topic")
                           << LOG_KV("topic", _topic);
-        return;
+        co_return;
     }
     auto buffer = buildAndEncodeMessage(AMOPMessage::Type::AMOPBroadcast, _data);
-    auto network = m_network;
-    // fire-and-forget through the coroutine fast path: the message is built in the coroutine and
-    // the payload is moved into it (the caller's buffer does not outlive the deferred send); a
-    // failed/unreachable node is logged and skipped by sendMessageByNodeIDs.
-    task::wait([](P2PInterface::Ptr _network, uint16_t _type, std::vector<P2pID> _nodeIDs,
-                   bcos::bytes _payload) -> task::Task<void> {
-        co_await _network->sendMessageByNodeIDs(_type, _nodeIDs, std::move(_payload), Options(0));
-    }(network, GatewayMessageType::AMOPMessageType, nodeIDs, std::move(buffer)));
+    auto dataSize = _data.size();
+    // a failed/unreachable node is logged and skipped by sendMessageByNodeIDs
+    co_await m_network->sendMessageByNodeIDs(
+        GatewayMessageType::AMOPMessageType, nodeIDs, std::move(buffer), Options(0));
     AMOP_LOG(DEBUG) << LOG_BADGE("asyncSendBroadbastMessage") << LOG_DESC("send broadcast message")
-                    << LOG_KV("topic", _topic) << LOG_KV("data size", _data.size());
+                    << LOG_KV("topic", _topic) << LOG_KV("data size", dataSize);
 }
 
 void AMOPImpl::onAMOPMessage(
@@ -649,44 +596,45 @@ void AMOPImpl::dispatcherAMOPMessage(
         onReceiveResponseTopicMessage(fromNodeID, amopMessage);
         break;
     case AMOPMessage::Type::AMOPRequest:
-        onReceiveAMOPMessage(fromNodeID, amopMessage,
-            [this, _session, _message](bytesPointer _responseData, int16_t _type) {
-                auto responseP2PMsg = std::dynamic_pointer_cast<P2PMessage>(
-                    m_network->messageFactory()->buildMessage());
-                AMOP_LOG(DEBUG) << LOG_BADGE("onReceiveAMOPMessage") << LOG_DESC("send response")
-                                << LOG_KV("type", _type) << LOG_KV("data", _responseData->size());
-                responseP2PMsg->setDstP2PNodeID(_message->srcP2PNodeID());
-                responseP2PMsg->setSrcP2PNodeID(_message->dstP2PNodeID());
-                responseP2PMsg->setSeq(_message->seq());
-                responseP2PMsg->setRespPacket();
-                responseP2PMsg->setPayload(*_responseData);
-                responseP2PMsg->setPacketType(_type);
-                // send the AMOP response through the coroutine fast path: the message is passed as
-                // a coroutine parameter so it is copied into the frame and stays alive for the
-                // (possibly deferred) send; its payload rides as a view (zero-copy).
-                auto network = m_network;
-                task::wait([](P2PInterface::Ptr _network,
-                               std::shared_ptr<P2PMessage> _responseP2PMsg) -> task::Task<void> {
-                    try
-                    {
-                        co_await _network->sendMessageByNodeID(_responseP2PMsg->dstP2PNodeID(),
-                            *_responseP2PMsg,
-                            ::ranges::views::single(_responseP2PMsg->payload()), Options{});
-                    }
-                    catch (std::exception const& e)
-                    {
-                        // A synchronous pre-send rejection (rate limit / max size) or an async
-                        // write failure on the AMOP response path is expected during bandwidth
-                        // saturation — log the dst and seq so the response-loss investigation
-                        // keeps the routing dimension.
-                        AMOP_LOG(WARNING) << LOG_BADGE("onReceiveAMOPMessage")
-                                          << LOG_DESC("send response failed")
-                                          << LOG_KV("seq", _responseP2PMsg->seq())
-                                          << LOG_KV("dst", _responseP2PMsg->dstP2PNodeID())
-                                          << LOG_KV("what", boost::diagnostic_information(e));
-                    }
-                }(network, responseP2PMsg));
-            });
+        // dispatch the request to the local client, then send the response back to the peer;
+        // all state is passed as coroutine parameters so it is copied into the frame and stays
+        // alive for the whole (possibly deferred) round trip
+        task::wait([](std::shared_ptr<AMOPImpl> _self, P2pID _fromNodeID,
+                       AMOPMessage::Ptr _amopMessage, std::shared_ptr<P2PMessage> _message)
+                       -> task::Task<void> {
+            auto [responseData, type] =
+                co_await _self->onReceiveAMOPMessage(_fromNodeID, _amopMessage);
+            auto responseP2PMsg = std::dynamic_pointer_cast<P2PMessage>(
+                _self->m_network->messageFactory()->buildMessage());
+            AMOP_LOG(DEBUG) << LOG_BADGE("onReceiveAMOPMessage") << LOG_DESC("send response")
+                            << LOG_KV("type", type) << LOG_KV("data", responseData->size());
+            responseP2PMsg->setDstP2PNodeID(_message->srcP2PNodeID());
+            responseP2PMsg->setSrcP2PNodeID(_message->dstP2PNodeID());
+            responseP2PMsg->setSeq(_message->seq());
+            responseP2PMsg->setRespPacket();
+            responseP2PMsg->setPayload(*responseData);
+            responseP2PMsg->setPacketType(type);
+            try
+            {
+                // the response payload rides as a view (zero-copy): responseP2PMsg lives in this
+                // frame for the duration of the co_await
+                co_await _self->m_network->sendMessageByNodeID(responseP2PMsg->dstP2PNodeID(),
+                    *responseP2PMsg, ::ranges::views::single(responseP2PMsg->payload()),
+                    Options{});
+            }
+            catch (std::exception const& e)
+            {
+                // A synchronous pre-send rejection (rate limit / max size) or an async
+                // write failure on the AMOP response path is expected during bandwidth
+                // saturation — log the dst and seq so the response-loss investigation
+                // keeps the routing dimension.
+                AMOP_LOG(WARNING) << LOG_BADGE("onReceiveAMOPMessage")
+                                  << LOG_DESC("send response failed")
+                                  << LOG_KV("seq", responseP2PMsg->seq())
+                                  << LOG_KV("dst", responseP2PMsg->dstP2PNodeID())
+                                  << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(shared_from_this(), fromNodeID, amopMessage, _message));
         break;
     case AMOPMessage::Type::AMOPBroadcast:
         onReceiveAMOPBroadcastMessage(fromNodeID, amopMessage);

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -454,7 +454,8 @@ bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> AMOPImpl::s
         try
         {
             auto resp = co_await network->sendMessageByNodeID(choosedNodeID, *message,
-                ::ranges::views::single(message->payload()), Options{c_amopResponseTimeoutMs, true});
+                ::ranges::views::single(message->payload()),
+                Options{c_amopResponseTimeoutMs, true});
             auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
             if (!respMessage)
             {

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -31,6 +31,28 @@ using namespace bcos::gateway;
 using namespace bcos::amop;
 using namespace bcos::protocol;
 
+namespace
+{
+// Decode an encoded AMOPMessage (carried inside an AMOPMessageType response) into the error it
+// represents: the AMOPMessage status field is the real error code, and tars status -7/-8 mean
+// the remote RPC service timed out and are mapped to a human-readable timeout message. Shared by
+// the local-client path (trySendTopicMessageToLocalClient) and the remote retry loop of
+// sendMessageByTopic so the status mapping stays in one place.
+bcos::Error::Ptr decodeAMOPErrorResponse(bcos::amop::AMOPMessage::Ptr const& _amopMsg)
+{
+    auto errorMessage = std::string(_amopMsg->data().begin(), _amopMsg->data().end());
+    auto errorCode = _amopMsg->status();
+    // tars error
+    if (_amopMsg->status() == (uint16_t)(-8) || _amopMsg->status() == (uint16_t)(-7))
+    {
+        errorMessage = "Access to the remote RPC service timed out, please make sure it "
+                       "is online";
+        errorCode = -1;
+    }
+    return BCOS_ERROR_PTR(errorCode, errorMessage);
+}
+}  // namespace
+
 AMOPImpl::~AMOPImpl() = default;
 
 TopicManager::Ptr AMOPImpl::topicManager()
@@ -357,20 +379,11 @@ AMOPImpl::trySendTopicMessageToLocalClient(const std::string& _topic, bcos::byte
     {
         // zero copy overhead
         auto amopMsg = m_messageFactory->buildMessage(ref(*response));
-        auto errorMessage = std::string(amopMsg->data().begin(), amopMsg->data().end());
-        auto errorCode = amopMsg->status();
-        // tars error
-        if (amopMsg->status() == (uint16_t)(-8) || amopMsg->status() == (uint16_t)(-7))
-        {
-            errorMessage =
-                "Access to the remote RPC service timed out, please make sure it "
-                "is online";
-            errorCode = -1;
-        }
-        error = BCOS_ERROR_PTR(errorCode, errorMessage);
+        error = decodeAMOPErrorResponse(amopMsg);
 
         AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic error: receive responseData")
-                       << LOG_KV("status", amopMsg->status()) << LOG_KV("msg", errorMessage);
+                       << LOG_KV("status", amopMsg->status())
+                       << LOG_KV("msg", error->errorMessage());
     }
     AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic: receive responseData")
                    << LOG_KV("size", response->size()) << LOG_KV("type", type);
@@ -475,21 +488,11 @@ bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> AMOPImpl::s
                 }
                 else
                 {
-                    auto errorMessage = std::string(amopMsg->data().begin(), amopMsg->data().end());
-                    auto errorCode = amopMsg->status();
-                    // tars error
-                    if (amopMsg->status() == (uint16_t)(-8) || amopMsg->status() == (uint16_t)(-7))
-                    {
-                        errorMessage =
-                            "Access to the remote RPC service timed out, please make sure it "
-                            "is online";
-                        errorCode = -1;
-                    }
-                    error = BCOS_ERROR_PTR(errorCode, errorMessage);
+                    error = decodeAMOPErrorResponse(amopMsg);
 
                     AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic error: receive responseData")
                                    << LOG_KV("status", amopMsg->status())
-                                   << LOG_KV("msg", errorMessage);
+                                   << LOG_KV("msg", error->errorMessage());
                 }
             }
             AMOP_LOG(INFO) << LOG_DESC("sendMessageByTopic: receive responseData")

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
@@ -26,7 +26,10 @@
 #include "bcos-gateway/libp2p/P2PSession.h"
 #include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/Timer.h"
+#include <bcos-task/Task.h>
 #include <boost/asio/io_context.hpp>
+#include <optional>
+#include <tuple>
 namespace bcos
 {
 namespace amop
@@ -50,22 +53,21 @@ public:
         std::vector<std::string> const& _topicList, std::function<void(Error::Ptr&&)> _callback);
 
     /**
-     * @brief: async send message to random node subscribe _topic
+     * @brief: send message to a random node subscribed to _topic
      * @param _topic: topic
      * @param _data: message data
-     * @param _respFunc: callback
-     * @return void
+     * @return {error, responseType, responseData}: error is nullptr on success
      */
-    virtual void asyncSendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc);
+    virtual task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
+        const std::string& _topic, bcos::bytesConstRef _data);
 
     /**
-     * @brief: async send message to all nodes subscribe _topic
+     * @brief: broadcast message to all nodes subscribed to _topic
      * @param _topic: topic
      * @param _data: message data
      * @return void
      */
-    virtual void asyncSendBroadcastMessageByTopic(
+    virtual task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data);
 
     virtual void onAMOPMessage(bcos::gateway::NetworkException const& _e,
@@ -114,14 +116,14 @@ protected:
         bcos::gateway::P2pID const& _nodeID, AMOPMessage::Ptr _msg);
 
     /**
-     * @brief: receive amop message
+     * @brief: receive amop request message from the given node and dispatch it to the local
+     *         client subscribed to the topic
      * @param _nodeID: the sender nodeID
-     * @param _id: the message id
      * @param _msg: message
-     * @return void
+     * @return {responseData, responseType}: the response to send back to the sender
      */
-    virtual void onReceiveAMOPMessage(bcos::gateway::P2pID const& _nodeID, AMOPMessage::Ptr _msg,
-        std::function<void(bytesPointer, int16_t)> const& _responseCallback);
+    virtual task::Task<std::tuple<bytesPointer, int16_t>> onReceiveAMOPMessage(
+        bcos::gateway::P2pID const& _nodeID, AMOPMessage::Ptr _msg);
 
     /**
      * @brief: receive broadcast message
@@ -135,13 +137,15 @@ protected:
 
 private:
     bcos::bytes buildAndEncodeMessage(uint32_t _type, bcos::bytesConstRef _data);
-    virtual void onReceiveAMOPMessage(bcos::gateway::P2pID const& _nodeID,
-        std::string const& _topic, bytesConstRef _data,
-        std::function<void(bytesPointer, int16_t)> const& _responseCallback);
-    void onRecvAMOPResponse(int16_t _type, bytesPointer _responseData,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _callback);
-    bool trySendTopicMessageToLocalClient(const std::string& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bytesConstRef)> _respFunc);
+    virtual task::Task<std::tuple<bytesPointer, int16_t>> onReceiveAMOPMessage(
+        bcos::gateway::P2pID const& _nodeID, std::string const& _topic, bytesConstRef _data);
+    /**
+     * @brief: send the topic message to a local client subscribed to _topic
+     * @return {error, responseType, responseData}, or nullopt when no local client subscribes
+     *         the topic
+     */
+    task::Task<std::optional<std::tuple<Error::Ptr, int16_t, bcos::bytes>>>
+        trySendTopicMessageToLocalClient(const std::string& _topic, bcos::bytesConstRef _data);
 
     std::shared_ptr<TopicManager> m_topicManager;
     std::shared_ptr<AMOPMessageFactory> m_messageFactory;

--- a/bcos-gateway/test/unittests/GatewayTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayTest.cpp
@@ -27,6 +27,7 @@
 #include "bcos-gateway/libamop/AMOPImpl.h"
 #include "bcos-gateway/libp2p/P2PInterface.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <bcos-task/Wait.h>
 #include <boost/test/unit_test.hpp>
 #include <fakeit.hpp>
 #include <memory>
@@ -331,15 +332,11 @@ BOOST_AUTO_TEST_CASE(testAMOPMock)
     fakeit::Mock<bcos::amop::AMOPImpl> mockAMOP;
 
     // Setup mock behaviors for AMOP operations using lambda pattern from testBaselineScheduler
-    fakeit::When(Method(mockAMOP, asyncSendMessageByTopic))
-        .AlwaysDo([](const std::string& /*topic*/, bcos::bytesConstRef /*data*/,
-                      const std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)>&
-                          callback) {
+    fakeit::When(Method(mockAMOP, sendMessageByTopic))
+        .AlwaysDo([](const std::string& /*topic*/, bcos::bytesConstRef /*data*/)
+                      -> bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> {
             // Simulate successful message send
-            if (callback)
-            {
-                callback(nullptr, 0, bcos::bytesConstRef{});
-            }
+            co_return std::make_tuple(bcos::Error::Ptr(nullptr), int16_t(0), bcos::bytes{});
         });
 
     fakeit::When(Method(mockAMOP, asyncSubscribeTopic))
@@ -359,16 +356,12 @@ BOOST_AUTO_TEST_CASE(testAMOPMock)
     std::string testClientID = "testClient";
     bcos::bytes testData = {0x1, 0x2, 0x3};
 
-    // Test message sending with callback
-    bool callbackInvoked = false;
-    amopRef.asyncSendMessageByTopic(testTopic,
-        bcos::bytesConstRef(testData.data(), testData.size()),
-        [&callbackInvoked](
-            const bcos::Error::Ptr& /*error*/, int16_t code, bcos::bytesConstRef /*response*/) {
-            callbackInvoked = true;
-            BOOST_CHECK_EQUAL(code, 0);
-        });
-    BOOST_CHECK(callbackInvoked);
+    // Test message sending
+    auto [sendError, sendCode, sendResponse] = bcos::task::syncWait(amopRef.sendMessageByTopic(
+        testTopic, bcos::bytesConstRef(testData.data(), testData.size())));
+    BOOST_CHECK(!sendError);
+    BOOST_CHECK_EQUAL(sendCode, 0);
+    BOOST_CHECK(sendResponse.empty());
 
     // Test topic subscription
     bool subscriptionCallbackInvoked = false;
@@ -379,7 +372,7 @@ BOOST_AUTO_TEST_CASE(testAMOPMock)
     BOOST_CHECK(subscriptionCallbackInvoked);
 
     // Verify methods were called
-    fakeit::Verify(Method(mockAMOP, asyncSendMessageByTopic)).Exactly(1);
+    fakeit::Verify(Method(mockAMOP, sendMessageByTopic)).Exactly(1);
     fakeit::Verify(Method(mockAMOP, asyncSubscribeTopic)).Exactly(1);
 }
 
@@ -402,27 +395,17 @@ BOOST_AUTO_TEST_CASE(testComplexGatewayScenario)
     fakeit::When(Method(mockGatewayNodeManager, unregisterNode)).AlwaysReturn(true);
 
     // Setup AMOP with multiple different behaviors for different calls
-    fakeit::When(Method(mockAMOP, asyncSendMessageByTopic))
-        .AlwaysDo([](const std::string& topic, bcos::bytesConstRef /*data*/,
-                      const std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)>&
-                          callback) {
+    fakeit::When(Method(mockAMOP, sendMessageByTopic))
+        .AlwaysDo([](const std::string& topic, bcos::bytesConstRef /*data*/)
+                      -> bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> {
             // Simulate different responses based on topic
-            if (topic == "successTopic")
-            {
-                if (callback)
-                {
-                    callback(nullptr, 0, bcos::bytesConstRef{});
-                }
-            }
-            else if (topic == "failTopic")
+            if (topic == "failTopic")
             {
                 auto error = std::make_shared<bcos::Error>(
                     bcos::Error::buildError("MockTest", -1, "Mock error for test"));
-                if (callback)
-                {
-                    callback(std::move(error), -1, bcos::bytesConstRef{});
-                }
+                co_return std::make_tuple(std::move(error), int16_t(-1), bcos::bytes{});
             }
+            co_return std::make_tuple(bcos::Error::Ptr(nullptr), int16_t(0), bcos::bytes{});
         });
 
     // Test the complex scenario
@@ -451,28 +434,19 @@ BOOST_AUTO_TEST_CASE(testComplexGatewayScenario)
     bcos::bytes testData = {0x1, 0x2, 0x3};
 
     // Test successful case
-    bool successCallbackInvoked = false;
-    amopRef.asyncSendMessageByTopic("successTopic",
-        bcos::bytesConstRef(testData.data(), testData.size()),
-        [&successCallbackInvoked](
-            const bcos::Error::Ptr& error, int16_t code, bcos::bytesConstRef /*response*/) {
-            successCallbackInvoked = true;
-            BOOST_CHECK(!error);
-            BOOST_CHECK_EQUAL(code, 0);
-        });
-    BOOST_CHECK(successCallbackInvoked);
+    auto [successError, successCode, successResponse] =
+        bcos::task::syncWait(amopRef.sendMessageByTopic(
+            "successTopic", bcos::bytesConstRef(testData.data(), testData.size())));
+    BOOST_CHECK(!successError);
+    BOOST_CHECK_EQUAL(successCode, 0);
+    BOOST_CHECK(successResponse.empty());
 
     // Test failure case
-    bool failureCallbackInvoked = false;
-    amopRef.asyncSendMessageByTopic("failTopic",
-        bcos::bytesConstRef(testData.data(), testData.size()),
-        [&failureCallbackInvoked](
-            const bcos::Error::Ptr& error, int16_t code, bcos::bytesConstRef /*response*/) {
-            failureCallbackInvoked = true;
-            BOOST_CHECK(error != nullptr);
-            BOOST_CHECK_EQUAL(code, -1);
-        });
-    BOOST_CHECK(failureCallbackInvoked);
+    auto [failError, failCode, failResponse] = bcos::task::syncWait(amopRef.sendMessageByTopic(
+        "failTopic", bcos::bytesConstRef(testData.data(), testData.size())));
+    BOOST_CHECK(failError != nullptr);
+    BOOST_CHECK_EQUAL(failCode, -1);
+    BOOST_CHECK(failResponse.empty());
 
     // Clean up - unregister nodes
     bool unreg1 = nodeManagerRef.unregisterNode("group1", nodeID1->hex());
@@ -485,7 +459,7 @@ BOOST_AUTO_TEST_CASE(testComplexGatewayScenario)
     fakeit::Verify(Method(mockP2PInterface, start)).Exactly(1);
     fakeit::Verify(Method(mockGatewayNodeManager, registerNode)).Exactly(2);
     fakeit::Verify(Method(mockGatewayNodeManager, unregisterNode)).Exactly(2);
-    fakeit::Verify(Method(mockAMOP, asyncSendMessageByTopic)).Exactly(2);
+    fakeit::Verify(Method(mockAMOP, sendMessageByTopic)).Exactly(2);
 }
 
 BOOST_AUTO_TEST_CASE(testErrorHandlingScenarios)
@@ -495,56 +469,40 @@ BOOST_AUTO_TEST_CASE(testErrorHandlingScenarios)
 
     // Setup error scenarios
     int callCount = 0;
-    fakeit::When(Method(mockAMOP, asyncSendMessageByTopic))
-        .AlwaysDo([&callCount](const std::string& /*topic*/, bcos::bytesConstRef /*data*/,
-                      const std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)>&
-                          callback) {
+    fakeit::When(Method(mockAMOP, sendMessageByTopic))
+        .AlwaysDo([&callCount](const std::string& /*topic*/, bcos::bytesConstRef /*data*/)
+                      -> bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> {
             ++callCount;
             if (callCount == 1)
             {
                 // First call succeeds
-                if (callback)
-                {
-                    callback(nullptr, 0, bcos::bytesConstRef{});
-                }
+                co_return std::make_tuple(bcos::Error::Ptr(nullptr), int16_t(0), bcos::bytes{});
             }
-            else
-            {
-                // Subsequent calls fail
-                auto error = std::make_shared<bcos::Error>(
-                    bcos::Error::buildError("MockTest", -2, "Network timeout"));
-                if (callback)
-                {
-                    callback(std::move(error), -2, bcos::bytesConstRef{});
-                }
-            }
+            // Subsequent calls fail
+            auto error = std::make_shared<bcos::Error>(
+                bcos::Error::buildError("MockTest", -2, "Network timeout"));
+            co_return std::make_tuple(std::move(error), int16_t(-2), bcos::bytes{});
         });
 
     bcos::amop::AMOPImpl& amopRef = mockAMOP.get();
     bcos::bytes testData = {0x1, 0x2, 0x3};
 
     // First call should succeed
-    bool firstCallSucceeded = false;
-    amopRef.asyncSendMessageByTopic("testTopic",
-        bcos::bytesConstRef(testData.data(), testData.size()),
-        [&firstCallSucceeded](
-            const bcos::Error::Ptr& error, int16_t code, bcos::bytesConstRef /*response*/) {
-            firstCallSucceeded = (error == nullptr && code == 0);
-        });
-    BOOST_CHECK(firstCallSucceeded);
+    auto [firstError, firstCode, firstResponse] = bcos::task::syncWait(
+        amopRef.sendMessageByTopic("testTopic", bcos::bytesConstRef(testData.data(),
+            testData.size())));
+    BOOST_CHECK(firstError == nullptr && firstCode == 0);
+    BOOST_CHECK(firstResponse.empty());
 
     // Second call should fail
-    bool secondCallFailed = false;
-    amopRef.asyncSendMessageByTopic("testTopic",
-        bcos::bytesConstRef(testData.data(), testData.size()),
-        [&secondCallFailed](
-            const bcos::Error::Ptr& error, int16_t code, bcos::bytesConstRef /*response*/) {
-            secondCallFailed = (error != nullptr && code == -2);
-        });
-    BOOST_CHECK(secondCallFailed);
+    auto [secondError, secondCode, secondResponse] = bcos::task::syncWait(
+        amopRef.sendMessageByTopic("testTopic", bcos::bytesConstRef(testData.data(),
+            testData.size())));
+    BOOST_CHECK(secondError != nullptr && secondCode == -2);
+    BOOST_CHECK(secondResponse.empty());
 
     // Verify both calls were made
-    fakeit::Verify(Method(mockAMOP, asyncSendMessageByTopic)).Exactly(2);
+    fakeit::Verify(Method(mockAMOP, sendMessageByTopic)).Exactly(2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/amop/AMOPSendMessagePathTest.cpp
+++ b/bcos-gateway/test/unittests/amop/AMOPSendMessagePathTest.cpp
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- * @brief test for AMOPImpl::asyncSendMessageByTopic retry path
+ * @brief test for AMOPImpl::sendMessageByTopic retry path
  * @file AMOPSendMessagePathTest.cpp
  */
 
@@ -28,6 +28,7 @@
 #include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 
+#include <bcos-task/Wait.h>
 #include <boost/test/unit_test.hpp>
 #include <fakeit.hpp>
 #include <algorithm>
@@ -109,13 +110,12 @@ struct AMOPSendFixture
     void send(std::string const& _topic, SendResult& _result)
     {
         bcos::bytes data = {'h', 'e', 'l', 'l', 'o'};
-        amop->asyncSendMessageByTopic(_topic, ref(data),
-            [&_result](bcos::Error::Ptr&& _error, int16_t _type, bytesConstRef _responseData) {
-                _result.called = true;
-                _result.error = std::move(_error);
-                _result.packetType = _type;
-                _result.responseData = bcos::bytes(_responseData.begin(), _responseData.end());
-            });
+        auto [error, packetType, responseData] =
+            bcos::task::syncWait(amop->sendMessageByTopic(_topic, ref(data)));
+        _result.called = true;
+        _result.error = std::move(error);
+        _result.packetType = packetType;
+        _result.responseData = std::move(responseData);
     }
 
     Mock<P2PInterface> networkMock;

--- a/bcos-rpc/bcos-rpc/Rpc.h
+++ b/bcos-rpc/bcos-rpc/Rpc.h
@@ -71,11 +71,10 @@ public:
     bcos::rpc::JsonRpcImpl_2_0::Ptr jsonRpcImpl() const { return m_jsonRpcImpl; }
     bcos::event::EventSub::Ptr eventSub() const { return m_eventSub; }
 
-    void asyncNotifyAMOPMessage(int16_t _type, std::string const& _topic,
-        bytesConstRef _requestData,
-        std::function<void(Error::Ptr&& _error, bytesPointer _responseData)> _callback) override
+    task::Task<std::tuple<Error::Ptr, bytesPointer>> notifyAMOPMessage(
+        int16_t _type, std::string const& _topic, bytesConstRef _requestData) override
     {
-        m_amopClient->asyncNotifyAMOPMessage(_type, _topic, _requestData, _callback);
+        co_return co_await m_amopClient->notifyAMOPMessage(_type, _topic, _requestData);
     }
 
     void setClientID(std::string const& _clientID)

--- a/bcos-rpc/bcos-rpc/amop/AMOPClient.cpp
+++ b/bcos-rpc/bcos-rpc/amop/AMOPClient.cpp
@@ -25,6 +25,7 @@
 #include <bcos-framework/protocol/CommonError.h>
 #include <bcos-protocol/amop/TopicItem.h>
 #include <bcos-rpc/Common.h>
+#include <bcos-task/Wait.h>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -120,7 +121,7 @@ void AMOPClient::onRecvAMOPRequest(
     if (onGatewayInactivated(*msgPtr, _session))
     {
         // try to send to local node
-        if (trySendAMOPRequestToLocalNode(_session, topic, *msgPtr))
+        if (trySendAMOPRequestToLocalNode(_session, topic, std::move(*msgPtr)))
         {
             return;
         }
@@ -131,69 +132,71 @@ void AMOPClient::onRecvAMOPRequest(
         return;
     }
     auto self = std::weak_ptr<AMOPClient>(shared_from_this());
-    m_gateway->asyncSendMessageByTopic(amopReq->topic(),
-        bytesConstRef(msgPtr->payload().data(), msgPtr->payload().size()),
-        [self, seq, msgPtr, topic, _session](
-            bcos::Error::Ptr&& _error, int16_t, bytesConstRef _responseData) {
-            try
+    task::wait([](std::weak_ptr<AMOPClient> self, bcos::gateway::GatewayInterface::Ptr gateway,
+                   std::string topic, std::shared_ptr<boostssl::ws::WsMessage> msgPtr,
+                   std::shared_ptr<WsSession> session, std::string seq) -> bcos::task::Task<void> {
+        try
+        {
+            auto [error, packetType, responseData] = co_await gateway->sendMessageByTopic(
+                topic, bytesConstRef(msgPtr->payload().data(), msgPtr->payload().size()));
+            auto amopClient = self.lock();
+            if (!amopClient)
             {
-                auto amopClient = self.lock();
-                if (!amopClient)
+                co_return;
+            }
+            bcos::boostssl::ws::WsMessage responseMsg;
+            auto orgSeq = seq;
+            if (error && error->errorCode() != bcos::protocol::CommonError::SUCCESS)
+            {
+                auto ret =
+                    amopClient->trySendAMOPRequestToLocalNode(session, topic, std::move(*msgPtr));
+                // to local node
+                if (ret)
                 {
-                    return;
+                    co_return;
                 }
-                bcos::boostssl::ws::WsMessage responseMsg;
-                auto orgSeq = seq;
-                if (_error && _error->errorCode() != bcos::protocol::CommonError::SUCCESS)
+                // tars timeout
+                auto errorCode = error->errorCode();
+                auto errorMsg = error->errorMessage();
+                if ((error->errorCode() == -7) || (error->errorCode() == -8))
                 {
-                    auto ret = amopClient->trySendAMOPRequestToLocalNode(_session, topic, *msgPtr);
-                    // to local node
-                    if (ret)
-                    {
-                        return;
-                    }
-                    // tars timeout
-                    auto errorCode = _error->errorCode();
-                    auto errorMsg = _error->errorMessage();
-                    if ((_error->errorCode() == -7) || (_error->errorCode() == -8))
-                    {
-                        errorMsg = "Access to gateway timed out, please check gateway alive";
-                    }
-                    responseMsg.setStatus(errorCode);
-                    // constructor the response
-                    responseMsg.setPayload(bcos::bytes(errorMsg.begin(), errorMsg.end()));
-                    // recover the seq
-                    responseMsg.setSeq(orgSeq);
-                    AMOP_CLIENT_LOG(ERROR)
-                        << LOG_BADGE("onRecvAMOPRequest error")
-                        << LOG_DESC("AMOP async send message callback") << LOG_KV("seq", seq)
-                        << LOG_KV("code", _error->errorCode())
-                        << LOG_KV("msg", _error->errorMessage());
-                    _session->asyncSendMessage(responseMsg);
-                    return;
+                    errorMsg = "Access to gateway timed out, please check gateway alive";
                 }
-                // Note: the decode function will recover m_seq of wsMessage, so it should be
-                // better not set orgSeq into the responseMsg before decode
-                auto size = responseMsg.decode(_responseData);
-                AMOP_CLIENT_LOG(DEBUG)
-                    << LOG_BADGE("onRecvAMOPRequest")
-                    << LOG_DESC("AMOP async send message: receive message response for sdk")
-                    << LOG_KV("size", size) << LOG_KV("seq", seq)
-                    << LOG_KV("type", responseMsg.packetType());
+                responseMsg.setStatus(errorCode);
+                // constructor the response
+                responseMsg.setPayload(bcos::bytes(errorMsg.begin(), errorMsg.end()));
                 // recover the seq
                 responseMsg.setSeq(orgSeq);
-                _session->asyncSendMessage(responseMsg);
+                AMOP_CLIENT_LOG(ERROR)
+                    << LOG_BADGE("onRecvAMOPRequest error")
+                    << LOG_DESC("AMOP async send message callback") << LOG_KV("seq", seq)
+                    << LOG_KV("code", error->errorCode())
+                    << LOG_KV("msg", error->errorMessage());
+                session->asyncSendMessage(responseMsg);
+                co_return;
             }
-            catch (std::exception const& e)
-            {
-                AMOP_CLIENT_LOG(WARNING) << LOG_DESC("onRecvAMOPRequest exception")
-                                         << LOG_KV("message", boost::diagnostic_information(e));
-            }
-        });
+            // Note: the decode function will recover m_seq of wsMessage, so it should be
+            // better not set orgSeq into the responseMsg before decode
+            auto size = responseMsg.decode(bcos::ref(responseData));
+            AMOP_CLIENT_LOG(DEBUG)
+                << LOG_BADGE("onRecvAMOPRequest")
+                << LOG_DESC("AMOP async send message: receive message response for sdk")
+                << LOG_KV("size", size) << LOG_KV("seq", seq)
+                << LOG_KV("type", responseMsg.packetType());
+            // recover the seq
+            responseMsg.setSeq(orgSeq);
+            session->asyncSendMessage(responseMsg);
+        }
+        catch (std::exception const& e)
+        {
+            AMOP_CLIENT_LOG(WARNING) << LOG_DESC("onRecvAMOPRequest exception")
+                                     << LOG_KV("message", boost::diagnostic_information(e));
+        }
+    }(self, m_gateway, topic, msgPtr, _session, seq));
 }
 
 bool AMOPClient::trySendAMOPRequestToLocalNode(std::shared_ptr<WsSession> _session,
-    std::string const& _topic, const boostssl::ws::WsMessage& _msg)
+    std::string const& _topic, boostssl::ws::WsMessage _msg)
 {
     // the local node has no client subscribe to the topic
     auto selectedSession = randomChooseSession(_topic);
@@ -201,32 +204,31 @@ bool AMOPClient::trySendAMOPRequestToLocalNode(std::shared_ptr<WsSession> _sessi
     {
         return false;
     }
-    auto self = std::weak_ptr<AMOPClient>(shared_from_this());
-    sendMessageToClient(
-        _topic, selectedSession, _msg, [self, _session](Error::Ptr&&, bytesPointer _responseData) {
-            try
-            {
-                auto amopClient = self.lock();
-                if (!amopClient)
-                {
-                    return;
-                }
-                bcos::boostssl::ws::WsMessage responseMsg;
-                auto size = responseMsg.decode(ref(*_responseData));
-                auto seq = responseMsg.seq();
-                _session->asyncSendMessage(responseMsg);
-                AMOP_CLIENT_LOG(DEBUG)
-                    << LOG_BADGE("trySendAMOPRequestToLocalNode")
-                    << LOG_DESC("AMOP async send message: receive message response for sdk")
-                    << LOG_KV("size", size) << LOG_KV("seq", seq)
-                    << LOG_KV("type", responseMsg.packetType());
-            }
-            catch (std::exception const& e)
-            {
-                AMOP_CLIENT_LOG(WARNING) << LOG_DESC("trySendAMOPRequestToLocalNode exception")
-                                         << LOG_KV("message", boost::diagnostic_information(e));
-            }
-        });
+    // fire-and-forget: forward the request to the selected local client and relay
+    // its response back to the requester session
+    task::wait([](std::shared_ptr<AMOPClient> keepAlive, std::shared_ptr<WsSession> session,
+                   std::string topic, std::shared_ptr<WsSession> selectedSession,
+                   boostssl::ws::WsMessage msg) -> bcos::task::Task<void> {
+        try
+        {
+            auto [error, responseData] = co_await keepAlive->sendMessageToClient(
+                topic, std::move(selectedSession), std::move(msg));
+            bcos::boostssl::ws::WsMessage responseMsg;
+            auto size = responseMsg.decode(ref(*responseData));
+            auto seq = responseMsg.seq();
+            session->asyncSendMessage(responseMsg);
+            AMOP_CLIENT_LOG(DEBUG)
+                << LOG_BADGE("trySendAMOPRequestToLocalNode")
+                << LOG_DESC("AMOP async send message: receive message response for sdk")
+                << LOG_KV("size", size) << LOG_KV("seq", seq)
+                << LOG_KV("type", responseMsg.packetType());
+        }
+        catch (std::exception const& e)
+        {
+            AMOP_CLIENT_LOG(WARNING) << LOG_DESC("trySendAMOPRequestToLocalNode exception")
+                                     << LOG_KV("message", boost::diagnostic_information(e));
+        }
+    }(shared_from_this(), _session, _topic, selectedSession, std::move(_msg)));
     return true;
 }
 
@@ -241,48 +243,99 @@ void AMOPClient::onRecvAMOPBroadcast(boostssl::ws::WsMessage _msg, std::shared_p
     // broadcast message to the sdks connected to the local node
     broadcastAMOPMessage(amopReq->topic(), _msg);
     // broadcast messsage to sdks connected to other nodes
-    m_gateway->asyncSendBroadcastMessageByTopic(
-        amopReq->topic(), bytesConstRef(_msg.payload().data(), _msg.payload().size()));
+    // copy the payload: task::wait is fire-and-forget, the coroutine may outlive this
+    // function scope, so the payload must be owned by the coroutine itself
+    task::wait([](bcos::gateway::GatewayInterface::Ptr gateway, std::string topic,
+                   bcos::bytes payload) -> bcos::task::Task<void> {
+        co_await gateway->sendBroadcastMessageByTopic(topic, bcos::ref(payload));
+    }(m_gateway, amopReq->topic(),
+        bcos::bytes(_msg.payload().begin(), _msg.payload().end())));
     AMOP_CLIENT_LOG(DEBUG) << LOG_BADGE("onRecvAMOPBroadcast") << LOG_KV("seq", seq)
                            << LOG_KV("topic", amopReq->topic());
 }
 
-void AMOPClient::sendMessageToClient(std::string const& _topic,
-    std::shared_ptr<WsSession> _selectSession, const boostssl::ws::WsMessage& _msg,
-    std::function<void(Error::Ptr&&, bytesPointer)> _callback)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bytesPointer>> AMOPClient::sendMessageToClient(
+    std::string const& _topic, std::shared_ptr<WsSession> _selectSession,
+    boostssl::ws::WsMessage _msg)
 {
-    // only the seq is needed by the callback (for logging), capture the scalar
-    auto seq = _msg.seq();
-    _selectSession->asyncSendMessage(_msg, Options(30000),
-        [seq = std::move(seq), _topic, _callback](bcos::Error::Ptr _error,
-            bcos::boostssl::ws::WsMessage _responseMsg, std::shared_ptr<WsSession> _session) {
-            if (_error && _error->errorCode() != bcos::protocol::CommonError::SUCCESS)
-            {
-                AMOP_CLIENT_LOG(WARNING)
-                    << LOG_BADGE("asyncNotifyAMOPMessage")
-                    << LOG_DESC("asyncSendMessage callback failed") << LOG_KV("topic", _topic)
-                    << LOG_KV("seq", seq) << LOG_KV("code", _error->errorCode())
-                    << LOG_KV("message", _error->errorMessage());
-            }
+    // WsSession::asyncSendMessage is the callback boundary of the ws layer; its callback may fire
+    // inline (disconnected / oversize / raw-mismatch) or later on the ws io thread. The bridge
+    // below is safe in both cases: the callback never resumes the coroutine directly, it only
+    // records the result and marks done; await_suspend runs AFTER asyncSendMessage returns and
+    // either resumes the coroutine itself (callback already fired — never from inside
+    // await_suspend, FIB-185) or suspends and leaves the resume to the callback.
+    struct WsSendAwaitable
+    {
+        struct State
+        {
+            // 0 = idle, 1 = suspended (callback resumes), 2 = done (await_suspend resumes itself)
+            std::atomic<int> sync{0};
+            std::coroutine_handle<> handle;
+            Error::Ptr error;
+            bytesPointer data;
+        };
 
-            AMOP_CLIENT_LOG(DEBUG) << LOG_BADGE("asyncNotifyAMOPMessage") << LOG_KV("seq", seq)
-                                   << LOG_KV("data size", _responseMsg.payload().size());
-            auto buffer = std::make_shared<bcos::bytes>();
-            if (!_error)
-            {
-                // Note: on error the response message is a default-constructed WsMessage,
-                // only encode the real response
-                _responseMsg.encode(*buffer);
-            }
+        std::shared_ptr<WsSession> m_session;
+        boostssl::ws::WsMessage m_msg;
+        std::string m_topic;
+        std::shared_ptr<State> m_state;
 
-            _callback(_error ? BCOS_ERROR_PTR(_error->errorCode(), _error->errorMessage()) :
-                               bcos::Error::Ptr(),
-                std::move(buffer));
-        });
+        bool await_ready() const noexcept { return false; }
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto seq = m_msg.seq();
+            m_session->asyncSendMessage(m_msg, Options(30000),
+                [state, seq, topic = m_topic](bcos::Error::Ptr _error,
+                    bcos::boostssl::ws::WsMessage _responseMsg, std::shared_ptr<WsSession>) {
+                    if (_error && _error->errorCode() != bcos::protocol::CommonError::SUCCESS)
+                    {
+                        AMOP_CLIENT_LOG(WARNING)
+                            << LOG_BADGE("notifyAMOPMessage")
+                            << LOG_DESC("asyncSendMessage callback failed")
+                            << LOG_KV("topic", topic) << LOG_KV("seq", seq)
+                            << LOG_KV("code", _error->errorCode())
+                            << LOG_KV("message", _error->errorMessage());
+                    }
+
+                    AMOP_CLIENT_LOG(DEBUG)
+                        << LOG_BADGE("notifyAMOPMessage") << LOG_KV("seq", seq)
+                        << LOG_KV("data size", _responseMsg.payload().size());
+                    auto buffer = std::make_shared<bcos::bytes>();
+                    if (!_error)
+                    {
+                        // Note: on error the response message is a default-constructed WsMessage,
+                        // only encode the real response
+                        _responseMsg.encode(*buffer);
+                    }
+                    state->error = _error ? BCOS_ERROR_PTR(_error->errorCode(),
+                                               _error->errorMessage()) :
+                                            bcos::Error::Ptr();
+                    state->data = std::move(buffer);
+                    if (state->sync.exchange(2, std::memory_order_acq_rel) == 1)
+                    {
+                        state->handle.resume();
+                    }
+                });
+            if (state->sync.exchange(1, std::memory_order_acq_rel) == 2)
+            {
+                // the callback already completed: resume ourselves AFTER await_suspend returns
+                return state->handle;
+            }
+            return std::noop_coroutine();
+        }
+        std::tuple<Error::Ptr, bytesPointer> await_resume()
+        {
+            return {std::move(m_state->error), std::move(m_state->data)};
+        }
+    };
+    co_return co_await WsSendAwaitable{std::move(_selectSession), std::move(_msg), _topic,
+        std::make_shared<WsSendAwaitable::State>()};
 }
 
-void AMOPClient::asyncNotifyAMOPMessage(std::string const& _topic, bytesConstRef _amopRequestData,
-    std::function<void(Error::Ptr&&, bytesPointer)> _callback)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bytesPointer>> AMOPClient::notifyAMOPMessage(
+    std::string const& _topic, bytesConstRef _amopRequestData)
 {
     auto clientSession = randomChooseSession(_topic);
 
@@ -294,38 +347,33 @@ void AMOPClient::asyncNotifyAMOPMessage(std::string const& _topic, bytesConstRef
         auto buffer = std::make_shared<bcos::bytes>();
         // Note: encode the message into buffer, response to the request-sdk
         responseMessage.encode(*buffer);
-        _callback(BCOS_ERROR_PTR(CommonError::NotFoundClientByTopicDispatchMsg,
-                      "NotFoundClientByTopicDispatchMsg"),
-            buffer);
-        AMOP_CLIENT_LOG(DEBUG) << LOG_BADGE("asyncNotifyAMOPMessage: no client found")
+        AMOP_CLIENT_LOG(DEBUG) << LOG_BADGE("notifyAMOPMessage: no client found")
                                << LOG_KV("topic", _topic);
-        return;
+        co_return std::make_tuple(
+            BCOS_ERROR_PTR(CommonError::NotFoundClientByTopicDispatchMsg,
+                "NotFoundClientByTopicDispatchMsg"),
+            buffer);
     }
-    AMOP_CLIENT_LOG(DEBUG) << LOG_BADGE("asyncNotifyAMOPMessage") << LOG_KV("topic", _topic)
+    AMOP_CLIENT_LOG(DEBUG) << LOG_BADGE("notifyAMOPMessage") << LOG_KV("topic", _topic)
                            << LOG_KV("choosedSession", clientSession->endPoint());
     bcos::boostssl::ws::WsMessage requestMsg;
     // Note: WsMessage won't generate seq automatically, we should setSeq
     // manually when need trigger callback after receive response message from the client
     requestMsg.setSeq(bcos::boostssl::ws::newSeq());
     requestMsg.setPacketType(AMOPClientMessageType::AMOP_REQUEST);
-    auto requestPayLoad = bcos::bytes(_amopRequestData.begin(), _amopRequestData.end());
-    requestMsg.setPayload(std::move(requestPayLoad));
-    sendMessageToClient(_topic, clientSession, requestMsg, _callback);
+    requestMsg.setPayload(bcos::bytes(_amopRequestData.begin(), _amopRequestData.end()));
+    co_return co_await sendMessageToClient(_topic, std::move(clientSession), std::move(requestMsg));
 }
 
-void AMOPClient::asyncNotifyAMOPBroadcastMessage(std::string const& _topic, bytesConstRef _data,
-    std::function<void(Error::Ptr&&, bytesPointer)> _callback)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bytesPointer>> AMOPClient::notifyAMOPBroadcastMessage(
+    std::string const& _topic, bytesConstRef _data)
 {
-    AMOP_CLIENT_LOG(DEBUG) << LOG_DESC("asyncNotifyAMOPBroadcastMessage")
-                           << LOG_KV("topic", _topic);
+    AMOP_CLIENT_LOG(DEBUG) << LOG_DESC("notifyAMOPBroadcastMessage") << LOG_KV("topic", _topic);
     bcos::boostssl::ws::WsMessage requestMsg;
     requestMsg.setPacketType(AMOPClientMessageType::AMOP_BROADCAST);
     requestMsg.setPayload(bcos::bytes(_data.begin(), _data.end()));
     broadcastAMOPMessage(_topic, requestMsg);
-    if (_callback)
-    {
-        _callback(nullptr, nullptr);
-    }
+    co_return std::make_tuple(bcos::Error::Ptr(), bytesPointer());
 }
 
 void AMOPClient::broadcastAMOPMessage(

--- a/bcos-rpc/bcos-rpc/amop/AMOPClient.h
+++ b/bcos-rpc/bcos-rpc/amop/AMOPClient.h
@@ -55,30 +55,32 @@ public:
     virtual ~AMOPClient() = default;
     /**
      * @brief receive amop request message from the gateway
-     *
+     * @return {error, responseData}: error is nullptr on success
      */
-    virtual void asyncNotifyAMOPMessage(int16_t _type, std::string const& _topic,
-        bytesConstRef _data, std::function<void(Error::Ptr&&, bytesPointer)> _callback)
+    virtual task::Task<std::tuple<Error::Ptr, bytesPointer>> notifyAMOPMessage(
+        int16_t _type, std::string const& _topic, bytesConstRef _data)
     {
         try
         {
             switch (_type)
             {
             case AMOPNotifyMessageType::Unicast:
-                asyncNotifyAMOPMessage(_topic, _data, _callback);
-                break;
+                co_return co_await notifyAMOPMessage(_topic, _data);
             case AMOPNotifyMessageType::Broadcast:
-                asyncNotifyAMOPBroadcastMessage(_topic, _data, _callback);
-                break;
+                co_return co_await notifyAMOPBroadcastMessage(_topic, _data);
             default:
-                BCOS_LOG(WARNING) << LOG_DESC("asyncNotifyAMOPMessage: unknown message type")
+                BCOS_LOG(WARNING) << LOG_DESC("notifyAMOPMessage: unknown message type")
                                   << LOG_KV("type", _type);
+                co_return std::make_tuple(
+                    BCOS_ERROR_PTR(-1, "unknown AMOP notify message type"), bytesPointer());
             }
         }
         catch (std::exception const& e)
         {
-            BCOS_LOG(WARNING) << LOG_DESC("asyncNotifyAMOPMessage exception")
+            BCOS_LOG(WARNING) << LOG_DESC("notifyAMOPMessage exception")
                               << LOG_KV("message", boost::diagnostic_information(e));
+            co_return std::make_tuple(
+                BCOS_ERROR_PTR(-1, boost::diagnostic_information(e)), bytesPointer());
         }
     }
 
@@ -127,10 +129,10 @@ protected:
 
     std::shared_ptr<boostssl::ws::WsSession> randomChooseSession(std::string const& _topic);
 
-    virtual void asyncNotifyAMOPMessage(std::string const& _topic, bytesConstRef _data,
-        std::function<void(Error::Ptr&&, bytesPointer)> _callback);
-    virtual void asyncNotifyAMOPBroadcastMessage(std::string const& _topic, bytesConstRef _data,
-        std::function<void(Error::Ptr&&, bytesPointer)> _callback);
+    virtual task::Task<std::tuple<Error::Ptr, bytesPointer>> notifyAMOPMessage(
+        std::string const& _topic, bytesConstRef _data);
+    virtual task::Task<std::tuple<Error::Ptr, bytesPointer>> notifyAMOPBroadcastMessage(
+        std::string const& _topic, bytesConstRef _data);
 
     std::map<std::string, std::shared_ptr<boostssl::ws::WsSession>> querySessionsByTopic(
         std::string const& _topic) const
@@ -155,13 +157,11 @@ protected:
 
     virtual void initMsgHandler();
 
-    void sendMessageToClient(std::string const& _topic,
-        std::shared_ptr<boostssl::ws::WsSession> _selectSession,
-        const boostssl::ws::WsMessage& _msg,
-        std::function<void(bcos::Error::Ptr&&, bytesPointer)> _callback);
+    task::Task<std::tuple<Error::Ptr, bytesPointer>> sendMessageToClient(std::string const& _topic,
+        std::shared_ptr<boostssl::ws::WsSession> _selectSession, boostssl::ws::WsMessage _msg);
 
     bool trySendAMOPRequestToLocalNode(std::shared_ptr<boostssl::ws::WsSession> _session,
-        std::string const& _topic, const boostssl::ws::WsMessage& _msg);
+        std::string const& _topic, boostssl::ws::WsMessage _msg);
 
     void broadcastAMOPMessage(std::string const& _topic, const boostssl::ws::WsMessage& _msg);
 

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -1229,28 +1229,28 @@ void JsonRpcImpl_2_0::getPeers(RespFunc _respFunc)
 {
     RPC_IMPL_LOG(TRACE) << LOG_DESC("getPeers");
     auto self = std::weak_ptr<JsonRpcImpl_2_0>(shared_from_this());
-    m_gatewayInterface->asyncGetPeers([m_respFunc = std::move(_respFunc), self](Error::Ptr _error,
-                                          bcos::gateway::GatewayInfo::Ptr _localP2pInfo,
-                                          bcos::gateway::GatewayInfosPtr _peersInfo) {
+    task::wait([](std::weak_ptr<JsonRpcImpl_2_0> self, RespFunc m_respFunc,
+                   bcos::gateway::GatewayInterface::Ptr gateway) -> task::Task<void> {
+        auto [error, localP2pInfo, peersInfo] = co_await gateway->getPeers();
         auto rpc = self.lock();
         if (!rpc)
         {
-            return;
+            co_return;
         }
         Json::Value jResp;
-        if (!_error || (_error->errorCode() == bcos::protocol::CommonError::SUCCESS))
+        if (!error || (error->errorCode() == bcos::protocol::CommonError::SUCCESS))
         {
-            rpc->gatewayInfoToJson(jResp, _localP2pInfo, _peersInfo);
+            rpc->gatewayInfoToJson(jResp, localP2pInfo, peersInfo);
         }
         else
         {
             RPC_IMPL_LOG(INFO) << LOG_BADGE("getPeers failed")
-                               << LOG_KV("code", _error ? _error->errorCode() : 0)
-                               << LOG_KV("message", _error ? _error->errorMessage() : "success");
+                               << LOG_KV("code", error ? error->errorCode() : 0)
+                               << LOG_KV("message", error ? error->errorMessage() : "success");
         }
 
-        m_respFunc(_error, jResp);
-    });
+        m_respFunc(error, jResp);
+    }(self, std::move(_respFunc), m_gatewayInterface));
 }
 
 NodeService::Ptr JsonRpcImpl_2_0::getNodeService(
@@ -1431,27 +1431,26 @@ void JsonRpcImpl_2_0::getGroupPeers(Json::Value& _response, std::string_view _gr
 void JsonRpcImpl_2_0::getGroupPeers(std::string_view _groupID, RespFunc _respFunc)
 {
     auto self = std::weak_ptr<JsonRpcImpl_2_0>(shared_from_this());
-    m_gatewayInterface->asyncGetPeers(
-        [_respFunc, group = std::string(_groupID), self](Error::Ptr _error,
-            bcos::gateway::GatewayInfo::Ptr _localP2pInfo,
-            bcos::gateway::GatewayInfosPtr _peersInfo) {
-            Json::Value jResp(Json::arrayValue);
-            if (_error)
-            {
-                RPC_IMPL_LOG(INFO)
-                    << LOG_BADGE("getGroupPeers failed") << LOG_KV("code", _error->errorCode())
-                    << LOG_KV("message", _error->errorMessage());
-                _respFunc(_error, jResp);
-                return;
-            }
-            auto rpc = self.lock();
-            if (!rpc)
-            {
-                return;
-            }
-            rpc->getGroupPeers(jResp, std::string_view(group), _localP2pInfo, _peersInfo);
-            _respFunc(_error, jResp);
-        });
+    task::wait([](std::weak_ptr<JsonRpcImpl_2_0> self, RespFunc respFunc, std::string group,
+                   bcos::gateway::GatewayInterface::Ptr gateway) -> task::Task<void> {
+        auto [error, localP2pInfo, peersInfo] = co_await gateway->getPeers();
+        Json::Value jResp(Json::arrayValue);
+        if (error)
+        {
+            RPC_IMPL_LOG(INFO)
+                << LOG_BADGE("getGroupPeers failed") << LOG_KV("code", error->errorCode())
+                << LOG_KV("message", error->errorMessage());
+            respFunc(error, jResp);
+            co_return;
+        }
+        auto rpc = self.lock();
+        if (!rpc)
+        {
+            co_return;
+        }
+        rpc->getGroupPeers(jResp, std::string_view(group), localP2pInfo, peersInfo);
+        respFunc(error, jResp);
+    }(self, std::move(_respFunc), std::string(_groupID), m_gatewayInterface));
 }
 
 void JsonRpcImpl_2_0::newBlockFilter(std::string_view _groupID, RespFunc _respFunc)

--- a/bcos-rpc/test/unittests/rpc/GatewayHandlersTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/GatewayHandlersTest.cpp
@@ -20,18 +20,17 @@ namespace bcos::test
 {
 namespace
 {
-// FakeGateWayWrapper::asyncGetPeers has an empty body (never calls back), which
-// would hang getPeers/getGroupPeers. Override it to call back with an error so
-// the handlers run their dispatch + error branch without needing valid
+// FakeGateWayWrapper::getPeers returns an empty (nullptr) result by default. Override it to
+// return an error so the handlers run their dispatch + error branch without needing valid
 // GatewayInfo (which the success path would serialize).
 class ErrorGateway : public FakeGateWayWrapper
 {
 public:
-    void asyncGetPeers(
-        std::function<void(Error::Ptr, gateway::GatewayInfo::Ptr, gateway::GatewayInfosPtr)>
-            _callback) override
+    bcos::task::Task<std::tuple<Error::Ptr, gateway::GatewayInfo::Ptr, gateway::GatewayInfosPtr>>
+    getPeers() override
     {
-        _callback(BCOS_ERROR_PTR(-1, "no peers in test"), nullptr, nullptr);
+        co_return std::make_tuple(BCOS_ERROR_PTR(-1, "no peers in test"),
+            gateway::GatewayInfo::Ptr(nullptr), gateway::GatewayInfosPtr(nullptr));
     }
 };
 

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -224,7 +224,8 @@ bcostars::GatewayServiceClient::getPeers()
         await_resume()
         {
             return std::make_tuple(
-                std::move(m_state->error), std::move(m_state->localInfo), std::move(m_state->peers));
+                std::move(m_state->error), std::move(m_state->localInfo),
+                std::move(m_state->peers));
         }
     };
 

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -140,58 +140,96 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::sendMessageBy
         std::move(buffer), std::make_shared<SendAwaitable::CompletionState>()};
     co_return co_await awaitable;
 }
-void bcostars::GatewayServiceClient::asyncGetPeers(std::function<void(
-        bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>
-        _callback)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr,
+    bcos::gateway::GatewayInfosPtr>>
+bcostars::GatewayServiceClient::getPeers()
 {
-    class Callback : public bcostars::GatewayServicePrxCallback
+    struct GetPeersAwaitable
     {
-    public:
-        Callback(std::function<void(
-                bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>
-                callback)
-          : m_callback(callback)
-        {}
-
-        void callback_asyncGetPeers(const bcostars::Error& ret,
-            const bcostars::GatewayInfo& _localInfo,
-            const std::vector<bcostars::GatewayInfo>& _peers) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            auto localGatewayInfo = fromTarsGatewayInfo(_localInfo);
-            auto peersGatewayInfos = std::make_shared<bcos::gateway::GatewayInfos>();
-            for (auto const& peerNodeInfo : _peers)
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+            bcos::gateway::GatewayInfo::Ptr localInfo;
+            bcos::gateway::GatewayInfosPtr peers;
+        };
+
+        class Callback : public bcostars::GatewayServicePrxCallback
+        {
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncGetPeers(const bcostars::Error& ret,
+                const bcostars::GatewayInfo& _localInfo,
+                const std::vector<bcostars::GatewayInfo>& _peers) override
             {
-                peersGatewayInfos->emplace_back(fromTarsGatewayInfo(peerNodeInfo));
+                s_tarsTimeoutCount.store(0);
+                auto localGatewayInfo = fromTarsGatewayInfo(_localInfo);
+                auto peersGatewayInfos = std::make_shared<bcos::gateway::GatewayInfos>();
+                for (auto const& peerNodeInfo : _peers)
+                {
+                    peersGatewayInfos->emplace_back(fromTarsGatewayInfo(peerNodeInfo));
+                }
+                complete(toBcosError(ret), std::move(localGatewayInfo),
+                    std::move(peersGatewayInfos));
             }
-            m_callback(toBcosError(ret), localGatewayInfo, peersGatewayInfos);
-        }
-        void callback_asyncGetPeers_exception(tars::Int32 ret) override
+            void callback_asyncGetPeers_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret), nullptr, nullptr);
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error, bcos::gateway::GatewayInfo::Ptr localInfo,
+                bcos::gateway::GatewayInfosPtr peers)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->localInfo = std::move(localInfo);
+                    m_state->peers = std::move(peers);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        GatewayServiceClient* m_self;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // see SendAwaitable::await_suspend for why this returns false on a synchronous
+        // connection-check failure
+        bool await_suspend(std::coroutine_handle<> _handle)
         {
-            s_tarsTimeoutCount++;
-            m_callback(toBcosError(ret), nullptr, nullptr);
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncGetPeers", m_self->m_prx,
+                [state](bcos::Error::Ptr _error) { state->error = std::move(_error); },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            m_self->m_prx->async_asyncGetPeers(new Callback(state));
+            return true;
         }
 
-    private:
-        std::function<void(
-            bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>
-            m_callback;
+        std::tuple<bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr,
+            bcos::gateway::GatewayInfosPtr>
+        await_resume()
+        {
+            return std::make_tuple(
+                std::move(m_state->error), std::move(m_state->localInfo), std::move(m_state->peers));
+        }
     };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncGetPeers", m_prx,
-        [_callback](bcos::Error::Ptr _error) {
-            if (_callback)
-            {
-                _callback(std::move(_error), nullptr, nullptr);
-            }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    m_prx->async_asyncGetPeers(new Callback(_callback));
+
+    GetPeersAwaitable awaitable{this, std::make_shared<GetPeersAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 bcos::task::Task<void> bcostars::GatewayServiceClient::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,
@@ -210,49 +248,87 @@ bcos::task::Task<void> bcostars::GatewayServiceClient::broadcastMessage(uint16_t
         std::vector<char>(srcNodeIDBytes.begin(), srcNodeIDBytes.end()),
         std::vector<char>(data.begin(), data.end()));
 };
-void bcostars::GatewayServiceClient::asyncGetGroupNodeInfo(
-    const std::string& _groupID, bcos::gateway::GetGroupNodeInfoFunc _onGetGroupNodeInfo)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+bcostars::GatewayServiceClient::getGroupNodeInfo(const std::string& _groupID)
 {
-    class Callback : public GatewayServicePrxCallback
+    struct GetGroupNodeInfoAwaitable
     {
-    public:
-        Callback(
-            bcos::gateway::GetGroupNodeInfoFunc callback, bcos::crypto::KeyFactory::Ptr keyFactory)
-          : m_callback(callback), m_keyFactory(keyFactory)
-        {}
-        void callback_asyncGetGroupNodeInfo(
-            const bcostars::Error& ret, const GroupNodeInfo& groupNodeInfo) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            auto bcosGroupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
-                [m_groupNodeInfo = groupNodeInfo]() mutable { return &m_groupNodeInfo; });
-            m_callback(toBcosError(ret), bcosGroupNodeInfo);
-        }
-        void callback_asyncGetGroupNodeInfo_exception(tars::Int32 ret) override
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+            bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo;
+        };
+
+        class Callback : public bcostars::GatewayServicePrxCallback
         {
-            s_tarsTimeoutCount++;
-            m_callback(toBcosError(ret), nullptr);
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncGetGroupNodeInfo(
+                const bcostars::Error& ret, const bcostars::GroupNodeInfo& groupNodeInfo) override
+            {
+                s_tarsTimeoutCount.store(0);
+                auto bcosGroupNodeInfo =
+                    std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
+                        [m_groupNodeInfo = groupNodeInfo]() mutable { return &m_groupNodeInfo; });
+                complete(toBcosError(ret), std::move(bcosGroupNodeInfo));
+            }
+            void callback_asyncGetGroupNodeInfo_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret), nullptr);
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error, bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->groupNodeInfo = std::move(groupNodeInfo);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        GatewayServiceClient* m_self;
+        std::string m_groupID;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // see SendAwaitable::await_suspend for why this returns false on a synchronous
+        // connection-check failure
+        bool await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncGetGroupNodeInfo",
+                m_self->m_prx,
+                [state](bcos::Error::Ptr _error) { state->error = std::move(_error); },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            m_self->m_prx->async_asyncGetGroupNodeInfo(new Callback(state), m_groupID);
+            return true;
         }
 
-    private:
-        bcos::gateway::GetGroupNodeInfoFunc m_callback;
-        bcos::crypto::KeyFactory::Ptr m_keyFactory;
+        std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr> await_resume()
+        {
+            return std::make_tuple(std::move(m_state->error), std::move(m_state->groupNodeInfo));
+        }
     };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncGetGroupNodeInfo", m_prx,
-        [_onGetGroupNodeInfo](bcos::Error::Ptr _error) {
-            if (_onGetGroupNodeInfo)
-            {
-                _onGetGroupNodeInfo(_error, nullptr);
-            }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    m_prx->async_asyncGetGroupNodeInfo(new Callback(_onGetGroupNodeInfo, m_keyFactory), _groupID);
+
+    GetGroupNodeInfoAwaitable awaitable{
+        this, _groupID, std::make_shared<GetGroupNodeInfoAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 void bcostars::GatewayServiceClient::asyncNotifyGroupInfo(
     bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(bcos::Error::Ptr&&)> _callback)
@@ -301,52 +377,100 @@ void bcostars::GatewayServiceClient::asyncNotifyGroupInfo(
         prx->async_asyncNotifyGroupInfo(new Callback(_callback), tarsGroupInfo);
     }
 }
-void bcostars::GatewayServiceClient::asyncSendMessageByTopic(const std::string& _topic,
-    bcos::bytesConstRef _data,
-    std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)> _respFunc)
+bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>>
+bcostars::GatewayServiceClient::sendMessageByTopic(
+    const std::string& _topic, bcos::bytesConstRef _data)
 {
-    class Callback : public bcostars::GatewayServicePrxCallback
+    struct SendTopicAwaitable
     {
-    public:
-        Callback(std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)> callback)
-          : m_callback(callback)
-        {}
-        void callback_asyncSendMessageByTopic(const bcostars::Error& ret, tars::Int32 _type,
-            const std::vector<tars::Char>& _responseData) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            auto data = bcos::bytesConstRef(
-                reinterpret_cast<const bcos::byte*>(_responseData.data()), _responseData.size());
-            m_callback(toBcosError(ret), _type, data);
-        }
-        void callback_asyncSendMessageByTopic_exception(tars::Int32 ret) override
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+            int16_t type = 0;
+            bcos::bytes data;
+        };
+
+        class Callback : public bcostars::GatewayServicePrxCallback
         {
-            s_tarsTimeoutCount++;
-            m_callback(toBcosError(ret), 0, {});
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncSendMessageByTopic(const bcostars::Error& ret, tars::Int32 _type,
+                const std::vector<tars::Char>& _responseData) override
+            {
+                s_tarsTimeoutCount.store(0);
+                complete(toBcosError(ret), static_cast<int16_t>(_type),
+                    bcos::bytes(_responseData.begin(), _responseData.end()));
+            }
+            void callback_asyncSendMessageByTopic_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret), 0, {});
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error, int16_t type, bcos::bytes data)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->type = type;
+                    m_state->data = std::move(data);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        GatewayServiceClient* m_self;
+        std::string m_topic;
+        std::shared_ptr<std::vector<char>> m_buffer;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // see SendAwaitable::await_suspend for why this returns false on a synchronous
+        // connection-check failure
+        bool await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto buffer = m_buffer;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncSendMessageByTopic",
+                m_self->m_prx,
+                [state, buffer](bcos::Error::Ptr _error) {
+                    state->error = std::move(_error);
+                    (void)buffer;
+                },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            m_self->m_prx->tars_set_timeout(m_self->c_amopTimeout)
+                ->async_asyncSendMessageByTopic(new Callback(state), m_topic, *buffer);
+            return true;
         }
 
-    private:
-        std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)> m_callback;
+        std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes> await_resume()
+        {
+            return std::make_tuple(
+                std::move(m_state->error), m_state->type, std::move(m_state->data));
+        }
     };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncSendMessageByTopic", m_prx,
-        [_respFunc](bcos::Error::Ptr _error) {
-            if (_respFunc)
-            {
-                _respFunc(std::move(_error), 0, {});
-            }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    std::vector<tars::Char> tarsRequestData(_data.begin(), _data.end());
-    m_prx->tars_set_timeout(c_amopTimeout)
-        ->async_asyncSendMessageByTopic(new Callback(_respFunc), _topic, tarsRequestData);
+
+    // copy the payload into an owned buffer before the RPC — the caller's bytesConstRef is not
+    // guaranteed to outlive the request
+    auto buffer = std::make_shared<std::vector<char>>(_data.begin(), _data.end());
+    SendTopicAwaitable awaitable{
+        this, _topic, std::move(buffer), std::make_shared<SendTopicAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
-void bcostars::GatewayServiceClient::asyncSendBroadcastMessageByTopic(
+bcos::task::Task<void> bcostars::GatewayServiceClient::sendBroadcastMessageByTopic(
     const std::string& _topic, bcos::bytesConstRef _data)
 {
     auto shouldBlockCall = shouldStopCall();
@@ -354,10 +478,12 @@ void bcostars::GatewayServiceClient::asyncSendBroadcastMessageByTopic(
         c_moduleName, "asyncSendBroadcastMessageByTopic", m_prx, nullptr, shouldBlockCall);
     if (!ret && shouldBlockCall)
     {
-        return;
+        co_return;
     }
-    std::vector<tars::Char> tarsRequestData(_data.begin(), _data.end());
+    // fire-and-forget: copy the payload into an owned buffer and send without a callback
+    std::vector<char> tarsRequestData(_data.begin(), _data.end());
     m_prx->async_asyncSendBroadcastMessageByTopic(nullptr, _topic, tarsRequestData);
+    co_return;
 }
 void bcostars::GatewayServiceClient::asyncSubscribeTopic(std::string const& _clientID,
     std::string const& _topicInfo, std::function<void(bcos::Error::Ptr&&)> _callback)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -41,9 +41,9 @@ public:
 
     void setKeyFactory(bcos::crypto::KeyFactory::Ptr keyFactory);
 
-    void asyncGetPeers(std::function<void(
-            bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>
-            _callback) override;
+    bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr,
+        bcos::gateway::GatewayInfosPtr>>
+    getPeers() override;
 
     // (coroutine) send message to a single node by awaiting the gateway-service RPC
     bcos::task::Task<bcos::Error::Ptr> sendMessageByNodeID(const std::string& _groupID,
@@ -54,16 +54,16 @@ public:
         const bcos::crypto::NodeID& srcNodeID,
         ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads) override;
 
-    void asyncGetGroupNodeInfo(const std::string& _groupID,
-        bcos::gateway::GetGroupNodeInfoFunc _onGetGroupNodeInfo) override;
+    bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+    getGroupNodeInfo(const std::string& _groupID) override;
 
     void asyncNotifyGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo,
         std::function<void(bcos::Error::Ptr&&)> _callback) override;
 
-    void asyncSendMessageByTopic(const std::string& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&&, int16_t, bcos::bytesConstRef)> _respFunc) override;
+    bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
+        const std::string& _topic, bcos::bytesConstRef _data) override;
 
-    void asyncSendBroadcastMessageByTopic(
+    bcos::task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) override;
 
     void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,
@@ -82,7 +82,7 @@ protected:
 private:
     bcostars::GatewayServicePrx m_prx;
     std::string m_gatewayServiceName;
-    // Note: only useful for asyncGetGroupNodeInfo
+    // Note: only useful for getGroupNodeInfo
     bcos::crypto::KeyFactory::Ptr m_keyFactory;
     std::string const c_moduleName = "GatewayServiceClient";
     // AMOP timeout 40s

--- a/bcos-tars-protocol/bcos-tars-protocol/client/RpcServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/RpcServiceClient.cpp
@@ -118,52 +118,97 @@ void bcostars::RpcServiceClient::asyncNotifyGroupInfo(
         prx->async_asyncNotifyGroupInfo(new Callback(_callback), tarsGroupInfo);
     }
 }
-void bcostars::RpcServiceClient::asyncNotifyAMOPMessage(int16_t _type, std::string const& _topic,
-    bcos::bytesConstRef _data,
-    std::function<void(bcos::Error::Ptr&& _error, bcos::bytesPointer _responseData)> _callback)
-
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::bytesPointer>>
+bcostars::RpcServiceClient::notifyAMOPMessage(
+    int16_t _type, std::string const& _topic, bcos::bytesConstRef _data)
 {
-    class Callback : public bcostars::RpcServicePrxCallback
+    struct NotifyAwaitable
     {
-    public:
-        Callback(std::function<void(bcos::Error::Ptr&&, bcos::bytesPointer)> callback)
-          : m_callback(callback)
-        {}
-
-        void callback_asyncNotifyAMOPMessage(
-            const bcostars::Error& ret, const std::vector<tars::Char>& _responseData) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            auto responseData =
-                std::make_shared<bcos::bytes>(_responseData.begin(), _responseData.end());
-            m_callback(toBcosError(ret), responseData);
-        }
-        void callback_asyncNotifyAMOPMessage_exception(tars::Int32 ret) override
-        {
-            s_tarsTimeoutCount++;
-            m_callback(toBcosError(ret), nullptr);
-        }
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+            bcos::bytesPointer data;
+        };
 
-    private:
-        std::function<void(bcos::Error::Ptr&&, bcos::bytesPointer)> m_callback;
-    };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncNotifyAMOPMessage", m_prx,
-        [_callback](bcos::Error::Ptr _error) {
-            if (_callback)
+        class Callback : public bcostars::RpcServicePrxCallback
+        {
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state)) {}
+
+            void callback_asyncNotifyAMOPMessage(
+                const bcostars::Error& ret, const std::vector<tars::Char>& _responseData) override
             {
-                _callback(std::move(_error), nullptr);
+                s_tarsTimeoutCount.store(0);
+                complete(toBcosError(ret),
+                    std::make_shared<bcos::bytes>(_responseData.begin(), _responseData.end()));
             }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    std::vector<tars::Char> request(_data.begin(), _data.end());
-    m_prx->tars_set_timeout(c_amopTimeout)
-        ->async_asyncNotifyAMOPMessage(new Callback(_callback), _type, _topic, request);
+            void callback_asyncNotifyAMOPMessage_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret), nullptr);
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error, bcos::bytesPointer data)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->data = std::move(data);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        RpcServiceClient* m_self;
+        int16_t m_type;
+        std::string m_topic;
+        std::shared_ptr<std::vector<char>> m_buffer;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // Returns false (no suspension) on a synchronous connection-check failure so the coroutine
+        // is never resumed from inside await_suspend — resuming a coroutine that is still executing
+        // await_suspend is undefined behaviour. Returns true (suspend) once the RPC is in flight.
+        bool await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto buffer = m_buffer;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncNotifyAMOPMessage", m_self->m_prx,
+                [state, buffer](bcos::Error::Ptr _error) {
+                    // connection-check failure: record the error; await_suspend returns false so
+                    // the coroutine continues on this thread and await_resume delivers it
+                    state->error = std::move(_error);
+                    (void)buffer;
+                },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            m_self->m_prx->tars_set_timeout(m_self->c_amopTimeout)
+                ->async_asyncNotifyAMOPMessage(new Callback(state), m_type, m_topic, *buffer);
+            return true;
+        }
+
+        std::tuple<bcos::Error::Ptr, bcos::bytesPointer> await_resume()
+        {
+            return {std::move(m_state->error), std::move(m_state->data)};
+        }
+    };
+
+    // copy the payload into an owned buffer before the RPC — the caller's bytesConstRef is not
+    // guaranteed to outlive the request
+    auto buffer = std::make_shared<std::vector<char>>(_data.begin(), _data.end());
+    NotifyAwaitable awaitable{this, _type, _topic, std::move(buffer),
+        std::make_shared<NotifyAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 void bcostars::RpcServiceClient::asyncNotifySubscribeTopic(
     std::function<void(bcos::Error::Ptr&& _error, std::string)> _callback)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/RpcServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/RpcServiceClient.cpp
@@ -180,7 +180,8 @@ bcostars::RpcServiceClient::notifyAMOPMessage(
             auto state = m_state;
             auto buffer = m_buffer;
             auto shouldBlockCall = m_self->shouldStopCall();
-            auto ret = checkConnection(m_self->c_moduleName, "asyncNotifyAMOPMessage", m_self->m_prx,
+            auto ret = checkConnection(m_self->c_moduleName, "asyncNotifyAMOPMessage",
+                m_self->m_prx,
                 [state, buffer](bcos::Error::Ptr _error) {
                     // connection-check failure: record the error; await_suspend returns false so
                     // the coroutine continues on this thread and await_resume delivers it

--- a/bcos-tars-protocol/bcos-tars-protocol/client/RpcServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/RpcServiceClient.h
@@ -54,9 +54,8 @@ public:
     void asyncNotifyGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo,
         std::function<void(bcos::Error::Ptr&&)> _callback) override;
 
-    void asyncNotifyAMOPMessage(int16_t _type, std::string const& _topic, bcos::bytesConstRef _data,
-        std::function<void(bcos::Error::Ptr&& _error, bcos::bytesPointer _responseData)> _callback)
-        override;
+    bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::bytesPointer>> notifyAMOPMessage(
+        int16_t _type, std::string const& _topic, bcos::bytesConstRef _data) override;
 
     void asyncNotifySubscribeTopic(
         std::function<void(bcos::Error::Ptr&& _error, std::string)> _callback) override;

--- a/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
+++ b/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
@@ -21,16 +21,31 @@ bcostars::Error GatewayServiceServer::asyncSendMessageByTopic(const std::string&
     tars::TarsCurrentPtr current)
 {
     current->setResponse(false);
-    m_gatewayInitializer->gateway()->asyncSendMessageByTopic(_topic,
-        bcos::bytesConstRef((const bcos::byte*)_data.data(), _data.size()),
-        [current](bcos::Error::Ptr&& _error, int16_t _type, bcos::bytesConstRef _responseData) {
-            std::vector<tars::Char> response;
-            if (_responseData)
-            {
-                response.assign(_responseData.begin(), _responseData.end());
-            }
-            async_response_asyncSendMessageByTopic(current, toTarsError(_error), _type, response);
-        });
+    auto gateway = m_gatewayInitializer->gateway();
+    // copy the payload and pass all state as coroutine parameters so it stays alive for the whole
+    // (possibly deferred) send; try/catch guarantees the RPC is always answered even if the send
+    // throws (current->setResponse(false) already disabled the automatic reply)
+    auto requestData = std::make_shared<std::vector<tars::Char>>(_data);
+    bcos::task::wait([](auto _gateway, auto _topic, auto _requestData,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto [error, type, responseData] = co_await _gateway->sendMessageByTopic(_topic,
+                bcos::bytesConstRef(
+                    (const bcos::byte*)_requestData->data(), _requestData->size()));
+            std::vector<tars::Char> response(responseData.begin(), responseData.end());
+            async_response_asyncSendMessageByTopic(
+                _current, toTarsError(error), type, response);
+        }
+        catch (std::exception const& e)
+        {
+            GATEWAYSERVICE_LOG(WARNING) << LOG_DESC("asyncSendMessageByTopic send exception")
+                                        << LOG_KV("topic", _topic)
+                                        << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_asyncSendMessageByTopic(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))), 0, {});
+        }
+    }(gateway, _topic, requestData, current));
     return {};
 }
 
@@ -48,8 +63,14 @@ bcostars::Error GatewayServiceServer::asyncSendBroadcastMessageByTopic(
     const std::string& _topic, const std::vector<tars::Char>& _data, tars::TarsCurrentPtr current)
 {
     current->setResponse(false);
-    m_gatewayInitializer->gateway()->asyncSendBroadcastMessageByTopic(
-        _topic, bcos::bytesConstRef((const bcos::byte*)_data.data(), _data.size()));
+    auto gateway = m_gatewayInitializer->gateway();
+    // copy the payload into the coroutine frame so it stays alive until the send completes
+    auto requestData = std::make_shared<std::vector<tars::Char>>(_data);
+    bcos::task::wait([](auto _gateway, auto _topic,
+                         auto _requestData) -> bcos::task::Task<void> {
+        co_await _gateway->sendBroadcastMessageByTopic(_topic,
+            bcos::bytesConstRef((const bcos::byte*)_requestData->data(), _requestData->size()));
+    }(gateway, _topic, requestData));
     async_response_asyncSendBroadcastMessageByTopic(
         current, toTarsError<bcos::Error::Ptr>(nullptr));
     return {};
@@ -92,20 +113,33 @@ bcostars::Error bcostars::GatewayServiceServer::asyncGetPeers(
 {
     GATEWAYSERVICE_LOG(DEBUG) << LOG_DESC("asyncGetPeers: request");
     current->setResponse(false);
-    m_gatewayInitializer->gateway()->asyncGetPeers(
-        [current](const bcos::Error::Ptr _error, bcos::gateway::GatewayInfo::Ptr _localP2pInfo,
-            bcos::gateway::GatewayInfosPtr _peers) {
-            auto localtarsP2pInfo = toTarsGatewayInfo(_localP2pInfo);
-            std::vector<bcostars::GatewayInfo> peersInfo;
-            if (_peers)
+    auto gateway = m_gatewayInitializer->gateway();
+    bcos::task::wait(
+        [](auto _gateway, auto _current) -> bcos::task::Task<void> {
+            try
             {
-                for (auto const& peer : *_peers)
+                auto [error, localP2pInfo, peers] = co_await _gateway->getPeers();
+                auto localtarsP2pInfo = toTarsGatewayInfo(localP2pInfo);
+                std::vector<bcostars::GatewayInfo> peersInfo;
+                if (peers)
                 {
-                    peersInfo.emplace_back(toTarsGatewayInfo(peer));
+                    for (auto const& peer : *peers)
+                    {
+                        peersInfo.emplace_back(toTarsGatewayInfo(peer));
+                    }
                 }
+                async_response_asyncGetPeers(
+                    _current, toTarsError(error), localtarsP2pInfo, peersInfo);
             }
-            async_response_asyncGetPeers(current, toTarsError(_error), localtarsP2pInfo, peersInfo);
-        });
+            catch (std::exception const& e)
+            {
+                GATEWAYSERVICE_LOG(WARNING) << LOG_DESC("asyncGetPeers exception")
+                                            << LOG_KV("what", boost::diagnostic_information(e));
+                async_response_asyncGetPeers(_current,
+                    toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))),
+                    bcostars::GatewayInfo(), {});
+            }
+        }(gateway, current));
     return {};
 }
 bcostars::Error bcostars::GatewayServiceServer::asyncSendMessageByNodeID(const std::string& groupID,
@@ -198,21 +232,35 @@ bcostars::Error bcostars::GatewayServiceServer::asyncGetGroupNodeInfo(
     const std::string& groupID, GroupNodeInfo&, tars::TarsCurrentPtr current)
 {
     current->setResponse(false);
-
-    m_gatewayInitializer->gateway()->asyncGetGroupNodeInfo(groupID,
-        [current](bcos::Error::Ptr _error, bcos::gateway::GroupNodeInfo::Ptr _bcosGroupNodeInfo) {
-            // Note: the nodeIDs maybe null if no connections
-            if (!_bcosGroupNodeInfo || _bcosGroupNodeInfo->nodeIDList().empty())
+    auto gateway = m_gatewayInitializer->gateway();
+    bcos::task::wait(
+        [](auto _gateway, auto _groupID, auto _current) -> bcos::task::Task<void> {
+            try
             {
+                auto [error, bcosGroupNodeInfo] =
+                    co_await _gateway->getGroupNodeInfo(_groupID);
+                // Note: the nodeIDs maybe null if no connections
+                if (!bcosGroupNodeInfo || bcosGroupNodeInfo->nodeIDList().empty())
+                {
+                    async_response_asyncGetGroupNodeInfo(
+                        _current, toTarsError(error), bcostars::GroupNodeInfo());
+                    co_return;
+                }
+                auto groupInfoImpl =
+                    std::dynamic_pointer_cast<bcostars::protocol::GroupNodeInfoImpl>(
+                        bcosGroupNodeInfo);
                 async_response_asyncGetGroupNodeInfo(
-                    current, toTarsError(_error), bcostars::GroupNodeInfo());
-                return;
+                    _current, toTarsError(error), groupInfoImpl->inner());
             }
-            auto groupInfoImpl = std::dynamic_pointer_cast<bcostars::protocol::GroupNodeInfoImpl>(
-                _bcosGroupNodeInfo);
-            async_response_asyncGetGroupNodeInfo(
-                current, toTarsError(_error), groupInfoImpl->inner());
-        });
-
+            catch (std::exception const& e)
+            {
+                GATEWAYSERVICE_LOG(WARNING) << LOG_DESC("asyncGetGroupNodeInfo exception")
+                                            << LOG_KV("groupID", _groupID)
+                                            << LOG_KV("what", boost::diagnostic_information(e));
+                async_response_asyncGetGroupNodeInfo(_current,
+                    toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))),
+                    bcostars::GroupNodeInfo());
+            }
+        }(gateway, groupID, current));
     return {};
 }

--- a/fisco-bcos-tars-service/RpcService/RpcServiceServer.cpp
+++ b/fisco-bcos-tars-service/RpcService/RpcServiceServer.cpp
@@ -3,6 +3,7 @@
 #include <bcos-tars-protocol/Common.h>
 #include <bcos-tars-protocol/ErrorConverter.h>
 #include <bcos-tars-protocol/protocol/TransactionSubmitResultImpl.h>
+#include <bcos-task/Wait.h>
 #include <servant/Servant.h>
 #include <memory>
 
@@ -42,16 +43,34 @@ bcostars::Error RpcServiceServer::asyncNotifyAMOPMessage(tars::Int32 _type,
     tars::TarsCurrentPtr current)
 {
     current->setResponse(false);
-    m_rpcInitializer->rpc()->asyncNotifyAMOPMessage(_type, _topic,
-        bcos::bytesConstRef((const bcos::byte*)_requestData.data(), _requestData.size()),
-        [current](bcos::Error::Ptr&& _error, bcos::bytesPointer _responseData) {
+    auto rpc = m_rpcInitializer->rpc();
+    // copy the payload and pass all state as coroutine parameters so it stays alive for the whole
+    // (possibly deferred) notify; try/catch guarantees the RPC is always answered even if the
+    // notify throws (current->setResponse(false) already disabled the automatic reply)
+    auto requestData = std::make_shared<std::vector<tars::Char>>(_requestData);
+    bcos::task::wait([](auto _rpc, auto _type, auto _topic, auto _requestData,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto [error, responseData] = co_await _rpc->notifyAMOPMessage(_type, _topic,
+                bcos::bytesConstRef(
+                    (const bcos::byte*)_requestData->data(), _requestData->size()));
             std::vector<tars::Char> response;
-            if (_responseData)
+            if (responseData)
             {
-                response.assign(_responseData->begin(), _responseData->end());
+                response.assign(responseData->begin(), responseData->end());
             }
-            async_response_asyncNotifyAMOPMessage(current, toTarsError(_error), response);
-        });
+            async_response_asyncNotifyAMOPMessage(_current, toTarsError(error), response);
+        }
+        catch (std::exception const& e)
+        {
+            RPCSERVICE_LOG(WARNING) << LOG_DESC("asyncNotifyAMOPMessage exception")
+                                    << LOG_KV("topic", _topic)
+                                    << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_asyncNotifyAMOPMessage(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))), {});
+        }
+    }(rpc, _type, _topic, requestData, current));
     return bcostars::Error();
 }
 

--- a/legacy/lightnode/fisco-bcos-lightnode/client/P2PClientImpl.h
+++ b/legacy/lightnode/fisco-bcos-lightnode/client/P2PClientImpl.h
@@ -55,89 +55,50 @@ public:
 
     task::Task<crypto::NodeIDPtr> randomSelectNode()
     {
-        struct Awaitable
+        auto [error, localGatewayInfo, peers] = co_await m_gateway->getPeers();
+        if (error)
         {
-            Awaitable(bcos::gateway::GatewayInterface::Ptr& gateway, std::string& groupID,
-                std::mt19937& rng)
-              : m_gateway(gateway), m_groupID(groupID), m_rng(rng)
-            {}
+            BOOST_THROW_EXCEPTION(*error);
+        }
 
-            constexpr bool await_ready() const noexcept { return false; }
-            void await_suspend(std::coroutine_handle<> handle)
+        std::string nodeID;
+        if (!peers->empty())
+        {
+            std::set<std::string> nodeIDs;
+            for (const auto& peerGatewayInfo : *peers)
             {
-                bcos::concepts::getRef(m_gateway).asyncGetPeers(
-                    [this, m_handle = handle](Error::Ptr error, const gateway::GatewayInfo::Ptr&,
-                        const gateway::GatewayInfosPtr& peerGatewayInfos) mutable {
-                        if (error)
-                        {
-                            m_error = std::move(error);
-                        }
-                        else
-                        {
-                            if (!peerGatewayInfos->empty())
-                            {
-                                std::set<std::string> nodeIDs;
-                                for (const auto& peerGatewayInfo : *peerGatewayInfos)
-                                {
-                                    auto nodeIDInfo = peerGatewayInfo->nodeIDInfo();
-                                    auto nodeInfo = nodeIDInfo.find(m_groupID);
+                auto nodeIDInfo = peerGatewayInfo->nodeIDInfo();
+                auto nodeInfo = nodeIDInfo.find(m_groupID);
 
-                                    if (nodeInfo != nodeIDInfo.end() && !nodeInfo->second.empty())
-                                    {
-                                        for (auto& it : nodeInfo->second)
-                                        {
-                                            if (it.second ==
-                                                    bcos::protocol::NodeType::CONSENSUS_NODE ||
-                                                it.second ==
-                                                    bcos::protocol::NodeType::OBSERVER_NODE)
-                                            {
-                                                nodeIDs.insert(it.first);
-                                                LIGHTNODE_LOG(TRACE)
-                                                    << LOG_KV("NodeID:", it.first)
-                                                    << LOG_KV("nodeType:", it.second);
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (!nodeIDs.empty())
-                                {
-                                    std::uniform_int_distribution<size_t> distribution{
-                                        0U, nodeIDs.size() - 1};
-                                    auto nodeIDIt = nodeIDs.begin();
-                                    auto step = distribution(m_rng);
-                                    for (size_t i = 0; i < step; ++i)
-                                    {
-                                        ++nodeIDIt;
-                                    }
-
-                                    m_nodeID = *nodeIDIt;
-                                }
-                            }
-                        }
-
-                        m_handle.resume();
-                    });
-            }
-            void await_resume()
-            {
-                if (m_error)
+                if (nodeInfo != nodeIDInfo.end() && !nodeInfo->second.empty())
                 {
-                    BOOST_THROW_EXCEPTION(*(m_error));
+                    for (auto& it : nodeInfo->second)
+                    {
+                        if (it.second == bcos::protocol::NodeType::CONSENSUS_NODE ||
+                            it.second == bcos::protocol::NodeType::OBSERVER_NODE)
+                        {
+                            nodeIDs.insert(it.first);
+                            LIGHTNODE_LOG(TRACE)
+                                << LOG_KV("NodeID:", it.first)
+                                << LOG_KV("nodeType:", it.second);
+                        }
+                    }
                 }
             }
 
-            bcos::gateway::GatewayInterface::Ptr& m_gateway;
-            std::string& m_groupID;
-            std::mt19937& m_rng;
+            if (!nodeIDs.empty())
+            {
+                std::uniform_int_distribution<size_t> distribution{0U, nodeIDs.size() - 1};
+                auto nodeIDIt = nodeIDs.begin();
+                auto step = distribution(m_rng);
+                for (size_t i = 0; i < step; ++i)
+                {
+                    ++nodeIDIt;
+                }
 
-            Error::Ptr m_error;
-            std::string m_nodeID;
-        };
-
-        auto awaitable = Awaitable(m_gateway, m_groupID, m_rng);
-        co_await awaitable;
-        auto& nodeID = awaitable.m_nodeID;
+                nodeID = *nodeIDIt;
+            }
+        }
 
         if (nodeID.empty())
         {
@@ -156,75 +117,42 @@ public:
 
     task::Task<bcos::crypto::NodeIDs> getAllNodeID()
     {
-        struct Awaitable
+        auto [error, localGatewayInfo, peers] = co_await m_gateway->getPeers();
+        if (error)
         {
-            Awaitable(bcos::gateway::GatewayInterface::Ptr& gateway, std::string& groupID)
-              : m_gateway(gateway), m_groupID(groupID)
-            {}
+            BOOST_THROW_EXCEPTION(*error);
+        }
 
-            constexpr bool await_ready() const noexcept { return false; }
-            void await_suspend(std::coroutine_handle<> handle)
+        std::set<std::string> nodeIDList;
+        if (!peers->empty())
+        {
+            std::set<std::string> nodeIDs;
+            for (const auto& peerGatewayInfo : *peers)
             {
-                bcos::concepts::getRef(m_gateway).asyncGetPeers(
-                    [this, m_handle = handle](Error::Ptr error, const gateway::GatewayInfo::Ptr&,
-                        const gateway::GatewayInfosPtr& peerGatewayInfos) mutable {
-                        if (error)
-                        {
-                            m_error = std::move(error);
-                        }
-                        else
-                        {
-                            if (!peerGatewayInfos->empty())
-                            {
-                                std::set<std::string> nodeIDs;
-                                for (const auto& peerGatewayInfo : *peerGatewayInfos)
-                                {
-                                    auto nodeIDInfo = peerGatewayInfo->nodeIDInfo();
-                                    auto nodeInfo = nodeIDInfo.find(m_groupID);
+                auto nodeIDInfo = peerGatewayInfo->nodeIDInfo();
+                auto nodeInfo = nodeIDInfo.find(m_groupID);
 
-                                    if (nodeInfo != nodeIDInfo.end() && !nodeInfo->second.empty())
-                                    {
-                                        for (auto& it : nodeInfo->second)
-                                        {
-                                            if (it.second ==
-                                                    bcos::protocol::NodeType::CONSENSUS_NODE ||
-                                                it.second ==
-                                                    bcos::protocol::NodeType::OBSERVER_NODE)
-                                            {
-                                                nodeIDs.insert(it.first);
-                                                LIGHTNODE_LOG(TRACE)
-                                                    << LOG_KV("NodeID:", it.first)
-                                                    << LOG_KV("nodeType:", it.second);
-                                            }
-                                        }
-                                    }
-                                }
-                                if (!nodeIDs.empty())
-                                {
-                                    m_nodeIDList = std::move(nodeIDs);
-                                }
-                            }
-                        }
-                        m_handle.resume();
-                    });
-            }
-            void await_resume()
-            {
-                if (m_error)
+                if (nodeInfo != nodeIDInfo.end() && !nodeInfo->second.empty())
                 {
-                    BOOST_THROW_EXCEPTION(*(m_error));
+                    for (auto& it : nodeInfo->second)
+                    {
+                        if (it.second == bcos::protocol::NodeType::CONSENSUS_NODE ||
+                            it.second == bcos::protocol::NodeType::OBSERVER_NODE)
+                        {
+                            nodeIDs.insert(it.first);
+                            LIGHTNODE_LOG(TRACE)
+                                << LOG_KV("NodeID:", it.first)
+                                << LOG_KV("nodeType:", it.second);
+                        }
+                    }
                 }
             }
-            bcos::gateway::GatewayInterface::Ptr& m_gateway;
-            std::string& m_groupID;
+            if (!nodeIDs.empty())
+            {
+                nodeIDList = std::move(nodeIDs);
+            }
+        }
 
-            Error::Ptr m_error;
-            std::set<std::string> m_nodeIDList;
-        };
-
-        auto awaitable = Awaitable(m_gateway, m_groupID);
-        co_await awaitable;
-        auto& nodeIDList = awaitable.m_nodeIDList;
         LIGHTNODE_LOG(DEBUG) << LOG_KV("nodeIDList size", nodeIDList.size());
         bcos::crypto::NodeIDs nodeIDs;
         for (const auto& nodeID : nodeIDList)


### PR DESCRIPTION
## 概述

将 gateway 网络路径上的回调式异步接口全链路改造为协程接口，去掉中间层的 Awaitable 包装，代码更简洁。

## 主要改动

### GatewayInterface 协程化
- `getPeers()` → `Task<tuple<Error::Ptr, GatewayInfo::Ptr, GatewayInfosPtr>>`
- `getGroupNodeInfo(string)` → `Task<tuple<Error::Ptr, GroupNodeInfo::Ptr>>`
- `sendMessageByTopic(topic, bytesConstRef)` → `Task<tuple<Error::Ptr, int16_t, bytes>>`
- `sendBroadcastMessageByTopic` → `Task<void>`
- 同步修改 Gateway / GatewayServiceClient / GatewayServiceServer、FrontService::start、JsonRpcImpl_2_0、AMOPClient、legacy P2PClientImpl、各 fake 及测试用例。

### AMOP 链路协程化
- `AMOPImpl::trySendTopicMessageToLocalClient` 改为协程（返回 `optional`，nullopt 表示无本地客户端订阅），删除原先的 LocalSendAwaitable 包装。
- 两个 `onReceiveAMOPMessage` 重载改为协程，删除 `onRecvAMOPResponse`；`dispatcherAMOPMessage` 的 AMOPRequest 分支用 `task::wait` 包协程收响应并回发。
- `RPCInterface::asyncNotifyAMOPMessage` 改为协程 `notifyAMOPMessage`；`AMOPImpl::onReceiveAMOPMessage` 中的 NotifyAwaitable 删除，单播直接 `co_await`，入站广播按客户端逐个 `task::wait` 协程实现异步并行。
- AMOPClient 内部 `notifyAMOPMessage`/`notifyAMOPBroadcastMessage`/`sendMessageToClient`/`trySendAMOPRequestToLocalNode` 全链路协程化；`RpcServiceClient`、`RpcServiceServer`（tars servant 用 `task::wait` 桥接）同步改造。

### 保留的回调边界（无法消除）
- ws 层 `WsSession::asyncSendMessage`：回调可能同步内联触发，桥接 awaitable 使用三态原子标记 + 对称转移，保证回调不会在 `await_suspend` 栈上 resume 协程。
- tars 生成的 `PrxCallback`（RpcServiceClient）。
- `Gateway::sendMessageByNodeID` 本地投递对 `LocalRouterTable` 回调的桥接。

## 测试
- test-bcos-gateway（146 例）、test-bcos-rpc（GatewayHandlersTest）、test-bcos-front、test-bcos-tars-protocol 全部通过。