### PR TITLE
fix: base fixes for ethereum compatibility

### DIFF
--- a/bcos-codec/bcos-codec/rlp/Common.h
+++ b/bcos-codec/bcos-codec/rlp/Common.h
@@ -117,7 +117,12 @@ inline size_t length(T const& n) noexcept
     {
         return 1;
     }
-    size_t word = n.backend().internal_limb_count;
+    // Only iterate the VALID limbs (n.backend().size()), never internal_limb_count:
+    // boost's cpp_int_backend copies only the significant limbs on assignment and leaves
+    // higher limbs untouched, so limbs()[size()..internal_limb_count) may hold STALE garbage
+    // from a previous larger value. Counting those would over-estimate the byte length and
+    // produce an RLP header that disagrees with the actual encoded payload (corrupt trie leaf).
+    size_t word = n.backend().size();
     for (; word > 0; --word)
     {
         if (n.backend().limbs()[word - 1] != 0)

--- a/bcos-codec/test/unittests/RLPTest.cpp
+++ b/bcos-codec/test/unittests/RLPTest.cpp
@@ -200,22 +200,34 @@ BOOST_AUTO_TEST_CASE(uint256EncodeAfterShrinkReuse)
     // object that previously held a wider value keeps STALE high limbs after a narrower value
     // is assigned. length() must scan only the valid limbs (backend().size()), otherwise the
     // RLP header overstates the payload length and the encoded bytes no longer round-trip.
+    //
+    // The narrowed value MUST be >= 0x80 (BYTES_HEAD_BASE): length() early-returns 1 for any
+    // smaller value and never reaches the limb scan the fix changed, so such a test would
+    // pass on the buggy base too. 0x1234 fits in a single limb (backend().size() == 1 after
+    // the shrink, below the old scan's internal_limb_count of 4), but the stale high limb
+    // from the 28-byte value is non-zero, which is exactly the trigger the old code got wrong.
     u256 v("0x0100020003000400050006000700080009000A0B4B000C000D000E01");
-    v = u256(0x14u);
-    BOOST_CHECK_EQUAL(bcos::codec::rlp::length(v), 1u);
+    v = u256(0x1234u);
+    BOOST_CHECK_EQUAL(bcos::codec::rlp::length(v), 3u);
     bcos::bytes encoded;
     bcos::codec::rlp::encode(encoded, v);
+    BOOST_CHECK_EQUAL(toHex(encoded), "821234");
     BOOST_CHECK_EQUAL(encoded.size(), bcos::codec::rlp::length(v));
 
-    // A list containing the shrunken value must decode back to the same value.
+    // A list containing the shrunken value must decode back to the same value. Shrink in
+    // place inside the vector element (rather than copying a pre-shrunk u256 into a fresh
+    // element) so the test does not depend on boost's copy-constructor semantics.
+    std::vector<u256> list{u256("0x0100020003000400050006000700080009000A0B4B000C000D000E01")};
+    list[0] = u256(0x1234u);
     bcos::bytes listEncoded;
-    bcos::codec::rlp::encode(listEncoded, std::vector<u256>{v});
+    bcos::codec::rlp::encode(listEncoded, list);
+    BOOST_CHECK_EQUAL(toHex(listEncoded), "c3821234");
     bcos::bytesRef input(listEncoded.data(), listEncoded.size());
     std::vector<u256> decoded;
     auto err = bcos::codec::rlp::decode(input, decoded);
     BOOST_CHECK(err == nullptr);
     BOOST_REQUIRE_EQUAL(decoded.size(), 1u);
-    BOOST_CHECK_EQUAL(decoded.front(), u256(0x14u));
+    BOOST_CHECK_EQUAL(decoded.front(), u256(0x1234u));
 }
 
 BOOST_AUTO_TEST_CASE(vectorsEncode)

--- a/bcos-codec/test/unittests/RLPTest.cpp
+++ b/bcos-codec/test/unittests/RLPTest.cpp
@@ -194,6 +194,30 @@ BOOST_AUTO_TEST_CASE(uint256Encode)
         "9c0100020003000400050006000700080009000a0b4b000c000d000e01");
 }
 
+BOOST_AUTO_TEST_CASE(uint256EncodeAfterShrinkReuse)
+{
+    // Regression: boost's cpp_int copies only the significant limbs on assignment, so a u256
+    // object that previously held a wider value keeps STALE high limbs after a narrower value
+    // is assigned. length() must scan only the valid limbs (backend().size()), otherwise the
+    // RLP header overstates the payload length and the encoded bytes no longer round-trip.
+    u256 v("0x0100020003000400050006000700080009000A0B4B000C000D000E01");
+    v = u256(0x14u);
+    BOOST_CHECK_EQUAL(bcos::codec::rlp::length(v), 1u);
+    bcos::bytes encoded;
+    bcos::codec::rlp::encode(encoded, v);
+    BOOST_CHECK_EQUAL(encoded.size(), bcos::codec::rlp::length(v));
+
+    // A list containing the shrunken value must decode back to the same value.
+    bcos::bytes listEncoded;
+    bcos::codec::rlp::encode(listEncoded, std::vector<u256>{v});
+    bcos::bytesRef input(listEncoded.data(), listEncoded.size());
+    std::vector<u256> decoded;
+    auto err = bcos::codec::rlp::decode(input, decoded);
+    BOOST_CHECK(err == nullptr);
+    BOOST_REQUIRE_EQUAL(decoded.size(), 1u);
+    BOOST_CHECK_EQUAL(decoded.front(), u256(0x14u));
+}
+
 BOOST_AUTO_TEST_CASE(vectorsEncode)
 {
     BOOST_CHECK_EQUAL(staticEncode(std::vector<uint64_t>{}), "c0");

--- a/bcos-codec/test/unittests/RLPTest.cpp
+++ b/bcos-codec/test/unittests/RLPTest.cpp
@@ -27,6 +27,7 @@
 #include <boost/test/unit_test.hpp>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 
 using namespace bcos;
@@ -213,12 +214,18 @@ BOOST_AUTO_TEST_CASE(uint256EncodeAfterShrinkReuse)
     const u256 narrow{0x1234u};
     u256 v("0x0100020003000400050006000700080009000A0B4B000C000D000E01");
     v = narrow;  // lvalue copy-assign: leaves stale high limbs in v
+    // internal_limb_count is a STATIC member of the fixed-width backend type; name the type
+    // once so the non-vacuity scans below neither access the static through an instance nor
+    // hardcode the count (4 limbs on a 64-bit-limb build, 8 on a 32-bit-limb build).
+    using U256BackendType = std::remove_reference_t<decltype(v.backend())>;
     // Precondition: the shrink must genuinely leave stale high limbs behind, otherwise this
-    // test is vacuous and would pass even with the buggy internal_limb_count scan.
+    // test is vacuous and would pass even with the buggy internal_limb_count scan. Scan up to
+    // internal_limb_count (not a hardcoded 4): on a 32-bit-limb build the 256-bit backend
+    // holds 8 limbs, and the scan must cover them all for the guard to stay non-vacuous.
     BOOST_REQUIRE_EQUAL(v.backend().size(), 1u);
     {
         bool hasStaleLimb = false;
-        for (size_t i = v.backend().size(); i < 4u; ++i)
+        for (size_t i = v.backend().size(); i < U256BackendType::internal_limb_count; ++i)
         {
             hasStaleLimb = hasStaleLimb || (v.backend().limbs()[i] != 0);
         }
@@ -239,7 +246,8 @@ BOOST_AUTO_TEST_CASE(uint256EncodeAfterShrinkReuse)
     BOOST_REQUIRE_EQUAL(list[0].backend().size(), 1u);
     {
         bool hasStaleLimb = false;
-        for (size_t i = list[0].backend().size(); i < 4u; ++i)
+        for (size_t i = list[0].backend().size(); i < U256BackendType::internal_limb_count;
+             ++i)
         {
             hasStaleLimb = hasStaleLimb || (list[0].backend().limbs()[i] != 0);
         }

--- a/bcos-codec/test/unittests/RLPTest.cpp
+++ b/bcos-codec/test/unittests/RLPTest.cpp
@@ -196,29 +196,56 @@ BOOST_AUTO_TEST_CASE(uint256Encode)
 
 BOOST_AUTO_TEST_CASE(uint256EncodeAfterShrinkReuse)
 {
-    // Regression: boost's cpp_int copies only the significant limbs on assignment, so a u256
-    // object that previously held a wider value keeps STALE high limbs after a narrower value
-    // is assigned. length() must scan only the valid limbs (backend().size()), otherwise the
-    // RLP header overstates the payload length and the encoded bytes no longer round-trip.
+    // Regression: boost's cpp_int_base COPY-assignment memcpys only the source's significant
+    // limbs and leaves the destination's higher limbs untouched, so a u256 that previously
+    // held a wider value keeps STALE high limbs after a narrower value is copy-assigned into
+    // it. MOVE-assignment from a temporary instead copies the temporary's whole internal limb
+    // array (whose high limbs are all zero), so `v = u256(0x1234u)` would NOT reproduce the
+    // stale-limb state and the test would be vacuous — the shrink must be done via lvalue
+    // copy-assignment. length() must scan only the valid limbs (backend().size()), otherwise
+    // the RLP header overstates the payload length and the encoded bytes no longer round-trip.
     //
     // The narrowed value MUST be >= 0x80 (BYTES_HEAD_BASE): length() early-returns 1 for any
     // smaller value and never reaches the limb scan the fix changed, so such a test would
     // pass on the buggy base too. 0x1234 fits in a single limb (backend().size() == 1 after
     // the shrink, below the old scan's internal_limb_count of 4), but the stale high limb
     // from the 28-byte value is non-zero, which is exactly the trigger the old code got wrong.
+    const u256 narrow{0x1234u};
     u256 v("0x0100020003000400050006000700080009000A0B4B000C000D000E01");
-    v = u256(0x1234u);
+    v = narrow;  // lvalue copy-assign: leaves stale high limbs in v
+    // Precondition: the shrink must genuinely leave stale high limbs behind, otherwise this
+    // test is vacuous and would pass even with the buggy internal_limb_count scan.
+    BOOST_REQUIRE_EQUAL(v.backend().size(), 1u);
+    {
+        bool hasStaleLimb = false;
+        for (size_t i = v.backend().size(); i < 4u; ++i)
+        {
+            hasStaleLimb = hasStaleLimb || (v.backend().limbs()[i] != 0);
+        }
+        BOOST_REQUIRE_MESSAGE(
+            hasStaleLimb, "shrink left no stale high limbs; test would be vacuous");
+    }
     BOOST_CHECK_EQUAL(bcos::codec::rlp::length(v), 3u);
     bcos::bytes encoded;
     bcos::codec::rlp::encode(encoded, v);
     BOOST_CHECK_EQUAL(toHex(encoded), "821234");
     BOOST_CHECK_EQUAL(encoded.size(), bcos::codec::rlp::length(v));
 
-    // A list containing the shrunken value must decode back to the same value. Shrink in
-    // place inside the vector element (rather than copying a pre-shrunk u256 into a fresh
-    // element) so the test does not depend on boost's copy-constructor semantics.
+    // A list containing the shrunken value must decode back to the same value. Shrink the
+    // vector element in place via the same lvalue copy-assign so it also carries stale high
+    // limbs (rather than copying a pre-shrunk u256 into a fresh element).
     std::vector<u256> list{u256("0x0100020003000400050006000700080009000A0B4B000C000D000E01")};
-    list[0] = u256(0x1234u);
+    list[0] = narrow;  // lvalue copy-assign: leaves stale high limbs in list[0]
+    BOOST_REQUIRE_EQUAL(list[0].backend().size(), 1u);
+    {
+        bool hasStaleLimb = false;
+        for (size_t i = list[0].backend().size(); i < 4u; ++i)
+        {
+            hasStaleLimb = hasStaleLimb || (list[0].backend().limbs()[i] != 0);
+        }
+        BOOST_REQUIRE_MESSAGE(
+            hasStaleLimb, "shrink left no stale high limbs; test would be vacuous");
+    }
     bcos::bytes listEncoded;
     bcos::codec::rlp::encode(listEncoded, list);
     BOOST_CHECK_EQUAL(toHex(listEncoded), "c3821234");

--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -389,7 +389,8 @@ CallParameters::UniquePtr TransactionExecutive::execute(CallParameters::UniquePt
         {
             ledger::account::EVMAccount address(*m_blockContext.storage(),
                 callParameters->senderAddress,
-                m_blockContext.features().get(ledger::Features::Flag::feature_raw_address));
+                m_blockContext.features().get(ledger::Features::Flag::feature_raw_address),
+                /*treatSystemAsUser=*/false);
             if (m_blockContext.features().get(ledger::Features::Flag::bugfix_nonce_initialize))
             {
                 if (!precompiled::contains(bcos::precompiled::c_systemTxsAddress,
@@ -424,7 +425,8 @@ CallParameters::UniquePtr TransactionExecutive::execute(CallParameters::UniquePt
                 // TODO)): set nonce here will be better
                 ledger::account::EVMAccount address(*m_blockContext.storage(),
                     callParameters->senderAddress,
-                    m_blockContext.features().get(ledger::Features::Flag::feature_raw_address));
+                    m_blockContext.features().get(ledger::Features::Flag::feature_raw_address),
+                    /*treatSystemAsUser=*/false);
                 task::wait([](decltype(address) addr, u256 callNonce) -> task::Task<void> {
                     if (!co_await addr.exists())
                     {
@@ -870,8 +872,9 @@ std::tuple<std::unique_ptr<HostContext>, CallParameters::UniquePtr> TransactionE
                 ledger::Features::Flag::bugfix_set_contract_nonce_when_create)) [[unlikely]]
         {
             // set nonce to 1 when create contract
-            ledger::account::EVMAccount account(
-                *m_blockContext.storage(), callParameters->codeAddress, false);
+            ledger::account::EVMAccount account(*m_blockContext.storage(),
+                callParameters->codeAddress, false,
+                /*treatSystemAsUser=*/false);
             task::wait([](decltype(account) contractAccount) -> task::Task<void> {
                 co_await contractAccount.setNonce("1");
             }(std::move(account)));

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -1144,7 +1144,8 @@ void TransactionExecutor::updateEoaNonce(std::unordered_map<std::string, u256> c
             LEDGER_LOG(TRACE) << METRIC << LOG_DESC("updateEoaNonce") << LOG_KV("sender", sender)
                               << LOG_KV("nonce", nonce);
             auto eoa = ledger::account::EVMAccount(*m_blockContext->storage(), sender,
-                m_blockContext->features().get(ledger::Features::Flag::feature_raw_address));
+                m_blockContext->features().get(ledger::Features::Flag::feature_raw_address),
+                /*treatSystemAsUser=*/false);
             auto nonceInStorage = task::syncWait(eoa.nonce());
             auto nonceToUpdate = std::max(u256(nonceInStorage.value_or("0")), nonce) + 1;
             task::syncWait(eoa.setNonce(nonceToUpdate.convert_to<std::string>()));
@@ -2208,8 +2209,8 @@ bcos::task::Task<std::optional<bcos::storage::Entry>> TransactionExecutor::getPe
     }
 
     const auto features = co_await ledger::getFeatures(*m_ledger);
-    auto eoa = bcos::ledger::account::EVMAccount(
-        *stateStorage, address, features.get(ledger::Features::Flag::feature_raw_address));
+    auto eoa = bcos::ledger::account::EVMAccount(*stateStorage, address,
+        features.get(ledger::Features::Flag::feature_raw_address), /*treatSystemAsUser=*/false);
     co_return co_await eoa.storageEntry(key);
 }
 

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -269,7 +269,8 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
     {
         // account must exist
         ledger::account::EVMAccount account(*m_executive->storage().getRawStorage(),
-            request->senderAddress, features().get(ledger::Features::Flag::feature_raw_address));
+            request->senderAddress, features().get(ledger::Features::Flag::feature_raw_address),
+            /*treatSystemAsUser=*/false);
         request->nonce = task::syncWait([](decltype(account) contract) -> task::Task<u256> {
             auto const nonceString = co_await contract.nonce();
             // uint in storage

--- a/bcos-executor/test/unittest/libvm/TestTransactionExecutive.cpp
+++ b/bcos-executor/test/unittest/libvm/TestTransactionExecutive.cpp
@@ -34,7 +34,8 @@ public:
         auto const sender = keyPair->address(hashImpl);
         auto const address = newLegacyEVMAddressString(sender.ref(), u256(nonce));
 
-        bcos::ledger::account::EVMAccount eoa(*storage, sender.hex(), false);
+        bcos::ledger::account::EVMAccount eoa(
+            *storage, sender.hex(), false, /*treatSystemAsUser=*/false);
         static_assert(bcos::ledger::account::Account<decltype(eoa)>);
 
         task::syncWait(eoa.create());
@@ -77,7 +78,8 @@ public:
 
         auto const nonceOfEoa = task::syncWait(eoa.nonce());
 
-        bcos::ledger::account::EVMAccount contractAddress(*storage, address, false);
+        bcos::ledger::account::EVMAccount contractAddress(
+            *storage, address, false, /*treatSystemAsUser=*/false);
         auto const nonceOfContract = task::syncWait(contractAddress.nonce());
         if (type == TransactionType::BCOSTransaction)
         {
@@ -105,7 +107,8 @@ public:
 
         auto const sender = keyPair->address(hashImpl);
 
-        bcos::ledger::account::EVMAccount eoa(*storage, sender.hex(), false);
+        bcos::ledger::account::EVMAccount eoa(
+            *storage, sender.hex(), false, /*treatSystemAsUser=*/false);
         task::syncWait(eoa.create());
         task::syncWait(eoa.setBalance(u256(1000000000000000ULL)));
 
@@ -145,7 +148,8 @@ public:
 
         auto const nonceOfEoa = task::syncWait(eoa.nonce());
 
-        bcos::ledger::account::EVMAccount contractAccount(*storage, contractAddress, false);
+        bcos::ledger::account::EVMAccount contractAccount(
+            *storage, contractAddress, false, /*treatSystemAsUser=*/false);
         auto const nonceOfContract = task::syncWait(contractAccount.nonce());
         if (type == TransactionType::BCOSTransaction)
         {
@@ -172,7 +176,8 @@ public:
 
         auto const sender = keyPair->address(hashImpl);
 
-        bcos::ledger::account::EVMAccount eoa(*storage, sender.hex(), false);
+        bcos::ledger::account::EVMAccount eoa(
+            *storage, sender.hex(), false, /*treatSystemAsUser=*/false);
         task::syncWait(eoa.create());
         task::syncWait(eoa.setBalance(u256(1000000000000000ULL)));
 
@@ -212,7 +217,8 @@ public:
 
         auto const nonceOfEoa = task::syncWait(eoa.nonce());
 
-        bcos::ledger::account::EVMAccount contractAccount(*storage, contractAddress, false);
+        bcos::ledger::account::EVMAccount contractAccount(
+            *storage, contractAddress, false, /*treatSystemAsUser=*/false);
         auto const nonceOfContract = task::syncWait(contractAccount.nonce());
         if (type == TransactionType::BCOSTransaction)
         {
@@ -240,7 +246,7 @@ public:
 
         auto sender = keyPair->address(hashImpl).hex();
 
-        bcos::ledger::account::EVMAccount eoa(*storage, sender, false);
+        bcos::ledger::account::EVMAccount eoa(*storage, sender, false, /*treatSystemAsUser=*/false);
         task::syncWait(eoa.create());
         task::syncWait(eoa.setBalance(u256(initBalance)));
 
@@ -298,7 +304,8 @@ public:
         ::ranges::input_range auto nonces, int32_t status)
     {
         auto const sender = keyPair->address(hashImpl);
-        bcos::ledger::account::EVMAccount eoa(*storage, sender.hex(), false);
+        bcos::ledger::account::EVMAccount eoa(
+            *storage, sender.hex(), false, /*treatSystemAsUser=*/false);
         task::syncWait(eoa.create());
         task::syncWait(eoa.setBalance(u256(1000000000000000ULL)));
 
@@ -423,7 +430,8 @@ BOOST_AUTO_TEST_CASE(testMultiNonce)
     commitBlock(newBlock);
 
     auto const sender = keyPair->address(hashImpl);
-    bcos::ledger::account::EVMAccount eoa(*storage, sender.hex(), false);
+    bcos::ledger::account::EVMAccount eoa(
+        *storage, sender.hex(), false, /*treatSystemAsUser=*/false);
     auto const nonceOfEoa = task::syncWait(eoa.nonce());
 
     BOOST_CHECK_EQUAL(nonceOfEoa.value(), "10020");

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -290,8 +290,11 @@ public:
       : m_storage(storage), m_tableName(std::move(tableName))
     {}
 
-    EVMAccount(Storage& storage, const evmc_address& address, bool binaryAddress,
-        bool treatSystemAsUser = false)
+    // `treatSystemAsUser` is deliberately without a default, for the same reason MPTAccount
+    // records for `binaryAddress` (MPTAccount.h): it decides whether the c_systemTxsAddress
+    // members route to /sys/ or /apps/, and guessing it wrong makes those reads silently miss.
+    EVMAccount(
+        Storage& storage, const evmc_address& address, bool binaryAddress, bool treatSystemAsUser)
       : m_storage(storage)
     {
         std::array<char, sizeof(address.bytes) * 2> table;  // NOLINT
@@ -327,8 +330,8 @@ public:
      * @param storage storage instance
      * @param address address of the account, hex string, should not contain 0x prefix
      */
-    EVMAccount(Storage& storage, std::string_view address, bool binaryAddress,
-        bool treatSystemAsUser = false)
+    EVMAccount(
+        Storage& storage, std::string_view address, bool binaryAddress, bool treatSystemAsUser)
       : m_storage(storage)
     {
         if (accountTablePrefix(address, treatSystemAsUser) == ledger::SYS_DIRECTORY::SYS_APPS)
@@ -356,8 +359,8 @@ public:
         }
     }
 
-    EVMAccount(Storage& storage, const bcos::Address& address, bool binaryAddress,
-        bool treatSystemAsUser = false)
+    EVMAccount(
+        Storage& storage, const bcos::Address& address, bool binaryAddress, bool treatSystemAsUser)
       : EVMAccount(
             storage,
             [](const bcos::Address& address) {

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "bcos-concepts/ByteBuffer.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage2/Storage.h"
@@ -21,6 +22,24 @@ struct FromTableName
 {
     explicit FromTableName() = default;
 };
+
+/// Route an account address to its storage table prefix — the single home for the
+/// /sys/ vs /apps/ policy so the v2 executor's writes and the ledger/RPC reads cannot
+/// drift apart. systemAsUser (executor_version >= ETHEREUM_EXECUTOR_VERSION) treats the
+/// c_systemTxsAddress members as ordinary user accounts under /apps/ — in Ethereum they
+/// are; the genesis MPT builder and the OP Storage2State already do the same.
+inline std::string_view accountTablePrefix(std::string_view address, bool systemAsUser)
+{
+    return (!systemAsUser &&
+               precompiled::contains(bcos::precompiled::c_systemTxsAddress, address)) ?
+               ledger::SYS_DIRECTORY::SYS_APPS :
+               ledger::SYS_DIRECTORY::USER_APPS;
+}
+
+inline std::string_view accountTablePrefix(std::string_view address, int executorVersion)
+{
+    return accountTablePrefix(address, executorVersion >= ledger::ETHEREUM_EXECUTOR_VERSION);
+}
 
 template <class Storage>
 class EVMAccount
@@ -284,7 +303,7 @@ public:
         std::array<char, sizeof(address.bytes) * 2> table;  // NOLINT
         boost::algorithm::hex_lower(concepts::bytebuffer::toView(address.bytes), table.data());
         auto const view = std::string_view(table.data(), table.size());
-        if (!treatSystemAsUser && precompiled::contains(bcos::precompiled::c_systemTxsAddress, view))
+        if (accountTablePrefix(view, treatSystemAsUser) == ledger::SYS_DIRECTORY::SYS_APPS)
         {
             m_tableName.reserve(ledger::SYS_DIRECTORY::SYS_APPS.size() + table.size());
             m_tableName.append(ledger::SYS_DIRECTORY::SYS_APPS);
@@ -318,7 +337,7 @@ public:
         bool treatSystemAsUser = false)
       : m_storage(storage)
     {
-        if (!treatSystemAsUser && precompiled::contains(bcos::precompiled::c_systemTxsAddress, address))
+        if (accountTablePrefix(address, treatSystemAsUser) == ledger::SYS_DIRECTORY::SYS_APPS)
         {
             m_tableName.reserve(ledger::SYS_DIRECTORY::SYS_APPS.size() + address.size());
             m_tableName.append(ledger::SYS_DIRECTORY::SYS_APPS);

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "bcos-concepts/ByteBuffer.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
-#include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage2/Storage.h"
@@ -34,11 +33,6 @@ inline std::string_view accountTablePrefix(std::string_view address, bool system
                precompiled::contains(bcos::precompiled::c_systemTxsAddress, address)) ?
                ledger::SYS_DIRECTORY::SYS_APPS :
                ledger::SYS_DIRECTORY::USER_APPS;
-}
-
-inline std::string_view accountTablePrefix(std::string_view address, int executorVersion)
-{
-    return accountTablePrefix(address, executorVersion >= ledger::ETHEREUM_EXECUTOR_VERSION);
 }
 
 template <class Storage>

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -277,13 +277,14 @@ public:
       : m_storage(storage), m_tableName(std::move(tableName))
     {}
 
-    EVMAccount(Storage& storage, const evmc_address& address, bool binaryAddress)
+    EVMAccount(Storage& storage, const evmc_address& address, bool binaryAddress,
+        bool treatSystemAsUser = false)
       : m_storage(storage)
     {
         std::array<char, sizeof(address.bytes) * 2> table;  // NOLINT
         boost::algorithm::hex_lower(concepts::bytebuffer::toView(address.bytes), table.data());
-        if (auto view = std::string_view(table.data(), table.size());
-            precompiled::contains(bcos::precompiled::c_systemTxsAddress, view))
+        auto const view = std::string_view(table.data(), table.size());
+        if (!treatSystemAsUser && precompiled::contains(bcos::precompiled::c_systemTxsAddress, view))
         {
             m_tableName.reserve(ledger::SYS_DIRECTORY::SYS_APPS.size() + table.size());
             m_tableName.append(ledger::SYS_DIRECTORY::SYS_APPS);
@@ -313,9 +314,11 @@ public:
      * @param storage storage instance
      * @param address address of the account, hex string, should not contain 0x prefix
      */
-    EVMAccount(Storage& storage, std::string_view address, bool binaryAddress) : m_storage(storage)
+    EVMAccount(Storage& storage, std::string_view address, bool binaryAddress,
+        bool treatSystemAsUser = false)
+      : m_storage(storage)
     {
-        if (precompiled::contains(bcos::precompiled::c_systemTxsAddress, address))
+        if (!treatSystemAsUser && precompiled::contains(bcos::precompiled::c_systemTxsAddress, address))
         {
             m_tableName.reserve(ledger::SYS_DIRECTORY::SYS_APPS.size() + address.size());
             m_tableName.append(ledger::SYS_DIRECTORY::SYS_APPS);
@@ -340,7 +343,8 @@ public:
         }
     }
 
-    EVMAccount(Storage& storage, const bcos::Address& address, bool binaryAddress)
+    EVMAccount(Storage& storage, const bcos::Address& address, bool binaryAddress,
+        bool treatSystemAsUser = false)
       : EVMAccount(
             storage,
             [](const bcos::Address& address) {
@@ -348,7 +352,7 @@ public:
                 ::ranges::copy(address, std::span{evmcAddress.bytes}.data());
                 return evmcAddress;
             }(address),
-            binaryAddress)
+            binaryAddress, treatSystemAsUser)
     {}
     ~EVMAccount() noexcept = default;
 

--- a/bcos-ledger/bcos-ledger/GenesisStateLoader.h
+++ b/bcos-ledger/bcos-ledger/GenesisStateLoader.h
@@ -93,8 +93,8 @@ task::Task<bcos::h256> importEthereumGenesisState(
             slots.emplace_back(evmKey, evmValue);
         }
 
-        account::EVMAccount account(
-            storage, address, features.get(Features::Flag::feature_raw_address));
+        account::EVMAccount account(storage, address,
+            features.get(Features::Flag::feature_raw_address), /*treatSystemAsUser=*/true);
         co_await account.create();
 
         if (codeHash.has_value())

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -71,13 +71,13 @@
 #include <exception>
 #include <future>
 #include <iterator>
+#include <list>
 #include <memory>
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/take.hpp>
 #include <utility>
-#include <list>
 
 using namespace bcos;
 using namespace bcos::ledger;
@@ -142,19 +142,22 @@ task::Task<std::optional<storage::Entry>> Ledger::getStorageAt(
 {
     // TODO)): blockNumber is not used nowadays
     std::ignore = _blockNumber;
-    // System-contract addresses (0x1000 range, etc.) are stored under the
-    // "/sys/" prefix by EVMAccount; user accounts under "/apps/". Picking the
-    // right prefix here keeps eth_getBalance / eth_getStorageAt /
-    // eth_getTransactionCount consistent with both the genesis alloc import and
-    // the v2 executor (which both go through EVMAccount). Without this, reads
-    // for system-range accounts hit the wrong table and return empty (e.g.
-    // EEST static VMTests that call 0x1000 saw balance=0 / storage=0).
-    auto const tablePrefix =
-        precompiled::contains(bcos::precompiled::c_systemTxsAddress, _address) ?
-            SYS_DIRECTORY::SYS_APPS :
-            SYS_DIRECTORY::USER_APPS;
-    auto const contractTableName = getContractTableName(tablePrefix, _address);
+    // Route through the shared policy (ledger::account::accountTablePrefix): below
+    // executor_version 2 the c_systemTxsAddress members live under /sys/; at v2 every
+    // address is an ordinary /apps/ account, matching the v2 executor's writes
+    // (EthereumState) and the genesis alloc import. Without this, reads for
+    // system-range accounts hit the wrong table and return empty (e.g. EEST static
+    // VMTests that call 0x1000 saw balance=0 / storage=0).
+    int executorVersion = 0;
     auto const stateStorage = getStateStorage();
+    if (auto const config = co_await getSystemConfig(
+            *stateStorage, std::string_view{magic_enum::enum_name(SystemConfig::executor_version)});
+        config.has_value())
+    {
+        executorVersion = std::stoi(std::get<0>(*config));
+    }
+    auto const tablePrefix = account::accountTablePrefix(_address, executorVersion);
+    auto const contractTableName = getContractTableName(tablePrefix, _address);
     co_return co_await bcos::storage2::readOne(
         *stateStorage, executor_v1::StateKeyView{contractTableName, _key});
 }
@@ -1876,8 +1879,7 @@ static void verifyL2FeatureFlagsSlot(
         // slot = keccak256(utf8("feature_flags") || be32(101))
         bcos::bytes slotInput;
         slotInput.reserve(c_l2FeatureFlagsKey.size() + 32);
-        slotInput.insert(
-            slotInput.end(), c_l2FeatureFlagsKey.begin(), c_l2FeatureFlagsKey.end());
+        slotInput.insert(slotInput.end(), c_l2FeatureFlagsKey.begin(), c_l2FeatureFlagsKey.end());
         bcos::bytes baseSlotBytes(32, 0);
         baseSlotBytes[31] = c_l2SystemConfigBaseSlot;
         slotInput.insert(slotInput.end(), baseSlotBytes.begin(), baseSlotBytes.end());

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -143,20 +143,15 @@ task::Task<std::optional<storage::Entry>> Ledger::getStorageAt(
 {
     // TODO)): blockNumber is not used nowadays
     std::ignore = _blockNumber;
-    // Route through the shared policy (ledger::account::accountTablePrefix): below
-    // executor_version 2 the c_systemTxsAddress members live under /sys/; at v2 every
-    // address is an ordinary /apps/ account, matching the v2 executor's writes
-    // (EthereumState) and the genesis alloc import. Without this, reads for
-    // system-range accounts hit the wrong table and return empty (e.g. EEST static
-    // VMTests that call 0x1000 saw balance=0 / storage=0).
-    int executorVersion = 0;
+    // Route through the shared policy (ledger::account::accountTablePrefix), with the
+    // executor_version read via the shared ledger::getExecutorVersion helper (the same
+    // whole-string parser the LedgerConfig derivations use): below executor_version 2 the
+    // c_systemTxsAddress members live under /sys/; at v2 every address is an ordinary
+    // /apps/ account, matching the v2 executor's writes (EthereumState) and the genesis
+    // alloc import. Without this, reads for system-range accounts hit the wrong table and
+    // return empty (e.g. EEST static VMTests that call 0x1000 saw balance=0 / storage=0).
     auto const stateStorage = getStateStorage();
-    if (auto const config = co_await getSystemConfig(
-            *stateStorage, std::string_view{magic_enum::enum_name(SystemConfig::executor_version)});
-        config.has_value())
-    {
-        executorVersion = std::stoi(std::get<0>(*config));
-    }
+    auto const executorVersion = co_await getExecutorVersion(*stateStorage);
     // Compute the routing bool at the call site (the version-taking overload was removed to
     // avoid a bool/int overload pair that reinterprets the same argument by type).
     auto const tablePrefix =

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -28,6 +28,7 @@
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/ledger/SystemConfigs.h"
 #include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-framework/storage2/Storage.h"
@@ -156,7 +157,10 @@ task::Task<std::optional<storage::Entry>> Ledger::getStorageAt(
     {
         executorVersion = std::stoi(std::get<0>(*config));
     }
-    auto const tablePrefix = account::accountTablePrefix(_address, executorVersion);
+    // Compute the routing bool at the call site (the version-taking overload was removed to
+    // avoid a bool/int overload pair that reinterprets the same argument by type).
+    auto const tablePrefix =
+        account::accountTablePrefix(_address, executorVersion >= ETHEREUM_EXECUTOR_VERSION);
     auto const contractTableName = getContractTableName(tablePrefix, _address);
     co_return co_await bcos::storage2::readOne(
         *stateStorage, executor_v1::StateKeyView{contractTableName, _key});
@@ -1935,8 +1939,8 @@ static void verifyL2FeatureFlagsSlot(
     }
 }
 
-static task::Task<void> importGenesisState(
-    ::ranges::forward_range auto const& allocs, auto& storage, const crypto::Hash& hashImpl)
+static task::Task<void> importGenesisState(::ranges::forward_range auto const& allocs,
+    auto& storage, const crypto::Hash& hashImpl, bool systemAsUser)
 {
     // allocs from NodeConfig carry 0x-prefixed hex; LedgerTest builds them without
     // a prefix. Strip a leading 0x so both shapes unhex cleanly. The exact-width /
@@ -1982,8 +1986,12 @@ static task::Task<void> importGenesisState(
             slots.emplace_back(evmKey, evmValue);
         }
 
-        account::EVMAccount account(
-            storage, address, features.get(Features::Flag::feature_raw_address));
+        // systemAsUser routes the c_systemTxsAddress members under /apps/ like the v2
+        // executor (EthereumState) and the RPC read side do. Reserved-address allocs are
+        // rejected earlier by computeGenesisStateTrie, so this is defensive uniformity
+        // rather than a reachable behaviour change.
+        account::EVMAccount account(storage, address,
+            features.get(Features::Flag::feature_raw_address), systemAsUser);
         co_await account.create();
 
         if (codeHash.has_value())
@@ -2517,8 +2525,11 @@ bool Ledger::buildGenesisBlock(
         }
 
         co_await setGenesisFeatures(genesis.m_features, features, *m_stateStorage);
-        co_await importGenesisState(
-            genesis.m_allocs, *m_stateStorage, *m_blockFactory->cryptoSuite()->hashImpl());
+        // executor_version is written to storage only below, after this import runs, so the
+        // routing flag must come from the genesis config here rather than be read back.
+        co_await importGenesisState(genesis.m_allocs, *m_stateStorage,
+            *m_blockFactory->cryptoSuite()->hashImpl(),
+            /*systemAsUser=*/genesis.m_executorVersion >= ETHEREUM_EXECUTOR_VERSION);
 
         // Scenario B (L2): block 1 builds the MPT incrementally on top of the genesis state
         // root (buildAndCollect with the genesis root as parent) and reads the parent trie

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -616,4 +616,25 @@ task::Task<std::optional<SystemConfigEntry>> tag_invoke(ledger::tag_t<getSystemC
     co_return {};
 }
 
+/// Read executor_version from SYS_CONFIG, parsed with the SAME whole-string parser
+/// (boost::lexical_cast) the two LedgerConfig derivations use — every consumer of the
+/// /sys/ vs /apps/ account routing policy must agree on the value, and std::stoi would
+/// silently accept trailing garbage ("2junk" -> 2). Absent config reads as 0 (a v0/v1
+/// chain). Accepts either a LedgerInterface or a storage2::ReadableStorage source,
+/// exactly like getSystemConfig.
+///
+/// Note this costs one SYS_CONFIG round trip per call; folding it into the per-block
+/// cached LedgerConfig (which also removes the double read on EthEndpoint's ledger
+/// fallback) is tracked as a follow-up ahead of the eth_sync EL wiring PR.
+inline task::Task<int> getExecutorVersion(auto& source)
+{
+    if (auto const config = co_await ledger::getSystemConfig(source,
+            std::string_view{magic_enum::enum_name(SystemConfig::executor_version)});
+        config.has_value())
+    {
+        co_return boost::lexical_cast<int>(std::get<0>(*config));
+    }
+    co_return 0;
+}
+
 }  // namespace bcos::ledger

--- a/bcos-ledger/bcos-ledger/mpt/EthTrieRoots.h
+++ b/bcos-ledger/bcos-ledger/mpt/EthTrieRoots.h
@@ -83,10 +83,13 @@ bcos::Bloom calculateLogsBloom(Blooms&& blooms)
 /// logsBloom from the receipt's log entries, and accumulate cumulativeGasUsed. The bloom is
 /// ALWAYS recomputed from logEntries, never taken from the producer — a wrong producer-filled
 /// bloom would otherwise be silently committed into the receipts trie and the block-level
-/// bloom. Throws std::runtime_error on a null receipt so every caller fails closed instead of
-/// dereferencing (BaselineScheduler calls this helper directly, with no call-site guard).
-/// Shared by BaselineScheduler::finishExecute and the engine's buildPayload so the two cannot
-/// drift — cumulativeGasUsed and the bloom feed the receipts trie, a consensus field.
+/// bloom. The logIndex stamp takes effect only on receipt implementations that persist it;
+/// on the tars receipt (the only production receipt type) setLogIndex is currently a no-op —
+/// logIndex() is hardcoded to 0 — tracked as a follow-up (the tars receipt needs the field).
+/// Throws std::runtime_error on a null receipt; both callers (BaselineScheduler::finishExecute
+/// and the engine's buildPayload) already guard nulls at the call site before any dereference,
+/// so this throw is defense-in-depth. Shared by the two so they cannot drift —
+/// cumulativeGasUsed and the bloom feed the receipts trie, a consensus field.
 /// @return The block's totalGasUsed (the last receipt's cumulativeGasUsed).
 template <::ranges::input_range Receipts>
 bcos::u256 finalizeReceipts(Receipts& receipts)

--- a/bcos-ledger/bcos-ledger/mpt/EthTrieRoots.h
+++ b/bcos-ledger/bcos-ledger/mpt/EthTrieRoots.h
@@ -24,8 +24,10 @@
 #include <bcos-framework/protocol/TransactionReceipt.h>
 #include <bcos-utilities/Bloom.h>
 #include <bcos-utilities/Common.h>
+#include <boost/throw_exception.hpp>
 #include <range/v3/range.hpp>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
 #include <vector>
 
@@ -77,11 +79,14 @@ bcos::Bloom calculateLogsBloom(Blooms&& blooms)
     return result;
 }
 
-/// Finalize executed receipts for commit: stamp transactionIndex / logIndex, fill a logsBloom
-/// the producer left empty (BaselineScheduler's own receipt phase always leaves it empty; an
-/// already-filled bloom is kept), and accumulate cumulativeGasUsed. Shared by
-/// BaselineScheduler::finishExecute and the engine's buildPayload so the two cannot drift —
-/// cumulativeGasUsed and the bloom feed the receipts trie, a consensus field.
+/// Finalize executed receipts for commit: stamp transactionIndex / logIndex, recompute the
+/// logsBloom from the receipt's log entries, and accumulate cumulativeGasUsed. The bloom is
+/// ALWAYS recomputed from logEntries, never taken from the producer — a wrong producer-filled
+/// bloom would otherwise be silently committed into the receipts trie and the block-level
+/// bloom. Throws std::runtime_error on a null receipt so every caller fails closed instead of
+/// dereferencing (BaselineScheduler calls this helper directly, with no call-site guard).
+/// Shared by BaselineScheduler::finishExecute and the engine's buildPayload so the two cannot
+/// drift — cumulativeGasUsed and the bloom feed the receipts trie, a consensus field.
 /// @return The block's totalGasUsed (the last receipt's cumulativeGasUsed).
 template <::ranges::input_range Receipts>
 bcos::u256 finalizeReceipts(Receipts& receipts)
@@ -91,13 +96,14 @@ bcos::u256 finalizeReceipts(Receipts& receipts)
     size_t logIndex = 0;
     for (auto const& receipt : receipts)
     {
+        if (!receipt)
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
+        }
         receipt->setTransactionIndex(transactionIndex++);
         receipt->setLogIndex(logIndex);
-        if (receipt->logsBloom().empty())
-        {
-            auto logBloom = bcos::getLogsBloom(receipt->logEntries());
-            receipt->setLogsBloom({logBloom.data(), logBloom.size()});
-        }
+        auto logBloom = bcos::getLogsBloom(receipt->logEntries());
+        receipt->setLogsBloom({logBloom.data(), logBloom.size()});
         logIndex += receipt->logEntries().size();
         totalGasUsed += receipt->gasUsed();
         receipt->setCumulativeGasUsed(totalGasUsed.str());

--- a/bcos-ledger/bcos-ledger/mpt/EthTrieRoots.h
+++ b/bcos-ledger/bcos-ledger/mpt/EthTrieRoots.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "HashBuilder.h"
+#include <bcos-framework/protocol/TransactionReceipt.h>
 #include <bcos-utilities/Bloom.h>
 #include <bcos-utilities/Common.h>
 #include <range/v3/range.hpp>
@@ -74,6 +75,34 @@ bcos::Bloom calculateLogsBloom(Blooms&& blooms)
         bcos::orBloom(result, bloom);
     }
     return result;
+}
+
+/// Finalize executed receipts for commit: stamp transactionIndex / logIndex, fill a logsBloom
+/// the producer left empty (BaselineScheduler's own receipt phase always leaves it empty; an
+/// already-filled bloom is kept), and accumulate cumulativeGasUsed. Shared by
+/// BaselineScheduler::finishExecute and the engine's buildPayload so the two cannot drift —
+/// cumulativeGasUsed and the bloom feed the receipts trie, a consensus field.
+/// @return The block's totalGasUsed (the last receipt's cumulativeGasUsed).
+template <::ranges::input_range Receipts>
+bcos::u256 finalizeReceipts(Receipts& receipts)
+{
+    bcos::u256 totalGasUsed;
+    size_t transactionIndex = 0;
+    size_t logIndex = 0;
+    for (auto const& receipt : receipts)
+    {
+        receipt->setTransactionIndex(transactionIndex++);
+        receipt->setLogIndex(logIndex);
+        if (receipt->logsBloom().empty())
+        {
+            auto logBloom = bcos::getLogsBloom(receipt->logEntries());
+            receipt->setLogsBloom({logBloom.data(), logBloom.size()});
+        }
+        logIndex += receipt->logEntries().size();
+        totalGasUsed += receipt->gasUsed();
+        receipt->setCumulativeGasUsed(totalGasUsed.str());
+    }
+    return totalGasUsed;
 }
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/FlatToMPT.h
+++ b/bcos-ledger/bcos-ledger/mpt/FlatToMPT.h
@@ -58,9 +58,12 @@ inline bcos::u256 entryToU256(bcos::storage::Entry const& entry)
     {
         return bcos::u256{0};
     }
-    // u256{std::string_view} selects boost::multiprecision's number(std::basic_string_view)
-    // overload, which parses exactly `value.size()` bytes.
-    return bcos::u256{value};
+    // Construct from a std::string_view WITH its explicit length: boost::multiprecision's
+    // number(std::basic_string_view) (number.hpp) parses exactly `value.size()` bytes via
+    // assign_from_string_view, so it never falls back to the NUL-terminated const char*
+    // overload and cannot read past the string_view into stale memory. (A plain u256{value}
+    // would already select this overload — this makes the intent explicit and future-proof.)
+    return bcos::u256{std::string_view{value.data(), value.size()}};
 }
 
 /// Copy an Entry's stored bytes into a 32-byte hash. Unlike nonce/balance, codeHash is stored as

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -121,7 +121,7 @@ public:
     /// silently miss on a raw-address chain.
     MPTAccount(Storage& storage, NodeStorage& nodeStorage, BackendStorage& backendStorage,
         bcos::Address address, bool binaryAddress)
-      : Base(storage, address, binaryAddress),
+      : Base(storage, address, binaryAddress, /*treatSystemAsUser=*/true),
         m_nodeStorage(nodeStorage),
         m_backendStorage(backendStorage),
         m_address(address)
@@ -138,7 +138,7 @@ public:
     /// from the account type.
     MPTAccount(Storage& storage, const evmc_address& address, bool binaryAddress)
         requires HistoricalStorageContext<Storage>
-      : Base(storage, address, binaryAddress),
+      : Base(storage, address, binaryAddress, /*treatSystemAsUser=*/true),
         m_nodeStorage(storage.mptNodeStorage()),
         m_backendStorage(storage.mptBackendStorage()),
         m_address(bcos::bytesConstRef{address.bytes, sizeof(address.bytes)})

--- a/bcos-ledger/test/CMakeLists.txt
+++ b/bcos-ledger/test/CMakeLists.txt
@@ -35,6 +35,12 @@ target_compile_definitions(${TEST_BINARY_NAME} PUBLIC _TESTS_)
 # data port (ports-data/) under the tests manifest feature
 target_compile_definitions(${TEST_BINARY_NAME} PRIVATE
     ETHEREUM_TESTS_DIR="${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/ethereum-tests")
+# The new test_AccountTablePrefix.cpp declares global `using namespace bcos;` at file scope
+# (same pattern as the other ledger suites); keep it out of the unity blob so those
+# using-directives cannot leak into sibling translation units (mirrors the tars-protocol
+# precedent for Web3TarsBridgeTest.cpp).
+set_source_files_properties("unittests/ledger/test_AccountTablePrefix.cpp"
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 # add_test(NAME test-ledger WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${TEST_BINARY_NAME})
 include(SearchTestCases)

--- a/bcos-ledger/test/unittests/ledger/test_AccountTablePrefix.cpp
+++ b/bcos-ledger/test/unittests/ledger/test_AccountTablePrefix.cpp
@@ -1,0 +1,63 @@
+/**
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_AccountTablePrefix.cpp
+ * @brief Matrix test for the system-address table-prefix policy (accountTablePrefix):
+ *        every c_systemTxsAddress member routes to /sys/ under legacy semantics and to
+ *        /apps/ under systemAsUser (v2/Ethereum) semantics; ordinary addresses always
+ *        route to /apps/.
+ */
+#include <bcos-framework/executor/PrecompiledTypeDef.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <boost/test/unit_test.hpp>
+#include <string_view>
+
+using namespace bcos;
+using namespace bcos::ledger;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(AccountTablePrefixTest)
+
+BOOST_AUTO_TEST_CASE(systemAddressesFollowFlag)
+{
+    for (auto const& address : precompiled::c_systemTxsAddress)
+    {
+        BOOST_TEST_INFO("address=" << address);
+        BOOST_CHECK_EQUAL(
+            account::accountTablePrefix(address, /*systemAsUser=*/false), SYS_DIRECTORY::SYS_APPS);
+        BOOST_CHECK_EQUAL(
+            account::accountTablePrefix(address, /*systemAsUser=*/true), SYS_DIRECTORY::USER_APPS);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(userAddressesAlwaysApps)
+{
+    // Two ordinary 40-hex addresses that are NOT in c_systemTxsAddress.
+    constexpr std::string_view user1 = "f39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+    constexpr std::string_view user2 = "00000000000000000000000000000000000abcde";
+    for (auto address : {user1, user2})
+    {
+        BOOST_TEST_INFO("address=" << address);
+        BOOST_CHECK_EQUAL(
+            account::accountTablePrefix(address, /*systemAsUser=*/false), SYS_DIRECTORY::USER_APPS);
+        BOOST_CHECK_EQUAL(
+            account::accountTablePrefix(address, /*systemAsUser=*/true), SYS_DIRECTORY::USER_APPS);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h
@@ -39,6 +39,10 @@ namespace bcostars
 {
 struct Transaction;
 }
+namespace bcostars::protocol
+{
+class TransactionImpl;
+}
 
 namespace bcos
 {
@@ -154,6 +158,13 @@ public:
     bcos::bytes signatureS;
     uint64_t signatureV{0};
 };
+
+// eth_sync: decode a raw signed EIP-2718 envelope into the tars TransactionImpl
+// used by the ledger / executor. As with takeToTarsTransaction(), the definition
+// lives in bcos-tars-protocol (protocol/Web3TarsBridge.cpp), the module that owns
+// the tars types, so bcos-rlp-protocol stays free of any tars dependency.
+std::shared_ptr<bcostars::protocol::TransactionImpl> decodeWeb3RawTransaction(
+    bcos::bytesConstRef raw, const bcos::crypto::Hash& hashImpl);
 }  // namespace rpc
 namespace codec::rlp
 {

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h
@@ -163,6 +163,11 @@ public:
 // used by the ledger / executor. As with takeToTarsTransaction(), the definition
 // lives in bcos-tars-protocol (protocol/Web3TarsBridge.cpp), the module that owns
 // the tars types, so bcos-rlp-protocol stays free of any tars dependency.
+// Throw contract: throws std::invalid_argument when the envelope fails RLP decode,
+// and the secp256k1 InvalidSignature from sender() when (r, s) is off-curve.
+// The canonical txHash is NOT computed here: TransactionImpl::calculateHash
+// recomputes it unconditionally from the signed payload, so hashImpl is only used
+// for that recompute.
 std::shared_ptr<bcostars::protocol::TransactionImpl> decodeWeb3RawTransaction(
     bcos::bytesConstRef raw, const bcos::crypto::Hash& hashImpl);
 }  // namespace rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -338,20 +338,6 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
     }
     auto const ledger = m_nodeService->ledger();
 
-    // Same routing policy as Ledger::getStorageAt, via the shared helper: below
-    // executor_version 2 the c_systemTxsAddress members live under /sys/; at v2 every
-    // address is an ordinary /apps/ account, matching the v2 executor's writes.
-    int executorVersion = 0;
-    if (auto const config = co_await ledger::getSystemConfig(*ledger,
-            std::string_view{magic_enum::enum_name(ledger::SystemConfig::executor_version)});
-        config.has_value())
-    {
-        executorVersion = std::stoi(std::get<0>(*config));
-    }
-    auto const tablePrefix = ledger::account::accountTablePrefix(
-        addressStr, executorVersion >= ledger::ETHEREUM_EXECUTOR_VERSION);
-    auto const contractTableName = getContractTableName(tablePrefix, addressStr);
-
     // The empty-slot value: a 32-byte zero, matching the flat read's padded rendering.
     constexpr const char* c_emptyStorageValue =
         "0x0000000000000000000000000000000000000000000000000000000000000000";
@@ -375,6 +361,16 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
             auto const stateStorage = stateStorageProvider();
             if (stateStorage)
             {
+                // Same routing policy as Ledger::getStorageAt, via the shared helpers:
+                // executor_version comes from ledger::getExecutorVersion (the same
+                // whole-string parser the LedgerConfig derivations use) and the prefix from
+                // ledger::account::accountTablePrefix. Only this flat-read branch needs the
+                // table name — the ledger fallback and the historical-MPT path below derive
+                // the routing themselves, so the SYS_CONFIG read is not paid there.
+                auto const executorVersion = co_await ledger::getExecutorVersion(*ledger);
+                auto const tablePrefix = ledger::account::accountTablePrefix(
+                    addressStr, executorVersion >= ledger::ETHEREUM_EXECUTOR_VERSION);
+                auto const contractTableName = getContractTableName(tablePrefix, addressStr);
                 if (auto const entry = co_await bcos::storage2::readOne(*stateStorage,
                         executor_v1::StateKey{contractTableName, positionBytes.toRawString()});
                     entry.has_value())

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -23,6 +23,7 @@
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/ledger/SystemConfigs.h"
 #include "bcos-ledger/LedgerMethods.h"
@@ -347,7 +348,8 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
     {
         executorVersion = std::stoi(std::get<0>(*config));
     }
-    auto const tablePrefix = ledger::account::accountTablePrefix(addressStr, executorVersion);
+    auto const tablePrefix = ledger::account::accountTablePrefix(
+        addressStr, executorVersion >= ledger::ETHEREUM_EXECUTOR_VERSION);
     auto const contractTableName = getContractTableName(tablePrefix, addressStr);
 
     // The empty-slot value: a 32-byte zero, matching the flat read's padded rendering.

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -20,9 +20,11 @@
 
 #include "EthEndpoint.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
+#include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/ledger/SystemConfigs.h"
 #include "bcos-ledger/LedgerMethods.h"
 #include "bcos-mempool/MemPoolImpl.h"
 #include "bcos-protocol/TransactionStatus.h"
@@ -335,14 +337,17 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
     }
     auto const ledger = m_nodeService->ledger();
 
-    // System-contract addresses (0x1000 range, etc.) are stored under the "/sys/" prefix by
-    // EVMAccount; user accounts under "/apps/". Picking the right prefix here keeps
-    // eth_getStorageAt consistent with both the genesis alloc import and the v2 executor
-    // (which both go through EVMAccount) — same logic as Ledger::getStorageAt.
-    auto const tablePrefix =
-        precompiled::contains(bcos::precompiled::c_systemTxsAddress, std::string_view{addressStr}) ?
-            ledger::SYS_DIRECTORY::SYS_APPS :
-            ledger::SYS_DIRECTORY::USER_APPS;
+    // Same routing policy as Ledger::getStorageAt, via the shared helper: below
+    // executor_version 2 the c_systemTxsAddress members live under /sys/; at v2 every
+    // address is an ordinary /apps/ account, matching the v2 executor's writes.
+    int executorVersion = 0;
+    if (auto const config = co_await ledger::getSystemConfig(*ledger,
+            std::string_view{magic_enum::enum_name(ledger::SystemConfig::executor_version)});
+        config.has_value())
+    {
+        executorVersion = std::stoi(std::get<0>(*config));
+    }
+    auto const tablePrefix = ledger::account::accountTablePrefix(addressStr, executorVersion);
     auto const contractTableName = getContractTableName(tablePrefix, addressStr);
 
     // The empty-slot value: a 32-byte zero, matching the flat read's padded rendering.

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
@@ -29,9 +29,13 @@
 
 #include "bcos-framework/protocol/Transaction.h"  // bcos::protocol::TransactionType
 #include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
 #include "bcos-tars-protocol/tars/Transaction.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <boost/throw_exception.hpp>
+#include <memory>
+#include <stdexcept>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <iterator>
 #include <range/v3/algorithm/move.hpp>
@@ -163,5 +167,33 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 
     // dataHash and sender left empty — TxValidator::verify() computes them
     return tarsTx;
+}
+
+std::shared_ptr<bcostars::protocol::TransactionImpl> decodeWeb3RawTransaction(
+    bcos::bytesConstRef raw, const bcos::crypto::Hash& hashImpl)
+{
+    Web3Transaction web3Tx;
+    bcos::bytesRef input(const_cast<byte*>(raw.data()), raw.size());
+    if (auto error = codec::rlp::decode(input, web3Tx); error != nullptr)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("decodeWeb3RawTransaction: " + error->errorMessage()));
+    }
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [m_tx = web3Tx.takeToTarsTransaction()]() mutable { return &m_tx; });
+
+    // Canonical tx hash (keccak of the full signed encoding), stored for the ledger /
+    // receipt paths exactly as eth_sendRawTransaction does.
+    auto txHash = web3Tx.txHash();
+    tx->mutableInner().extraTransactionHash.assign(txHash.begin(), txHash.end());
+
+    // Restore the sender from the signature so the executor can validate the nonce /
+    // balance without a separate recovery pass.
+    auto senderHex = web3Tx.sender();
+    bcos::bytes senderBytes = bcos::fromHex(
+        senderHex.rfind("0x", 0) == 0 ? senderHex.substr(2) : senderHex);
+    tx->forceSender(senderBytes);
+    tx->calculateHash(hashImpl);
+    return tx;
 }
 }  // namespace bcos::rpc

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
@@ -179,12 +179,17 @@ std::shared_ptr<bcostars::protocol::TransactionImpl> decodeWeb3RawTransaction(
         BOOST_THROW_EXCEPTION(
             std::invalid_argument("decodeWeb3RawTransaction: " + error->errorMessage()));
     }
+    // Recover the sender BEFORE takeToTarsTransaction(): that call is destructive by
+    // contract (ranges::move of data/signatureR/signatureS), and sender() re-runs
+    // encodeForSign() over exactly those members. It happens to work today only because the
+    // moved members are containers of trivially-copyable bytes; recovering first removes the
+    // dependency on move-semantics detail entirely.
+    auto senderHex = web3Tx.sender();
     auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
         [m_tx = web3Tx.takeToTarsTransaction()]() mutable { return &m_tx; });
 
     // Restore the sender from the signature so the executor can validate the nonce /
     // balance without a separate recovery pass.
-    auto senderHex = web3Tx.sender();
     bcos::bytes senderBytes =
         bcos::fromHex(senderHex.rfind("0x", 0) == 0 ? senderHex.substr(2) : senderHex);
     tx->forceSender(senderBytes);

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
@@ -33,12 +33,12 @@
 #include "bcos-tars-protocol/tars/Transaction.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
-#include <boost/throw_exception.hpp>
-#include <memory>
-#include <stdexcept>
 #include <bcos-crypto/hash/Keccak256.h>
+#include <boost/throw_exception.hpp>
 #include <iterator>
+#include <memory>
 #include <range/v3/algorithm/move.hpp>
+#include <stdexcept>
 
 namespace bcos::rpc
 {
@@ -182,16 +182,11 @@ std::shared_ptr<bcostars::protocol::TransactionImpl> decodeWeb3RawTransaction(
     auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
         [m_tx = web3Tx.takeToTarsTransaction()]() mutable { return &m_tx; });
 
-    // Canonical tx hash (keccak of the full signed encoding), stored for the ledger /
-    // receipt paths exactly as eth_sendRawTransaction does.
-    auto txHash = web3Tx.txHash();
-    tx->mutableInner().extraTransactionHash.assign(txHash.begin(), txHash.end());
-
     // Restore the sender from the signature so the executor can validate the nonce /
     // balance without a separate recovery pass.
     auto senderHex = web3Tx.sender();
-    bcos::bytes senderBytes = bcos::fromHex(
-        senderHex.rfind("0x", 0) == 0 ? senderHex.substr(2) : senderHex);
+    bcos::bytes senderBytes =
+        bcos::fromHex(senderHex.rfind("0x", 0) == 0 ? senderHex.substr(2) : senderHex);
     tx->forceSender(senderBytes);
     tx->calculateHash(hashImpl);
     return tx;

--- a/bcos-tars-protocol/test/CMakeLists.txt
+++ b/bcos-tars-protocol/test/CMakeLists.txt
@@ -39,5 +39,7 @@ set_source_files_properties("BlockImplTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCL
 set_source_files_properties("BlockHeaderImplTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties("unittests/protocol/New1_Web3TxHashCanonicalTest.cpp"
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_source_files_properties("unittests/protocol/Web3TarsBridgeTest.cpp"
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 add_test(NAME test-tars-protocol WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${TEST_BINARY_NAME})

--- a/bcos-tars-protocol/test/unittests/protocol/Web3TarsBridgeTest.cpp
+++ b/bcos-tars-protocol/test/unittests/protocol/Web3TarsBridgeTest.cpp
@@ -1,0 +1,133 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Web3TarsBridgeTest.cpp
+ * @brief Round-trip tests for decodeWeb3RawTransaction (protocol/Web3TarsBridge.cpp):
+ *        a real signed EIP-1559 envelope and a 0x7e deposit envelope are decoded into
+ *        TransactionImpl; fields, the recovered sender and the canonical txHash must
+ *        come back intact, and malformed input must throw std::invalid_argument.
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1KeyPair.h>
+#include <bcos-rlp-protocol/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+namespace
+{
+// Fixed key (0xdead...beef) so the expected sender is stable across runs.
+std::shared_ptr<Secp256k1KeyPair> bridgeTestKeyPair()
+{
+    auto secret = std::make_shared<KeyImpl>(
+        h256("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef").asBytes());
+    return std::make_shared<Secp256k1KeyPair>(secret);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(Web3TarsBridgeTest)
+
+BOOST_AUTO_TEST_CASE(decodeEip1559RoundTrip)
+{
+    Keccak256 hashImpl;
+    auto keyPair = bridgeTestKeyPair();
+    auto const expectedSender = keyPair->address(std::make_shared<Keccak256>());
+
+    rpc::Web3Transaction tx;
+    tx.type = rpc::TransactionType::EIP1559;
+    tx.chainId = 1;
+    tx.nonce = 7;
+    tx.maxPriorityFeePerGas = u256(1000000000);
+    tx.maxFeePerGas = u256(2000000000);
+    tx.gasLimit = 21000;
+    tx.to = Address("0x727fc6e68397b6f1234567890abcdef123456789");
+    tx.value = u256("1000000000000000");
+    tx.data = fromHex("0xdeadbeef");
+
+    auto signature = secp256k1Sign(*keyPair, tx.hashForSign());
+    BOOST_REQUIRE_EQUAL(signature->size(), 65u);
+    tx.signatureR.assign(signature->begin(), signature->begin() + 32);
+    tx.signatureS.assign(signature->begin() + 32, signature->begin() + 64);
+    tx.signatureV = (*signature)[64];
+
+    auto raw = tx.encode();
+    BOOST_REQUIRE_EQUAL(raw.front(), static_cast<byte>(0x02));
+
+    auto decoded = rpc::decodeWeb3RawTransaction(bytesConstRef(raw.data(), raw.size()), hashImpl);
+    BOOST_REQUIRE(decoded);
+
+    BOOST_CHECK_EQUAL(decoded->web3TypedTxKind(), 2u);
+    BOOST_CHECK_EQUAL(decoded->nonce(), std::string_view("0x7"));
+    BOOST_CHECK_EQUAL(
+        decoded->to(), std::string_view("0x727fc6e68397b6f1234567890abcdef123456789"));
+    BOOST_CHECK_EQUAL(decoded->value(), u256("1000000000000000"));
+    BOOST_CHECK_EQUAL(decoded->gasLimit(), 21000);
+    BOOST_REQUIRE(decoded->maxFeePerGas().has_value());
+    BOOST_CHECK_EQUAL(*decoded->maxFeePerGas(), u256(2000000000));
+
+    // The sender is recovered from the signature and must be the signing key's address.
+    auto decodedSender = decoded->sender();
+    BOOST_CHECK_EQUAL(bytes(decodedSender.begin(), decodedSender.end()), expectedSender.asBytes());
+
+    // hash() is the canonical txHash = keccak256 of the raw signed envelope.
+    BOOST_CHECK_EQUAL(decoded->hash(), keccak256Hash(bytesConstRef(raw.data(), raw.size())));
+}
+
+BOOST_AUTO_TEST_CASE(decodeDepositRoundTrip)
+{
+    Keccak256 hashImpl;
+
+    rpc::Web3Transaction tx;
+    tx.type = rpc::TransactionType::Deposit;
+    tx.sourceHash = h256("0x1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd");
+    tx.from = Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead");
+    tx.to = Address("0x727fc6e68397b6f1234567890abcdef123456789");
+    tx.mint = u256(0);
+    tx.value = u256(5);
+    tx.gasLimit = 21000;
+    tx.data = {};
+
+    auto raw = tx.encode();
+    BOOST_REQUIRE_EQUAL(raw.front(), static_cast<byte>(0x7e));
+
+    auto decoded = rpc::decodeWeb3RawTransaction(bytesConstRef(raw.data(), raw.size()), hashImpl);
+    BOOST_REQUIRE(decoded);
+
+    BOOST_CHECK_EQUAL(decoded->web3TypedTxKind(), 0x7eu);
+    // Deposit is unsigned: the sender comes from the from field, not EC recovery.
+    auto decodedSender = decoded->sender();
+    BOOST_CHECK_EQUAL(bytes(decodedSender.begin(), decodedSender.end()), tx.from.asBytes());
+    BOOST_CHECK_EQUAL(decoded->hash(), keccak256Hash(bytesConstRef(raw.data(), raw.size())));
+}
+
+BOOST_AUTO_TEST_CASE(decodeMalformedThrows)
+{
+    Keccak256 hashImpl;
+    auto garbage = fromHex("0x02ff00");
+    BOOST_CHECK_THROW(
+        rpc::decodeWeb3RawTransaction(bytesConstRef(garbage.data(), garbage.size()), hashImpl),
+        std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger codec PRIVATE rlp-protocol)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger codec rlp-protocol)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -700,7 +700,9 @@ private:
                     // Raw-only entries (forced transactions) carry no decoded form and are
                     // not modeled as ledger transactions until execution wiring lands; the
                     // persisted transaction list therefore matches the receipts list, which
-                    // also only covers the executed (decoded) subset.
+                    // also only covers the executed (decoded) subset. (On the v2 path
+                    // buildPayload already refused payloads carrying such entries, so this
+                    // filter only ever sees them on legacy executors.)
                     for (auto const& tx : it->second.executionPayload.transactions)
                     {
                         if (tx.decoded)
@@ -797,9 +799,10 @@ private:
         // admissibility were already enforced by validatePayloadAttributes, which runs
         // before buildPayload). They carry no decoded executable form yet: 0x7E deposit
         // execution (runDeposit) and raw->executable decoding for typed/legacy forced
-        // transactions belong to the execution-lane wiring, so raw-only entries are
-        // placed in the payload, participate in the transactions root via their
-        // canonical keccak256(raw) hash, but are not executed and do not advance state.
+        // transactions belong to the execution-lane wiring. Until that wiring lands, the
+        // v2 (Ethereum roots) path REFUSES any payload still carrying raw-only entries —
+        // the receipts guard in Step 2e-0 below throws — because receipts could not be
+        // keyed at their true transactions-trie indexes.
         if (payloadAttributes.transactions.has_value())
         {
             for (auto const& forcedHex : *payloadAttributes.transactions)
@@ -1051,9 +1054,10 @@ private:
 
         // Step 2c: Execute transactions via the scheduler, over the decoded executable
         // forms. Raw-only entries (forced transactions from the OP attributes list) have
-        // no executable form yet and are skipped — see the forced-transaction comment
-        // above. Materialized into a vector because scheduler implementations require a
-        // sized range (a lazy filter view is not sized).
+        // no executable form yet and are skipped here; on the v2 path the Step 2e-0 guard
+        // below then refuses the whole payload (fail closed), so this skip is only ever
+        // committed on legacy executors. Materialized into a vector because scheduler
+        // implementations require a sized range (a lazy filter view is not sized).
         auto executableTransactions =
             executionPayload.transactions | ::ranges::views::filter([](auto const& transaction) {
                 return transaction.decoded != nullptr;
@@ -1124,13 +1128,25 @@ private:
         u256 totalGasUsed;
         if (ethereumRoots)
         {
+            // A v2 payload carrying forced (raw-only) transactions is REFUSED: receipts cover
+            // only the decoded executable subset while txsRoot commits every raw entry, so the
+            // receipts trie would be keyed 0..M-1 over M < N entries — receipt i would land at
+            // the wrong trie key and no external Ethereum verifier could reproduce
+            // receiptsRoot/blockHash. Executing raw-only entries (0x7E deposits and raw->
+            // executable decoding for the other forced kinds) belongs to the execution-lane
+            // wiring; until that lands, failing closed is the only correct outcome.
+            if (executableTransactions.size() != executionPayload.transactions.size())
+            {
+                BOOST_THROW_EXCEPTION(std::runtime_error{
+                    "Payload contains raw-only (forced/deposit) transactions not executable "
+                    "yet: " +
+                    std::to_string(executionPayload.transactions.size()) + " raw vs " +
+                    std::to_string(executableTransactions.size()) + " decoded"});
+            }
             // Receipt i commits the EIP-2718 type of transaction i, so the counts must match
             // exactly: more receipts than executed transactions is unpairable (would read past
             // txTypes), and fewer would silently commit a short receipts trie that no external
-            // Ethereum verifier can reproduce — fail closed on either. Forced (raw-only)
-            // transactions are counted in txsRoot but produce no receipts until the
-            // execution-lane wiring lands; strict per-payload-index pairing (including
-            // deposit kinds) comes with that wiring.
+            // Ethereum verifier can reproduce — fail closed on either.
             if (receipts.size() != executableTransactions.size())
             {
                 BOOST_THROW_EXCEPTION(std::runtime_error{

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -988,8 +988,9 @@ private:
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
 
         // Ethereum-compatible roots (executor_version >= 2): txsRoot/receiptsRoot commit to
-        // the transaction / receipt tries and empty blocks get emptyRootHash(); legacy
-        // executors keep the Merkle roots and the zero empty-root behaviour.
+        // the transaction / receipt tries; legacy executors keep the Merkle roots for
+        // non-empty blocks. Empty blocks get emptyRootHash() on every executor version (see
+        // the empty-block branch below) — there is no zero empty-root behaviour.
         const bool ethereumRoots =
             ledgerConfig.executorVersion() >= ledger::ETHEREUM_EXECUTOR_VERSION;
 

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -32,7 +32,9 @@
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-ledger/LedgerMethods.h"
-#include <bcos-ledger/mpt/Constants.h>
+#include "bcos-ledger/mpt/Constants.h"
+#include "bcos-ledger/mpt/EthTrieRoots.h"
+#include "bcos-rlp-protocol/EthReceipt.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -981,6 +983,12 @@ private:
         // header by finalizeEthBlockHeader.
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
 
+        // Ethereum-compatible roots (executor_version >= 2): txsRoot/receiptsRoot commit to
+        // the transaction / receipt tries and empty blocks get emptyRootHash(); legacy
+        // executors keep the Merkle roots and the zero empty-root behaviour.
+        const bool ethereumRoots =
+            ledgerConfig.executorVersion() >= ledger::ETHEREUM_EXECUTOR_VERSION;
+
         // Execute transactions (if any) and finalize the Eth header with its RLP hash.
         if (executionPayload.transactions.empty())
         {
@@ -1001,16 +1009,19 @@ private:
             // (bcos-tars-protocol/impl/TarsHashable.h).
             emptyHeader->setExtraData(std::move(extraData));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
-            // An empty block's transaction/receipt tries are the canonical empty-trie root, not
-            // the all-zero hash (validateHeader rejects a zero receiptsRoot/txsRoot).
-            emptyHeader->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
-            emptyHeader->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
+            // An empty block's transaction/receipt tries: for the Ethereum executor (v2)
+            // these are the canonical empty-trie root, not the all-zero hash (validateHeader
+            // rejects a zero receiptsRoot/txsRoot); legacy executors keep the zero behaviour.
+            emptyHeader->setReceiptsRoot(
+                ethereumRoots ? bcos::ledger::mpt::emptyRootHash() : h256{});
+            emptyHeader->setTxsRoot(ethereumRoots ? bcos::ledger::mpt::emptyRootHash() : h256{});
             emptyHeader->setGasUsed(0);
             detail::finalizeEthBlockHeader(
                 *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot,
                 forkVersion);
             executionPayload.stateRoot = emptyHeader->stateRoot();
-            executionPayload.receiptsRoot = bcos::ledger::mpt::emptyRootHash();
+            executionPayload.receiptsRoot =
+                ethereumRoots ? bcos::ledger::mpt::emptyRootHash() : h256{};
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
@@ -1050,12 +1061,22 @@ private:
         auto receipts = co_await m_scheduler.get().executeBlock(view, m_executor.get(),
             *blockHeader, executableTransactions | ::ranges::views::indirect, ledgerConfig);
 
-        // Step 2d: Compute transaction root (Merkle over tx hashes)
-        // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
-        // once MPTStorage is available. The current tx->hash() call lacks exception
-        // handling for malformed transactions. An empty transaction list maps to the
-        // canonical empty-trie root (validateHeader rejects an all-zero txsRoot).
-        h256 txRoot = bcos::ledger::mpt::emptyRootHash();
+        // Step 2d: Compute transaction root.
+        //  - Ethereum executor (v2): commit to the transaction trie over each transaction's
+        //    EIP-2718 wire bytes (ledger::mpt::calculateTransactionsRoot).
+        //  - legacy: Merkle over tx hashes (unchanged).
+        h256 txRoot;
+        if (ethereumRoots)
+        {
+            std::vector<bcos::bytesConstRef> txRaws;
+            txRaws.reserve(executionPayload.transactions.size());
+            for (auto const& transaction : executionPayload.transactions)
+            {
+                txRaws.emplace_back(bcos::ref(transaction.raw));
+            }
+            txRoot = ledger::mpt::calculateTransactionsRoot(txRaws);
+        }
+        else
         {
             auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
             auto hasher = hashImpl.hasher();
@@ -1080,16 +1101,85 @@ private:
             }
         }
 
-        // Step 2e: Compute receipt root (Merkle over receipt hashes). An empty receipt list
-        // maps to the canonical empty-trie root (validateHeader rejects an all-zero
-        // receiptsRoot).
-        h256 receiptRoot = bcos::ledger::mpt::emptyRootHash();
+        // Step 2e-0: Validate receipts and (v2) fill per-receipt cumulativeGasUsed + logsBloom.
+        // The raw SchedulerSerialImpl path skips BaselineScheduler's receipt phase (the
+        // documented empty-logsBloom limitation) — the Ethereum receipts trie and the
+        // block-level bloom need those fields.
+        u256 cumulativeGasUsed;
+        for (auto& receipt : receipts)
         {
-            // Validate receipts are non-null before computing hashes
-            if (::ranges::any_of(receipts, [](auto& r) { return !r; }))
+            if (!receipt)
             {
                 BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
             }
+            if (ethereumRoots)
+            {
+                // Respect a bloom the scheduler already filled (BaselineScheduler's receipt
+                // phase does); only the raw SchedulerSerialImpl path leaves it empty.
+                if (receipt->logsBloom().empty())
+                {
+                    auto logBloom = bcos::getLogsBloom(receipt->logEntries());
+                    receipt->setLogsBloom({logBloom.data(), logBloom.size()});
+                }
+                cumulativeGasUsed += receipt->gasUsed();
+                receipt->setCumulativeGasUsed(cumulativeGasUsed.str());
+            }
+        }
+
+        // Step 2e: Compute receipt root.
+        //  - Ethereum executor (v2): commit to the receipts trie over EthReceipt RLP
+        //    (ledger::mpt::calculateReceiptsRoot); the EIP-2718 type comes from the executed
+        //    transaction at the same index.
+        //  - legacy: Merkle over receipt hashes (unchanged).
+        h256 receiptRoot;
+        if (ethereumRoots)
+        {
+            // Receipt i commits the EIP-2718 type of transaction i, so more receipts than
+            // executed transactions is unpairable (and would read past txTypes); fewer is
+            // tolerated like the legacy path, which also hashed whatever the scheduler
+            // returned.
+            if (receipts.size() > executableTransactions.size())
+            {
+                BOOST_THROW_EXCEPTION(std::runtime_error{
+                    "Scheduler returned more receipts than executed transactions: " +
+                    std::to_string(receipts.size()) + " > " +
+                    std::to_string(executableTransactions.size())});
+            }
+            std::vector<uint8_t> txTypes;
+            txTypes.reserve(executableTransactions.size());
+            for (auto const& transaction : executableTransactions)
+            {
+                txTypes.push_back(transaction->web3TypedTxKind());
+            }
+            std::vector<bcos::bytes> receiptRlps;
+            receiptRlps.reserve(receipts.size());
+            size_t index = 0;
+            for (auto const& receipt : receipts)
+            {
+                protocol::EthReceiptData eth;
+                if (auto err =
+                        protocol::toEthReceiptData(*receipt, txTypes[index], eth);
+                    err != nullptr)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        std::runtime_error("toEthReceiptData: " + err->errorMessage()));
+                }
+                bcos::bytes encoded;
+                protocol::EthReceipt ethReceipt(std::move(eth));
+                ethReceipt.rlpEncode(encoded);
+                receiptRlps.push_back(std::move(encoded));
+                ++index;
+            }
+            std::vector<bcos::bytesConstRef> refs;
+            refs.reserve(receiptRlps.size());
+            for (auto const& rlp : receiptRlps)
+            {
+                refs.emplace_back(bcos::ref(rlp));
+            }
+            receiptRoot = ledger::mpt::calculateReceiptsRoot(refs);
+        }
+        else
+        {
             auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
             auto hasher = hashImpl.hasher();
             crypto::merkle::Merkle<std::remove_reference_t<decltype(hasher)>> merkle(
@@ -1112,14 +1202,9 @@ private:
         Bloom logsBloom{};
         for (auto& receipt : receipts)
         {
-            if (!receipt)
-            {
-                BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
-            }
             totalGasUsed += receipt->gasUsed();
-            // The v2 (pure-Ethereum) executor's receipts carry an empty logsBloom (a
-            // documented limitation — evmoneReceiptToBcos does not compute it), so tolerate
-            // empty blooms instead of indexing past their (zero) length.
+            // v2 receipts have their bloom filled in Step 2e-0; legacy receipts may carry an
+            // empty bloom (documented limitation), which is tolerated here.
             if (!receipt->logsBloom().empty())
             {
                 orBloom(logsBloom, receipt->logsBloom());

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -148,9 +148,8 @@ bcos::protocol::EthBlockVersion ethBlockVersionFor(evmc_revision rev);
 // excessBlobGas and @p parentBeaconBlockRoot must be engaged (this function uses .value()
 // on them and would throw std::bad_optional_access otherwise). buildPayload guarantees the
 // precondition under the same forkVersion-derived gate; a direct caller must too.
-void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
-    const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
-    bcos::protocol::EthBlockVersion forkVersion);
+void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header, const ExecutionPayload& payload,
+    std::optional<bcos::h256> parentBeaconBlockRoot, bcos::protocol::EthBlockVersion forkVersion);
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -662,8 +661,8 @@ private:
                     if (auto mismatch = detail::compareWithBuiltPayload(
                             request.executionPayload, builtIt->second.executionPayload))
                     {
-                        co_return makeStatus(PayloadValidationStatus::InvalidBlockHash,
-                            std::nullopt, mismatch);
+                        co_return makeStatus(
+                            PayloadValidationStatus::InvalidBlockHash, std::nullopt, mismatch);
                     }
                 }
             }
@@ -714,7 +713,8 @@ private:
                     }
                     blockTxs = std::make_shared<protocol::ConstTransactions>(
                         it->second.executionPayload.transactions |
-                        ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
+                        ::ranges::views::filter(
+                            [](auto const& tx) { return tx.decoded != nullptr; }) |
                         ::ranges::views::transform([](auto const& tx) {
                             return protocol::Transaction::ConstPtr(tx.decoded);
                         }) |
@@ -746,9 +746,8 @@ private:
             // executed (unbounded memory over time). Keep only the just-committed block; the
             // newPayload() parent check accepts the head hash directly, so dropping older
             // blockHash rows is safe.
-            std::erase_if(m_blockHashToPayloadId, [&](auto const& kv) {
-                return kv.first != request.executionPayload.blockHash;
-            });
+            std::erase_if(m_blockHashToPayloadId,
+                [&](auto const& kv) { return kv.first != request.executionPayload.blockHash; });
             std::erase_if(m_payloadCache, [&](auto const& kv) { return kv.first != payloadId; });
         }
 
@@ -879,11 +878,12 @@ private:
         auto chainRevision = ledgerConfig.evmcRevisionForBlock(nextBlockNumber);
         if (!chainRevision.has_value())
         {
-            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
-                "EngineService: no on-chain EVM revision configured for block " +
-                std::to_string(nextBlockNumber) +
-                "; cannot derive the Eth header fork era (a v2 chain persists evmc_revision "
-                "at genesis)"});
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFork{} << bcos::errinfo_comment{
+                    "EngineService: no on-chain EVM revision configured for block " +
+                    std::to_string(nextBlockNumber) +
+                    "; cannot derive the Eth header fork era (a v2 chain persists evmc_revision "
+                    "at genesis)"});
         }
         auto forkVersion = bcos::engine::detail::ethBlockVersionFor(*chainRevision);
 
@@ -897,16 +897,18 @@ private:
         if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN &&
             !payloadAttributes.parentBeaconBlockRoot.has_value())
         {
-            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
-                "EngineService: chain EVM revision requires the V3 payload attributes "
-                "(parentBeaconBlockRoot); forkchoiceUpdated must be called at version >= 3"});
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFork{} << bcos::errinfo_comment{
+                    "EngineService: chain EVM revision requires the V3 payload attributes "
+                    "(parentBeaconBlockRoot); forkchoiceUpdated must be called at version >= 3"});
         }
         if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI &&
             !payloadAttributes.withdrawals.has_value())
         {
-            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
-                "EngineService: chain EVM revision requires the V2 payload attributes "
-                "(withdrawals); forkchoiceUpdated must be called at version >= 2"});
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFork{} << bcos::errinfo_comment{
+                    "EngineService: chain EVM revision requires the V2 payload attributes "
+                    "(withdrawals); forkchoiceUpdated must be called at version >= 2"});
         }
         // The reverse direction: a method version NEWER than the chain fork cannot be
         // served either. The served ExecutionPayload shape is contracted by the method the
@@ -918,18 +920,20 @@ private:
         if (version >= static_cast<std::uint32_t>(ApiVersion::V3) &&
             forkVersion < bcos::protocol::EthBlockVersion::CANCUN)
         {
-            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
-                "EngineService: forkchoiceUpdatedV3 requires a CANCUN-or-later chain fork; "
-                "chain EVM revision maps to " +
-                std::to_string(static_cast<int>(forkVersion))});
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFork{} << bcos::errinfo_comment{
+                    "EngineService: forkchoiceUpdatedV3 requires a CANCUN-or-later chain fork; "
+                    "chain EVM revision maps to " +
+                    std::to_string(static_cast<int>(forkVersion))});
         }
         if (version >= static_cast<std::uint32_t>(ApiVersion::V2) &&
             forkVersion < bcos::protocol::EthBlockVersion::SHANGHAI)
         {
-            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
-                "EngineService: forkchoiceUpdatedV2 requires a SHANGHAI-or-later chain "
-                "fork; chain EVM revision maps to " +
-                std::to_string(static_cast<int>(forkVersion))});
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFork{} << bcos::errinfo_comment{
+                    "EngineService: forkchoiceUpdatedV2 requires a SHANGHAI-or-later chain "
+                    "fork; chain EVM revision maps to " +
+                    std::to_string(static_cast<int>(forkVersion))});
         }
 
         // The payload SHAPE also follows the chain fork, not the request's method version
@@ -974,8 +978,8 @@ private:
             // The served payload value and the hashed header value must agree (both go
             // through withdrawalsRootFor): a consumer rebuilding the header from the
             // payload's withdrawalsRoot field must reproduce blockHash.
-            executionPayload.withdrawalsRoot = bcos::engine::detail::withdrawalsRootFor(
-                executionPayload);
+            executionPayload.withdrawalsRoot =
+                bcos::engine::detail::withdrawalsRootFor(executionPayload);
         }
 
         // Fill gasLimit from ledger config. baseFeePerGas is carried in the payload (currently
@@ -1009,19 +1013,16 @@ private:
             // (bcos-tars-protocol/impl/TarsHashable.h).
             emptyHeader->setExtraData(std::move(extraData));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
-            // An empty block's transaction/receipt tries: for the Ethereum executor (v2)
-            // these are the canonical empty-trie root, not the all-zero hash (validateHeader
-            // rejects a zero receiptsRoot/txsRoot); legacy executors keep the zero behaviour.
-            emptyHeader->setReceiptsRoot(
-                ethereumRoots ? bcos::ledger::mpt::emptyRootHash() : h256{});
-            emptyHeader->setTxsRoot(ethereumRoots ? bcos::ledger::mpt::emptyRootHash() : h256{});
+            // An empty block's transaction/receipt tries are the canonical empty-trie root,
+            // not the all-zero hash (validateHeader rejects a zero receiptsRoot/txsRoot) —
+            // on every executor version.
+            emptyHeader->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
+            emptyHeader->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
             emptyHeader->setGasUsed(0);
-            detail::finalizeEthBlockHeader(
-                *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot,
-                forkVersion);
+            detail::finalizeEthBlockHeader(*emptyHeader, executionPayload,
+                payloadAttributes.parentBeaconBlockRoot, forkVersion);
             executionPayload.stateRoot = emptyHeader->stateRoot();
-            executionPayload.receiptsRoot =
-                ethereumRoots ? bcos::ledger::mpt::emptyRootHash() : h256{};
+            executionPayload.receiptsRoot = bcos::ledger::mpt::emptyRootHash();
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
@@ -1065,7 +1066,9 @@ private:
         //  - Ethereum executor (v2): commit to the transaction trie over each transaction's
         //    EIP-2718 wire bytes (ledger::mpt::calculateTransactionsRoot).
         //  - legacy: Merkle over tx hashes (unchanged).
-        h256 txRoot;
+        // Both roots default to the canonical empty-trie root (validateHeader rejects an
+        // all-zero root); the branches below overwrite them for non-empty blocks.
+        h256 txRoot = bcos::ledger::mpt::emptyRootHash();
         if (ethereumRoots)
         {
             std::vector<bcos::bytesConstRef> txRaws;
@@ -1101,29 +1104,20 @@ private:
             }
         }
 
-        // Step 2e-0: Validate receipts and (v2) fill per-receipt cumulativeGasUsed + logsBloom.
-        // The raw SchedulerSerialImpl path skips BaselineScheduler's receipt phase (the
-        // documented empty-logsBloom limitation) — the Ethereum receipts trie and the
-        // block-level bloom need those fields.
-        u256 cumulativeGasUsed;
+        // Step 2e-0: Validate receipts and (v2) finalize per-receipt fields — transactionIndex,
+        // logIndex, logsBloom and cumulativeGasUsed — via the helper shared with
+        // BaselineScheduler's receipt phase (the raw SchedulerSerialImpl path skips that
+        // phase); the receipts trie and the block-level bloom need those fields.
         for (auto& receipt : receipts)
         {
             if (!receipt)
             {
                 BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
             }
-            if (ethereumRoots)
-            {
-                // Respect a bloom the scheduler already filled (BaselineScheduler's receipt
-                // phase does); only the raw SchedulerSerialImpl path leaves it empty.
-                if (receipt->logsBloom().empty())
-                {
-                    auto logBloom = bcos::getLogsBloom(receipt->logEntries());
-                    receipt->setLogsBloom({logBloom.data(), logBloom.size()});
-                }
-                cumulativeGasUsed += receipt->gasUsed();
-                receipt->setCumulativeGasUsed(cumulativeGasUsed.str());
-            }
+        }
+        if (ethereumRoots)
+        {
+            ledger::mpt::finalizeReceipts(receipts);
         }
 
         // Step 2e: Compute receipt root.
@@ -1131,7 +1125,7 @@ private:
         //    (ledger::mpt::calculateReceiptsRoot); the EIP-2718 type comes from the executed
         //    transaction at the same index.
         //  - legacy: Merkle over receipt hashes (unchanged).
-        h256 receiptRoot;
+        h256 receiptRoot = bcos::ledger::mpt::emptyRootHash();
         if (ethereumRoots)
         {
             // Receipt i commits the EIP-2718 type of transaction i, so more receipts than
@@ -1157,8 +1151,7 @@ private:
             for (auto const& receipt : receipts)
             {
                 protocol::EthReceiptData eth;
-                if (auto err =
-                        protocol::toEthReceiptData(*receipt, txTypes[index], eth);
+                if (auto err = protocol::toEthReceiptData(*receipt, txTypes[index], eth);
                     err != nullptr)
                 {
                     BOOST_THROW_EXCEPTION(
@@ -1166,7 +1159,11 @@ private:
                 }
                 bcos::bytes encoded;
                 protocol::EthReceipt ethReceipt(std::move(eth));
-                ethReceipt.rlpEncode(encoded);
+                if (auto err = ethReceipt.rlpEncode(encoded); err != nullptr)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        std::runtime_error("EthReceipt rlpEncode: " + err->errorMessage()));
+                }
                 receiptRlps.push_back(std::move(encoded));
                 ++index;
             }

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -35,6 +35,7 @@
 #include "bcos-ledger/mpt/Constants.h"
 #include "bcos-ledger/mpt/EthTrieRoots.h"
 #include "bcos-rlp-protocol/EthReceipt.h"
+#include "bcos-rlp-protocol/Web3TxEnvelope.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -1108,7 +1109,9 @@ private:
         // Step 2e-0: Validate receipts and (v2) finalize per-receipt fields — transactionIndex,
         // logIndex, logsBloom and cumulativeGasUsed — via the helper shared with
         // BaselineScheduler's receipt phase (the raw SchedulerSerialImpl path skips that
-        // phase); the receipts trie and the block-level bloom need those fields.
+        // phase); the receipts trie and the block-level bloom need those fields. The helper
+        // re-checks null itself; this loop also guards the legacy path below, which never
+        // calls the helper.
         for (auto& receipt : receipts)
         {
             if (!receipt)
@@ -1116,35 +1119,58 @@ private:
                 BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
             }
         }
+        // v2: filled by finalizeReceipts below (the single derivation, shared with
+        // BaselineScheduler); legacy: summed per receipt in Step 2f.
+        u256 totalGasUsed;
         if (ethereumRoots)
         {
-            ledger::mpt::finalizeReceipts(receipts);
+            // Receipt i commits the EIP-2718 type of transaction i, so the counts must match
+            // exactly: more receipts than executed transactions is unpairable (would read past
+            // txTypes), and fewer would silently commit a short receipts trie that no external
+            // Ethereum verifier can reproduce — fail closed on either. Forced (raw-only)
+            // transactions are counted in txsRoot but produce no receipts until the
+            // execution-lane wiring lands; strict per-payload-index pairing (including
+            // deposit kinds) comes with that wiring.
+            if (receipts.size() != executableTransactions.size())
+            {
+                BOOST_THROW_EXCEPTION(std::runtime_error{
+                    "Scheduler returned mismatched receipts vs executed transactions: " +
+                    std::to_string(receipts.size()) +
+                    " != " + std::to_string(executableTransactions.size())});
+            }
+            totalGasUsed = ledger::mpt::finalizeReceipts(receipts);
         }
 
         // Step 2e: Compute receipt root.
         //  - Ethereum executor (v2): commit to the receipts trie over EthReceipt RLP
-        //    (ledger::mpt::calculateReceiptsRoot); the EIP-2718 type comes from the executed
-        //    transaction at the same index.
+        //    (ledger::mpt::calculateReceiptsRoot); the EIP-2718 type is derived from the
+        //    executed transaction's signed envelope at the same index.
         //  - legacy: Merkle over receipt hashes (unchanged).
         h256 receiptRoot = bcos::ledger::mpt::emptyRootHash();
         if (ethereumRoots)
         {
-            // Receipt i commits the EIP-2718 type of transaction i, so more receipts than
-            // executed transactions is unpairable (and would read past txTypes); fewer is
-            // tolerated like the legacy path, which also hashed whatever the scheduler
-            // returned.
-            if (receipts.size() > executableTransactions.size())
-            {
-                BOOST_THROW_EXCEPTION(std::runtime_error{
-                    "Scheduler returned more receipts than executed transactions: " +
-                    std::to_string(receipts.size()) + " > " +
-                    std::to_string(executableTransactions.size())});
-            }
             std::vector<uint8_t> txTypes;
             txTypes.reserve(executableTransactions.size());
             for (auto const& transaction : executableTransactions)
             {
-                txTypes.push_back(transaction->web3TypedTxKind());
+                // Derive the EIP-2718 type from the SIGNED envelope's first byte (EIP-2718:
+                // a type byte is < 0x80; a legacy signing preimage starts with an RLP list
+                // header) — never from the web3TypedTxKind tars mirror, which a peer can
+                // rewrite. calculateHash already applies the same envelope-first defense
+                // for deposit detection (TransactionImpl.cpp). A mirror that disagrees
+                // with the envelope is a tampered or corrupt transaction: fail closed.
+                auto const envelope = transaction->extraTransactionBytes();
+                auto const kind = bcos::rlp::protocol::isTypedWeb3Envelope(envelope) ?
+                                      static_cast<uint8_t>(envelope[0]) :
+                                      uint8_t{0};
+                if (transaction->web3TypedTxKind() != kind)
+                {
+                    BOOST_THROW_EXCEPTION(std::runtime_error{
+                        "web3TypedTxKind mirror disagrees with the signed envelope: mirror=" +
+                        std::to_string(transaction->web3TypedTxKind()) +
+                        ", envelope=" + std::to_string(kind)});
+                }
+                txTypes.push_back(kind);
             }
             std::vector<bcos::bytes> receiptRlps;
             receiptRlps.reserve(receipts.size());
@@ -1195,14 +1221,18 @@ private:
             }
         }
 
-        // Step 2f: Compute gas used and block-level logsBloom from receipts.
-        u256 totalGasUsed;
+        // Step 2f: Compute gas used (legacy only) and block-level logsBloom from receipts.
+        // The v2 totalGasUsed came from finalizeReceipts in Step 2e-0; re-summing it here
+        // would be a second derivation of the same consensus value.
         Bloom logsBloom{};
         for (auto& receipt : receipts)
         {
-            totalGasUsed += receipt->gasUsed();
-            // v2 receipts have their bloom filled in Step 2e-0; legacy receipts may carry an
-            // empty bloom (documented limitation), which is tolerated here.
+            if (!ethereumRoots)
+            {
+                totalGasUsed += receipt->gasUsed();
+            }
+            // v2 receipts have their bloom recomputed from their logs in Step 2e-0; legacy
+            // receipts may carry an empty bloom (documented limitation), tolerated here.
             if (!receipt->logsBloom().empty())
             {
                 orBloom(logsBloom, receipt->logsBloom());

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -86,7 +86,12 @@ static protocol::Transaction::Ptr makeTx(std::string_view senderBytes, int64_t n
 /// type=Web3Transaction, extraTransactionBytes = 0x02 || rlp(unsigned fields),
 /// signature = r(32) || s(32) || yParity(1). calculateHash() runs the same raw-bytes
 /// splice buildPayload uses, so constructing one also validates the payload shape.
-static protocol::Transaction::Ptr makeWeb3Tx(std::string_view senderBytes, uint64_t nonce)
+/// mirrorKind is written to the web3TypedTxKind tars mirror; the default 2 agrees with
+/// the 0x02 envelope. buildPayload derives the receipt's EIP-2718 type from the signed
+/// envelope and fails closed when the mirror disagrees — pass a wrong mirrorKind to
+/// exercise that rejection (a peer can rewrite the mirror; never the envelope).
+static protocol::Transaction::Ptr makeWeb3Tx(
+    std::string_view senderBytes, uint64_t nonce, uint8_t mirrorKind = 2)
 {
     bytes body;
     bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));  // chainId
@@ -107,6 +112,7 @@ static protocol::Transaction::Ptr makeWeb3Tx(std::string_view senderBytes, uint6
     auto tx = std::make_shared<TestTransactionImpl>();
     tx->mutableInner().type = static_cast<int>(bcos::protocol::TransactionType::Web3Transaction);
     tx->mutableInner().extraTransactionBytes.assign(payload.begin(), payload.end());
+    tx->mutableInner().web3TypedTxKind = static_cast<tars::Char>(mirrorKind);
     bytes signature(65, 0);
     signature[31] = 0x12;  // r != 0
     signature[63] = 0x34;  // s != 0
@@ -256,39 +262,53 @@ struct StubExecutor
 
 struct StubScheduler
 {
+    // One default receipt per executed transaction: buildPayload fails closed when the
+    // receipt count differs from the executed-transaction count (a short receipts trie
+    // would silently diverge from any external verifier), so a stub returning an empty
+    // list for a non-empty block would make every payload build throw.
     template <class Storage, class Executor>
     task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
-        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
+        const protocol::BlockHeader&, ::ranges::input_range auto&& transactions,
+        const ledger::LedgerConfig&)
     {
-        co_return {};
+        std::vector<protocol::TransactionReceipt::Ptr> receipts;
+        for (auto const& transaction : transactions)
+        {
+            (void)transaction;
+            receipts.push_back(std::make_shared<bcostars::protocol::TransactionReceiptImpl>());
+        }
+        co_return receipts;
     }
 };
 
 struct BloomScheduler
 {
     // The engine finalizes the returned receipts in place (transactionIndex / logIndex /
-    // cumulativeGasUsed), so keeping them here lets the test pin the header roots against
-    // the exact receipt objects the roots were computed from.
+    // logsBloom / cumulativeGasUsed), so keeping them here lets the test pin the header
+    // roots against the exact receipt objects the roots were computed from.
     std::vector<protocol::TransactionReceipt::Ptr> lastReceipts;
 
     template <class Storage, class Executor>
     task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
         const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
     {
-        Bloom bloom1{};
-        bloom1[255] = static_cast<bcos::byte>(0x01);
-        Bloom bloom2{};
-        bloom2[255] = static_cast<bcos::byte>(0x02);
+        // One log entry per receipt: finalizeReceipts recomputes each receipt's logsBloom
+        // from its log entries (a producer-filled bloom is never trusted) and stamps
+        // logIndex 0 then 1 across the two receipts.
+        protocol::LogEntries logs1{protocol::LogEntry{toBytes("11111111111111111111"),
+            {h256("1111111111111111111111111111111111111111111111111111111111111111")}, {}}};
+        protocol::LogEntries logs2{protocol::LogEntry{toBytes("22222222222222222222"),
+            {h256("2222222222222222222222222222222222222222222222222222222222222222")}, {}}};
 
         Keccak256 hasher;
         auto receipt1 = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
-        receipt1->setLogsBloom({bloom1.data(), bloom1.size()});
+        receipt1->setLogEntries(logs1);
         // Non-zero gasUsed so the cumulativeGasUsed assertions below can distinguish real
         // accumulation (21000 then 51000) from a no-op finalizeReceipts.
         receipt1->inner().data.gasUsed = "21000";
         receipt1->calculateHash(hasher);
         auto receipt2 = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
-        receipt2->setLogsBloom({bloom2.data(), bloom2.size()});
+        receipt2->setLogEntries(logs2);
         receipt2->inner().data.gasUsed = "30000";
         receipt2->calculateHash(hasher);
 
@@ -308,6 +328,19 @@ struct OverReceiptScheduler
         co_return std::vector<protocol::TransactionReceipt::Ptr>{
             std::make_shared<bcostars::protocol::TransactionReceiptImpl>(),
             std::make_shared<bcostars::protocol::TransactionReceiptImpl>(),
+            std::make_shared<bcostars::protocol::TransactionReceiptImpl>()};
+    }
+};
+
+// Returns FEWER receipts than there are transactions: the short receipts trie would
+// silently diverge from any external Ethereum verifier, so the engine must fail closed.
+struct UnderReceiptScheduler
+{
+    template <class Storage, class Executor>
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
+    {
+        co_return std::vector<protocol::TransactionReceipt::Ptr>{
             std::make_shared<bcostars::protocol::TransactionReceiptImpl>()};
     }
 };
@@ -1306,24 +1339,32 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
 
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 2));
 
-    // Verify bloom aggregation: bloom1[255]=0x01 | bloom2[255]=0x02 = 0x03
-    BOOST_CHECK_EQUAL(static_cast<int>(payload->executionPayload.logsBloom[255]), 0x03);
-    // Other bytes remain zero (only the last byte was set in both blooms)
-    for (size_t i = 0; i < 255; ++i)
-    {
-        BOOST_CHECK_EQUAL(static_cast<int>(payload->executionPayload.logsBloom[i]), 0);
-    }
-
-    // Pin the v2 receipts root against an independently recomputed trie. (txsRoot is
-    // committed to the header only — the Engine API payload carries no field for it.)
-    // The engine finalized the stub's receipts in place: indices stamped, gas accumulated.
+    // Bloom finalization and aggregation: finalizeReceipts recomputes each receipt's
+    // bloom from its log entries (a producer-filled bloom is never trusted), and the
+    // block bloom is the OR of the per-receipt blooms. NOTE: RefDataContainer::operator==
+    // compares POINTERS, not contents — compare hex encodings instead.
     BOOST_REQUIRE_EQUAL(bloomScheduler.lastReceipts.size(), 2u);
+    auto const expectedBloom1 = bcos::getLogsBloom(bloomScheduler.lastReceipts[0]->logEntries());
+    auto const expectedBloom2 = bcos::getLogsBloom(bloomScheduler.lastReceipts[1]->logEntries());
+    BOOST_REQUIRE(expectedBloom1 != Bloom{} && expectedBloom2 != Bloom{});
+    BOOST_CHECK_EQUAL(toHex(bloomScheduler.lastReceipts[0]->logsBloom()), toHex(expectedBloom1));
+    BOOST_CHECK_EQUAL(toHex(bloomScheduler.lastReceipts[1]->logsBloom()), toHex(expectedBloom2));
+    Bloom expectedBlockBloom{};
+    bcos::orBloom(expectedBlockBloom, expectedBloom1);
+    bcos::orBloom(expectedBlockBloom, expectedBloom2);
+    BOOST_CHECK(payload->executionPayload.logsBloom == expectedBlockBloom);
+
+    // The engine finalized the stub's receipts in place: indices stamped, gas accumulated.
+    // (logIndex is stamped by finalizeReceipts but cannot be pinned here: the tars-backed
+    // TransactionReceiptImpl hardcodes logIndex() to 0 and setLogIndex is a no-op.)
     BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->transactionIndex(), 0u);
     BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->transactionIndex(), 1u);
     // gasUsed 21000 then 30000: finalizeReceipts must accumulate to 21000 / 51000 (the stub
     // carries non-zero gasUsed precisely so these assertions can detect a no-op finalizer).
     BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->cumulativeGasUsed(), "21000");
     BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->cumulativeGasUsed(), "51000");
+    // totalGasUsed flows from finalizeReceipts' return into the payload's gasUsed.
+    BOOST_CHECK_EQUAL(payload->executionPayload.gasUsed, bcos::u256(51000));
 
     std::vector<bcos::bytes> receiptRlps;
     for (auto const& receipt : bloomScheduler.lastReceipts)
@@ -1342,11 +1383,56 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
     }
     BOOST_CHECK_EQUAL(
         payload->executionPayload.receiptsRoot, ledger::mpt::calculateReceiptsRoot(receiptRefs));
+
+    // Pin txsRoot: the Engine API payload carries no field for it, so rebuild the Eth
+    // header with the transactions trie root computed over the payload's raw wire bytes
+    // and check keccak(rlp(header)) == blockHash — the same reconstruction
+    // buildPayloadEmptyBlockInjectsRlpHash performs for the empty block.
+    std::vector<bcos::bytesConstRef> txRaws;
+    for (auto const& engineTx : payload->executionPayload.transactions)
+    {
+        txRaws.emplace_back(bcos::ref(engineTx.raw));
+    }
+    auto const expectedTxsRoot = ledger::mpt::calculateTransactionsRoot(txRaws);
+
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    auto const& executionPayload = payload->executionPayload;
+    header->setParentInfo(bcos::protocol::ParentInfo{
+        .blockNumber = static_cast<int64_t>(executionPayload.blockNumber) - 1,
+        .blockHash = executionPayload.parentHash});
+    header->setNumber(static_cast<int64_t>(executionPayload.blockNumber));
+    // Internal BlockHeader milliseconds; the bridge converts to seconds at encode.
+    header->setTimestamp(static_cast<int64_t>(executionPayload.timestamp));
+    header->setCoinbase(executionPayload.feeRecipient);
+    header->setUncleHash(bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setPrevRandao(executionPayload.prevRandao);
+    header->setNonce(bcos::h64(0));
+    header->setDifficulty(bcos::u256(0));
+    header->setGasLimit(executionPayload.gasLimit);
+    header->setGasUsed(executionPayload.gasUsed);
+    header->setStateRoot(executionPayload.stateRoot);
+    header->setReceiptsRoot(executionPayload.receiptsRoot);
+    header->setTxsRoot(expectedTxsRoot);
+    header->setLogsBloom(
+        bcos::bytesConstRef(executionPayload.logsBloom.data(), executionPayload.logsBloom.size()));
+    header->setBaseFee(executionPayload.baseFeePerGas);
+    header->setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::SHANGHAI);
+
+    bcos::protocol::EthBlockHeader ethHeader(*header);
+    bcos::bytes headerRlp;
+    ethHeader.rlpEncode(headerRlp);
+    BOOST_CHECK_EQUAL(
+        executionPayload.blockHash.hex(), bcos::crypto::keccak256Hash(bcos::ref(headerRlp)).hex());
 }
 
 // Receipt i commits the EIP-2718 type of transaction i: a scheduler that returns MORE
 // receipts than executed transactions is unpairable, and the engine must throw instead of
-// reading past the transaction list.
+// reading past the transaction list. Match the message, not just the type — any unrelated
+// runtime_error on the build path would fake-pass a type-only assertion.
 BOOST_AUTO_TEST_CASE(build_payload_rejects_more_receipts_than_transactions)
 {
     MemPoolImpl memPool;
@@ -1367,9 +1453,70 @@ BOOST_AUTO_TEST_CASE(build_payload_rejects_more_receipts_than_transactions)
             memPool, globalStateStorageFixture.storage, sharedStubExecutor(), overReceiptScheduler,
             testBlockFactory());
 
-    BOOST_CHECK_THROW(
+    BOOST_CHECK_EXCEPTION(
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
-        std::runtime_error);
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find("mismatched receipts vs executed transactions") !=
+                   std::string::npos;
+        });
+}
+
+// The symmetric failure: a scheduler returning FEWER receipts than executed transactions
+// would silently commit a short receipts trie that no external Ethereum verifier can
+// reproduce, so the engine must fail closed on that too.
+BOOST_AUTO_TEST_CASE(build_payload_rejects_fewer_receipts_than_transactions)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("b1b1b1b1b1b1b1b1b1b1", 20);
+    auto tx = makeWeb3Tx(sender, 0);
+    auto tx2 = makeWeb3Tx(sender, 1);
+    memPool.add(std::vector{tx, tx2});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto payloadAttributes = makePayloadAttributesV2();
+
+    UnderReceiptScheduler underReceiptScheduler;
+    auto engineService =
+        EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, UnderReceiptScheduler>(
+            memPool, globalStateStorageFixture.storage, sharedStubExecutor(), underReceiptScheduler,
+            testBlockFactory());
+
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find("mismatched receipts vs executed transactions") !=
+                   std::string::npos;
+        });
+}
+
+// The receipt's EIP-2718 type is derived from the signed envelope's first byte, never the
+// web3TypedTxKind tars mirror (a peer can rewrite the mirror; never the envelope). A mirror
+// that disagrees with the envelope — here mirror=1 on a 0x02 envelope — must fail closed
+// instead of silently committing a wrong receiptsRoot.
+BOOST_AUTO_TEST_CASE(build_payload_rejects_forged_tx_kind_mirror)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("b2b2b2b2b2b2b2b2b2b2", 20);
+    auto tx = makeWeb3Tx(sender, 0, 1);  // forged mirror: claims kind 1, envelope says 2
+    memPool.add(std::vector{tx});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto payloadAttributes = makePayloadAttributesV2();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find(
+                       "web3TypedTxKind mirror disagrees with the signed envelope") !=
+                   std::string::npos;
+        });
 }
 
 // ---- B4: Karst method surface (forkchoiceUpdatedV3 -> getPayloadV5 -> newPayloadV4) ----

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -207,7 +207,8 @@ struct RealGlobalStateStorageFixture
         // Use the same path here so the sealed nonce the test relies on is visible to seal().
         evmc_address addr{};
         std::copy_n(sender.begin(), std::min(sender.size(), sizeof(addr.bytes)), addr.bytes);
-        ledger::account::EVMAccount account{backendStorage, addr, false};
+        ledger::account::EVMAccount account{backendStorage, addr, false,
+            /*treatSystemAsUser=*/true};
         task::syncWait(account.setNonce(std::move(nonce)));
     }
 
@@ -1224,22 +1225,25 @@ BOOST_AUTO_TEST_CASE(forkchoice_attributes_reject_blob_forced_transactions)
     BOOST_CHECK_EQUAL(static_cast<int>(badHexResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Invalid));
 
-    // A deposit in the forced transaction list is admissible (dep-1 arrives this way)
-    // AND actually lands in the built payload, byte-for-byte.
+    // A deposit in the forced transaction list passes attribute validation (dep-1 arrives
+    // this way), but buildPayload then FAILS CLOSED: a raw-only entry cannot produce a
+    // reproducible receiptsRoot until the execution-lane wiring executes deposits.
     auto depositAttributes = makePayloadAttributesV3();
     depositAttributes.transactions = std::vector<std::string>{"0x7e010203"};
-    auto depositResult =
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, &depositAttributes, 3));
-    BOOST_CHECK_EQUAL(static_cast<int>(depositResult.payloadStatus.status),
-        static_cast<int>(PayloadValidationStatus::Valid));
-    BOOST_REQUIRE(depositResult.payloadId.has_value());
-    auto depositPayload = task::syncWait(engineService.getPayload(*depositResult.payloadId, 3));
-    BOOST_REQUIRE_EQUAL(depositPayload->executionPayload.transactions.size(), 1);
-    BOOST_CHECK(depositPayload->executionPayload.transactions.front().raw ==
-                (bytes{0x7e, 0x01, 0x02, 0x03}));
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &depositAttributes, 3)),
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find(
+                       "raw-only (forced/deposit) transactions not executable yet") !=
+                   std::string::npos;
+        });
 }
 
-BOOST_AUTO_TEST_CASE(forced_transactions_enter_payload_first)
+// Forced transactions (deposits) are placed FIRST in the engine transaction list, ahead of
+// the pool transactions, in the order the CL gave them — but on the v2 path the build then
+// fails closed on the raw-only entries (see the receipts guard in buildPayload), so the
+// ordering is only observable via the refusal's raw-vs-decoded counts for now.
+BOOST_AUTO_TEST_CASE(forced_transactions_fail_closed_until_execution_lane_wiring)
 {
     MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
@@ -1252,22 +1256,17 @@ BOOST_AUTO_TEST_CASE(forced_transactions_enter_payload_first)
     globalStateStorageFixture.setNonce(sender, "0");
     auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
 
-    // Two forced transactions (dep-1 first) plus one mempool transaction:
-    // payload order = forced list order, then pool transactions.
+    // Two forced transactions (dep-1 first) plus one mempool transaction: the payload would
+    // commit 3 raw transactions but only 1 executable, so buildPayload refuses it.
     auto attributes = makePayloadAttributesV3();
     attributes.transactions = std::vector<std::string>{"0x7e0102030405", "0x02f8aabb"};
-    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
-    BOOST_REQUIRE(result.payloadId.has_value());
-
-    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
-    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 3);
-    // Forced first, in the order the attributes gave them, byte-for-byte.
-    BOOST_CHECK(payload->executionPayload.transactions[0].raw ==
-                (bytes{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05}));
-    BOOST_CHECK(payload->executionPayload.transactions[0].decoded == nullptr);
-    BOOST_CHECK(payload->executionPayload.transactions[1].raw == (bytes{0x02, 0xf8, 0xaa, 0xbb}));
-    // The mempool transaction follows the forced list.
-    BOOST_CHECK(payload->executionPayload.transactions[2].decoded == poolTx);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3)),
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find(
+                       "raw-only (forced/deposit) transactions not executable yet: 3 raw vs 1 "
+                       "decoded") != std::string::npos;
+        });
 }
 
 BOOST_AUTO_TEST_CASE(no_tx_pool_true_excludes_mempool_transactions)
@@ -1283,17 +1282,19 @@ BOOST_AUTO_TEST_CASE(no_tx_pool_true_excludes_mempool_transactions)
     globalStateStorageFixture.setNonce(sender, "0");
     auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
 
-    // noTxPool=true with a forced deposit: the payload contains exactly the forced
-    // list; the sealable mempool transaction must not appear and stays in the pool.
+    // noTxPool=true with a forced deposit: the build fails closed on the raw-only entry
+    // (until the execution-lane wiring lands), and the sealable mempool transaction — never
+    // sealed under noTxPool — stays in the pool.
     auto attributes = makePayloadAttributesV3();
     attributes.noTxPool = true;
     attributes.transactions = std::vector<std::string>{"0x7e010203"};
-    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
-    BOOST_REQUIRE(result.payloadId.has_value());
-    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
-    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 1);
-    BOOST_CHECK(
-        payload->executionPayload.transactions.front().raw == (bytes{0x7e, 0x01, 0x02, 0x03}));
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3)),
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find(
+                       "raw-only (forced/deposit) transactions not executable yet") !=
+                   std::string::npos;
+        });
     auto retained = memPool.get(std::vector{poolTx->hash()});
     BOOST_REQUIRE_EQUAL(retained.size(), 1);
     BOOST_CHECK(retained[0]);
@@ -1515,6 +1516,38 @@ BOOST_AUTO_TEST_CASE(build_payload_rejects_forged_tx_kind_mirror)
         std::runtime_error, [](const std::runtime_error& e) {
             return std::string(e.what()).find(
                        "web3TypedTxKind mirror disagrees with the signed envelope") !=
+                   std::string::npos;
+        });
+}
+
+// A v2 payload whose transactions list carries raw-only entries (forced/deposit transactions
+// from the OP attributes list, .decoded == nullptr) commits a transactions trie of N entries
+// while receipts cover only the M < N decoded executables — receipt i would be keyed at the
+// wrong receipts-trie index and no external Ethereum verifier could reproduce
+// receiptsRoot/blockHash. Until the execution-lane wiring executes deposits, buildPayload must
+// fail closed on that shape rather than build an unreproducible block.
+BOOST_AUTO_TEST_CASE(build_payload_rejects_forced_raw_only_transactions)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("b3b3b3b3b3b3b3b3b3b3", 20);
+    auto tx = makeWeb3Tx(sender, 0);
+    memPool.add(std::vector{tx});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto payloadAttributes = makePayloadAttributesV2();
+    // A forced deposit (validateRawTransactionKind admits 0x7E) plus one decoded pool
+    // transaction: 2 raw entries in the payload, only 1 executable.
+    payloadAttributes.transactions = std::vector<std::string>{"0x7e010203"};
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        std::runtime_error, [](const std::runtime_error& e) {
+            return std::string(e.what()).find(
+                       "raw-only (forced/deposit) transactions not executable yet") !=
                    std::string::npos;
         });
 }

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -5,7 +5,6 @@
 
 #include "engine/bcos-engine/EngineServiceImpl.h"
 
-#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-concepts/ByteBuffer.h>
@@ -19,7 +18,10 @@
 #include <bcos-framework/testutils/faker/FakeBlock.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-ledger/Ledger.h>
+#include <bcos-ledger/mpt/EthTrieRoots.h>
 #include <bcos-mempool/MemPoolImpl.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-rlp-protocol/EthReceipt.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-tars-protocol/protocol/TransactionReceiptImpl.h>
 #include <bcos-task/Wait.h>
@@ -178,8 +180,7 @@ struct RealGlobalStateStorageFixture
         // buildPayload FAILS CLOSED when the revision is absent (it never falls back to
         // the compile-time default), so the missing-revision test passes writeEvmcRevision
         // = false to reach that branch.
-        writeSysConfig(
-            magic_enum::enum_name(ledger::SystemConfig::executor_version),
+        writeSysConfig(magic_enum::enum_name(ledger::SystemConfig::executor_version),
             std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION));
         if (writeEvmcRevision)
         {
@@ -208,8 +209,7 @@ private:
     void writeSysConfig(std::string_view key, std::string value)
     {
         storage::Entry entry;
-        entry.set(bcos::storage::serialize::encode(
-            ledger::SystemConfigEntry{std::move(value), 0}));
+        entry.set(bcos::storage::serialize::encode(ledger::SystemConfigEntry{std::move(value), 0}));
         task::syncWait(storage2::writeOne(backendStorage,
             bcos::executor_v1::StateKey{ledger::SYS_CONFIG, key}, std::move(entry)));
     }
@@ -266,6 +266,11 @@ struct StubScheduler
 
 struct BloomScheduler
 {
+    // The engine finalizes the returned receipts in place (transactionIndex / logIndex /
+    // cumulativeGasUsed), so keeping them here lets the test pin the header roots against
+    // the exact receipt objects the roots were computed from.
+    std::vector<protocol::TransactionReceipt::Ptr> lastReceipts;
+
     template <class Storage, class Executor>
     task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
         const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
@@ -283,7 +288,23 @@ struct BloomScheduler
         receipt2->setLogsBloom({bloom2.data(), bloom2.size()});
         receipt2->calculateHash(hasher);
 
-        co_return std::vector<protocol::TransactionReceipt::Ptr>{receipt1, receipt2};
+        lastReceipts = {receipt1, receipt2};
+        co_return lastReceipts;
+    }
+};
+
+// Returns more receipts than there are transactions: receipt i pairs with transaction i
+// for the receipts trie, so the excess is unpairable and the engine must throw.
+struct OverReceiptScheduler
+{
+    template <class Storage, class Executor>
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
+    {
+        co_return std::vector<protocol::TransactionReceipt::Ptr>{
+            std::make_shared<bcostars::protocol::TransactionReceiptImpl>(),
+            std::make_shared<bcostars::protocol::TransactionReceiptImpl>(),
+            std::make_shared<bcostars::protocol::TransactionReceiptImpl>()};
     }
 };
 
@@ -553,7 +574,8 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejected_when_evm_revision_missing)
 {
     MemPoolImpl memPool;
     // executor_version=2 but NO SYSTEM_KEY_EVMC_REVISION row.
-    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_CANCUN, /*writeEvmcRevision=*/false);
+    RealGlobalStateStorageFixture globalStateStorageFixture(
+        EVMC_CANCUN, /*writeEvmcRevision=*/false);
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
@@ -583,13 +605,13 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_empty_withdrawals)
     auto payloadAttributes = makePayloadAttributesV3();
     payloadAttributes.withdrawals = std::vector<WithdrawalV1>{
         WithdrawalV1{.index = 1, .validatorIndex = 2, .amount = 3, .address = Address{}}};
-    auto result = task::syncWait(
-        engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Invalid));
     BOOST_REQUIRE(result.payloadStatus.validationError.has_value());
-    BOOST_CHECK_NE(result.payloadStatus.validationError->find("non-empty withdrawals"),
-        std::string::npos);
+    BOOST_CHECK_NE(
+        result.payloadStatus.validationError->find("non-empty withdrawals"), std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
@@ -909,9 +931,8 @@ BOOST_AUTO_TEST_CASE(get_payload_v5_rejects_a_v3_committed_entry_without_withdra
     BOOST_CHECK_EQUAL(
         static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
 
-    BOOST_CHECK_EXCEPTION(
-        task::syncWait(engineService.getPayload(*result.payloadId, 5)), IncompatiblePayloadVersion,
-        [](const IncompatiblePayloadVersion& e) {
+    BOOST_CHECK_EXCEPTION(task::syncWait(engineService.getPayload(*result.payloadId, 5)),
+        IncompatiblePayloadVersion, [](const IncompatiblePayloadVersion& e) {
             // Pin the REWRITE-path message (the entry was rewritten by the V3 commit and
             // lost its withdrawalsRoot), not just the exception type — a swapped gate that
             // keeps IncompatiblePayloadVersion must still fail (T4).
@@ -1288,6 +1309,61 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
     {
         BOOST_CHECK_EQUAL(static_cast<int>(payload->executionPayload.logsBloom[i]), 0);
     }
+
+    // Pin the v2 receipts root against an independently recomputed trie. (txsRoot is
+    // committed to the header only — the Engine API payload carries no field for it.)
+    // The engine finalized the stub's receipts in place: indices stamped, gas accumulated.
+    BOOST_REQUIRE_EQUAL(bloomScheduler.lastReceipts.size(), 2u);
+    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->transactionIndex(), 0u);
+    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->transactionIndex(), 1u);
+    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->cumulativeGasUsed(), "0");
+    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->cumulativeGasUsed(), "0");
+
+    std::vector<bcos::bytes> receiptRlps;
+    for (auto const& receipt : bloomScheduler.lastReceipts)
+    {
+        protocol::EthReceiptData eth;
+        BOOST_REQUIRE(protocol::toEthReceiptData(*receipt, tx->web3TypedTxKind(), eth) == nullptr);
+        protocol::EthReceipt ethReceipt(std::move(eth));
+        bcos::bytes encoded;
+        BOOST_REQUIRE(ethReceipt.rlpEncode(encoded) == nullptr);
+        receiptRlps.push_back(std::move(encoded));
+    }
+    std::vector<bcos::bytesConstRef> receiptRefs;
+    for (auto const& rlp : receiptRlps)
+    {
+        receiptRefs.emplace_back(bcos::ref(rlp));
+    }
+    BOOST_CHECK_EQUAL(
+        payload->executionPayload.receiptsRoot, ledger::mpt::calculateReceiptsRoot(receiptRefs));
+}
+
+// Receipt i commits the EIP-2718 type of transaction i: a scheduler that returns MORE
+// receipts than executed transactions is unpairable, and the engine must throw instead of
+// reading past the transaction list.
+BOOST_AUTO_TEST_CASE(build_payload_rejects_more_receipts_than_transactions)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("bebebebebebebebebebe", 20);
+    auto tx = makeWeb3Tx(sender, 0);
+    auto tx2 = makeWeb3Tx(sender, 1);
+    memPool.add(std::vector{tx, tx2});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto payloadAttributes = makePayloadAttributesV2();
+
+    OverReceiptScheduler overReceiptScheduler;
+    auto engineService =
+        EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, OverReceiptScheduler>(
+            memPool, globalStateStorageFixture.storage, sharedStubExecutor(), overReceiptScheduler,
+            testBlockFactory());
+
+    BOOST_CHECK_THROW(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        std::runtime_error);
 }
 
 // ---- B4: Karst method surface (forkchoiceUpdatedV3 -> getPayloadV5 -> newPayloadV4) ----
@@ -1500,18 +1576,16 @@ BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)
     auto result =
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
     BOOST_REQUIRE(result.payloadId.has_value());
-    BOOST_CHECK_EXCEPTION(
-        task::syncWait(engineService.getPayload(*result.payloadId, 5)), IncompatiblePayloadVersion,
-        [](const IncompatiblePayloadVersion& e) {
+    BOOST_CHECK_EXCEPTION(task::syncWait(engineService.getPayload(*result.payloadId, 5)),
+        IncompatiblePayloadVersion, [](const IncompatiblePayloadVersion& e) {
             return std::string(e.what()).find("incompatible with requested method version") !=
                    std::string::npos;
         });
     // getPayloadV4 has the same window: op-geth's GetPayloadV4 also admits only
     // PayloadV3 builds, and the V4 response shape needs the same three fields a V2 build
     // does not have.
-    BOOST_CHECK_EXCEPTION(
-        task::syncWait(engineService.getPayload(*result.payloadId, 4)), IncompatiblePayloadVersion,
-        [](const IncompatiblePayloadVersion& e) {
+    BOOST_CHECK_EXCEPTION(task::syncWait(engineService.getPayload(*result.payloadId, 4)),
+        IncompatiblePayloadVersion, [](const IncompatiblePayloadVersion& e) {
             return std::string(e.what()).find("incompatible with requested method version") !=
                    std::string::npos;
         });
@@ -1619,8 +1693,7 @@ static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
     bcos::protocol::BlockFactory::Ptr blockFactory, bcos::crypto::HashType parentHash)
 {
     auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
-    header->setParentInfo(bcos::protocol::ParentInfo{
-        .blockNumber = 9, .blockHash = parentHash});
+    header->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 9, .blockHash = parentHash});
     header->setNumber(10);
     // Internal BlockHeader timestamps are milliseconds: the whole-second value × 1000.
     header->setTimestamp(1700000000 * 1000LL);
@@ -1684,8 +1757,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
     payload.blobGasUsed = bcos::u256(0);
     payload.excessBlobGas = bcos::u256(0);
 
-    auto beaconRoot = bcos::h256(
-        "3333333333333333333333333333333333333333333333333333333333333333");
+    auto beaconRoot =
+        bcos::h256("3333333333333333333333333333333333333333333333333333333333333333");
     bcos::engine::detail::finalizeEthBlockHeader(
         *header, payload, beaconRoot, bcos::protocol::EthBlockVersion::CANCUN);
 
@@ -1750,8 +1823,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
     // V3/CANCUN: everything present.
     {
         auto header = makeValidCancunHeader(blockFactory, parentHash);
-        auto beaconRoot = bcos::h256(
-            "3333333333333333333333333333333333333333333333333333333333333333");
+        auto beaconRoot =
+            bcos::h256("3333333333333333333333333333333333333333333333333333333333333333");
         payload.blobGasUsed = bcos::u256(0);
         payload.excessBlobGas = bcos::u256(0);
         bcos::engine::detail::finalizeEthBlockHeader(
@@ -1767,12 +1840,12 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
     // (regression: PRAGUE previously produced a header that failed validateHeader).
     {
         auto header = makeValidCancunHeader(blockFactory, parentHash);
-        auto beaconRoot = bcos::h256(
-            "3333333333333333333333333333333333333333333333333333333333333333");
+        auto beaconRoot =
+            bcos::h256("3333333333333333333333333333333333333333333333333333333333333333");
         payload.blobGasUsed = bcos::u256(0);
         payload.excessBlobGas = bcos::u256(0);
-        BOOST_CHECK_NO_THROW(bcos::engine::detail::finalizeEthBlockHeader(*header, payload,
-            beaconRoot, bcos::protocol::EthBlockVersion::PRAGUE));
+        BOOST_CHECK_NO_THROW(bcos::engine::detail::finalizeEthBlockHeader(
+            *header, payload, beaconRoot, bcos::protocol::EthBlockVersion::PRAGUE));
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::PRAGUE);
         BOOST_REQUIRE(header->requestsHash().has_value());
         BOOST_CHECK_EQUAL(header->requestsHash()->hex(),
@@ -1829,8 +1902,8 @@ BOOST_AUTO_TEST_CASE(buildPayloadEmptyBlockInjectsRlpHash)
     header->setStateRoot(executionPayload.stateRoot);
     header->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
     header->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
-    header->setLogsBloom(bcos::bytesConstRef(
-        executionPayload.logsBloom.data(), executionPayload.logsBloom.size()));
+    header->setLogsBloom(
+        bcos::bytesConstRef(executionPayload.logsBloom.data(), executionPayload.logsBloom.size()));
     header->setBaseFee(executionPayload.baseFeePerGas);
     header->setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
     header->setBlobGasUsed(executionPayload.blobGasUsed.value_or(bcos::u256(0)));
@@ -1842,8 +1915,7 @@ BOOST_AUTO_TEST_CASE(buildPayloadEmptyBlockInjectsRlpHash)
     bcos::protocol::EthBlockHeader ethHeader(*header);
     bcos::bytes rlp;
     ethHeader.rlpEncode(rlp);
-    BOOST_CHECK_EQUAL(
-        blockHash.hex(), bcos::crypto::keccak256Hash(bcos::ref(rlp)).hex());
+    BOOST_CHECK_EQUAL(blockHash.hex(), bcos::crypto::keccak256Hash(bcos::ref(rlp)).hex());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -283,9 +283,13 @@ struct BloomScheduler
         Keccak256 hasher;
         auto receipt1 = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
         receipt1->setLogsBloom({bloom1.data(), bloom1.size()});
+        // Non-zero gasUsed so the cumulativeGasUsed assertions below can distinguish real
+        // accumulation (21000 then 51000) from a no-op finalizeReceipts.
+        receipt1->inner().data.gasUsed = "21000";
         receipt1->calculateHash(hasher);
         auto receipt2 = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
         receipt2->setLogsBloom({bloom2.data(), bloom2.size()});
+        receipt2->inner().data.gasUsed = "30000";
         receipt2->calculateHash(hasher);
 
         lastReceipts = {receipt1, receipt2};
@@ -1316,8 +1320,10 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
     BOOST_REQUIRE_EQUAL(bloomScheduler.lastReceipts.size(), 2u);
     BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->transactionIndex(), 0u);
     BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->transactionIndex(), 1u);
-    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->cumulativeGasUsed(), "0");
-    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->cumulativeGasUsed(), "0");
+    // gasUsed 21000 then 30000: finalizeReceipts must accumulate to 21000 / 51000 (the stub
+    // carries non-zero gasUsed precisely so these assertions can detect a no-op finalizer).
+    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[0]->cumulativeGasUsed(), "21000");
+    BOOST_CHECK_EQUAL(bloomScheduler.lastReceipts[1]->cumulativeGasUsed(), "51000");
 
     std::vector<bcos::bytes> receiptRlps;
     for (auto const& receipt : bloomScheduler.lastReceipts)

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -204,11 +204,13 @@ struct RealGlobalStateStorageFixture
     {
         // The mempool stores senders as raw bytes and MemPoolImpl::seal/remove resolve the
         // account via the evmc_address overload (lower-case hex path), matching the executor.
-        // Use the same path here so the sealed nonce the test relies on is visible to seal().
+        // seal() reads the sender's nonce with treatSystemAsUser=false (MemPoolImpl.h), so the
+        // write mirrors that flag exactly — the sealed nonce the test relies on is then
+        // visible to seal().
         evmc_address addr{};
         std::copy_n(sender.begin(), std::min(sender.size(), sizeof(addr.bytes)), addr.bytes);
         ledger::account::EVMAccount account{backendStorage, addr, false,
-            /*treatSystemAsUser=*/true};
+            /*treatSystemAsUser=*/false};
         task::syncWait(account.setNonce(std::move(nonce)));
     }
 

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -1260,8 +1260,11 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
         c_initialBlockNumber, c_initialBlockNumber);
     std::string sender("cccccccccccccccccccc", 20);
     // Web3-shaped: only transactions with an EIP-2718 wire form enter OP payloads.
+    // The BloomScheduler stub returns two receipts, so the block must carry two
+    // transactions — the engine pairs receipt i with transaction i for the receipts trie.
     auto tx = makeWeb3Tx(sender, 0);
-    memPool.add(std::vector{tx});
+    auto tx2 = makeWeb3Tx(sender, 1);
+    memPool.add(std::vector{tx, tx2});
     globalStateStorageFixture.setNonce(sender, "0");
     auto payloadAttributes = makePayloadAttributesV2();
 

--- a/ethereum-executor/EthereumState.h
+++ b/ethereum-executor/EthereumState.h
@@ -239,7 +239,7 @@ class EthereumState
         using namespace bcos::ledger::account;
         auto& storage = m_storage;
 
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         // Do NOT gate on SYS_TABLES existence alone: the PoW reward path writes
         // the flat BALANCE row but (historically) never registers the account
@@ -351,7 +351,7 @@ class EthereumState
     {
         using namespace bcos::ledger::account;
         auto& storage = m_storage;
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         if (!co_await evmAccount.exists())
             co_return {};
@@ -380,7 +380,7 @@ class EthereumState
     {
         using namespace bcos::ledger::account;
         auto& storage = m_storage;
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         // SLOAD on a non-existent account returns 0 per EVM spec.
         // EVMAccount::storage() already returns empty bytes32 for missing
@@ -668,7 +668,7 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
         if (acc.erase_if_empty && rev >= EVMC_SPURIOUS_DRAGON && acc.is_empty())
             continue;
 
-        EVMAccount<Storage> bcosAcc(m_storage, addr, false);
+        EVMAccount<Storage> bcosAcc(m_storage, addr, false, /*treatSystemAsUser=*/true);
         if (!co_await bcosAcc.exists())
             co_await bcosAcc.create();
         co_await bcosAcc.setNonce(std::to_string(acc.nonce));
@@ -712,7 +712,7 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
         {
             // Genuine deletion: clear account state (including storage, so that
             // a later CREATE/CREATE2 at this address is not an EIP-7610 collision).
-            EVMAccount<Storage> bcosAcc(m_storage, addr, false);
+            EVMAccount<Storage> bcosAcc(m_storage, addr, false, /*treatSystemAsUser=*/true);
             if (co_await bcosAcc.exists())
             {
                 co_await bcosAcc.setBalance(0);
@@ -725,7 +725,7 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
                  !acc.just_created)
         {
             // EIP-161: empty touched account is deleted.
-            EVMAccount<Storage> bcosAcc(m_storage, addr, false);
+            EVMAccount<Storage> bcosAcc(m_storage, addr, false, /*treatSystemAsUser=*/true);
             if (co_await bcosAcc.exists())
             {
                 co_await bcosAcc.setBalance(0);

--- a/ethereum-executor/tests/EESTRunner.cpp
+++ b/ethereum-executor/tests/EESTRunner.cpp
@@ -918,7 +918,8 @@ public:
             evmc_address addr;
             std::copy(addrBytes.begin(), addrBytes.end(), addr.bytes);
 
-            ledger::account::EVMAccount<MutableStorage> evmAccount(storage, addr, false);
+            ledger::account::EVMAccount<MutableStorage> evmAccount(
+                storage, addr, false, /*treatSystemAsUser=*/true);
 
             task::tbb::syncWait([&]() -> task::Task<void> {
                 if (!co_await evmAccount.exists())
@@ -1208,7 +1209,8 @@ public:
             evmc_address addr;
             std::copy(addrBytes.begin(), addrBytes.end(), addr.bytes);
 
-            ledger::account::EVMAccount<MutableStorage> evmAccount(storage, addr, false);
+            ledger::account::EVMAccount<MutableStorage> evmAccount(
+                storage, addr, false, /*treatSystemAsUser=*/true);
 
             task::tbb::syncWait([&]() -> task::Task<void> {
                 // nonce
@@ -1335,7 +1337,8 @@ public:
             {
                 evmc_address senderAddr{};
                 std::copy(senderBytes.begin(), senderBytes.end(), senderAddr.bytes);
-                ledger::account::EVMAccount<MutableStorage> senderAcct(storage, senderAddr, false);
+                ledger::account::EVMAccount<MutableStorage> senderAcct(
+                    storage, senderAddr, false, /*treatSystemAsUser=*/true);
                 auto txNonce = test::hexToU256(fixture.transaction.nonce);
                 auto nonceStr = txNonce.str(0, std::ios_base::dec);
                 task::tbb::syncWait([&]() -> task::Task<void> {
@@ -1650,7 +1653,8 @@ public:
                 }
                 evmc_address senderAddr{};
                 std::copy(senderBytes.begin(), senderBytes.end(), senderAddr.bytes);
-                ledger::account::EVMAccount<MutableStorage> senderAcct(storage, senderAddr, false);
+                ledger::account::EVMAccount<MutableStorage> senderAcct(
+                    storage, senderAddr, false, /*treatSystemAsUser=*/true);
                 auto txNonce = test::hexToU256(tx.nonce);
                 auto nonceStr = txNonce.str(0, std::ios_base::dec);
                 task::tbb::syncWait([&]() -> task::Task<void> {

--- a/ethereum-executor/tests/TestStorageBridge.h
+++ b/ethereum-executor/tests/TestStorageBridge.h
@@ -98,7 +98,7 @@ private:
         using namespace bcos::ledger::account;
         auto& storage = const_cast<Storage&>(m_storage);
 
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         if (!co_await evmAccount.exists())
             co_return std::nullopt;
@@ -165,7 +165,7 @@ private:
     {
         using namespace bcos::ledger::account;
         auto& storage = const_cast<Storage&>(m_storage);
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         if (!co_await evmAccount.exists())
             co_return {};
@@ -182,7 +182,7 @@ private:
     {
         using namespace bcos::ledger::account;
         auto& storage = const_cast<Storage&>(m_storage);
-        EVMAccount<Storage> evmAccount(storage, addr, false);
+        EVMAccount<Storage> evmAccount(storage, addr, false, /*treatSystemAsUser=*/true);
 
         // SLOAD on a non-existent account returns 0 per EVM spec.
         co_return co_await evmAccount.storage(key);
@@ -203,7 +203,7 @@ task::Task<void> testApplyStateDiff(
     // Phase 1: Process modified_accounts FIRST so created accounts exist.
     for (auto const& m : diff.modified_accounts)
     {
-        EVMAccount<Storage> acc(storage, m.addr, false);
+        EVMAccount<Storage> acc(storage, m.addr, false, /*treatSystemAsUser=*/true);
         if (!co_await acc.exists())
             co_await acc.create();
         co_await acc.setNonce(std::to_string(m.nonce));
@@ -241,7 +241,7 @@ task::Task<void> testApplyStateDiff(
         if (inModified)
             continue;
 
-        EVMAccount<Storage> acc(storage, addr, false);
+        EVMAccount<Storage> acc(storage, addr, false, /*treatSystemAsUser=*/true);
         if (co_await acc.exists())
         {
             co_await acc.setBalance(0);

--- a/mempool/bcos-mempool/MemPoolImpl.h
+++ b/mempool/bcos-mempool/MemPoolImpl.h
@@ -174,7 +174,8 @@ public:
             // overload would treat them as a hex string and compute a wrong table path, so the
             // nonce read below would miss the account entirely. Build an evmc_address instead
             // so the same hex path is used as the executor.
-            ledger::account::EVMAccount account(state, senderToAddress(sender), m_rawAddress);
+            ledger::account::EVMAccount account(
+                state, senderToAddress(sender), m_rawAddress, /*treatSystemAsUser=*/false);
 
             int64_t currentNonce = 0;
             if (auto nonceStr = task::syncWait(account.nonce()))
@@ -226,7 +227,8 @@ public:
             auto nextIt = senderIndex.equal_range(sender).second;
             // Same hex-path note as in seal(): the raw sender bytes must go through the
             // evmc_address overload so the account nonce read finds the executor's account.
-            ledger::account::EVMAccount account(state, senderToAddress(sender), m_rawAddress);
+            ledger::account::EVMAccount account(
+                state, senderToAddress(sender), m_rawAddress, /*treatSystemAsUser=*/false);
             if (auto nonceStr = task::syncWait(account.nonce()))
             {
                 int64_t nonce = 0;

--- a/mempool/test/unittests/mempool/MemPoolImplTest.cpp
+++ b/mempool/test/unittests/mempool/MemPoolImplTest.cpp
@@ -146,13 +146,13 @@ static evmc_address senderToEvmc(std::string_view sender)
 
 static std::optional<std::string> readNonce(MapStateStorage& s, std::string_view sender)
 {
-    ledger::account::EVMAccount acc{s, senderToEvmc(sender), false};
+    ledger::account::EVMAccount acc{s, senderToEvmc(sender), false, /*treatSystemAsUser=*/false};
     return task::syncWait(acc.nonce());
 }
 
 static void setNonce(MapStateStorage& s, std::string_view sender, std::string nonce)
 {
-    ledger::account::EVMAccount acc{s, senderToEvmc(sender), false};
+    ledger::account::EVMAccount acc{s, senderToEvmc(sender), false, /*treatSystemAsUser=*/false};
     task::syncWait(acc.setNonce(std::move(nonce)));
 }
 

--- a/opstack-executor/OpScheduler.h
+++ b/opstack-executor/OpScheduler.h
@@ -263,7 +263,8 @@ public:
                     co_await bcos::ledger::readFromStorage(features, view, blockNumber);
 
                     bcos::ledger::account::EVMAccount account(view, parseAddress(contract),
-                        features.get(bcos::ledger::Features::Flag::feature_raw_address));
+                        features.get(bcos::ledger::Features::Flag::feature_raw_address),
+                        /*treatSystemAsUser=*/true);
                     auto code = co_await account.code();
                     if (!code)
                     {
@@ -310,7 +311,8 @@ public:
                     co_await bcos::ledger::readFromStorage(features, view, blockNumber);
 
                     bcos::ledger::account::EVMAccount account(view, parseAddress(contract),
-                        features.get(bcos::ledger::Features::Flag::feature_raw_address));
+                        features.get(bcos::ledger::Features::Flag::feature_raw_address),
+                        /*treatSystemAsUser=*/true);
                     auto abi = co_await account.abi();
                     if (!abi)
                     {
@@ -349,8 +351,9 @@ public:
         auto view = this->m_multiLayerStorage->fork();
         bcos::ledger::Features features;
         co_await bcos::ledger::readFromStorage(features, view, number);
-        bcos::ledger::account::EVMAccount account(
-            view, addressOwned, features.get(bcos::ledger::Features::Flag::feature_raw_address));
+        bcos::ledger::account::EVMAccount account(view, addressOwned,
+            features.get(bcos::ledger::Features::Flag::feature_raw_address),
+            /*treatSystemAsUser=*/true);
         co_return co_await account.storageEntry(keyOwned);
     }
 

--- a/opstack-executor/tests/OpSchedulerTest.cpp
+++ b/opstack-executor/tests/OpSchedulerTest.cpp
@@ -271,7 +271,8 @@ void seedSender(MLS& mls, bcos::Address const& addr, bcos::crypto::Hash::Ptr con
 {
     auto view = mls.fork();
     view.newMutable();
-    bcos::ledger::account::EVMAccount account(view, addr, /*rawAddress=*/false);
+    bcos::ledger::account::EVMAccount account(
+        view, addr, /*rawAddress=*/false, /*treatSystemAsUser=*/true);
     bcos::task::syncWait(account.create());
     bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
     bcos::task::syncWait(account.setNonce("0"));
@@ -552,7 +553,8 @@ void fundCallAccount(MLS& mls, bcos::Address const& addr, bcos::crypto::Hash::Pt
 {
     auto view = mls.fork();
     view.newMutable();
-    bcos::ledger::account::EVMAccount account(view, addr, /*rawAddress=*/false);
+    bcos::ledger::account::EVMAccount account(
+        view, addr, /*rawAddress=*/false, /*treatSystemAsUser=*/true);
     bcos::task::syncWait(account.create());
     bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
     bcos::task::syncWait(account.setNonce("0"));
@@ -569,7 +571,8 @@ void seedCorruptAccount(
 {
     auto view = mls.fork();
     view.newMutable();
-    bcos::ledger::account::EVMAccount account(view, addr, /*binaryAddress=*/false);
+    bcos::ledger::account::EVMAccount account(
+        view, addr, /*binaryAddress=*/false, /*treatSystemAsUser=*/true);
     bcos::task::syncWait(account.create());
     bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
     bcos::task::syncWait(account.setNonce("0"));
@@ -700,7 +703,8 @@ void seedContractWithSlot(MLS& mls, bcos::Address const& addr, bcos::h256 const&
 {
     auto view = mls.fork();
     view.newMutable();
-    bcos::ledger::account::EVMAccount account(view, addr, /*rawAddress=*/false);
+    bcos::ledger::account::EVMAccount account(
+        view, addr, /*rawAddress=*/false, /*treatSystemAsUser=*/true);
     bcos::task::syncWait(account.create());
     // CALLDATASIZE; PUSH1 0x0f; JUMPI;            (calldata? → setter at 0x0f)
     // PUSH1 0; SLOAD; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN;

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -6,9 +6,13 @@ mock_consensus_client.py — FISCO-BCOS Engine API Smoke Test (Karst dialect)
 
   1. engine_exchangeCapabilities   — 节点实现的全部方法(Karst 三件套 + V1-V3 旧版本)
   2. engine_forkchoiceUpdatedV3    — 无 payloadAttributes(纯状态更新)
-  3. engine_forkchoiceUpdatedV3    — 带 payloadAttributes:秒级时间戳、注入一笔 0x7e
-                                     deposit 裸交易、noTxPool true/false 轮换
-  4. engine_getPayloadV5           — 校验 V5 响应形状,断言 deposit 原字节在列
+  3. engine_forkchoiceUpdatedV3    — 带 payloadAttributes:秒级时间戳、noTxPool
+                                     true/false 轮换;无 forced 交易的空 payload
+                                     跑通 FCU -> getPayloadV5 -> newPayloadV4 -> 提交
+  3b. forced 0x7e deposit          — KNOWN GAP pin:execution-lane wiring 落地前,v2
+                                     buildPayload 的 fail-closed guard 拒绝该形态
+                                     (详见 test_forced_deposit_refused_... docstring)
+  4. engine_getPayloadV5           — 校验 V5 响应形状(含秒级时间戳线契约)
   5. engine_newPayloadV4           — [payload, [], beaconRoot, []] 提交
   6. V2 旧版本回路                 — FCU V2 -> getPayloadV2 -> newPayloadV2 仍然可用
   7. 负测                          — 未实现版本 -38005、未知 payloadId -38001、缺参 -32602
@@ -242,9 +246,19 @@ def next_timestamp() -> str:
     return hex(int(time.time()) + _timestamp_bump)
 
 
-def run_karst_block_flow(no_tx_pool: bool) -> bool:
-    """One op-node-shaped block: FCU V3 (deposit injected) -> getPayloadV5 -> newPayloadV4."""
-    label = f"noTxPool={str(no_tx_pool).lower()}"
+def run_karst_block_flow(no_tx_pool: bool, inject_deposit: bool) -> bool:
+    """One op-node-shaped block: FCU V3 -> getPayloadV5 -> newPayloadV4 (+ commit).
+
+    inject_deposit=True reproduces the OP shape where payloadAttributes carries the forced
+    0x7e deposit. That shape is currently REFUSED on the v2 harness chain by buildPayload's
+    fail-closed guard (no 0x7E execution until the eth_sync execution-lane wiring lands), so
+    the deposit round-trip itself is pinned as a known gap in
+    test_forced_deposit_refused_until_execution_lane_wiring, and this flow is driven with
+    inject_deposit=False: an (empty) build -> get -> newPayload -> commit round-trip that
+    still covers the V5 response shape, the Unix-seconds wire contract and the committed
+    block's head/timestamp checks.
+    """
+    label = f"noTxPool={str(no_tx_pool).lower()}, deposit={str(inject_deposit).lower()}"
     _log_test(f"FCU V3 + getPayloadV5 + newPayloadV4 ({label})")
 
     head_hash = get_head_hash()
@@ -255,13 +269,12 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
     }
     timestamp_hex = next_timestamp()
     sent_seconds = int(timestamp_hex, 16)
-    payload_attrs = {
+    payload_attrs: Dict[str, Any] = {
         "timestamp": timestamp_hex,
         "prevRandao": PREV_RANDAO,
         "suggestedFeeRecipient": FEE_RECIPIENT,
         "withdrawals": [],
         "parentBeaconBlockRoot": ZERO_HASH,
-        "transactions": [DEPOSIT_RAW],
         "noTxPool": no_tx_pool,
         "gasLimit": ATTRS_GAS_LIMIT,
         # Bare JSON number, NOT a hex string: op-node serializes MinBaseFee as a plain
@@ -275,6 +288,8 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
         # built extraData.
         "eip1559Params": "0x0000000000000000",
     }
+    if inject_deposit:
+        payload_attrs["transactions"] = [DEPOSIT_RAW]
 
     fcu = rpc_result("engine_forkchoiceUpdatedV3", [fc_state, payload_attrs])
     status = fcu["payloadStatus"]["status"]
@@ -323,15 +338,28 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
         )
         return False
 
-    # dep-1 byte fidelity: the injected deposit's raw bytes lead the transaction list.
     txs = payload["transactions"]
-    if not txs or txs[0].lower() != DEPOSIT_RAW.lower():
-        _log_fail(f"deposit raw bytes not first in payload transactions: {txs[:2]}")
-        return False
-    if no_tx_pool and len(txs) != 1:
-        _log_fail(f"noTxPool=true payload must contain exactly the forced deposit, got {len(txs)}")
-        return False
-    _log_info(f"deposit in payload at index 0 ({len(txs)} tx total)")
+    if inject_deposit:
+        # dep-1 byte fidelity: the injected deposit's raw bytes lead the transaction list.
+        if not txs or txs[0].lower() != DEPOSIT_RAW.lower():
+            _log_fail(f"deposit raw bytes not first in payload transactions: {txs[:2]}")
+            return False
+        if no_tx_pool and len(txs) != 1:
+            _log_fail(
+                f"noTxPool=true payload must contain exactly the forced deposit, got {len(txs)}"
+            )
+            return False
+        _log_info(f"deposit in payload at index 0 ({len(txs)} tx total)")
+    else:
+        # No forced transactions (and an empty mempool in this harness): a noTxPool=true
+        # payload must be empty. Under noTxPool=false the mempool is the only source, so
+        # just report the count either way.
+        if no_tx_pool and txs:
+            _log_fail(
+                f"noTxPool=true with no forced txs must be empty, got {len(txs)} txs"
+            )
+            return False
+        _log_info(f"{len(txs)} tx total")
 
     beacon_root = result.get("parentBeaconBlockRoot", ZERO_HASH)
     new_status = rpc_result("engine_newPayloadV4", [payload, [], beacon_root, []])
@@ -369,6 +397,68 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
 
     _log_pass()
     return True
+
+
+def test_forced_deposit_refused_until_execution_lane_wiring() -> None:
+    """KNOWN GAP pin: a v2 payload carrying a forced 0x7e deposit is REFUSED fail-closed.
+
+    Round-4/5 review consensus (this PR series): on executor_version >= 2 the engine commits
+    txsRoot over EVERY raw payload transaction but can only build receipts for the executed
+    (decoded) subset, and a 0x7e deposit has no executable form yet — so a deposit-carrying
+    payload would commit an M-entry receipts trie beside an N-entry transactions trie keyed
+    0..M-1 that no external Ethereum verifier can reproduce. buildPayload therefore throws
+    (EngineServiceImpl.h: "Payload contains raw-only (forced/deposit) transactions not
+    executable yet"). Deposit execution (0x7E) + raw->executable decoding land in the
+    eth_sync execution-lane wiring PR; this pin turns RED the day the FCU starts building
+    the deposit again, at which point the full deposit round-trip in run_karst_block_flow
+    (inject_deposit=True) must be restored.
+    """
+    _log_test(
+        "FCU V3 + forced 0x7e deposit -> refused (known gap until execution-lane wiring)"
+    )
+
+    head_hash = get_head_hash()
+    fc_state = {
+        "headBlockHash": head_hash,
+        "safeBlockHash": head_hash,
+        "finalizedBlockHash": head_hash,
+    }
+
+    for no_tx_pool in (True, False):
+        payload_attrs: Dict[str, Any] = {
+            "timestamp": next_timestamp(),
+            "prevRandao": PREV_RANDAO,
+            "suggestedFeeRecipient": FEE_RECIPIENT,
+            "withdrawals": [],
+            "parentBeaconBlockRoot": ZERO_HASH,
+            "transactions": [DEPOSIT_RAW],
+            "noTxPool": no_tx_pool,
+            "gasLimit": ATTRS_GAS_LIMIT,
+            "minBaseFee": 0,
+            "eip1559Params": "0x0000000000000000",
+        }
+        data = rpc_raw("engine_forkchoiceUpdatedV3", [fc_state, payload_attrs])
+        if "error" not in data:
+            _log_fail(
+                f"noTxPool={str(no_tx_pool).lower()}: deposit payload was BUILT instead of "
+                "refused — execution-lane wiring landed? Restore the deposit round-trip in "
+                "run_karst_block_flow(inject_deposit=True) and drop this pin."
+            )
+            return
+        code = data["error"].get("code")
+        msg = str(data["error"].get("message", ""))
+        # The -32603 message is the boost diagnostic (throw site + type), not the guard's
+        # what() text; anchor on the code and the buildPayload throw site.
+        if code != -32603 or "buildPayload" not in msg:
+            _log_fail(
+                f"noTxPool={str(no_tx_pool).lower()}: expected -32603 from buildPayload, "
+                f"got code={code}: {msg[:200]}"
+            )
+            return
+        _log_info(
+            f"noTxPool={str(no_tx_pool).lower()}: deposit payload refused by buildPayload (-32603)"
+        )
+    _log_pass()
 
 
 def run_v2_block_flow() -> None:
@@ -687,10 +777,15 @@ def main() -> int:
         # 2. Pure forkchoice update (no payload build).
         test_forkchoice_v3_without_payload()
 
-        # 3./4./5. Two full block flows with noTxPool rotation: the forced deposit must
-        # be the whole payload under noTxPool=true, and still lead it under false.
-        if run_karst_block_flow(no_tx_pool=True):
-            run_karst_block_flow(no_tx_pool=False)
+        # 3. Known gap until the eth_sync execution-lane wiring lands: the forced 0x7e
+        # deposit shape is refused fail-closed by v2 buildPayload (pin below). The wiring
+        # PR restores the deposit round-trip in run_karst_block_flow(inject_deposit=True).
+        test_forced_deposit_refused_until_execution_lane_wiring()
+
+        # 4./5. Full build -> get -> newPayload -> commit flows with noTxPool rotation
+        # (no forced transactions; the harness mempool is empty, so the payload is empty).
+        if run_karst_block_flow(no_tx_pool=True, inject_deposit=False):
+            run_karst_block_flow(no_tx_pool=False, inject_deposit=False)
 
         # 6. The pre-Karst surface is still live.
         run_v2_block_flow()

--- a/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
+++ b/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
@@ -169,7 +169,8 @@ public:
                 auto& callNonce = m_data->m_nonce;
                 ledger::account::EVMAccount account(m_data->m_rollbackableStorage, m_data->m_origin,
                     m_data->m_ledgerConfig.get().features().get(
-                        ledger::Features::Flag::feature_raw_address));
+                        ledger::Features::Flag::feature_raw_address),
+                    /*treatSystemAsUser=*/false);
 
                 if (!co_await account.exists())
                 {

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -150,7 +150,8 @@ task::Task<std::shared_ptr<Executable>> getExecutable(
         }
     }
 
-    if (Account<std::decay_t<decltype(storage)>> account(storage, address, binaryAddress);
+    if (Account<std::decay_t<decltype(storage)>> account(
+            storage, address, binaryAddress, /*treatSystemAsUser=*/false);
         auto codeEntry = co_await account.code())
     {
         auto executable = std::make_shared<Executable>(std::move(*codeEntry));
@@ -310,7 +311,8 @@ public:
     {
         return Account<std::decay_t<Storage>>(hostContext.m_rollbackableStorage.get(), address,
             hostContext.m_ledgerConfig.get().features().get(
-                ledger::Features::Flag::feature_raw_address));
+                ledger::Features::Flag::feature_raw_address),
+            /*treatSystemAsUser=*/false);
     }
 
     // Tag-forwarding variant: passes all tags through to the underlying
@@ -397,7 +399,8 @@ public:
     task::Task<h256> codeHashAt(const evmc_address& address, auto&&... /*unused*/)
     {
         Account<Storage> account(m_rollbackableStorage.get(), address,
-            m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
+            m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address),
+            /*treatSystemAsUser=*/false);
         co_return co_await account.codeHash();
     }
 

--- a/transaction-executor/tests/CompatHostContextTest.cpp
+++ b/transaction-executor/tests/CompatHostContextTest.cpp
@@ -770,7 +770,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2930_access_list_multi_slot)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const code = eip2929::warmAccountThenRevertBytecode(coldTarget);
         auto const hash = hashImpl->hash(bcos::bytesConstRef(code.data(), code.size()));
@@ -873,7 +874,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_revert_rolls_back_child_warm)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const code = eip2929::warmAccountThenRevertBytecode(coldTarget);
         auto const hash = hashImpl->hash(bcos::bytesConstRef(code.data(), code.size()));
@@ -929,7 +931,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_success_commits_child_warm)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const code = eip2929::warmAccountThenStopBytecode(coldTarget);
         auto const hash = hashImpl->hash(bcos::bytesConstRef(code.data(), code.size()));
@@ -981,7 +984,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_inner_fail_outer_ok)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> innerAcc(
-            rollbackableStorage, inner, false);
+            rollbackableStorage, inner, false,
+            /*treatSystemAsUser=*/false);
         co_await innerAcc.create();
         auto const innerCode = eip2929::warmAccountThenRevertBytecode(bAddr);
         auto const innerHash =
@@ -989,7 +993,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_inner_fail_outer_ok)
         co_await innerAcc.setCode(innerCode, "", innerHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> outerAcc(
-            rollbackableStorage, outer, false);
+            rollbackableStorage, outer, false,
+            /*treatSystemAsUser=*/false);
         co_await outerAcc.create();
         auto const outerCode = eip2929::callThenRevertBytecode(inner);
         auto const outerHash =
@@ -1046,7 +1051,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_parent_call_nested_revert_rolls_back_child_
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1054,7 +1060,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_parent_call_nested_revert_rolls_back_child_
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const childCode = eip2929::warmAccountThenRevertBytecode(coldTarget);
         auto const childHash =
@@ -1062,7 +1069,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_parent_call_nested_revert_rolls_back_child_
         co_await childAcc.setCode(childCode, "", childHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> parentAcc(
-            rollbackableStorage, parentContract, false);
+            rollbackableStorage, parentContract, false,
+            /*treatSystemAsUser=*/false);
         co_await parentAcc.create();
         auto const parentCode = eip2929::callThenRevertBytecode(childContract);
         auto const parentHash =
@@ -1104,7 +1112,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_sequential_child_revert_then_success_warm)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> child1Acc(
-            rollbackableStorage, child1, false);
+            rollbackableStorage, child1, false,
+            /*treatSystemAsUser=*/false);
         co_await child1Acc.create();
         auto const child1Code = eip2929::warmAccountThenRevertBytecode(warmFromChild1);
         auto const child1Hash =
@@ -1112,7 +1121,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_sequential_child_revert_then_success_warm)
         co_await child1Acc.setCode(child1Code, "", child1Hash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> child2Acc(
-            rollbackableStorage, child2, false);
+            rollbackableStorage, child2, false,
+            /*treatSystemAsUser=*/false);
         co_await child2Acc.create();
         auto const child2Code = eip2929::warmAccountThenStopBytecode(warmFromChild2);
         auto const child2Hash =
@@ -1173,7 +1183,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_child_revert_preserves_parent_warm_same_add
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1181,7 +1192,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_child_revert_preserves_parent_warm_same_add
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const childCode = eip2929::warmAccountThenRevertBytecode(sharedAddr);
         auto const childHash =
@@ -1189,7 +1201,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_child_revert_preserves_parent_warm_same_add
         co_await childAcc.setCode(childCode, "", childHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> parentAcc(
-            rollbackableStorage, parentContract, false);
+            rollbackableStorage, parentContract, false,
+            /*treatSystemAsUser=*/false);
         co_await parentAcc.create();
         auto const parentCode = eip2929::warmAddressThenCallBytecode(sharedAddr, childContract);
         auto const parentHash =
@@ -1223,7 +1236,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_staticcall_child_revert_rollback)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1231,7 +1245,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_staticcall_child_revert_rollback)
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> innerAcc(
-            rollbackableStorage, innerContract, false);
+            rollbackableStorage, innerContract, false,
+            /*treatSystemAsUser=*/false);
         co_await innerAcc.create();
         auto const innerCode = eip2929::warmAccountThenRevertBytecode(coldTarget);
         auto const innerHash =
@@ -1239,7 +1254,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_staticcall_child_revert_rollback)
         co_await innerAcc.setCode(innerCode, "", innerHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> parentAcc(
-            rollbackableStorage, parentContract, false);
+            rollbackableStorage, parentContract, false,
+            /*treatSystemAsUser=*/false);
         co_await parentAcc.create();
         auto const parentCode = eip2929::staticCallThenRevertBytecode(innerContract);
         auto const parentHash =
@@ -1273,7 +1289,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_delegatecall_shares_warm_set)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1281,7 +1298,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_delegatecall_shares_warm_set)
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> calleeAcc(
-            rollbackableStorage, delegateCallee, false);
+            rollbackableStorage, delegateCallee, false,
+            /*treatSystemAsUser=*/false);
         co_await calleeAcc.create();
         auto const calleeCode = eip2929::warmAccountThenStopBytecode(warmAddr);
         auto const calleeHash =
@@ -1289,7 +1307,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_delegatecall_shares_warm_set)
         co_await calleeAcc.setCode(calleeCode, "", calleeHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> parentAcc(
-            rollbackableStorage, parentContract, false);
+            rollbackableStorage, parentContract, false,
+            /*treatSystemAsUser=*/false);
         co_await parentAcc.create();
         auto const parentCode = eip2929::delegateCallThenStopBytecode(delegateCallee);
         auto const parentHash =
@@ -1327,7 +1346,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_inner_ok_outer_fail)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1335,7 +1355,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_inner_ok_outer_fail)
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> innerAcc(
-            rollbackableStorage, inner, false);
+            rollbackableStorage, inner, false,
+            /*treatSystemAsUser=*/false);
         co_await innerAcc.create();
         auto const innerCode = eip2929::warmAccountThenStopBytecode(xAddr);
         auto const innerHash =
@@ -1343,7 +1364,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_inner_ok_outer_fail)
         co_await innerAcc.setCode(innerCode, "", innerHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> runnerAcc(
-            rollbackableStorage, runner, false);
+            rollbackableStorage, runner, false,
+            /*treatSystemAsUser=*/false);
         co_await runnerAcc.create();
         auto const runnerCode = eip2929::callThenRevertBytecode(inner);
         auto const runnerHash =
@@ -1381,7 +1403,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_oog_rolls_back_child_warm)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         evmc_address coldTarget2{};
         coldTarget2.bytes[19] = 0x8a;
@@ -1439,7 +1462,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_revert_preserves_tx_baseline)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const code = eip2929::warmAccountThenRevertBytecode(coldTarget);
         auto const hash = hashImpl->hash(bcos::bytesConstRef(code.data(), code.size()));
@@ -1499,7 +1523,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_revert_rolls_back_storage_slot)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto code = eip2929::storageWriterBytecode();
         code.pop_back();  // remove STOP
@@ -1548,7 +1573,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_top_level_create_execute_revert_keeps_contr
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1579,7 +1605,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_top_level_create_execute_oog_keeps_contract
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1628,7 +1655,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_create_fail_keeps_contract_warm)
         co_await host.prepare();
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> senderAcc(
-            rollbackableStorage, host.message().recipient, false);
+            rollbackableStorage, host.message().recipient, false,
+            /*treatSystemAsUser=*/false);
         auto const nonceStr = co_await senderAcc.nonce();
         u256 const nonce(nonceStr.value_or(std::string("0")));
 
@@ -1679,7 +1707,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_create_fail_evmone_inner_warm_rolled_back)
         co_await host.prepare();
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> senderAcc(
-            rollbackableStorage, host.message().recipient, false);
+            rollbackableStorage, host.message().recipient, false,
+            /*treatSystemAsUser=*/false);
         auto const nonceStr = co_await senderAcc.nonce();
         u256 const nonce(nonceStr.value_or(std::string("0")));
 
@@ -1727,7 +1756,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_create2_fail_keeps_contract_warm)
         co_await host.prepare();
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> senderAcc(
-            rollbackableStorage, host.message().recipient, false);
+            rollbackableStorage, host.message().recipient, false,
+            /*treatSystemAsUser=*/false);
         auto const nonceStr = co_await senderAcc.nonce();
         u256 const nonce(nonceStr.value_or(std::string("0")));
 
@@ -1762,7 +1792,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_top_level_revert_rolls_back_runtime_warm)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1770,7 +1801,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_top_level_revert_rolls_back_runtime_warm)
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> runnerAcc(
-            rollbackableStorage, runner, false);
+            rollbackableStorage, runner, false,
+            /*treatSystemAsUser=*/false);
         co_await runnerAcc.create();
         auto const runnerCode = eip2929::warmAccountThenRevertBytecode(runtimeTarget);
         auto const runnerHash =
@@ -1805,7 +1837,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_commit_then_parent_revert)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> originAcc(
-            rollbackableStorage, origin, false);
+            rollbackableStorage, origin, false,
+            /*treatSystemAsUser=*/false);
         if (!co_await originAcc.exists())
         {
             co_await originAcc.create();
@@ -1813,7 +1846,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_commit_then_parent_revert)
         co_await originAcc.setBalance(bcos::u256(1) << 96);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> innerAcc(
-            rollbackableStorage, inner, false);
+            rollbackableStorage, inner, false,
+            /*treatSystemAsUser=*/false);
         co_await innerAcc.create();
         auto const innerCode = eip2929::warmAccountThenStopBytecode(xAddr);
         auto const innerHash =
@@ -1821,7 +1855,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_nested_commit_then_parent_revert)
         co_await innerAcc.setCode(innerCode, "", innerHash);
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> runnerAcc(
-            rollbackableStorage, runner, false);
+            rollbackableStorage, runner, false,
+            /*treatSystemAsUser=*/false);
         co_await runnerAcc.create();
         auto const runnerCode = eip2929::callThenRevertBytecode(inner);
         auto const runnerHash =
@@ -1858,7 +1893,8 @@ BOOST_AUTO_TEST_CASE(TE_FC_A_eip2929_checkpoint_off_nested_call)
 
     syncWait([&]() -> task::Task<void> {
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> childAcc(
-            rollbackableStorage, childContract, false);
+            rollbackableStorage, childContract, false,
+            /*treatSystemAsUser=*/false);
         co_await childAcc.create();
         auto const code = eip2929::warmAccountThenStopBytecode(coldTarget);
         auto const hash = hashImpl->hash(bcos::bytesConstRef(code.data(), code.size()));

--- a/transaction-executor/tests/Eip2929TestHelpers.h
+++ b/transaction-executor/tests/Eip2929TestHelpers.h
@@ -299,7 +299,8 @@ bcos::task::Task<int64_t> measureProbeGasTask(Fixture& fixture,
     runner.bytes[19] = runnerTag;
 
     bcos::ledger::account::EVMAccount<decltype(fixture.rollbackableStorage)> originAcc(
-        fixture.rollbackableStorage, origin, false);
+        fixture.rollbackableStorage, origin, false,
+        /*treatSystemAsUser=*/false);
     if (!co_await originAcc.exists())
     {
         co_await originAcc.create();
@@ -307,7 +308,8 @@ bcos::task::Task<int64_t> measureProbeGasTask(Fixture& fixture,
     co_await originAcc.setBalance(bcos::u256(1) << 96);
 
     bcos::ledger::account::EVMAccount<decltype(fixture.rollbackableStorage)> runnerAcc(
-        fixture.rollbackableStorage, runner, false);
+        fixture.rollbackableStorage, runner, false,
+        /*treatSystemAsUser=*/false);
     if (!co_await runnerAcc.exists())
     {
         co_await runnerAcc.create();

--- a/transaction-executor/tests/FIB88_92_ErrorHandlingTest.cpp
+++ b/transaction-executor/tests/FIB88_92_ErrorHandlingTest.cpp
@@ -125,7 +125,8 @@ BOOST_AUTO_TEST_CASE(FIB88_InsufficientBalanceConsumesAllGas)
 
         // Set sender balance to 100 but try to transfer 1000
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> senderAccount(
-            rollbackableStorage, sender, false);
+            rollbackableStorage, sender, false,
+            /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(bcos::u256(100));
 
         constexpr int64_t GAS_LIMIT = 300000;
@@ -365,7 +366,8 @@ BOOST_AUTO_TEST_CASE(FIB88_FlagOff_InsufficientBalancePreservesGas)
         evmc_address recipient = bcos::unhexAddress("0x0000000000000000000000000000000000000DDD");
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> senderAccount(
-            rollbackableStorage, sender, false);
+            rollbackableStorage, sender, false,
+            /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(bcos::u256(100));
 
         constexpr int64_t GAS_LIMIT = 300000;

--- a/transaction-executor/tests/TestHostContext.cpp
+++ b/transaction-executor/tests/TestHostContext.cpp
@@ -442,7 +442,8 @@ static bcos::task::Task<void> testNestConstructor(auto* self, bool web3)
 
     if (web3)
     {
-        bcos::ledger::account::EVMAccount account(self->storage, address1, false);
+        bcos::ledger::account::EVMAccount account(
+            self->storage, address1, false, /*treatSystemAsUser=*/false);
         auto nonce = co_await account.nonce();
         BOOST_REQUIRE(nonce.has_value());
         BOOST_TEST(nonce.value() == "11");
@@ -465,7 +466,8 @@ static bcos::task::Task<void> testNestConstructor(auto* self, bool web3)
         BOOST_CHECK_NE(address2, bcos::Address{});
         if (web3)
         {
-            bcos::ledger::account::EVMAccount account(self->storage, address2, false);
+            bcos::ledger::account::EVMAccount account(
+                self->storage, address2, false, /*treatSystemAsUser=*/false);
             auto nonce = co_await account.nonce();
             BOOST_REQUIRE(nonce.has_value());
             BOOST_TEST(nonce.value() == "1");
@@ -533,10 +535,12 @@ BOOST_AUTO_TEST_CASE(transferBalance)
         message.gas = 21000;
 
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> senderAccount(
-            rollbackableStorage, message.sender, false);
+            rollbackableStorage, message.sender, false,
+            /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(bcos::u256(1001));
         bcos::ledger::account::EVMAccount<decltype(rollbackableStorage)> recipientAccount(
-            rollbackableStorage, message.recipient, false);
+            rollbackableStorage, message.recipient, false,
+            /*treatSystemAsUser=*/false);
         co_await recipientAccount.setBalance(bcos::u256(0));
 
         evmc_address origin{};

--- a/transaction-executor/tests/TestTransactionExecutor.cpp
+++ b/transaction-executor/tests/TestTransactionExecutor.cpp
@@ -193,7 +193,8 @@ BOOST_AUTO_TEST_CASE(costBalance)
         transaction->forceSender(
             bytes(senderAddress.bytes, senderAddress.bytes + sizeof(senderAddress.bytes)));
 
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
 
         constexpr static int64_t initBalance = 149586;
         co_await senderAccount.setBalance(initBalance);
@@ -233,7 +234,8 @@ BOOST_AUTO_TEST_CASE(insufficientBalanceNoLogs)
         // Use a deployer with enough balance for deployment
         auto deployer = unhexAddress("e0e794ca86d198042b64285c5ce667aee747509b"sv);
         deployTx->forceSender(bytes(deployer.bytes, deployer.bytes + sizeof(deployer.bytes)));
-        ledger::account::EVMAccount deployerAccount(storage, deployer, false);
+        ledger::account::EVMAccount deployerAccount(
+            storage, deployer, false, /*treatSystemAsUser=*/false);
         co_await deployerAccount.setBalance(100000000000);
 
         auto deployReceipt = co_await executor.executeTransaction(
@@ -251,7 +253,8 @@ BOOST_AUTO_TEST_CASE(insufficientBalanceNoLogs)
         auto lowBalanceSender = unhexAddress("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"sv);
         callTx->forceSender(
             bytes(lowBalanceSender.bytes, lowBalanceSender.bytes + sizeof(lowBalanceSender.bytes)));
-        ledger::account::EVMAccount lowAccount(storage, lowBalanceSender, false);
+        ledger::account::EVMAccount lowAccount(
+            storage, lowBalanceSender, false, /*treatSystemAsUser=*/false);
         co_await lowAccount.setBalance(0);
 
         auto callReceipt = co_await executor.executeTransaction(
@@ -388,11 +391,13 @@ BOOST_AUTO_TEST_CASE(web3Nonce)
         BOOST_CHECK_EQUAL(
             receipt->status(), static_cast<int32_t>(protocol::TransactionStatus::None));
 
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         auto nonce = co_await senderAccount.nonce();
         BOOST_TEST(nonce.value() == "6");
 
-        ledger::account::EVMAccount helloworldAccount(storage, receipt->contractAddress(), false);
+        ledger::account::EVMAccount helloworldAccount(
+            storage, receipt->contractAddress(), false, /*treatSystemAsUser=*/false);
         auto contractNonce = co_await helloworldAccount.nonce();
         BOOST_CHECK_EQUAL(contractNonce.value(), "1");
 
@@ -403,7 +408,8 @@ BOOST_AUTO_TEST_CASE(web3Nonce)
         auto rawExpectAddr = newLegacyEVMAddress(bytesConstRef{helloworldAddress.bytes}, 1);
         evmc_address expectAddress;
         std::copy(rawExpectAddr.begin(), rawExpectAddr.end(), expectAddress.bytes);
-        ledger::account::EVMAccount expectAccount(storage, expectAddress, false);
+        ledger::account::EVMAccount expectAccount(
+            storage, expectAddress, false, /*treatSystemAsUser=*/false);
 
         auto input = abiCodec.abiIn("deployAndCall(int256)", bcos::s256(90));
         auto deployCallTx = transactionFactory.createTransaction(0,
@@ -450,7 +456,8 @@ BOOST_AUTO_TEST_CASE(web3Nonce)
         BOOST_TEST(receipt->status() == 0);
         bcos::Address address1{};
         abiCodec.abiOut(receipt->output(), address1);
-        bcos::ledger::account::EVMAccount deployAccount(storage, address1, false);
+        bcos::ledger::account::EVMAccount deployAccount(
+            storage, address1, false, /*treatSystemAsUser=*/false);
         BOOST_CHECK_EQUAL((co_await deployAccount.nonce()).value(), "11");
 
         for (auto i : ::ranges::views::iota(1, 11))
@@ -458,7 +465,8 @@ BOOST_AUTO_TEST_CASE(web3Nonce)
             auto rawAddr = newLegacyEVMAddress(bytesConstRef{address1.data(), address1.size()}, i);
             evmc_address expectAddress;
             std::copy(rawAddr.begin(), rawAddr.end(), expectAddress.bytes);
-            ledger::account::EVMAccount account(storage, expectAddress, false);
+            ledger::account::EVMAccount account(
+                storage, expectAddress, false, /*treatSystemAsUser=*/false);
             BOOST_TEST(co_await account.exists());
             BOOST_TEST((co_await account.nonce()).value() == "1");
         }
@@ -514,7 +522,8 @@ BOOST_AUTO_TEST_CASE(cashRevert)
         BOOST_CHECK_EQUAL(receipt->status(), 7);
         BOOST_CHECK_EQUAL(receipt->contractAddress(), "");
 
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         auto nonce = co_await senderAccount.nonce();
         BOOST_CHECK_EQUAL(nonce.value(), "1");
     }());
@@ -551,7 +560,8 @@ BOOST_AUTO_TEST_CASE(buyGasFailsDrainsLowBalance)
             bytes(senderAddress.bytes, senderAddress.bytes + sizeof(senderAddress.bytes)));
         dynamic_cast<bcostars::protocol::TransactionImpl&>(*transaction).mutableInner().type = 1;
 
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(500);
 
         auto receipt = co_await executor.executeTransaction(
@@ -597,7 +607,8 @@ BOOST_AUTO_TEST_CASE(buyGasFailsChargesIntrinsicPenalty)
 
         constexpr static int64_t initBalance = 50'000;
         constexpr static int64_t intrinsicCost = 21'000;
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(initBalance);
 
         auto receipt = co_await executor.executeTransaction(
@@ -643,7 +654,8 @@ BOOST_AUTO_TEST_CASE(buyGasAndRefundSuccessFlow)
         dynamic_cast<bcostars::protocol::TransactionImpl&>(*transaction).mutableInner().type = 1;
 
         constexpr static int64_t initBalance = 1'000'000;
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(initBalance);
 
         auto receipt = co_await executor.executeTransaction(
@@ -692,7 +704,8 @@ BOOST_AUTO_TEST_CASE(buyGasChargesOnEvmFailure)
         dynamic_cast<bcostars::protocol::TransactionImpl&>(*transaction).mutableInner().type = 1;
 
         constexpr static int64_t initBalance = 100'000;
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(initBalance);
 
         auto receipt = co_await executor.executeTransaction(
@@ -727,7 +740,8 @@ BOOST_AUTO_TEST_CASE(proxyReceive)
         using namespace std::string_view_literals;
         auto sender = "e0e794ca86d198042b64285c5ce667aee747509b"sv;
         evmc_address senderAddress = unhexAddress(sender);
-        ledger::account::EVMAccount senderAccount(storage, senderAddress, false);
+        ledger::account::EVMAccount senderAccount(
+            storage, senderAddress, false, /*treatSystemAsUser=*/false);
         co_await senderAccount.setBalance(500);
 
         bcos::bytes input;
@@ -743,7 +757,8 @@ BOOST_AUTO_TEST_CASE(proxyReceive)
         BOOST_CHECK_GT(receipt->contractAddress().size(), 0);
         BOOST_CHECK_EQUAL(co_await senderAccount.balance(), 450);
 
-        ledger::account::EVMAccount implAccount(storage, receipt->contractAddress(), false);
+        ledger::account::EVMAccount implAccount(
+            storage, receipt->contractAddress(), false, /*treatSystemAsUser=*/false);
         BOOST_CHECK_EQUAL(co_await implAccount.balance(), 50);
 
         bcos::bytes input2;
@@ -774,7 +789,8 @@ BOOST_AUTO_TEST_CASE(proxyReceive)
         BOOST_CHECK_EQUAL(receipt3->status(), 0);
         BOOST_CHECK_EQUAL(co_await senderAccount.balance(), 350);
 
-        ledger::account::EVMAccount proxyAccount(storage, receipt2->contractAddress(), false);
+        ledger::account::EVMAccount proxyAccount(
+            storage, receipt2->contractAddress(), false, /*treatSystemAsUser=*/false);
         BOOST_CHECK_EQUAL(co_await proxyAccount.balance(), 100);
         BOOST_CHECK_EQUAL(co_await implAccount.balance(), 50);
 

--- a/transaction-executor/tests/Web3NonceOrderTest.cpp
+++ b/transaction-executor/tests/Web3NonceOrderTest.cpp
@@ -84,7 +84,8 @@ public:
             BOOST_CHECK_EQUAL(
                 lowReceipt->status(), static_cast<int32_t>(protocol::TransactionStatus::None));
 
-            ledger::account::EVMAccount senderAccount(storage, sender, false);
+            ledger::account::EVMAccount senderAccount(
+                storage, sender, false, /*treatSystemAsUser=*/false);
             co_return (co_await senderAccount.nonce()).value();
         }());
     }

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler-tpp.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler-tpp.h
@@ -167,6 +167,20 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
         }
     }
 
+    // Finalize receipts BEFORE the parallel region. calculateReceiptRoot's sibling task reads
+    // receipt->hash() on the same objects finalizeReceipts mutates (transactionIndex /
+    // logsBloom / cumulativeGasUsed); benign today because TransactionReceiptImpl::hash()
+    // returns the cached dataHash over disjoint members, but finalizing first removes any
+    // scheduling dependence and matches the engine's sequential ordering. The block's receipt
+    // list is restamped here too (clearReceipts/appendReceipt), so the parallel region only
+    // reads.
+    totalGasUsed += ledger::mpt::finalizeReceipts(receipts);
+    block.clearReceipts();
+    for (auto&& receipt : receipts)
+    {
+        block.appendReceipt(receipt);
+    }
+
     tbb::parallel_invoke([&]() { transactionRoot = calculateTransactionRoot(block, hashImpl); },
         [&]() {
             // When the block was built with an Ethereum MPT root (shouldBuildMPT), the header
@@ -181,14 +195,6 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
                 calculateStateRoot(storage, block.blockHeader()->version(), hashImpl, features));
         },
         [&]() { receiptRoot = calculateReceiptRoot(receipts, block, hashImpl); },
-        [&]() {
-            block.clearReceipts();
-            totalGasUsed += ledger::mpt::finalizeReceipts(receipts);
-            for (auto&& receipt : receipts)
-            {
-                block.appendReceipt(receipt);
-            }
-        },
         [&]() {
             sysBlock = ::ranges::any_of(transactions, [](auto const& transaction) {
                 return precompiled::contains(

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler-tpp.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler-tpp.h
@@ -154,6 +154,19 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
     h256 stateRoot;
     h256 receiptRoot;
 
+    // Null-check every receipt BEFORE the parallel region below: calculateReceiptRoot
+    // dereferences receipt->hash() with no check of its own, so a throw from the sibling
+    // finalizeReceipts task would not dominate a concurrent segfault. Same guard shape as
+    // the engine's buildPayload (EngineServiceImpl.h); receipts is iterated by multiple
+    // lambdas below already, so it is at least a forward range and one extra pass is safe.
+    for (auto& receipt : receipts)
+    {
+        if (!receipt)
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
+        }
+    }
+
     tbb::parallel_invoke([&]() { transactionRoot = calculateTransactionRoot(block, hashImpl); },
         [&]() {
             // When the block was built with an Ethereum MPT root (shouldBuildMPT), the header
@@ -892,7 +905,8 @@ void BaselineScheduler<MultiLayerStorage, Executor, SchedulerImpl, Ledger>::getC
             co_await ledger::getLedgerConfig(view, blockNumber, self->m_blockFactory.get());
 
         ledger::account::EVMAccount account(view, contractAddress,
-            ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address));
+            ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address),
+            /*treatSystemAsUser=*/false);
         auto code = co_await account.code();
 
         if (!code)
@@ -918,7 +932,8 @@ void BaselineScheduler<MultiLayerStorage, Executor, SchedulerImpl, Ledger>::getA
             co_await ledger::getLedgerConfig(view, blockNumber, self->m_blockFactory.get());
 
         ledger::account::EVMAccount account(view, contractAddress,
-            ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address));
+            ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address),
+            /*treatSystemAsUser=*/false);
         auto abi = co_await account.abi();
 
         if (!abi)
@@ -938,8 +953,9 @@ BaselineScheduler<MultiLayerStorage, Executor, SchedulerImpl, Ledger>::getPendin
     auto view = m_multiLayerStorage.get().fork();
     auto ledgerConfig = co_await ledger::getLedgerConfig(view, number, m_blockFactory.get());
 
-    ledger::account::EVMAccount account(
-        view, address, ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address));
+    ledger::account::EVMAccount account(view, address,
+        ledgerConfig->features().get(ledger::Features::Flag::feature_raw_address),
+        /*treatSystemAsUser=*/false);
     co_return co_await account.storageEntry(key);
 }
 template <class MultiLayerStorage, class Executor, class SchedulerImpl, class Ledger>

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler-tpp.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler-tpp.h
@@ -44,6 +44,7 @@
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-framework/txpool/TxPoolInterface.h"
+#include "bcos-ledger/mpt/EthTrieRoots.h"
 #include "bcos-ledger/mpt/MPTBuilder.h"
 #include "bcos-task/TBBWait.h"
 #include "bcos-task/Wait.h"
@@ -168,18 +169,10 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
         },
         [&]() { receiptRoot = calculateReceiptRoot(receipts, block, hashImpl); },
         [&]() {
-            size_t logIndex = 0;
             block.clearReceipts();
-            for (auto&& [index, receipt] : ::ranges::views::enumerate(receipts))
+            totalGasUsed += ledger::mpt::finalizeReceipts(receipts);
+            for (auto&& receipt : receipts)
             {
-                receipt->setTransactionIndex(index);
-                receipt->setLogIndex(logIndex);
-                auto logBloom = getLogsBloom(receipt->logEntries());
-                receipt->setLogsBloom({logBloom.data(), logBloom.size()});
-                logIndex += receipt->logEntries().size();
-                totalGasUsed += receipt->gasUsed();
-                receipt->setCumulativeGasUsed(totalGasUsed.str());
-
                 block.appendReceipt(receipt);
             }
         },

--- a/transaction-scheduler/tests/SharedBaselineSchedulerMock.h
+++ b/transaction-scheduler/tests/SharedBaselineSchedulerMock.h
@@ -121,7 +121,8 @@ struct SharedMockExecutor
             co_return {};
         }
 
-        ledger::account::EVMAccount account(storage, m_probeAddress, false);
+        ledger::account::EVMAccount account(
+            storage, m_probeAddress, false, /*treatSystemAsUser=*/false);
         if (m_mode == Mode::WriteThenReadSlot)
         {
             co_await account.setStorage(m_probeSlot, m_writeValue);

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -139,7 +139,7 @@ std::shared_ptr<bcostars::protocol::TransactionImpl> EEMakeTransferTx(
 task::Task<void> EEFundAccount(EEBackendStorage& storage, evmc_address const& addr, u256 balance)
 {
     using namespace bcos::ledger::account;
-    EVMAccount<EEBackendStorage> acc(storage, addr, false);
+    EVMAccount<EEBackendStorage> acc(storage, addr, false, /*treatSystemAsUser=*/true);
     if (!co_await acc.exists())
     {
         co_await acc.create();
@@ -152,7 +152,8 @@ template <class Storage>
 task::Task<u256> EEReadBalance(Storage& storage, evmc_address const& addr)
 {
     using namespace bcos::ledger::account;
-    EVMAccount<std::remove_reference_t<Storage>> acc(storage, addr, false);
+    EVMAccount<std::remove_reference_t<Storage>> acc(
+        storage, addr, false, /*treatSystemAsUser=*/true);
     co_return co_await acc.balance();
 }
 
@@ -906,14 +907,15 @@ BOOST_AUTO_TEST_CASE(ethereumStateHasStorageSemantics)
 
         EEMutableStorage storage;
         {
-            EVMAccount<EEMutableStorage> acc(storage, plainAcc, false);
+            EVMAccount<EEMutableStorage> acc(storage, plainAcc, false, /*treatSystemAsUser=*/true);
             if (!co_await acc.exists())
                 co_await acc.create();
             co_await acc.setNonce("0");
             co_await acc.setBalance(u256(1));
         }
         {
-            EVMAccount<EEMutableStorage> acc(storage, slottedAcc, false);
+            EVMAccount<EEMutableStorage> acc(
+                storage, slottedAcc, false, /*treatSystemAsUser=*/true);
             if (!co_await acc.exists())
                 co_await acc.create();
             co_await acc.setNonce("0");
@@ -922,7 +924,8 @@ BOOST_AUTO_TEST_CASE(ethereumStateHasStorageSemantics)
 
         // Give slottedAcc one real storage slot (beyond the fixed fields).
         {
-            EVMAccount<EEMutableStorage> acc(storage, slottedAcc, false);
+            EVMAccount<EEMutableStorage> acc(
+                storage, slottedAcc, false, /*treatSystemAsUser=*/true);
             evmc_bytes32 key{};
             key.bytes[31] = 1;
             evmc_bytes32 value{};
@@ -965,7 +968,8 @@ BOOST_AUTO_TEST_CASE(callDryRunSkipsNonceAndGasValidation)
         // would be NONCE_TOO_LOW if the executor validated it like a real tx.
         {
             using namespace bcos::ledger::account;
-            EVMAccount<EEBackendStorage> acc(backendStorage, sender, false);
+            EVMAccount<EEBackendStorage> acc(
+                backendStorage, sender, false, /*treatSystemAsUser=*/true);
             co_await acc.setNonce("3");
         }
         co_await EEFundAccount(backendStorage, recipient, 0);


### PR DESCRIPTION
## 概述

本 PR 是 eth_sync 分支拆分提交的第一个 PR，包含对现有基础代码的兼容性修复，为后续以太坊同步功能做铺垫。

## 包含内容

- **commit 1 `c538a717f`** `fix: base fixes for ethereum compatibility`：基础兼容性修复
- **commit 2 `0f48b684c`** `fix(engine): commit v2 blocks to ethereum tries, harden receipt/tx pairing`：engine v2 区块提交到 ethereum tries，强化 receipt/tx 配对校验
- **commit 3 `8179614fb`** `fix: address review findings`：修复全部 8 条评审意见
- **commit 4 `e745a6ff0`** `fix: address round-4 review findings (fail-closed forced-tx guard, required treatSystemAsUser, shared executor_version read, non-vacuous RLP test)`：修复 round-4 全部 11 条评审意见（含 3 条 BLOCKING），详见汇总评论

## 评审意见修复明细（commit 3）

- **F1（HIGH）**：修复 `/apps/` 与 `/sys/` 表路径读写不一致问题。在 `EVMAccount.h` 新增共享助手 `accountTablePrefix(address, systemAsUser)` / `accountTablePrefix(address, executorVersion)`，`Ledger.cpp::getStorageAt` 与 `EthEndpoint.cpp` 均改为先读取 `executor_version` 系统配置再路由，测试 bridge（`TestStorageBridge.h`）统一按 `treatSystemAsUser=true` 构造，保证读写路径一致。
- **F2**：engine 空块路径与初始化器恢复无条件 `emptyRootHash()` 初始化（base 本就没有"legacy 零根行为"，此前注释有误）。
- **F3**：抽取共享助手 `ledger::mpt::finalizeReceipts()` 至 `bcos-ledger/mpt/EthTrieRoots.h`（bloom 仅在为空时回填，并回填 transactionIndex/logIndex，返回 totalGasUsed），`BaselineScheduler-tpp.h` 与 engine 路径统一调用。
- **F4**：`RLPTest.cpp` 新增 `uint256EncodeAfterShrinkReuse` 回归测试，覆盖 limb shrink 后复用编码场景。
- **F5**：`EngineServiceTest.cpp` 增强断言——pin receiptsRoot（独立重算 trie 对比）、transactionIndex、cumulativeGasUsed；新增 `build_payload_rejects_more_receipts_than_transactions` 用例，验证 receipt 多于交易时抛出 `std::runtime_error`。
- **F6**：删除 `Web3TarsBridge.cpp` 中 `txHash()` 死代码，`Web3Transaction.h` 补充异常契约文档；新增 `Web3TarsBridgeTest.cpp` 覆盖 EIP-1559 round-trip、0x7e deposit 类型、malformed 输入抛 `std::invalid_argument`。
- **F7**：engine 中补充 `rlpEncode` 返回值检查。
- **F8**：`EVMAccount.h` 通过 clang-format。

## 测试

- 新增/修改测试全部通过：test-bcos-codec、test-bcos-framework、test-bcos-tars-protocol（含新增 Web3TarsBridgeTest）、test-bcos-engine（全套件）、test-bcos-ledger（含 genesis）、test-ethereum-state-smoke、test-bcos-tool、test-bcos-utilities、test-scheduler、test-legacy-ledger 及 3 个 opstack-executor 测试。
- 本地 ASan 环境下有 4 个测试失败（test-transaction-executor 2 个用例、test-bcos-rpc、test-bcos-executor、test-transaction-scheduler），已通过纯 upstream（release-3.18.0, 03287d48b）对照实验确认为 upstream 既有问题，与本 PR 无关。

---

## 约束与后续(记录于 round-5 评审后)

### 部署/排序约束(对应 round-5 F2,无代码改动)
`executor_version >= 2`(v2/Ethereum executor)的链在 **eth_sync execution-lane wiring PR(0x7E deposit 执行 + raw→executable 解码)落地之前**,**不得由会通过 `payloadAttributes.transactions` 注入 forced/deposit 交易的共识层(如 op-node)驱动**:v2 `buildPayload` 会 fail-closed 拒绝此类 payload(否则将提交 N 条交易的 txsRoot 与仅 M 条已执行交易的 receipts trie,外部以太坊验证器无法复现)。这是两轮评审明确要求的取舍;仓库自带的 Karst 引擎 API 冒烟测试(`tests/mock_consensus_client.py`)已据此把 deposit 建块流程改为 KNOWN-GAP pin,并在 wiring PR 落地后恢复完整 deposit round-trip。

### 后续(follow-up,deadline:eth_sync EL wiring PR 引入第 4 个 reader 之前)
- **executor_version 读取合并**(round-5 F4 / round-2 F8):`Ledger::getStorageAt` / `EthEndpoint::getStorageAt` 从每块缓存的 `LedgerConfig::executorVersion()` 取 routing bool,删除 `ledger::getExecutorVersion` 及两处每次调用的 SYS_CONFIG 读取(含 EthEndpoint 回退路径的双读)。
- **mempool 路由对齐**(round-5 F5):把由 `LedgerConfig::executorVersion()` 推导的 routing bool 穿入 `MemPoolImpl::seal/remove`,使 Ethereum 族读路径统一走 `accountTablePrefix(addr, true)`(今日不可达,属加固)。
- **`decodeWeb3RawTransaction` 迁移**(round-2/round-5 F1):连同其声明、CMake 条目与 `Web3TarsBridgeTest.cpp` 随 eth_sync EL wiring PR 迁移(补齐 blob/deposit 拒绝等准入闸门),不在本 PR 拆分。
