### PR TITLE
Refactor front network path to coroutine-based interfaces

### DIFF
--- a/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.h
+++ b/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.h
@@ -23,6 +23,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <iostream>
 #include <memory>
+#include <utility>
 
 namespace bcos::boostssl
 {
@@ -34,14 +35,14 @@ struct NodeIPEndpoint
 {
     using Ptr = std::shared_ptr<NodeIPEndpoint>;
     NodeIPEndpoint() = default;
-    NodeIPEndpoint(std::string _host, uint16_t _port);
-    NodeIPEndpoint(const boost::asio::ip::address& _addr, uint16_t _port);
+        NodeIPEndpoint(std::string _host, uint16_t _port);
+        NodeIPEndpoint(const boost::asio::ip::address& _addr, uint16_t _port);
     NodeIPEndpoint(const NodeIPEndpoint& _nodeIPEndpoint) = default;
     NodeIPEndpoint(NodeIPEndpoint&& _nodeIPEndpoint) noexcept = default;
     NodeIPEndpoint& operator=(const NodeIPEndpoint& _nodeIPEndpoint) = default;
     NodeIPEndpoint& operator=(NodeIPEndpoint&& _nodeIPEndpoint) noexcept = default;
 
-    ~NodeIPEndpoint() = default;
+    virtual ~NodeIPEndpoint() = default;
     NodeIPEndpoint(const boost::asio::ip::tcp::endpoint& _endpoint);
     bool operator<(const NodeIPEndpoint& rhs) const;
     bool operator==(const NodeIPEndpoint& rhs) const;

--- a/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.h
+++ b/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.h
@@ -23,7 +23,6 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <iostream>
 #include <memory>
-#include <utility>
 
 namespace bcos::boostssl
 {
@@ -35,14 +34,14 @@ struct NodeIPEndpoint
 {
     using Ptr = std::shared_ptr<NodeIPEndpoint>;
     NodeIPEndpoint() = default;
-        NodeIPEndpoint(std::string _host, uint16_t _port);
-        NodeIPEndpoint(const boost::asio::ip::address& _addr, uint16_t _port);
+    NodeIPEndpoint(std::string _host, uint16_t _port);
+    NodeIPEndpoint(const boost::asio::ip::address& _addr, uint16_t _port);
     NodeIPEndpoint(const NodeIPEndpoint& _nodeIPEndpoint) = default;
     NodeIPEndpoint(NodeIPEndpoint&& _nodeIPEndpoint) noexcept = default;
     NodeIPEndpoint& operator=(const NodeIPEndpoint& _nodeIPEndpoint) = default;
     NodeIPEndpoint& operator=(NodeIPEndpoint&& _nodeIPEndpoint) noexcept = default;
 
-    virtual ~NodeIPEndpoint() = default;
+    ~NodeIPEndpoint() = default;
     NodeIPEndpoint(const boost::asio::ip::tcp::endpoint& _endpoint);
     bool operator<(const NodeIPEndpoint& rhs) const;
     bool operator==(const NodeIPEndpoint& rhs) const;

--- a/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
+++ b/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
@@ -60,7 +60,7 @@ public:
     // the height and serves the latest state — byte-for-byte the pre-existing behaviour of
     // every implementation with no historical state to offer (tars SchedulerService, fakes),
     // which is why this is a defaulted method and not a pure one (same pattern as
-    // FrontInterface::asyncBroadcastMessageByOwnedPayload). BaselineScheduler overrides it
+    // FrontInterface::broadcastMessageByOwnedPayload). BaselineScheduler overrides it
     // with a real execution against the MPT state committed at that block. A distinct name
     // rather than a call() overload: -Woverloaded-virtual (in -Wall, promoted by -Werror)
     // would otherwise fire in every subclass that overrides only the latest-state call().

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -207,7 +207,7 @@ public:
      *        state as coroutine parameters)
      * @return error: nullptr on success, the gateway send failure otherwise
      */
-    virtual task::Task<Error::Ptr> sendResponse(const std::string& _id, int _moduleID,
+    virtual task::Task<Error::Ptr> sendResponse(std::string _id, int _moduleID,
         bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) = 0;
 
     virtual task::Task<void> broadcastMessage(

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -30,10 +30,10 @@
 #include <functional>
 #include <range/v3/view/any_view.hpp>
 #include <range/v3/view/single.hpp>
+#include <tuple>
 
 namespace bcos::front
 {
-using GetGroupNodeInfoFunc = std::function<void(Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr)>;
 using ReceiveMsgFunc = std::function<void(Error::Ptr)>;
 using ResponseFunc = std::function<void(bytesConstRef)>;
 using CallbackFunc = std::function<void(
@@ -134,8 +134,8 @@ private:
 /**
  * @brief: the interface provided by the front service
  *
- * enable_shared_from_this lets the owned-payload bridges (asyncBroadcastMessageByOwnedPayload /
- * asyncSendMessageByNodeIDByOwnedPayload) pass an owning Ptr as the coroutine parameter, so the
+ * enable_shared_from_this lets the owned-payload bridges (broadcastMessageByOwnedPayload /
+ * sendMessageByNodeIDByOwnedPayload) pass an owning Ptr as the coroutine parameter, so the
  * front object (FrontService / FrontServiceClient / test fakes, all shared_ptr-owned) stays alive
  * for the whole detached send instead of holding a raw `this`.
  */
@@ -157,57 +157,58 @@ public:
     virtual void stop() = 0;
 
     /**
-     * @brief: get groupNodeInfo from the gateway
-     * @param _getGroupNodeInfoFunc: get groupNodeInfo callback
-     * @return void
+     * @brief: (coroutine) get the latest groupNodeInfo the gateway pushed to this front
+     * @return {error, groupNodeInfo}: error is nullptr on success; groupNodeInfo may be nullptr
+     *         if the gateway has not pushed one yet
      */
-    virtual void asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInfo) = 0;
+    virtual task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+    getGroupNodeInfo() = 0;
     virtual bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo() const
     {
         BOOST_THROW_EXCEPTION(std::runtime_error("Unimplemented!"));
     }
     /**
-     * @brief: receive nodeIDs from gateway, call by gateway
+     * @brief: (coroutine) receive nodeIDs from gateway, called by gateway
      * @param _groupID: groupID
      * @param _groupNodeInfo: the groupNodeInfo
-     * @return void
+     * @return error: nullptr on success
      */
-    virtual void onReceiveGroupNodeInfo(const std::string& _groupID,
-        bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo, ReceiveMsgFunc _receiveMsgCallback) = 0;
+    virtual task::Task<Error::Ptr> onReceiveGroupNodeInfo(
+        std::string _groupID, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) = 0;
 
     /**
-     * @brief: receive message from gateway, call by gateway
+     * @brief: (coroutine) receive message from gateway, called by gateway
      * @param _groupID: groupID
      * @param _nodeID: the node send this message
-     * @param _data: received message data
-     * @return void
+     * @param _data: received message data (a view — the caller keeps the buffer alive until the
+     *        returned task completes; implementations copy before any deferred dispatch)
+     * @return error: nullptr on success
      */
-    virtual void onReceiveMessage(const std::string& _groupID,
-        const bcos::crypto::NodeIDPtr& _nodeID, bytesConstRef _data,
-        ReceiveMsgFunc _receiveMsgCallback) = 0;
+    virtual task::Task<Error::Ptr> onReceiveMessage(
+        std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) = 0;
 
     /**
-     * @brief: receive broadcast message from gateway, call by gateway
+     * @brief: (coroutine) receive broadcast message from gateway, called by gateway
      * @param _groupID: groupID
-     * @param _nodeID: the node send this message
-     * @param _data: received message data
-     * @return void
+     * @param _nodeID: the node send the message
+     * @param _data: received message data (a view — same lifetime contract as onReceiveMessage)
+     * @return error: nullptr on success
      */
-    virtual void onReceiveBroadcastMessage(const std::string& _groupID,
-        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
-        ReceiveMsgFunc _receiveMsgCallback) = 0;
+    virtual task::Task<Error::Ptr> onReceiveBroadcastMessage(
+        std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) = 0;
 
     /**
-     * @brief: send response
+     * @brief: (coroutine) send response
      * @param _id: the request id
      * @param _moduleID: moduleID
      * @param _nodeID: the receiver nodeID
-     * @param _data: message
-     * @return void
+     * @param _data: message (a view — the caller keeps the buffer alive until the returned task
+     *        completes; fire-and-forget callers wrap the co_await in task::wait and pass owned
+     *        state as coroutine parameters)
+     * @return error: nullptr on success, the gateway send failure otherwise
      */
-    virtual void asyncSendResponse(const std::string& _id, int _moduleID,
-        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
-        ReceiveMsgFunc _receiveMsgCallback) = 0;
+    virtual task::Task<Error::Ptr> sendResponse(const std::string& _id, int _moduleID,
+        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) = 0;
 
     virtual task::Task<void> broadcastMessage(
         uint16_t type, int moduleID,
@@ -257,7 +258,7 @@ public:
      * @param moduleID: moduleID
      * @param payload: already-encoded message body; ownership is transferred to the callee
      */
-    virtual void asyncBroadcastMessageByOwnedPayload(
+    virtual void broadcastMessageByOwnedPayload(
         uint16_t type, int moduleID, bytesPointer payload)
     {
         task::wait([](FrontServiceInterface::Ptr self, uint16_t _type, int _moduleID,
@@ -271,7 +272,7 @@ public:
      * @brief send an already-encoded message to one node, taking ownership of the payload so the
      *        send can be deferred without the caller keeping the buffer alive.
      *
-     * Same rationale as asyncBroadcastMessageByOwnedPayload: the production FrontService dispatches
+     * Same rationale as broadcastMessageByOwnedPayload: the production FrontService dispatches
      * the gateway send off the caller thread (PBFT under m_mutex must not contend the gateway
      * session lock; sendViewChange / sendRecoverResponse run there). Point-to-point sends encode
      * the wire frame anyway, so this is not zero-copy; owning the payload only keeps it alive
@@ -282,7 +283,7 @@ public:
      * @param nodeID: the receiver nodeID
      * @param payload: already-encoded message body; ownership is transferred to the callee
      */
-    virtual void asyncSendMessageByNodeIDByOwnedPayload(
+    virtual void sendMessageByNodeIDByOwnedPayload(
         int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
     {
         task::wait([](FrontServiceInterface::Ptr self, int _moduleID,

--- a/bcos-framework/bcos-framework/protocol/CommonError.h
+++ b/bcos-framework/bcos-framework/protocol/CommonError.h
@@ -32,6 +32,7 @@ enum CommonError : int32_t
     GatewaySendMsgFailed = 1003,
     GatewayBandwidthOverFlow = 1004,
     GatewayQPSOverFlow = 1005,
+    MessageDecodeFailed = 1006,  // front failed to decode the received message
     TransactionsMissing = 2000,  // for transaction sync
     InconsistentTransactions = 2001,
     TxsSignatureVerifyFailed = 2002,

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -314,17 +314,24 @@ public:
     void start() override {}
     void stop() override {}
 
-    void asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _func) override { _func(nullptr, m_groupInfo); }
+    task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo()
+        override
+    {
+        co_return std::make_tuple(Error::Ptr(nullptr), m_groupInfo);
+    }
 
     bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo() const override { return m_groupInfo; }
     // for gateway: useless here
-    void onReceiveGroupNodeInfo(
-        const std::string&, bcos::gateway::GroupNodeInfo::Ptr, ReceiveMsgFunc) override
-    {}
+    task::Task<Error::Ptr> onReceiveGroupNodeInfo(
+        std::string, bcos::gateway::GroupNodeInfo::Ptr) override
+    {
+        co_return nullptr;
+    }
     // for gateway: useless here
-    void onReceiveMessage(
-        const std::string&, const NodeIDPtr&, bytesConstRef, ReceiveMsgFunc) override
-    {}
+    task::Task<Error::Ptr> onReceiveMessage(std::string, NodeIDPtr, bytesConstRef) override
+    {
+        co_return nullptr;
+    }
     bcos::task::Task<void> broadcastMessage(
         uint16_t type, int moduleID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override
@@ -347,12 +354,13 @@ public:
     }
 
     // useless for sync/pbft/txpool
-    void onReceiveBroadcastMessage(
-        const std::string&, NodeIDPtr, bytesConstRef, ReceiveMsgFunc) override
-    {}
+    task::Task<Error::Ptr> onReceiveBroadcastMessage(std::string, NodeIDPtr, bytesConstRef) override
+    {
+        co_return nullptr;
+    }
 
-    void asyncSendResponse(const std::string& _id, int _moduleId, bcos::crypto::NodeIDPtr _nodeID,
-        bytesConstRef _responseData, ReceiveMsgFunc _responseCallback) override
+    task::Task<Error::Ptr> sendResponse(const std::string& _id, int _moduleId,
+        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _responseData) override
     {
         // m_fakeGateWay is only nulled by ~SyncFixture() teardown, after stop() has joined all
         // worker threads, so there is no live race here. The guard is pure defense: a test that
@@ -360,9 +368,10 @@ public:
         // of a null-deref.
         if (m_fakeGateWay)
         {
-            return m_fakeGateWay->asyncSendResponse(
-                _id, _moduleId, _nodeID, _responseData, _responseCallback);
+            m_fakeGateWay->asyncSendResponse(
+                _id, _moduleId, _nodeID, _responseData, [](Error::Ptr) {});
         }
+        co_return nullptr;
     }
 
     bcos::task::Task<SendResult> sendMessageByNodeID(int _moduleId,

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -359,7 +359,7 @@ public:
         co_return nullptr;
     }
 
-    task::Task<Error::Ptr> sendResponse(const std::string& _id, int _moduleId,
+    task::Task<Error::Ptr> sendResponse(std::string _id, int _moduleId,
         bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _responseData) override
     {
         // m_fakeGateWay is only nulled by ~SyncFixture() teardown, after stop() has joined all

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -366,12 +366,17 @@ public:
         // worker threads, so there is no live race here. The guard is pure defense: a test that
         // holds a frontService() handle and sends after fixture destruction gets a no-op instead
         // of a null-deref.
+        Error::Ptr error;
         if (m_fakeGateWay)
         {
+            // the fake gateway invokes the callback synchronously; forward its error so the
+            // fake honours the same contract as the real sendResponse
             m_fakeGateWay->asyncSendResponse(
-                _id, _moduleId, _nodeID, _responseData, [](Error::Ptr) {});
+                _id, _moduleId, _nodeID, _responseData, [&error](Error::Ptr _error) {
+                    error = std::move(_error);
+                });
         }
-        co_return nullptr;
+        co_return error;
     }
 
     bcos::task::Task<SendResult> sendMessageByNodeID(int _moduleId,

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -424,7 +424,7 @@ std::string FrontService::registerCallback(
  * @param _data: message (a view kept alive by the caller for the duration of the co_await)
  * @return error: nullptr on success, the gateway send failure otherwise
  */
-task::Task<Error::Ptr> FrontService::sendResponse(const std::string& _id, int _moduleID,
+task::Task<Error::Ptr> FrontService::sendResponse(std::string _id, int _moduleID,
     bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data)
 {
     FrontMessage message;

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -257,7 +257,7 @@ void FrontService::start()
         auto [error, groupNodeInfo] = co_await gateway->getGroupNodeInfo(groupID);
         if (error)
         {
-            FRONT_LOG(ERROR) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo failed")
+            FRONT_LOG(ERROR) << LOG_BADGE("start") << LOG_DESC("getGroupNodeInfo failed")
                              << LOG_KV("code", error->errorCode())
                              << LOG_KV("message", error->errorMessage());
             co_return;
@@ -265,10 +265,9 @@ void FrontService::start()
         auto frontService = self.lock();
         if (frontService && groupNodeInfo)
         {
-            FRONT_LOG(INFO) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo callback")
+            FRONT_LOG(INFO) << LOG_BADGE("start") << LOG_DESC("getGroupNodeInfo callback")
                             << LOG_KV("node size", groupNodeInfo->nodeIDList().size());
-            frontService->onReceiveGroupNodeInfo(
-                frontService->groupID(), groupNodeInfo, nullptr);
+            co_await frontService->onReceiveGroupNodeInfo(frontService->groupID(), groupNodeInfo);
         }
     }(self, m_gatewayInterface, m_groupID));
 
@@ -354,11 +353,11 @@ void FrontService::stop()
 }
 
 /**
- * @brief: get nodeIDs from frontservice
- * @param _onGetGroupNodeInfo: response callback
- * @return void
+ * @brief: (coroutine) get the latest groupNodeInfo the gateway pushed to this front
+ * @return {error, groupNodeInfo}: error is nullptr on success
  */
-void FrontService::asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInfo)
+task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+FrontService::getGroupNodeInfo()
 {
     bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo;
     {
@@ -366,16 +365,10 @@ void FrontService::asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInf
         groupNodeInfo = m_groupNodeInfo;
     }
 
-    FRONT_LOG(DEBUG) << LOG_DESC("asyncGetGroupNodeInfo")
+    FRONT_LOG(DEBUG) << LOG_DESC("getGroupNodeInfo")
                      << LOG_KV("nodeIDs.size()",
                             (groupNodeInfo ? groupNodeInfo->nodeIDList().size() : 0));
-    if (_onGetGroupNodeInfo)
-    {
-        dispatchTo(*m_ioServicePool, [_onGetGroupNodeInfo = std::move(_onGetGroupNodeInfo),
-                                         groupNodeInfo = std::move(groupNodeInfo)]() mutable {
-            _onGetGroupNodeInfo(nullptr, groupNodeInfo);
-        });
-    }
+    co_return std::make_tuple(nullptr, std::move(groupNodeInfo));
 }
 
 /**
@@ -426,15 +419,28 @@ std::string FrontService::registerCallback(
 }
 
 /**
- * @brief: send response
+ * @brief: (coroutine) send response
  * @param _id: the request uuid
- * @param _data: message
- * @return void
+ * @param _data: message (a view kept alive by the caller for the duration of the co_await)
+ * @return error: nullptr on success, the gateway send failure otherwise
  */
-void FrontService::asyncSendResponse(const std::string& _id, int _moduleID,
-    bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback)
+task::Task<Error::Ptr> FrontService::sendResponse(const std::string& _id, int _moduleID,
+    bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data)
 {
-    sendMessage(_moduleID, _nodeID, _id, _data, true, _receiveMsgCallback);
+    FrontMessage message;
+    message.setModuleID(_moduleID);
+    message.setUuid(bytesConstRef(reinterpret_cast<const bcos::byte*>(_id.data()), _id.size()));
+    message.setResponse();
+
+    // the header lives in this coroutine frame and the payload view is kept alive by the caller,
+    // so the gateway send below stays zero-copy
+    bytes header;
+    message.encodeHeader(header);
+
+    co_return co_await m_gatewayInterface->sendMessageByNodeID(m_groupID, _moduleID, m_nodeID,
+        std::move(_nodeID),
+        ::ranges::views::concat(::ranges::views::single(bcos::ref(std::as_const(header))),
+            ::ranges::views::single(_data)));
 }
 
 task::Task<void> FrontService::broadcastMessage(
@@ -452,7 +458,7 @@ task::Task<void> FrontService::broadcastMessage(
             ::ranges::views::single(bcos::ref(std::as_const(header))), std::move(payloads)));
 }
 
-void FrontService::asyncBroadcastMessageByOwnedPayload(
+void FrontService::broadcastMessageByOwnedPayload(
     uint16_t type, int moduleID, bytesPointer payload)
 {
     // FIB-185: enqueue the gateway broadcast onto the serial send queue and return immediately, so
@@ -474,7 +480,7 @@ void FrontService::asyncBroadcastMessageByOwnedPayload(
     });
 }
 
-void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
+void FrontService::sendMessageByNodeIDByOwnedPayload(
     int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
 {
     // FIB-185: enqueue the point-to-point send onto the serial queue and return immediately, so the
@@ -624,14 +630,13 @@ void FrontService::enqueueSend(std::function<void()> _sendTask)
 }
 
 /**
- * @brief: receive nodeIDs from gateway
+ * @brief: (coroutine) receive nodeIDs from gateway
  * @param _groupID: groupID
  * @param _groupNodeInfo: nodeIDs pushed by gateway
- * @param _receiveMsgCallback: response callback
- * @return void
+ * @return error: nullptr on success
  */
-void FrontService::onReceiveGroupNodeInfo(const std::string& _groupID,
-    bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo, ReceiveMsgFunc _receiveMsgCallback)
+task::Task<Error::Ptr> FrontService::onReceiveGroupNodeInfo(
+    std::string _groupID, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo)
 {
     {
         protocolNegotiate(_groupNodeInfo);
@@ -652,10 +657,7 @@ void FrontService::onReceiveGroupNodeInfo(const std::string& _groupID,
             }
         });
 
-    if (_receiveMsgCallback)
-    {
-        _receiveMsgCallback(nullptr);
-    }
+    co_return nullptr;
 }
 
 void FrontService::protocolNegotiate(bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo)
@@ -726,20 +728,25 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
     auto frontServiceWeakPtr = std::weak_ptr<FrontService>(
         std::static_pointer_cast<FrontService>(shared_from_this()));
     auto respFunc = [frontServiceWeakPtr, _moduleID, _nodeID, _uuid](bytesConstRef _data) {
-        auto frontService = frontServiceWeakPtr.lock();
-        if (frontService)
-        {
-            frontService->sendMessage(
-                _moduleID, _nodeID, _uuid, _data, true, [_uuid](const Error::Ptr& _error) {
-                    if (_error && (_error->errorCode() != CommonError::SUCCESS))
-                    {
-                        FRONT_LOG(ERROR)
-                            << LOG_BADGE("onReceiveMessage sendMessage callback")
-                            << LOG_KV("uuid", _uuid) << LOG_KV("code", _error->errorCode())
-                            << LOG_KV("message", _error->errorMessage());
-                    }
-                });
-        }
+        // the module hands us a transient view: copy it into the detached coroutine frame so the
+        // fire-and-forget response send never dangles
+        task::wait([](std::weak_ptr<FrontService> _weak, int moduleID,
+                       bcos::crypto::NodeIDPtr nodeID, std::string uuid,
+                       bytes data) -> task::Task<void> {
+            auto frontService = _weak.lock();
+            if (!frontService)
+            {
+                co_return;
+            }
+            auto error = co_await frontService->sendResponse(
+                uuid, moduleID, std::move(nodeID), bcos::ref(data));
+            if (error && (error->errorCode() != CommonError::SUCCESS))
+            {
+                FRONT_LOG(ERROR) << LOG_BADGE("onReceiveMessage sendMessage callback")
+                                 << LOG_KV("uuid", uuid) << LOG_KV("code", error->errorCode())
+                                 << LOG_KV("message", error->errorMessage());
+            }
+        }(frontServiceWeakPtr, _moduleID, _nodeID, _uuid, bytes(_data.begin(), _data.end())));
     };
     // cancel the timer first
     if (callback->timeoutHandler)
@@ -757,15 +764,14 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
     });
 }
 /**
- * @brief: receive message from gateway
+ * @brief: (coroutine) receive message from gateway
  * @param _groupID: groupID
  * @param _nodeID: the node send the message
- * @param _data: received message data
- * @param _receiveMsgCallback: response callback
- * @return void
+ * @param _data: received message data (a view kept alive by the caller until this task completes)
+ * @return error: nullptr on success
  */
-void FrontService::onReceiveMessage(const std::string& _groupID,
-    const bcos::crypto::NodeIDPtr& _nodeID, bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback)
+task::Task<Error::Ptr> FrontService::onReceiveMessage(
+    std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data)
 {
     try
     {
@@ -819,75 +825,20 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
                          << LOG_KV("failed", boost::diagnostic_information(e));
     }
 
-    if (_receiveMsgCallback)
-    {
-        dispatchTo(
-            *m_ioServicePool, [_receiveMsgCallback = std::move(_receiveMsgCallback)]() mutable {
-                _receiveMsgCallback(nullptr);
-            });
-    }
+    co_return nullptr;
 }
 
 /**
- * @brief: receive broadcast message from gateway
+ * @brief: (coroutine) receive broadcast message from gateway
  * @param _groupID: groupID
  * @param _nodeID: the node send the message
- * @param _data: received message data
- * @param _receiveMsgCallback: response callback
- * @return void
+ * @param _data: received message data (a view — same lifetime contract as onReceiveMessage)
+ * @return error: nullptr on success
  */
-void FrontService::onReceiveBroadcastMessage(const std::string& _groupID,
-    bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback)
+task::Task<Error::Ptr> FrontService::onReceiveBroadcastMessage(
+    std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data)
 {
-    onReceiveMessage(_groupID, _nodeID, _data, _receiveMsgCallback);
-}
-
-/**
- * @brief: send message
- * @param _moduleID: moduleID
- * @param _nodeID: the node the message sent to
- * @param _uuid: uuid identify this message
- * @param _data: send data payload
- * @param isResponse: if send response message
- * @param _receiveMsgCallback: response callback
- * @return void
- */
-void FrontService::sendMessage(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-    const std::string& _uuid, bytesConstRef _data, bool isResponse,
-    const ReceiveMsgFunc& _receiveMsgCallback)
-{
-    FrontMessage message;
-    message.setModuleID(_moduleID);
-    message.setUuid(bytesConstRef(reinterpret_cast<const bcos::byte*>(_uuid.data()), _uuid.size()));
-    if (isResponse)
-    {
-        message.setResponse();
-    }
-
-    // header + payload must both outlive the non-blocking task::wait: copy them into owned
-    // buffers held by the coroutine frame (sendMessage is the bridge from borrowed-callback APIs,
-    // so it cannot preserve zero-copy)
-    bytes header;
-    message.encodeHeader(header);
-
-    auto gateway = m_gatewayInterface;
-    auto hdr = std::make_shared<bytes>(std::move(header));
-    auto payload = std::make_shared<bytes>(_data.begin(), _data.end());
-    task::wait([](gateway::GatewayInterface::Ptr _gateway, std::string _groupID, int _moduleID,
-                   bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _nodeID,
-                   std::shared_ptr<bytes> _hdr, std::shared_ptr<bytes> _payload,
-                   ReceiveMsgFunc _receiveMsgCallback) -> task::Task<void> {
-        auto error = co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
-            std::move(_nodeID),
-            ::ranges::views::concat(::ranges::views::single(bcos::ref(std::as_const(*_hdr))),
-                ::ranges::views::single(
-                    bytesConstRef(_payload->data(), _payload->size()))));
-        if (_receiveMsgCallback)
-        {
-            _receiveMsgCallback(std::move(error));
-        }
-    }(gateway, m_groupID, _moduleID, m_nodeID, std::move(_nodeID), hdr, payload,
-        _receiveMsgCallback));
+    co_return co_await onReceiveMessage(std::move(_groupID), std::move(_nodeID), _data);
 }
 
 /**

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -823,6 +823,8 @@ task::Task<Error::Ptr> FrontService::onReceiveMessage(
     {
         FRONT_LOG(ERROR) << "onReceiveMessage"
                          << LOG_KV("failed", boost::diagnostic_information(e));
+        co_return BCOS_ERROR_PTR(
+            CommonError::MessageDecodeFailed, boost::diagnostic_information(e));
     }
 
     co_return nullptr;

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -773,9 +773,12 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
 task::Task<Error::Ptr> FrontService::onReceiveMessage(
     std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data)
 {
+    FrontMessage message;
+    // only the decode step maps to MessageDecodeFailed on the gateway ACK — anything raised
+    // later (response-callback handling, dispatcher posting onto a stopping io pool) is not a
+    // decode failure and must not be reported to the peer as one (Round-3 review finding)
     try
     {
-        FrontMessage message;
         auto ret = message.decode(_data);
         if (MessageDecodeStatus::MESSAGE_COMPLETE != ret)
         {
@@ -783,16 +786,26 @@ task::Task<Error::Ptr> FrontService::onReceiveMessage(
                              << LOG_KV("length", _data.size()) << LOG_KV("nodeID", m_nodeID->hex());
             BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment("illegal message"));
         }
+    }
+    catch (const std::exception& e)
+    {
+        FRONT_LOG(ERROR) << "onReceiveMessage"
+                         << LOG_KV("failed", boost::diagnostic_information(e));
+        co_return BCOS_ERROR_PTR(
+            CommonError::MessageDecodeFailed, boost::diagnostic_information(e));
+    }
 
-        int moduleID = message.moduleID();
-        int ext = message.ext();
-        std::string uuid = std::string(message.uuid().begin(), message.uuid().end());
+    int moduleID = message.moduleID();
+    int ext = message.ext();
+    std::string uuid = std::string(message.uuid().begin(), message.uuid().end());
 
-        FRONT_LOG(TRACE) << LOG_BADGE("onReceiveMessage") << LOG_KV("moduleID", moduleID)
-                         << LOG_KV("uuid", uuid) << LOG_KV("ext", ext)
-                         << LOG_KV("groupID", _groupID) << LOG_KV("nodeID", _nodeID->hex())
-                         << LOG_KV("length", _data.size());
+    FRONT_LOG(TRACE) << LOG_BADGE("onReceiveMessage") << LOG_KV("moduleID", moduleID)
+                     << LOG_KV("uuid", uuid) << LOG_KV("ext", ext)
+                     << LOG_KV("groupID", _groupID) << LOG_KV("nodeID", _nodeID->hex())
+                     << LOG_KV("length", _data.size());
 
+    try
+    {
         if (message.isResponse())
         {
             handleCallback(nullptr, message.payload(), uuid, moduleID, _nodeID);
@@ -821,10 +834,10 @@ task::Task<Error::Ptr> FrontService::onReceiveMessage(
     }
     catch (const std::exception& e)
     {
-        FRONT_LOG(ERROR) << "onReceiveMessage"
+        // non-decode failure (e.g. shutdown ordering): log locally and ack success as before
+        // round-2 — it must not be mislabelled MessageDecodeFailed on the peer ACK
+        FRONT_LOG(ERROR) << "onReceiveMessage dispatch"
                          << LOG_KV("failed", boost::diagnostic_information(e));
-        co_return BCOS_ERROR_PTR(
-            CommonError::MessageDecodeFailed, boost::diagnostic_information(e));
     }
 
     co_return nullptr;

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -789,10 +789,9 @@ task::Task<Error::Ptr> FrontService::onReceiveMessage(
     }
     catch (const std::exception& e)
     {
-        FRONT_LOG(ERROR) << "onReceiveMessage"
-                         << LOG_KV("failed", boost::diagnostic_information(e));
-        co_return BCOS_ERROR_PTR(
-            CommonError::MessageDecodeFailed, boost::diagnostic_information(e));
+        auto detail = boost::diagnostic_information(e);
+        FRONT_LOG(ERROR) << "onReceiveMessage" << LOG_KV("failed", detail);
+        co_return BCOS_ERROR_PTR(CommonError::MessageDecodeFailed, std::move(detail));
     }
 
     int moduleID = message.moduleID();

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -65,7 +65,7 @@ public:
      * @param _data: message (a view kept alive by the caller for the duration of the co_await)
      * @return error: nullptr on success, the gateway send failure otherwise
      */
-    task::Task<Error::Ptr> sendResponse(const std::string& _id, int _moduleID,
+    task::Task<Error::Ptr> sendResponse(std::string _id, int _moduleID,
         bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) override;
 
     task::Task<void> broadcastMessage(

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -52,21 +52,21 @@ public:
     void checkParams();
 
     /**
-     * @brief: get nodeIDs from frontservice
-     * @param _onGetGroupNodeInfoFunc: response callback
-     * @return void
+     * @brief: (coroutine) get the latest groupNodeInfo the gateway pushed to this front
+     * @return {error, groupNodeInfo}: error is nullptr on success
      */
-    void asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInfoFunc) override;
+    task::Task<std::tuple<Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>> getGroupNodeInfo()
+        override;
     /**
-     * @brief: send response
+     * @brief: (coroutine) send response
      * @param _id: the request id
      * @param _moduleID: moduleID
      * @param _nodeID: the receiver nodeID
-     * @param _data: message
-     * @return void
+     * @param _data: message (a view kept alive by the caller for the duration of the co_await)
+     * @return error: nullptr on success, the gateway send failure otherwise
      */
-    void asyncSendResponse(const std::string& _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback) override;
+    task::Task<Error::Ptr> sendResponse(const std::string& _id, int _moduleID,
+        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) override;
 
     task::Task<void> broadcastMessage(
         uint16_t type, int moduleID,
@@ -85,61 +85,45 @@ public:
     // FIB-185: dispatch the gateway broadcast onto a serial send queue (off the caller thread) so a
     // caller holding a lock (PBFT under m_mutex) is not coupled to gateway session-lock contention.
     // The owned payload is captured by the queued task -> the message body is never copied.
-    void asyncBroadcastMessageByOwnedPayload(
+    void broadcastMessageByOwnedPayload(
         uint16_t type, int moduleID, bytesPointer payload) override;
 
     // FIB-185: dispatch the point-to-point gateway send onto the serial send queue (off the caller
     // thread), so sendViewChange / sendRecoverResponse run under m_mutex without contending the
     // gateway session lock. Point-to-point encodes the wire frame, so this is not zero-copy; the
     // owned payload is captured only to keep it alive across the deferred encode.
-    void asyncSendMessageByNodeIDByOwnedPayload(
+    void sendMessageByNodeIDByOwnedPayload(
         int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload) override;
 
     /**
-     * @brief: receive nodeIDs from gateway
+     * @brief: (coroutine) receive nodeIDs from gateway
      * @param _groupID: groupID
-     * @param _nodeIDs: nodeIDs pushed by gateway
-     * @param _receiveMsgCallback: response callback
-     * @return void
+     * @param _groupNodeInfo: nodeIDs pushed by gateway
+     * @return error: nullptr on success
      */
-    void onReceiveGroupNodeInfo(const std::string& _groupID,
-        bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo,
-        ReceiveMsgFunc _receiveMsgCallback) override;
+    task::Task<Error::Ptr> onReceiveGroupNodeInfo(std::string _groupID,
+        bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) override;
 
     /**
-     * @brief: receive message from gateway
+     * @brief: (coroutine) receive message from gateway
      * @param _groupID: groupID
      * @param _nodeID: the node send the message
-     * @param _data: received message data
-     * @param _receiveMsgCallback: response callback
-     * @return void
+     * @param _data: received message data (a view kept alive by the caller until the task
+     *        completes; the payload is copied before the deferred module dispatch)
+     * @return error: nullptr on success
      */
-    void onReceiveMessage(const std::string& _groupID, const bcos::crypto::NodeIDPtr& _nodeID,
-        bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback) override;
+    task::Task<Error::Ptr> onReceiveMessage(std::string _groupID,
+        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) override;
 
     /**
-     * @brief: receive broadcast message from gateway
+     * @brief: (coroutine) receive broadcast message from gateway
      * @param _groupID: groupID
      * @param _nodeID: the node send the message
-     * @param _data: received message data
-     * @param _receiveMsgCallback: response callback
-     * @return void
+     * @param _data: received message data (a view — same lifetime contract as onReceiveMessage)
+     * @return error: nullptr on success
      */
-    void onReceiveBroadcastMessage(const std::string& _groupID, bcos::crypto::NodeIDPtr _nodeID,
-        bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback) override;
-
-    /**
-     * @brief: send message
-     * @param _moduleID: moduleID
-     * @param _nodeID: the node the message sent to
-     * @param _uuid: uuid identify this message
-     * @param _data: send data payload
-     * @param isResponse: if send response message
-     * @param _receiveMsgCallback: response callback
-     * @return void
-     */
-    void sendMessage(int _moduleID, bcos::crypto::NodeIDPtr _nodeID, const std::string& _uuid,
-        bytesConstRef _data, bool isResponse, const ReceiveMsgFunc& _receiveMsgCallback);
+    task::Task<Error::Ptr> onReceiveBroadcastMessage(std::string _groupID,
+        bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data) override;
 
     /**
      * @brief: handle message timeout
@@ -218,8 +202,8 @@ protected:
     // gateway send.
     void enqueueSend(std::function<void()> _sendTask);
 
-    // shared uuid/timer/callback registration used by both asyncSendMessageByNodeID and the
-    // coroutine sendMessageByNodeID, so the uuid/timer/addCallback logic is not duplicated.
+    // shared uuid/timer/callback registration used by the coroutine sendMessageByNodeID, so the
+    // uuid/timer/addCallback logic is not duplicated.
     // Returns the generated uuid (used as the message id for the module-level response routing).
     std::string registerCallback(
         bcos::crypto::NodeIDPtr _nodeID, uint32_t _timeout, CallbackFunc _callbackFunc);

--- a/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
+++ b/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
@@ -7,8 +7,8 @@
  *        and, under TLS-churn, that lock is contended by session connect/disconnect; running the
  *        send on the caller thread (e.g. the PBFT consensus worker holding m_mutex) couples
  *        consensus to gateway lock contention and halts consensus. Both the broadcast
- *        (asyncBroadcastMessageByOwnedPayload, used by PBFT's prepare/commit/view-change
- *        broadcasts) and the point-to-point send (asyncSendMessageByNodeIDByOwnedPayload, used by
+ *        (broadcastMessageByOwnedPayload, used by PBFT's prepare/commit/view-change
+ *        broadcasts) and the point-to-point send (sendMessageByNodeIDByOwnedPayload, used by
  *        sendViewChange/sendRecoverResponse) hand the owned payload to a serial send queue and
  *        return immediately. These tests pin that: with a gateway whose send blocks, the caller
  *        returns promptly and the send runs on another thread.
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(asyncBroadcastByOwnedPayload_returnsWithoutBlockingOnGatewa
 
     auto callerThread = std::this_thread::get_id();
     auto startTime = utcSteadyTime();
-    front->asyncBroadcastMessageByOwnedPayload(static_cast<uint16_t>(1), /*moduleID*/ 111, payload);
+    front->broadcastMessageByOwnedPayload(static_cast<uint16_t>(1), /*moduleID*/ 111, payload);
     auto elapsed = utcSteadyTime() - startTime;
 
     // Deferred to the serial send queue: the caller returns promptly even though the gateway
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(asyncBroadcastByOwnedPayload_returnsWithoutBlockingOnGatewa
     front->stop();
 }
 
-BOOST_AUTO_TEST_CASE(asyncSendByNodeIDByOwnedPayload_returnsWithoutBlockingOnGatewaySend)
+BOOST_AUTO_TEST_CASE(sendByNodeIDByOwnedPayload_returnsWithoutBlockingOnGatewaySend)
 {
     auto gateway = std::make_shared<BlockingGateway>();
     auto front = buildFrontServiceWith(gateway);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(asyncSendByNodeIDByOwnedPayload_returnsWithoutBlockingOnGat
 
     auto callerThread = std::this_thread::get_id();
     auto startTime = utcSteadyTime();
-    front->asyncSendMessageByNodeIDByOwnedPayload(/*moduleID*/ 111, dstNodeID, payload);
+    front->sendMessageByNodeIDByOwnedPayload(/*moduleID*/ 111, dstNodeID, payload);
     auto elapsed = utcSteadyTime() - startTime;
 
     // Deferred to the serial send queue: the caller (PBFT under m_mutex, via sendViewChange /

--- a/bcos-front/test/unittests/FakeGateway.cpp
+++ b/bcos-front/test/unittests/FakeGateway.cpp
@@ -52,15 +52,15 @@ bcos::task::Task<bcos::Error::Ptr> bcos::front::test::FakeGateway::sendMessageBy
     {
         co_return m_sendError;
     }
+    Error::Ptr error = nullptr;
     if (auto frontService = m_frontService.lock())
     {
-        frontService->onReceiveMessage(
-            _groupID, _dstNodeID, bcos::ref(buffer), bcos::gateway::ErrorRespFunc());
+        error = co_await frontService->onReceiveMessage(_groupID, _dstNodeID, bcos::ref(buffer));
     }
 
     FRONT_LOG(DEBUG) << "[FakeGateway] sendMessageByNodeID" << LOG_KV("groupID", _groupID)
                      << LOG_KV("nodeID", _srcNodeID->hex()) << LOG_KV("nodeID", _dstNodeID->hex());
-    co_return nullptr;
+    co_return error;
 }
 bcos::task::Task<void> bcos::front::test::FakeGateway::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,
@@ -71,8 +71,14 @@ bcos::task::Task<void> bcos::front::test::FakeGateway::broadcastMessage(uint16_t
         const_cast<bcos::crypto::NodeID*>(std::addressof(srcNodeID)), [](auto* ptr) {});
     if (auto frontService = m_frontService.lock())
     {
-        frontService->onReceiveBroadcastMessage(
-            std::string{groupID}, nodeIDPtr, ref(data), ErrorRespFunc());
+        auto error = co_await frontService->onReceiveBroadcastMessage(
+            std::string{groupID}, nodeIDPtr, ref(data));
+        if (error)
+        {
+            FRONT_LOG(WARNING) << "onReceiveBroadcastMessage error"
+                               << LOG_KV("code", error->errorCode())
+                               << LOG_KV("msg", error->errorMessage());
+        }
     }
     FRONT_LOG(DEBUG) << "asyncSendBroadcastMessage" << LOG_KV("groupID", groupID);
     co_return;

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -81,6 +81,29 @@ BOOST_AUTO_TEST_CASE(testFrontService_buildFrontService)
     BOOST_CHECK(frontService->moduleID2MessageDispatcher().empty());
 }
 
+BOOST_AUTO_TEST_CASE(testFrontService_onReceiveMessage_decodeFailed)
+{
+    // Round-3 review (BLOCKING test gap): the fail-closed MessageDecodeFailed (1006) path added
+    // in round 2 must be pinned — a malformed/illegal frame is rejected with 1006 (which the
+    // gateway now ACKs to the sender), never ACKed as SUCCESS.
+    auto frontService = buildFrontService();
+    auto srcNodeID = createKey(g_srcNodeID);
+
+    // truncated / illegal frame
+    bcos::bytes garbage{'x', 'y', 'z'};
+    auto error = task::syncWait(
+        frontService->onReceiveMessage(g_groupID, srcNodeID, bcos::ref(garbage)));
+    BOOST_REQUIRE(error);
+    BOOST_CHECK_EQUAL(error->errorCode(), bcos::protocol::CommonError::MessageDecodeFailed);
+
+    // the broadcast entry delegates to onReceiveMessage, so it shares the same fail-closed path
+    auto broadcastError = task::syncWait(
+        frontService->onReceiveBroadcastMessage(g_groupID, srcNodeID, bcos::ref(garbage)));
+    BOOST_REQUIRE(broadcastError);
+    BOOST_CHECK_EQUAL(
+        broadcastError->errorCode(), bcos::protocol::CommonError::MessageDecodeFailed);
+}
+
 BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_fireAndForget)
 {
     auto frontService = buildFrontService();

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -161,8 +161,8 @@ BOOST_AUTO_TEST_CASE(testFrontService_onRecieveNodeIDsAnd)
 
     auto groupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>();
     groupNodeInfo->setNodeIDList(std::move(expectedNodeIDList));
-    frontService->onReceiveGroupNodeInfo(
-        "1", groupNodeInfo, [](Error::Ptr _error) { BOOST_CHECK(_error == nullptr); });
+    auto error = task::syncWait(frontService->onReceiveGroupNodeInfo("1", groupNodeInfo));
+    BOOST_CHECK(error == nullptr);
 
     // Use wait_for with timeout to avoid hanging indefinitely on CI
     auto status = f.wait_for(std::chrono::seconds(10));
@@ -175,15 +175,15 @@ BOOST_AUTO_TEST_CASE(testFrontService_onRecieveNodeIDsAnd)
     }
 }
 
-BOOST_AUTO_TEST_CASE(testFrontService_asyncSendResponse_coroutine)
+BOOST_AUTO_TEST_CASE(testFrontService_sendResponse_coroutine)
 {
     auto frontService = buildFrontService();
     auto dstNodeID = createKey(g_dstNodeID_0);
     std::string data(100000, '#');
     int moduleID = 12345;
 
-    // the module dispatcher replies through the (kept) asyncSendResponse API, which is now a thin
-    // wrapper over the coroutine sendMessage(isResponse=true)
+    // the module dispatcher replies through the coroutine sendResponse API; the detached task owns
+    // the id/nodeID/payload copies so the bytesConstRef view stays valid until the send completes
     auto resultPromise = std::make_shared<std::promise<SendResult>>();
     auto resultFuture = resultPromise->get_future();
     frontService->registerModuleMessageDispatcher(moduleID,
@@ -191,9 +191,14 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendResponse_coroutine)
             const std::string& _id, bytesConstRef _data) {
             (void)_nodeID;
             (void)_data;
-            frontService->asyncSendResponse(_id, moduleID, dstNodeID,
-                bytesConstRef((unsigned char*)data.data(), data.size()),
-                [](Error::Ptr _error) { (void)_error; });
+            task::wait([](decltype(frontService) _frontService, std::string _responseID,
+                           decltype(dstNodeID) _dstNodeID, int _moduleID,
+                           std::string _payload) -> task::Task<void> {
+                auto error = co_await _frontService->sendResponse(_responseID, _moduleID,
+                    _dstNodeID,
+                    bytesConstRef((unsigned char*)_payload.data(), _payload.size()));
+                (void)error;
+            }(frontService, _id, dstNodeID, moduleID, data));
         });
 
     auto self = frontService;
@@ -300,7 +305,7 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine_withResponse
     // Round-6 review finding 2 (test gap): the response-waiting coroutine path (_timeout > 0) was
     // never covered — the existing coroutine test passes _timeout == 0, which returns before the
     // SendResponseAwaitable is even constructed. This drives the real response path end-to-end:
-    // the module dispatcher receives the request and replies via sendMessage(isResponse=true), the
+    // the module dispatcher receives the request and replies via sendResponse, the
     // fake gateway loops the response back, and handleCallback completes the registered
     // SendResponseAwaitable, which resumes the suspended coroutine with the SendResult.
     auto frontService = buildFrontService();
@@ -323,10 +328,14 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine_withResponse
             // reply with an isResponse=true frame carrying the same uuid; the fake gateway loops
             // it back to onReceiveMessage, where message.isResponse() triggers handleCallback ->
             // SendResponseAwaitable::complete
-            frontService->sendMessage(moduleID, dstNodeID, _id,
-                bytesConstRef(reinterpret_cast<const bcos::byte*>(responsePayload.data()),
-                    responsePayload.size()),
-                true, nullptr);
+            auto fs = frontService;
+            task::wait([](decltype(fs) _frontService, int _moduleID,
+                           bcos::crypto::NodeIDPtr _dstNodeID, std::string _id,
+                           bcos::bytes _payload) -> task::Task<void> {
+                (void)co_await _frontService->sendResponse(
+                    _id, _moduleID, std::move(_dstNodeID), bcos::ref(_payload));
+            }(fs, moduleID, dstNodeID, _id,
+                bcos::bytes(responsePayload.begin(), responsePayload.end())));
         });
 
     auto self = frontService;

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -249,7 +249,7 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(
  * @return void
  */
 void Gateway::onReceiveP2PMessage(const std::string& _groupID, NodeIDPtr _srcNodeID,
-    NodeIDPtr _dstNodeID, bytesConstRef _payload, ErrorRespFunc _errorRespFunc)
+    NodeIDPtr _dstNodeID, std::shared_ptr<P2PMessage> _msg, ErrorRespFunc _errorRespFunc)
 {
     auto frontService =
         m_gatewayNodeManager->localRouterTable()->getFrontService(_groupID, _dstNodeID);
@@ -273,13 +273,13 @@ void Gateway::onReceiveP2PMessage(const std::string& _groupID, NodeIDPtr _srcNod
         return;
     }
 
-    // the payload view dies when this p2p handler returns; copy it into an owned coroutine
-    // parameter so it stays alive for the whole (possibly deferred) dispatch
+    // zero-copy: the owning P2PMessage is held by this coroutine frame for the whole (possibly
+    // deferred) dispatch, so the payload view into it stays valid until the task completes
     task::wait([](FrontServiceInfo::Ptr _frontServiceInfo, std::string _groupID,
-                   NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bcos::bytes _payload,
+                   NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, std::shared_ptr<P2PMessage> _msg,
                    ErrorRespFunc _errorRespFunc) -> task::Task<void> {
         auto error = co_await _frontServiceInfo->frontService()->onReceiveMessage(
-            _groupID, _srcNodeID, bcos::ref(_payload));
+            _groupID, _srcNodeID, _msg->payload());
         if (_errorRespFunc)
         {
             _errorRespFunc(error);
@@ -290,8 +290,8 @@ void Gateway::onReceiveP2PMessage(const std::string& _groupID, NodeIDPtr _srcNod
                            << LOG_KV("dstNodeID", _dstNodeID->hex())
                            << LOG_KV("code", (error ? error->errorCode() : 0))
                            << LOG_KV("msg", (error ? error->errorMessage() : ""));
-    }(frontService, _groupID, _srcNodeID, _dstNodeID,
-        bcos::bytes(_payload.begin(), _payload.end()), std::move(_errorRespFunc)));
+    }(frontService, _groupID, _srcNodeID, _dstNodeID, std::move(_msg),
+        std::move(_errorRespFunc)));
 }
 
 bool Gateway::checkGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo)
@@ -404,7 +404,7 @@ void Gateway::onReceiveP2PMessage(
     auto srcNodeIDPtr = m_gatewayNodeManager->keyFactory()->createKey(srcNodeID);
     auto dstNodeIDPtr = m_gatewayNodeManager->keyFactory()->createKey(dstNodeIDs[0]);
     auto gateway = std::weak_ptr<Gateway>(shared_from_this());
-    onReceiveP2PMessage(groupID, srcNodeIDPtr, dstNodeIDPtr, payload,
+    onReceiveP2PMessage(groupID, srcNodeIDPtr, dstNodeIDPtr, _msg,
         [groupID, moduleID, srcNodeIDPtr, dstNodeIDPtr, _session, _msg, gateway](
             Error::Ptr _error) {
             auto gatewayPtr = gateway.lock();
@@ -492,8 +492,8 @@ void Gateway::onReceiveBroadcastMessage(
         m_gatewayNodeManager->keyFactory()->createKey((_msg->options().srcNodeID()));
 
     auto type = _msg->ext();
-    m_gatewayNodeManager->localRouterTable()->broadcastMsg(type, groupID, moduleID,
-        srcNodeIDPtr, bytesConstRef(_msg->payload().data(), _msg->payload().size()));
+    m_gatewayNodeManager->localRouterTable()->broadcastMsg(
+        type, groupID, moduleID, srcNodeIDPtr, _msg);
 }
 
 void bcos::gateway::Gateway::enableReadOnlyMode()

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -202,6 +202,21 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(
             {
                 co_return nullptr;
             }
+            if (respCode == bcos::protocol::CommonError::MessageDecodeFailed)
+            {
+                // a receiver-side decode rejection is a property of the bytes, not of the route:
+                // re-sending the identical payload to another gateway cannot succeed, and
+                // reporting GatewaySendMsgFailed here would misdirect the diagnosis. Return the
+                // real code the destination front produced (Round-3 review finding).
+                GATEWAY_LOG(DEBUG) << LOG_BADGE("Gateway::sendMessageByNodeID")
+                                   << LOG_KV("p2pid", printShortP2pID(p2pID))
+                                   << LOG_KV("moduleID", _moduleID)
+                                   << LOG_KV("message",
+                                          "destination front failed to decode the message, "
+                                          "terminal");
+                co_return BCOS_ERROR_PTR(bcos::protocol::CommonError::MessageDecodeFailed,
+                    "the destination front failed to decode the message");
+            }
             GATEWAY_LOG(DEBUG) << LOG_BADGE("Gateway::sendMessageByNodeID")
                                << LOG_KV("p2pid", printShortP2pID(p2pID))
                                << LOG_KV("moduleID", _moduleID) << LOG_KV("code", respCode)

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -149,73 +149,13 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(
         {
             buffer.insert(buffer.end(), data.begin(), data.end());
         }
-        // Local delivery is asynchronous (the front's onReceiveMessage completes the callback);
-        // bridge it to the co_await so the delivery result is delivered as the return value.
-        struct LocalSendAwaitable
-        {
-            struct State
-            {
-                std::atomic<bool> done{false};
-                std::coroutine_handle<> handle;
-                Error::Ptr error;
-            };
-
-            LocalRouterTable* m_table;
-            std::string m_groupID;
-            bcos::crypto::NodeIDPtr m_srcNodeID;
-            bcos::crypto::NodeIDPtr m_dstNodeID;
-            std::shared_ptr<bcos::bytes> m_buffer;
-            std::shared_ptr<State> m_state;
-            // the io pool used to complete the coroutine OFF the caller's stack: the completion
-            // callback may run synchronously on the caller's own io thread (IOServicePool::dispatch
-            // executes inline when the current thread already belongs to the pool), and resuming
-            // the suspended coroutine from inside its own await_suspend is the exact hazard
-            // send()/drop() avoid by posting (FIB-185).
-            std::shared_ptr<ASIOInterface> m_asioInterface;
-
-            bool await_ready() const noexcept { return false; }
-            void await_suspend(std::coroutine_handle<> h)
-            {
-                m_state->handle = h;
-                auto state = m_state;
-                auto buffer = m_buffer;
-                auto asioInterface = m_asioInterface;
-                bool accepted = m_table->sendMessage(m_groupID, m_srcNodeID, m_dstNodeID,
-                    bcos::ref(*buffer),
-                    [state, buffer, asioInterface](Error::Ptr _error) {
-                        // completes exactly once; the buffer is kept alive until after the resume
-                        // (the borrowed front may still be reading it). Post the resume off this
-                        // stack — the callback may run inline on the caller's io thread.
-                        if (!state->done.exchange(true))
-                        {
-                            state->error = std::move(_error);
-                            (void)buffer;
-                            asioInterface->post([state]() { state->handle.resume(); });
-                        }
-                    });
-                if (!accepted)
-                {
-                    // the destination front is not hosted locally: fail immediately
-                    if (!state->done.exchange(true))
-                    {
-                        state->error = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
-                            "could not find a gateway to send this message, groupID:" + m_groupID +
-                                " ,dstNodeID:" + m_dstNodeID->hex());
-                        asioInterface->post([state]() { state->handle.resume(); });
-                    }
-                }
-            }
-            Error::Ptr await_resume() { return std::move(m_state->error); }
-        };
         GATEWAY_LOG(DEBUG) << LOG_DESC("local delivery of sendMessageByNodeID")
                            << LOG_KV("groupID", _groupID)
                            << LOG_KV("srcNodeID", _srcNodeID->hex())
                            << LOG_KV("dstNodeID", _dstNodeID->hex());
-        co_return co_await LocalSendAwaitable{
-            m_gatewayNodeManager->localRouterTable().get(), _groupID, std::move(_srcNodeID),
-            std::move(_dstNodeID), std::make_shared<bcos::bytes>(std::move(buffer)),
-            std::make_shared<LocalSendAwaitable::State>(),
-            m_p2pInterface->host()->asioInterface()};
+        // the joined buffer lives in this frame, so the view stays valid across the co_await
+        co_return co_await m_gatewayNodeManager->localRouterTable()->sendMessage(
+            _groupID, std::move(_srcNodeID), std::move(_dstNodeID), bcos::ref(buffer));
     }
 
     // zero-copy: the message (header/options only) and the payload views both live in this frame
@@ -333,19 +273,25 @@ void Gateway::onReceiveP2PMessage(const std::string& _groupID, NodeIDPtr _srcNod
         return;
     }
 
-    frontService->frontService()->onReceiveMessage(_groupID, _srcNodeID, _payload,
-        [_groupID, _srcNodeID, _dstNodeID, _errorRespFunc](Error::Ptr _error) {
-            if (_errorRespFunc)
-            {
-                _errorRespFunc(_error);
-            }
-            GATEWAY_LOG(TRACE) << LOG_DESC("onReceiveP2PMessage callback")
-                               << LOG_KV("groupID", _groupID)
-                               << LOG_KV("srcNodeID", _srcNodeID->hex())
-                               << LOG_KV("dstNodeID", _dstNodeID->hex())
-                               << LOG_KV("code", (_error ? _error->errorCode() : 0))
-                               << LOG_KV("msg", (_error ? _error->errorMessage() : ""));
-        });
+    // the payload view dies when this p2p handler returns; copy it into an owned coroutine
+    // parameter so it stays alive for the whole (possibly deferred) dispatch
+    task::wait([](FrontServiceInfo::Ptr _frontServiceInfo, std::string _groupID,
+                   NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bcos::bytes _payload,
+                   ErrorRespFunc _errorRespFunc) -> task::Task<void> {
+        auto error = co_await _frontServiceInfo->frontService()->onReceiveMessage(
+            _groupID, _srcNodeID, bcos::ref(_payload));
+        if (_errorRespFunc)
+        {
+            _errorRespFunc(error);
+        }
+        GATEWAY_LOG(TRACE) << LOG_DESC("onReceiveP2PMessage callback")
+                           << LOG_KV("groupID", _groupID)
+                           << LOG_KV("srcNodeID", _srcNodeID->hex())
+                           << LOG_KV("dstNodeID", _dstNodeID->hex())
+                           << LOG_KV("code", (error ? error->errorCode() : 0))
+                           << LOG_KV("msg", (error ? error->errorMessage() : ""));
+    }(frontService, _groupID, _srcNodeID, _dstNodeID,
+        bcos::bytes(_payload.begin(), _payload.end()), std::move(_errorRespFunc)));
 }
 
 bool Gateway::checkGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo)
@@ -546,7 +492,7 @@ void Gateway::onReceiveBroadcastMessage(
         m_gatewayNodeManager->keyFactory()->createKey((_msg->options().srcNodeID()));
 
     auto type = _msg->ext();
-    m_gatewayNodeManager->localRouterTable()->asyncBroadcastMsg(type, groupID, moduleID,
+    m_gatewayNodeManager->localRouterTable()->broadcastMsg(type, groupID, moduleID,
         srcNodeIDPtr, bytesConstRef(_msg->payload().data(), _msg->payload().size()));
 }
 

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -89,13 +89,14 @@ public:
      * @param _groupID: groupID
      * @param _srcNodeID: the sender nodeID
      * @param _dstNodeID: the receiver nodeID
-     * @param _payload: message content
+     * @param _msg: the received p2p message, passed by ownership so its payload buffer stays
+     *        alive for the whole (possibly deferred) dispatch, keeping the dispatch zero-copy
      * @param _errorRespFunc: error func
      * @return void
      */
     virtual void onReceiveP2PMessage(const std::string& _groupID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        bytesConstRef _payload, ErrorRespFunc _errorRespFunc = ErrorRespFunc());
+        std::shared_ptr<P2PMessage> _msg, ErrorRespFunc _errorRespFunc = ErrorRespFunc());
 
     P2PInterface::Ptr p2pInterface() const;
     GatewayNodeManager::Ptr gatewayNodeManager();

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -442,17 +442,20 @@ void GatewayNodeManager::syncLatestNodeIDList()
                                << LOG_KV("nodeCount", groupNodeInfos->nodeIDList().size());
         for (const auto& entry : localNodeEntryPoints)
         {
-            entry.second->frontService()->onReceiveGroupNodeInfo(
-                groupID, groupNodeInfos, [](Error::Ptr _error) {
-                    if (!_error)
-                    {
-                        return;
-                    }
-                    NODE_MANAGER_LOG(WARNING)
-                        << LOG_DESC("syncLatestNodeIDList onReceiveGroupNodeInfo callback")
-                        << LOG_KV("codeCode", _error->errorCode())
-                        << LOG_KV("codeMessage", _error->errorMessage());
-                });
+            task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService,
+                           std::string _groupID,
+                           GroupNodeInfo::Ptr _groupNodeInfo) -> task::Task<void> {
+                auto error = co_await _frontService->onReceiveGroupNodeInfo(
+                    std::move(_groupID), std::move(_groupNodeInfo));
+                if (!error)
+                {
+                    co_return;
+                }
+                NODE_MANAGER_LOG(WARNING)
+                    << LOG_DESC("syncLatestNodeIDList onReceiveGroupNodeInfo callback")
+                    << LOG_KV("codeCode", error->errorCode())
+                    << LOG_KV("codeMessage", error->errorMessage());
+            }(entry.second->frontService(), groupID, groupNodeInfos));
         }
     }
 }

--- a/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.cpp
@@ -21,6 +21,7 @@
 #include "bcos-framework/protocol/CommonError.h"
 #include "bcos-framework/protocol/ServiceDesc.h"
 #include "bcos-gateway/Common.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-tars-protocol/client/FrontServiceClient.h"
 #include "fisco-bcos-tars-service/Common/TarsUtils.h"
 #include <bcos-task/Wait.h>
@@ -262,7 +263,7 @@ bool LocalRouterTable::eraseUnreachableNodes()
 }
 
 bool LocalRouterTable::broadcastMsg(uint16_t _nodeType, const std::string& _groupID,
-    uint16_t _moduleID, NodeIDPtr _srcNodeID, bytesConstRef _payload) const
+    uint16_t _moduleID, NodeIDPtr _srcNodeID, std::shared_ptr<P2PMessage> _msg) const
 {
     auto frontServiceList = getGroupFrontServiceList(_groupID);
     if (frontServiceList.empty())
@@ -270,6 +271,9 @@ bool LocalRouterTable::broadcastMsg(uint16_t _nodeType, const std::string& _grou
         return false;
     }
     auto srcNodeIDHex = _srcNodeID->hex();
+    // zero-copy: each dispatch task below owns the P2PMessage, so the payload view into it
+    // stays valid for the whole (possibly deferred) per-front dispatch
+    auto payloadSize = _msg->payload().size();
     for (auto const& it : frontServiceList)
     {
         if (it->nodeID() == srcNodeIDHex)
@@ -286,15 +290,13 @@ bool LocalRouterTable::broadcastMsg(uint16_t _nodeType, const std::string& _grou
         ROUTER_LOG(TRACE) << LOG_BADGE(
                                  "LocalRouterTable: dispatcher broadcast-type message to node")
                           << LOG_KV("type", _nodeType) << LOG_KV("groupID", _groupID)
-                          << LOG_KV("moduleID", _moduleID) << LOG_KV("payloadSize", _payload.size())
+                          << LOG_KV("moduleID", _moduleID) << LOG_KV("payloadSize", payloadSize)
                           << LOG_KV("dst", dstNodeID);
-        // the payload view dies when the p2p handler returns; copy it into an owned coroutine
-        // parameter so it stays alive for the whole (possibly deferred) dispatch
         task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService, std::string _groupID,
-                       uint16_t _moduleID, NodeIDPtr _srcNodeID, bcos::bytes _payload,
+                       uint16_t _moduleID, NodeIDPtr _srcNodeID, std::shared_ptr<P2PMessage> _msg,
                        std::string _dstNodeID) -> task::Task<void> {
             auto error =
-                co_await _frontService->onReceiveMessage(_groupID, _srcNodeID, bcos::ref(_payload));
+                co_await _frontService->onReceiveMessage(_groupID, _srcNodeID, _msg->payload());
             if (error)
             {
                 GATEWAY_LOG(ERROR) << LOG_DESC("ROUTER_LOG error") << LOG_KV("groupID", _groupID)
@@ -303,8 +305,7 @@ bool LocalRouterTable::broadcastMsg(uint16_t _nodeType, const std::string& _grou
                                    << LOG_KV("code", error->errorCode())
                                    << LOG_KV("msg", error->errorMessage());
             }
-        }(frontService, _groupID, _moduleID, _srcNodeID,
-            bcos::bytes(_payload.begin(), _payload.end()), dstNodeID));
+        }(frontService, _groupID, _moduleID, _srcNodeID, _msg, dstNodeID));
     }
     return true;
 }

--- a/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.cpp
@@ -18,10 +18,12 @@
  * @date 2021-12-29
  */
 #include "LocalRouterTable.h"
+#include "bcos-framework/protocol/CommonError.h"
 #include "bcos-framework/protocol/ServiceDesc.h"
 #include "bcos-gateway/Common.h"
 #include "bcos-tars-protocol/client/FrontServiceClient.h"
 #include "fisco-bcos-tars-service/Common/TarsUtils.h"
+#include <bcos-task/Wait.h>
 using namespace bcos;
 using namespace bcos::protocol;
 using namespace bcos::gateway;
@@ -259,7 +261,7 @@ bool LocalRouterTable::eraseUnreachableNodes()
     return updated;
 }
 
-bool LocalRouterTable::asyncBroadcastMsg(uint16_t _nodeType, const std::string& _groupID,
+bool LocalRouterTable::broadcastMsg(uint16_t _nodeType, const std::string& _groupID,
     uint16_t _moduleID, NodeIDPtr _srcNodeID, bytesConstRef _payload) const
 {
     auto frontServiceList = getGroupFrontServiceList(_groupID);
@@ -286,37 +288,39 @@ bool LocalRouterTable::asyncBroadcastMsg(uint16_t _nodeType, const std::string& 
                           << LOG_KV("type", _nodeType) << LOG_KV("groupID", _groupID)
                           << LOG_KV("moduleID", _moduleID) << LOG_KV("payloadSize", _payload.size())
                           << LOG_KV("dst", dstNodeID);
-        frontService->onReceiveMessage(_groupID, _srcNodeID, _payload,
-            [_groupID, _moduleID, _srcNodeID, dstNodeID](Error::Ptr _error) {
-                if (_error)
-                {
-                    GATEWAY_LOG(ERROR)
-                        << LOG_DESC("ROUTER_LOG error") << LOG_KV("groupID", _groupID)
-                        << LOG_KV("moduleID", _moduleID) << LOG_KV("src", _srcNodeID->hex())
-                        << LOG_KV("dst", dstNodeID) << LOG_KV("code", _error->errorCode())
-                        << LOG_KV("msg", _error->errorMessage());
-                }
-            });
+        // the payload view dies when the p2p handler returns; copy it into an owned coroutine
+        // parameter so it stays alive for the whole (possibly deferred) dispatch
+        task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService, std::string _groupID,
+                       uint16_t _moduleID, NodeIDPtr _srcNodeID, bcos::bytes _payload,
+                       std::string _dstNodeID) -> task::Task<void> {
+            auto error =
+                co_await _frontService->onReceiveMessage(_groupID, _srcNodeID, bcos::ref(_payload));
+            if (error)
+            {
+                GATEWAY_LOG(ERROR) << LOG_DESC("ROUTER_LOG error") << LOG_KV("groupID", _groupID)
+                                   << LOG_KV("moduleID", _moduleID)
+                                   << LOG_KV("src", _srcNodeID->hex()) << LOG_KV("dst", _dstNodeID)
+                                   << LOG_KV("code", error->errorCode())
+                                   << LOG_KV("msg", error->errorMessage());
+            }
+        }(frontService, _groupID, _moduleID, _srcNodeID,
+            bcos::bytes(_payload.begin(), _payload.end()), dstNodeID));
     }
     return true;
 }
 
 
 // send message to the local nodes
-bool LocalRouterTable::sendMessage(const std::string& _groupID, NodeIDPtr _srcNodeID,
-    NodeIDPtr _dstNodeID, bytesConstRef _payload, ErrorRespFunc _errorRespFunc)
+task::Task<bcos::Error::Ptr> LocalRouterTable::sendMessage(const std::string& _groupID,
+    NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bytesConstRef _payload)
 {
     auto frontServiceInfo = getFrontService(_groupID, _dstNodeID);
     if (!frontServiceInfo)
     {
-        return false;
+        co_return BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
+            "could not find a gateway to send this message, groupID:" + _groupID +
+                " ,dstNodeID:" + _dstNodeID->hex());
     }
-    frontServiceInfo->frontService()->onReceiveMessage(
-        _groupID, _srcNodeID, _payload, [_errorRespFunc](Error::Ptr _error) {
-            if (_errorRespFunc)
-            {
-                _errorRespFunc(_error);
-            }
-        });
-    return true;
+    co_return co_await frontServiceInfo->frontService()->onReceiveMessage(
+        _groupID, std::move(_srcNodeID), _payload);
 }

--- a/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.cpp
@@ -312,7 +312,7 @@ bool LocalRouterTable::broadcastMsg(uint16_t _nodeType, const std::string& _grou
 
 
 // send message to the local nodes
-task::Task<bcos::Error::Ptr> LocalRouterTable::sendMessage(const std::string& _groupID,
+task::Task<bcos::Error::Ptr> LocalRouterTable::sendMessage(std::string _groupID,
     NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bytesConstRef _payload)
 {
     auto frontServiceInfo = getFrontService(_groupID, _dstNodeID);

--- a/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.h
@@ -29,6 +29,8 @@ namespace bcos
 {
 namespace gateway
 {
+class P2PMessage;
+
 class LocalRouterTable
 {
 public:
@@ -57,7 +59,7 @@ public:
     GroupNodeListType nodeList() const;
 
     bool broadcastMsg(uint16_t _nodeType, const std::string& _groupID, uint16_t _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, bytesConstRef _payload) const;
+        bcos::crypto::NodeIDPtr _srcNodeID, std::shared_ptr<P2PMessage> _msg) const;
 
     task::Task<bcos::Error::Ptr> sendMessage(const std::string& _groupID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,

--- a/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.h
@@ -23,6 +23,7 @@
 #include "bcos-crypto/interfaces/crypto/KeyInterface.h"
 #include "bcos-framework/gateway/GatewayInterface.h"
 #include "bcos-framework/multigroup/GroupInfo.h"
+#include <bcos-task/Task.h>
 #include <memory>
 namespace bcos
 {
@@ -55,11 +56,12 @@ public:
     // groupID => nodeID => FrontServiceInfo
     GroupNodeListType nodeList() const;
 
-    bool asyncBroadcastMsg(uint16_t _nodeType, const std::string& _groupID, uint16_t _moduleID,
+    bool broadcastMsg(uint16_t _nodeType, const std::string& _groupID, uint16_t _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bytesConstRef _payload) const;
 
-    bool sendMessage(const std::string& _groupID, bcos::crypto::NodeIDPtr _srcNodeID,
-        bcos::crypto::NodeIDPtr _dstNodeID, bytesConstRef _payload, ErrorRespFunc _errorRespFunc);
+    task::Task<bcos::Error::Ptr> sendMessage(const std::string& _groupID,
+        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+        bytesConstRef _payload);
 
 private:
     bcos::crypto::KeyFactory::Ptr m_keyFactory;

--- a/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/LocalRouterTable.h
@@ -61,7 +61,7 @@ public:
     bool broadcastMsg(uint16_t _nodeType, const std::string& _groupID, uint16_t _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, std::shared_ptr<P2PMessage> _msg) const;
 
-    task::Task<bcos::Error::Ptr> sendMessage(const std::string& _groupID,
+    task::Task<bcos::Error::Ptr> sendMessage(std::string _groupID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
         bytesConstRef _payload);
 

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
@@ -291,7 +291,7 @@ bcos::task::Task<void> bcos::gateway::PeersRouterTable::broadcastMessage(uint16_
     {
         if (c_fileLogLevel <= TRACE) [[unlikely]]
         {
-            ROUTER_LOG(TRACE) << LOG_BADGE("PeersRouterTable") << LOG_DESC("asyncBroadcastMsg")
+            ROUTER_LOG(TRACE) << LOG_BADGE("PeersRouterTable") << LOG_DESC("broadcastMsg")
                               << LOG_KV("nodeType", type) << LOG_KV("moduleID", moduleID)
                               << LOG_KV("dst", printShortP2pID(peer));
         }

--- a/bcos-gateway/test/integtests/GatewayTest.cpp
+++ b/bcos-gateway/test/integtests/GatewayTest.cpp
@@ -54,8 +54,12 @@ std::vector<bcos::front::FrontService::Ptr> buildFrontServiceVector()
                 auto frontService = frontServiceWeakptr.lock();
                 if (frontService)
                 {
-                    frontService->asyncSendResponse(
-                        _id, bcos::protocol::ModuleID::AMOP, _nodeID, _data, [](Error::Ptr) {});
+                    task::wait([](std::shared_ptr<bcos::front::FrontService> _frontService,
+                                   std::string _responseID, bcos::crypto::NodeIDPtr _nodeID,
+                                   bcos::bytes _payload) -> task::Task<void> {
+                        co_await _frontService->sendResponse(_responseID,
+                            bcos::protocol::ModuleID::AMOP, _nodeID, bcos::ref(_payload));
+                    }(frontService, _id, _nodeID, bcos::bytes(_data.begin(), _data.end())));
                 }
             });
         frontServiceVector.push_back(frontService);
@@ -73,29 +77,27 @@ BOOST_AUTO_TEST_CASE(test_FrontServiceEcho)
     // echo test
     for (const auto& frontService : frontServiceVector)
     {
-        frontService->asyncGetGroupNodeInfo([frontService](Error::Ptr _error,
-                                                bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) {
-            BOOST_CHECK(_error == nullptr);
-            auto const& nodeIDs = _groupNodeInfo->nodeIDList();
-            BOOST_CHECK_EQUAL(nodeIDs.size(), nodeCount);
+        auto [error, groupNodeInfo] = task::syncWait(frontService->getGroupNodeInfo());
+        BOOST_CHECK(error == nullptr);
+        auto const& nodeIDs = groupNodeInfo->nodeIDList();
+        BOOST_CHECK_EQUAL(nodeIDs.size(), nodeCount);
 
-            for (const auto& nodeIDStr : nodeIDs)
-            {
-                auto nodeID = keyFactory->createKey(fromHex(nodeIDStr));
-                std::string sendStr = boost::uuids::to_string(boost::uuids::random_generator()());
+        for (const auto& nodeIDStr : nodeIDs)
+        {
+            auto nodeID = keyFactory->createKey(fromHex(nodeIDStr));
+            std::string sendStr = boost::uuids::to_string(boost::uuids::random_generator()());
 
-                auto payload = bcos::bytesConstRef((bcos::byte*)sendStr.data(), sendStr.size());
+            auto payload = bcos::bytesConstRef((bcos::byte*)sendStr.data(), sendStr.size());
 
-                auto result = task::syncWait(frontService->sendMessageByNodeID(
-                    bcos::protocol::ModuleID::AMOP, nodeID, ::ranges::views::single(payload),
-                    10000));
+            auto result = task::syncWait(frontService->sendMessageByNodeID(
+                bcos::protocol::ModuleID::AMOP, nodeID, ::ranges::views::single(payload),
+                10000));
 
-                BOOST_CHECK(!result.uuid.empty());
-                BOOST_CHECK(result.error == nullptr);
-                std::string retStr(result.payload.begin(), result.payload.end());
-                BOOST_CHECK_EQUAL(sendStr, retStr);
-            }
-        });
+            BOOST_CHECK(!result.uuid.empty());
+            BOOST_CHECK(result.error == nullptr);
+            std::string retStr(result.payload.begin(), result.payload.end());
+            BOOST_CHECK_EQUAL(sendStr, retStr);
+        }
     }
 }
 
@@ -106,29 +108,27 @@ BOOST_AUTO_TEST_CASE(test_FrontServiceTimeout)
     // echo test
     for (const auto& frontService : frontServiceVector)
     {
-        frontService->asyncGetGroupNodeInfo([frontService](Error::Ptr _error,
-                                                bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) {
-            BOOST_CHECK(_error == nullptr);
-            auto const& nodeIDs = _groupNodeInfo->nodeIDList();
-            BOOST_CHECK_EQUAL(nodeIDs.size(), nodeCount);
+        auto [error, groupNodeInfo] = task::syncWait(frontService->getGroupNodeInfo());
+        BOOST_CHECK(error == nullptr);
+        auto const& nodeIDs = groupNodeInfo->nodeIDList();
+        BOOST_CHECK_EQUAL(nodeIDs.size(), nodeCount);
 
-            for (const auto& nodeIDStr : nodeIDs)
-            {
-                auto nodeID = keyFactory->createKey(fromHex(nodeIDStr));
-                std::string sendStr = boost::uuids::to_string(boost::uuids::random_generator()());
+        for (const auto& nodeIDStr : nodeIDs)
+        {
+            auto nodeID = keyFactory->createKey(fromHex(nodeIDStr));
+            std::string sendStr = boost::uuids::to_string(boost::uuids::random_generator()());
 
-                auto payload = bcos::bytesConstRef((bcos::byte*)sendStr.data(), sendStr.size());
+            auto payload = bcos::bytesConstRef((bcos::byte*)sendStr.data(), sendStr.size());
 
-                auto result = task::syncWait(frontService->sendMessageByNodeID(
-                    bcos::protocol::ModuleID::AMOP + 1, nodeID, ::ranges::views::single(payload),
-                    10000));
+            auto result = task::syncWait(frontService->sendMessageByNodeID(
+                bcos::protocol::ModuleID::AMOP + 1, nodeID, ::ranges::views::single(payload),
+                10000));
 
-                BOOST_CHECK(!result.uuid.empty());
-                BOOST_CHECK(result.error != nullptr);
-                BOOST_CHECK_EQUAL(
-                    result.error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
-            }
-        });
+            BOOST_CHECK(!result.uuid.empty());
+            BOOST_CHECK(result.error != nullptr);
+            BOOST_CHECK_EQUAL(
+                result.error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
+        }
     }
 }
 

--- a/bcos-gateway/test/main/main.cpp
+++ b/bcos-gateway/test/main/main.cpp
@@ -65,8 +65,12 @@ int main(int argc, const char** argv)
                     GATEWAY_MAIN_LOG(INFO)
                         << LOG_DESC("echo") << LOG_KV("to", _nodeID->hex())
                         << LOG_KV("content", std::string(_data.begin(), _data.end()));
-                    frontService->asyncSendResponse(
-                        _id, bcos::protocol::ModuleID::AMOP, _nodeID, _data, [](Error::Ptr) {});
+                    task::wait([](std::shared_ptr<bcos::front::FrontService> _frontService,
+                                   std::string _responseID, bcos::crypto::NodeIDPtr _nodeID,
+                                   bcos::bytes _payload) -> task::Task<void> {
+                        co_await _frontService->sendResponse(_responseID,
+                            bcos::protocol::ModuleID::AMOP, _nodeID, bcos::ref(_payload));
+                    }(frontService, _id, _nodeID, bcos::bytes(_data.begin(), _data.end())));
                 }
             });
         auto keyFactory = std::make_shared<bcos::crypto::KeyFactoryImpl>();
@@ -74,53 +78,50 @@ int main(int argc, const char** argv)
         {
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
-            frontService->asyncGetGroupNodeInfo(
-                [frontService, keyFactory](
-                    Error::Ptr _error, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) {
-                    (void)_error;
-                    if (!_groupNodeInfo || _groupNodeInfo->nodeIDList().empty())
-                    {
-                        return;
-                    }
-                    auto const& nodeIDs = _groupNodeInfo->nodeIDList();
-                    for (const auto& nodeIDStr : nodeIDs)
-                    {
-                        auto nodeID = keyFactory->createKey(fromHex(nodeIDStr));
-                        std::string randStr =
-                            boost::uuids::to_string(boost::uuids::random_generator()());
-                        GATEWAY_MAIN_LOG(INFO) << LOG_DESC("request") << LOG_KV("to", nodeID->hex())
-                                               << LOG_KV("content", randStr);
+            auto [error, groupNodeInfo] = task::syncWait(frontService->getGroupNodeInfo());
+            (void)error;
+            if (!groupNodeInfo || groupNodeInfo->nodeIDList().empty())
+            {
+                continue;
+            }
+            auto const& nodeIDs = groupNodeInfo->nodeIDList();
+            for (const auto& nodeIDStr : nodeIDs)
+            {
+                auto nodeID = keyFactory->createKey(fromHex(nodeIDStr));
+                std::string randStr = boost::uuids::to_string(boost::uuids::random_generator()());
+                GATEWAY_MAIN_LOG(INFO)
+                    << LOG_DESC("request") << LOG_KV("to", nodeID->hex())
+                    << LOG_KV("content", randStr);
 
-                        auto payload = bytesConstRef((bcos::byte*)randStr.data(), randStr.size());
+                auto payload = bytesConstRef((bcos::byte*)randStr.data(), randStr.size());
 
-                        auto result = task::syncWait(frontService->sendMessageByNodeID(
-                            bcos::protocol::ModuleID::AMOP, nodeID,
-                            ::ranges::views::single(payload), 10000));
+                auto result = task::syncWait(frontService->sendMessageByNodeID(
+                    bcos::protocol::ModuleID::AMOP, nodeID, ::ranges::views::single(payload),
+                    10000));
 
-                        if (result.error && (result.error->errorCode() != 0))
-                        {
-                            GATEWAY_MAIN_LOG(ERROR)
-                                << LOG_DESC("request error") << LOG_KV("to", nodeID->hex())
-                                << LOG_KV("id", result.uuid);
-                            continue;
-                        }
+                if (result.error && (result.error->errorCode() != 0))
+                {
+                    GATEWAY_MAIN_LOG(ERROR)
+                        << LOG_DESC("request error") << LOG_KV("to", nodeID->hex())
+                        << LOG_KV("id", result.uuid);
+                    continue;
+                }
 
-                        std::string retMsg(result.payload.begin(), result.payload.end());
-                        if (retMsg == randStr)
-                        {
-                            GATEWAY_MAIN_LOG(INFO)
-                                << LOG_DESC("response ok") << LOG_KV("from", nodeID->hex())
-                                << LOG_KV("id", result.uuid);
-                        }
-                        else
-                        {
-                            GATEWAY_MAIN_LOG(ERROR)
-                                << LOG_DESC("response error") << LOG_KV("from", nodeID->hex())
-                                << LOG_KV("id", result.uuid) << LOG_KV("req", randStr)
-                                << LOG_KV("rep", retMsg);
-                        }
-                    }
-                });
+                std::string retMsg(result.payload.begin(), result.payload.end());
+                if (retMsg == randStr)
+                {
+                    GATEWAY_MAIN_LOG(INFO)
+                        << LOG_DESC("response ok") << LOG_KV("from", nodeID->hex())
+                        << LOG_KV("id", result.uuid);
+                }
+                else
+                {
+                    GATEWAY_MAIN_LOG(ERROR)
+                        << LOG_DESC("response error") << LOG_KV("from", nodeID->hex())
+                        << LOG_KV("id", result.uuid) << LOG_KV("req", randStr)
+                        << LOG_KV("rep", retMsg);
+                }
+            }
         }
     }
     catch (const std::exception& e)

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
@@ -52,7 +52,7 @@ void PBFTCache::onCheckPointTimeout()
     auto encodedData = m_config->codec()->encode(checkPointMsg);
     // only broadcast message to consensus node
     // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
 }
 
@@ -245,7 +245,7 @@ bool PBFTCache::checkAndPreCommit()
     auto encodedData = m_config->codec()->encode(commitReq, m_config->pbftMsgDefaultVersion());
     // only broadcast message to consensus nodes
     // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     m_precommitted = true;
     // collect the commitReq and try to commit

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -830,7 +830,7 @@ NewViewMsgInterface::Ptr PBFTCacheProcessor::checkAndTryIntoNewView()
     auto encodedData = m_config->codec()->encode(newViewMsg);
     // only broadcast message to the consensus nodes
     // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     m_newViewGenerated = true;
     PBFT_LOG(INFO) << LOG_DESC("The next leader broadcast NewView request")

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -107,17 +107,21 @@ void PBFTEngine::initSendResponseHandler()
             {
                 return;
             }
-            frontService->asyncSendResponse(
-                _id, _moduleID, _dstNode, _data, [_id, _moduleID, _dstNode](Error::Ptr _error) {
-                    if (_error)
-                    {
-                        PBFT_LOG(TRACE) << LOG_DESC("sendResponse failed") << LOG_KV("uuid", _id)
-                                        << LOG_KV("module", std::to_string(_moduleID))
-                                        << LOG_KV("dst", _dstNode->shortHex())
-                                        << LOG_KV("code", _error->errorCode())
-                                        << LOG_KV("msg", _error->errorMessage());
-                    }
-                });
+            // fire-and-forget: the coroutine parameters own the payload copy so nothing
+            // dangles after task::wait detaches
+            task::wait([](FrontServiceInterface::Ptr _frontService, std::string _id, int _moduleID,
+                           NodeIDPtr _dstNode, bcos::bytes _payload) -> task::Task<void> {
+                auto error = co_await _frontService->sendResponse(
+                    _id, _moduleID, _dstNode, bcos::ref(_payload));
+                if (error)
+                {
+                    PBFT_LOG(TRACE) << LOG_DESC("sendResponse failed") << LOG_KV("uuid", _id)
+                                    << LOG_KV("module", std::to_string(_moduleID))
+                                    << LOG_KV("dst", _dstNode->shortHex())
+                                    << LOG_KV("code", error->errorCode())
+                                    << LOG_KV("msg", error->errorMessage());
+                }
+            }(frontService, _id, _moduleID, _dstNode, _data.toBytes()));
         }
         catch (std::exception const& e)
         {
@@ -330,7 +334,7 @@ void PBFTEngine::onProposalApplySuccess(
     auto encodedData = m_config->codec()->encode(checkPointMsg);
     // only broadcast message to the consensus nodes
     // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     auto startT = utcTime();
     auto recordT = utcTime();
@@ -482,7 +486,7 @@ void PBFTEngine::onRecvProposal(bool _containSysTxs, const protocol::Block& prop
                    << LOG_KV("encode(ms)", encodeEnd - encodeStart)
                    << LOG_KV("asyncSend(ms)", utcTime() - encodeEnd);
     // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
 
     // handle the pre-prepare packet
@@ -1337,7 +1341,7 @@ void PBFTEngine::broadcastPrepareMsg(PBFTMessageInterface::Ptr const& _prePrepar
                    << LOG_KV("index", _prePrepareMsg->index());
     // only broadcast to the consensus nodes
     // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     // try to precommit the message
     m_cacheProcessor->checkAndPreCommit();
@@ -1485,7 +1489,7 @@ void PBFTEngine::sendViewChange(bcos::crypto::NodeIDPtr _dstNode)
     // FIB-185: send off the m_mutex critical section via the owned-payload point-to-point entry
     // (the gateway session-lock acquire runs on the front's send queue, not on the consensus
     // worker)
-    m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+    m_config->frontService()->sendMessageByNodeIDByOwnedPayload(
         ModuleID::PBFT, std::move(_dstNode), std::move(encodedData));
     // collect the viewchangeReq
     m_cacheProcessor->addViewChangeReq(viewChangeReq);
@@ -1507,7 +1511,7 @@ void PBFTEngine::sendRecoverResponse(bcos::crypto::NodeIDPtr _dstNode)
     auto encodedData = m_config->codec()->encode(response);
     // FIB-185: send off the m_mutex critical section via the owned-payload point-to-point entry
     // (copy _dstNode; it is logged below). The gateway send runs on the front's send queue.
-    m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+    m_config->frontService()->sendMessageByNodeIDByOwnedPayload(
         ModuleID::PBFT, _dstNode, std::move(encodedData));
     PBFT_LOG(DEBUG) << LOG_DESC("sendRecoverResponse") << LOG_KV("peer", _dstNode->shortHex())
                     << m_config->printCurrentState();
@@ -1522,13 +1526,13 @@ void PBFTEngine::broadcastViewChangeReq()
     PBFT_LOG(INFO) << LOG_DESC("broadcastViewChangeReq") << printPBFTMsgInfo(viewChangeReq)
                    << LOG_KV("packetSize", encodedData->size());
     // FIB-185: this runs under m_mutex (onTimeout -> triggerTimeout holds it). Hand the owned
-    // payload to FrontService::asyncBroadcastMessageByOwnedPayload, which enqueues the gateway send
+    // payload to FrontService::broadcastMessageByOwnedPayload, which enqueues the gateway send
     // onto its serial send queue and returns immediately -- the gateway-session-lock-acquiring send
     // no longer runs on the consensus worker while m_mutex is held (the coupling that wedged
     // consensus under session-teardown churn is decoupled at the FrontService layer), and the owned
     // payload is forwarded without copying. The view-change cache mutations below stay under the
     // lock, unchanged.
-    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+    m_config->frontService()->broadcastMessageByOwnedPayload(
         bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
 
     // collect the viewchangeReq

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -134,17 +134,22 @@ void BlockSync::initSendResponseHandler()
             {
                 return;
             }
-            frontService->asyncSendResponse(
-                _id, _moduleID, _dstNode, _data, [_id, _moduleID, _dstNode](Error::Ptr _error) {
-                    if (_error)
-                    {
-                        BLKSYNC_LOG(TRACE) << LOG_DESC("sendResponse failed") << LOG_KV("uuid", _id)
-                                           << LOG_KV("module", std::to_string(_moduleID))
-                                           << LOG_KV("dst", _dstNode->shortHex())
-                                           << LOG_KV("code", _error->errorCode())
-                                           << LOG_KV("msg", _error->errorMessage());
-                    }
-                });
+            // fire-and-forget: the coroutine parameters own the payload copy so nothing
+            // dangles after task::wait detaches
+            task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService, std::string _id,
+                           int _moduleID, NodeIDPtr _dstNode,
+                           bcos::bytes _payload) -> task::Task<void> {
+                auto error = co_await _frontService->sendResponse(
+                    _id, _moduleID, _dstNode, bcos::ref(_payload));
+                if (error)
+                {
+                    BLKSYNC_LOG(TRACE) << LOG_DESC("sendResponse failed") << LOG_KV("uuid", _id)
+                                       << LOG_KV("module", std::to_string(_moduleID))
+                                       << LOG_KV("dst", _dstNode->shortHex())
+                                       << LOG_KV("code", error->errorCode())
+                                       << LOG_KV("msg", error->errorMessage());
+                }
+            }(frontService, _id, _moduleID, _dstNode, _data.toBytes()));
         }
         catch (std::exception const& e)
         {
@@ -670,7 +675,7 @@ void BlockSync::requestBlocks(BlockNumber _from, BlockNumber _to, int32_t blockD
                 }
                 auto encodedData = blockRequest->encode();
                 // owned payload -> zero-copy through the front/gateway coroutine fast path
-                m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+                m_config->frontService()->sendMessageByNodeIDByOwnedPayload(
                     ModuleID::BlockSync, _p->nodeId(), std::move(encodedData));
 
                 m_maxRequestNumber = std::max(m_maxRequestNumber.load(), to);
@@ -883,7 +888,7 @@ void BlockSync::fetchAndSendBlock(
                 _block->encode(blockData);
                 blocksReq->appendBlockData(std::move(blockData));
                 blocksReq->setNumber(_number);
-                config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+                config->frontService()->sendMessageByNodeIDByOwnedPayload(
                     ModuleID::BlockSync, _peer, blocksReq->encode());
                 BLKSYNC_LOG(DEBUG)
                     << BLOCK_NUMBER(_number) << LOG_DESC("fetchAndSendBlock: response block")

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -10,8 +10,8 @@ bcostars::FrontServiceClient::FrontServiceClient(
 {}
 namespace
 {
-// shared awaitable for the Error-returning onReceive* RPCs: the Callback completes the coroutine
-// exactly once (via exchange) with the tars error converted to a bcos error
+// shared awaitable for the Error-returning RPCs (onReceive* and sendResponse): the Callback
+// completes the coroutine exactly once (via exchange) with the tars error converted to a bcos error
 struct ErrorAwaitable
 {
     struct CompletionState
@@ -47,6 +47,14 @@ struct ErrorAwaitable
             complete(bcostars::toBcosError(ret));
         }
         void callback_onReceiveBroadcastMessage_exception(tars::Int32 ret) override
+        {
+            complete(bcostars::toBcosError(ret));
+        }
+        void callback_asyncSendResponse(const bcostars::Error& ret) override
+        {
+            complete(bcostars::toBcosError(ret));
+        }
+        void callback_asyncSendResponse_exception(tars::Int32 ret) override
         {
             complete(bcostars::toBcosError(ret));
         }
@@ -288,11 +296,14 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::sendResponse(
     bcos::bytesConstRef _data)
 {
     auto nodeIDData = _nodeID->data();
-    // oneway RPC (no callback): marshal the arguments and fire
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->asyncSendResponse(_id, _moduleID, std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
-            std::vector<char>(_data.begin(), _data.end()));
-    co_return nullptr;
+    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+        [proxy = m_proxy, timeout = c_frontServiceTimeout, id = std::move(_id), _moduleID,
+            nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
+            data = std::vector<char>(_data.begin(), _data.end())](
+            FrontServicePrxCallback* callback) mutable {
+            proxy->tars_set_timeout(timeout)->async_asyncSendResponse(callback, id, _moduleID,
+                nodeID, data);
+        }};
 }
 bcos::task::Task<void> bcostars::FrontServiceClient::broadcastMessage(uint16_t _type,
     int _moduleID, ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -17,6 +17,14 @@ struct ErrorAwaitable
     struct CompletionState
     {
         std::atomic<bool> completed{false};
+        // true only while await_suspend is still executing: complete() must never resume the
+        // coroutine from inside await_suspend — resuming a coroutine that is still executing
+        // await_suspend is undefined behaviour. A synchronous completion (tars local reject /
+        // exception fired on the caller's stack before the request leaves it) only records the
+        // result here; await_suspend then observes the completed state and returns false, so the
+        // coroutine continues through await_resume on this stack instead of being resumed
+        // re-entrantly.
+        std::atomic<bool> inAwaitSuspend{false};
         std::coroutine_handle<> handle;
         bcos::Error::Ptr error;
     };
@@ -65,7 +73,13 @@ struct ErrorAwaitable
             if (!m_state->completed.exchange(true))
             {
                 m_state->error = std::move(error);
-                m_state->handle.resume();
+                // a completion arriving while await_suspend is still on this stack must not resume
+                // the coroutine re-entrantly (see CompletionState::inAwaitSuspend): await_suspend
+                // observes the completed state and returns false instead
+                if (!m_state->inAwaitSuspend.load(std::memory_order_acquire))
+                {
+                    m_state->handle.resume();
+                }
             }
         }
         std::shared_ptr<CompletionState> m_state;
@@ -77,10 +91,26 @@ struct ErrorAwaitable
 
     constexpr static bool await_ready() noexcept { return false; }
 
-    void await_suspend(std::coroutine_handle<> _handle)
+    // returns false (no suspension) if the RPC completed synchronously inside await_suspend, so
+    // the coroutine is never resumed from within await_suspend (undefined behaviour) — it then
+    // continues on this stack through await_resume. Returns true once the RPC is in flight and
+    // the completion callback will fire on the tars network thread.
+    bool await_suspend(std::coroutine_handle<> _handle)
     {
         m_state->handle = _handle;
-        m_invoker(new Callback(m_state));
+        m_state->inAwaitSuspend.store(true, std::memory_order_release);
+        try
+        {
+            m_invoker(new Callback(m_state));
+        }
+        catch (...)
+        {
+            // the RPC was never issued: clear the guard before the exception resumes the coroutine
+            m_state->inAwaitSuspend.store(false, std::memory_order_release);
+            throw;
+        }
+        m_state->inAwaitSuspend.store(false, std::memory_order_release);
+        return !m_state->completed.load(std::memory_order_acquire);
     }
 
     bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
@@ -95,6 +125,9 @@ bcostars::FrontServiceClient::getGroupNodeInfo()
         struct CompletionState
         {
             std::atomic<bool> completed{false};
+            // see ErrorAwaitable::CompletionState::inAwaitSuspend: complete() must not resume the
+            // coroutine from inside await_suspend
+            std::atomic<bool> inAwaitSuspend{false};
             std::coroutine_handle<> handle;
             bcos::Error::Ptr error;
             bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo;
@@ -125,7 +158,11 @@ bcostars::FrontServiceClient::getGroupNodeInfo()
                 {
                     m_state->error = std::move(error);
                     m_state->groupNodeInfo = std::move(groupNodeInfo);
-                    m_state->handle.resume();
+                    // see CompletionState::inAwaitSuspend: no resume from inside await_suspend
+                    if (!m_state->inAwaitSuspend.load(std::memory_order_acquire))
+                    {
+                        m_state->handle.resume();
+                    }
                 }
             }
             std::shared_ptr<CompletionState> m_state;
@@ -136,11 +173,24 @@ bcostars::FrontServiceClient::getGroupNodeInfo()
 
         constexpr static bool await_ready() noexcept { return false; }
 
-        void await_suspend(std::coroutine_handle<> _handle)
+        // see ErrorAwaitable::await_suspend for why this returns false on a synchronous
+        // completion instead of resuming from inside await_suspend
+        bool await_suspend(std::coroutine_handle<> _handle)
         {
             m_state->handle = _handle;
-            m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
-                ->async_asyncGetGroupNodeInfo(new Callback(m_state));
+            m_state->inAwaitSuspend.store(true, std::memory_order_release);
+            try
+            {
+                m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
+                    ->async_asyncGetGroupNodeInfo(new Callback(m_state));
+            }
+            catch (...)
+            {
+                m_state->inAwaitSuspend.store(false, std::memory_order_release);
+                throw;
+            }
+            m_state->inAwaitSuspend.store(false, std::memory_order_release);
+            return !m_state->completed.load(std::memory_order_acquire);
         }
 
         std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr> await_resume()
@@ -202,6 +252,9 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
         struct CompletionState
         {
             std::atomic<bool> completed{false};
+            // see ErrorAwaitable::CompletionState::inAwaitSuspend: complete() must not resume the
+            // coroutine from inside await_suspend
+            std::atomic<bool> inAwaitSuspend{false};
             std::coroutine_handle<> handle;
             bcos::front::SendResult result;
         };
@@ -209,8 +262,11 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
         class Callback : public FrontServicePrxCallback
         {
         public:
-            Callback(std::shared_ptr<CompletionState> state, FrontServiceClient* self)
-              : m_state(std::move(state)), m_self(self)
+            // owns the keyFactory across the RPC (the callback may fire on the tars network
+            // thread after the client would otherwise be gone): no raw FrontServiceClient* is held
+            Callback(std::shared_ptr<CompletionState> state,
+                bcos::crypto::KeyFactory::Ptr keyFactory)
+              : m_state(std::move(state)), m_keyFactory(std::move(keyFactory))
             {}
 
             void callback_asyncSendMessageByNodeID(const bcostars::Error& ret,
@@ -236,7 +292,7 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
                 result.error = toBcosError(ret);
                 if (!responseNodeID.empty())
                 {
-                    result.nodeID = m_self->m_keyFactory->createKey(bcos::bytesConstRef(
+                    result.nodeID = m_keyFactory->createKey(bcos::bytesConstRef(
                         (const bcos::byte*)responseNodeID.data(), responseNodeID.size()));
                 }
                 result.payload.assign(responseData.begin(), responseData.end());
@@ -249,12 +305,16 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
                 if (!m_state->completed.exchange(true))
                 {
                     m_state->result = std::move(result);
-                    m_state->handle.resume();
+                    // see CompletionState::inAwaitSuspend: no resume from inside await_suspend
+                    if (!m_state->inAwaitSuspend.load(std::memory_order_acquire))
+                    {
+                        m_state->handle.resume();
+                    }
                 }
             }
 
             std::shared_ptr<CompletionState> m_state;
-            FrontServiceClient* m_self;
+            bcos::crypto::KeyFactory::Ptr m_keyFactory;
         };
 
         FrontServiceClient* m_self;
@@ -266,15 +326,29 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
 
         constexpr static bool await_ready() noexcept { return false; }
 
-        void await_suspend(std::coroutine_handle<> _handle)
+        // see ErrorAwaitable::await_suspend for why this returns false on a synchronous
+        // completion instead of resuming from inside await_suspend
+        bool await_suspend(std::coroutine_handle<> _handle)
         {
             m_state->handle = _handle;
             auto state = m_state;
             auto nodeIDData = m_nodeID->data();
-            m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
-                ->async_asyncSendMessageByNodeID(new Callback(state, m_self), m_moduleID,
-                    std::vector<char>(nodeIDData.begin(), nodeIDData.end()), *m_buffer, m_timeout,
-                    (m_timeout > 0));
+            m_state->inAwaitSuspend.store(true, std::memory_order_release);
+            try
+            {
+                m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
+                    ->async_asyncSendMessageByNodeID(
+                        new Callback(state, m_self->m_keyFactory), m_moduleID,
+                        std::vector<char>(nodeIDData.begin(), nodeIDData.end()), *m_buffer,
+                        m_timeout, (m_timeout > 0));
+            }
+            catch (...)
+            {
+                m_state->inAwaitSuspend.store(false, std::memory_order_release);
+                throw;
+            }
+            m_state->inAwaitSuspend.store(false, std::memory_order_release);
+            return !m_state->completed.load(std::memory_order_acquire);
         }
 
         bcos::front::SendResult await_resume() { return std::move(m_state->result); }

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -8,142 +8,181 @@ bcostars::FrontServiceClient::FrontServiceClient(
     bcostars::FrontServicePrx proxy, bcos::crypto::KeyFactory::Ptr keyFactory)
   : m_proxy(proxy), m_keyFactory(keyFactory)
 {}
-void bcostars::FrontServiceClient::asyncGetGroupNodeInfo(
-    bcos::front::GetGroupNodeInfoFunc _onGetGroupNodeInfo)
+namespace
 {
-    class Callback : public FrontServicePrxCallback
+// shared awaitable for the Error-returning onReceive* RPCs: the Callback completes the coroutine
+// exactly once (via exchange) with the tars error converted to a bcos error
+struct ErrorAwaitable
+{
+    struct CompletionState
     {
-    public:
-        Callback(bcos::front::GetGroupNodeInfoFunc callback, FrontServiceClient* self)
-          : m_callback(callback)
-        {}
-        void callback_asyncGetGroupNodeInfo(
-            const bcostars::Error& ret, const GroupNodeInfo& groupNodeInfo) override
-        {
-            auto bcosGroupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
-                [m_groupNodeInfo = groupNodeInfo]() mutable { return &m_groupNodeInfo; });
-            m_callback(toBcosError(ret), bcosGroupNodeInfo);
-        }
-        void callback_asyncGetGroupNodeInfo_exception(tars::Int32 ret) override
-        {
-            m_callback(toBcosError(ret), nullptr);
-        }
-
-    private:
-        bcos::front::GetGroupNodeInfoFunc m_callback;
+        std::atomic<bool> completed{false};
+        std::coroutine_handle<> handle;
+        bcos::Error::Ptr error;
     };
 
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->async_asyncGetGroupNodeInfo(new Callback(_onGetGroupNodeInfo, this));
-}
-void bcostars::FrontServiceClient::onReceiveGroupNodeInfo(const std::string& _groupID,
-    bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo,
-    bcos::front::ReceiveMsgFunc _receiveMsgCallback)
-{
-    class Callback : public FrontServicePrxCallback
+    class Callback : public bcostars::FrontServicePrxCallback
     {
     public:
-        Callback(bcos::front::ReceiveMsgFunc callback) : m_callback(callback) {}
+        explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state)) {}
 
         void callback_onReceiveGroupNodeInfo(const bcostars::Error& ret) override
         {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(toBcosError(ret));
+            complete(bcostars::toBcosError(ret));
         }
-
         void callback_onReceiveGroupNodeInfo_exception(tars::Int32 ret) override
         {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(toBcosError(ret));
+            complete(bcostars::toBcosError(ret));
+        }
+        void callback_onReceiveMessage(const bcostars::Error& ret) override
+        {
+            complete(bcostars::toBcosError(ret));
+        }
+        void callback_onReceiveMessage_exception(tars::Int32 ret) override
+        {
+            complete(bcostars::toBcosError(ret));
+        }
+        void callback_onReceiveBroadcastMessage(const bcostars::Error& ret) override
+        {
+            complete(bcostars::toBcosError(ret));
+        }
+        void callback_onReceiveBroadcastMessage_exception(tars::Int32 ret) override
+        {
+            complete(bcostars::toBcosError(ret));
         }
 
     private:
-        bcos::front::ReceiveMsgFunc m_callback;
+        void complete(bcos::Error::Ptr error)
+        {
+            if (!m_state->completed.exchange(true))
+            {
+                m_state->error = std::move(error);
+                m_state->handle.resume();
+            }
+        }
+        std::shared_ptr<CompletionState> m_state;
     };
+
+    std::shared_ptr<CompletionState> m_state;
+    // issues the RPC with the given callback (owns the marshaled arguments)
+    std::function<void(bcostars::FrontServicePrxCallback*)> m_invoker;
+
+    constexpr static bool await_ready() noexcept { return false; }
+
+    void await_suspend(std::coroutine_handle<> _handle)
+    {
+        m_state->handle = _handle;
+        m_invoker(new Callback(m_state));
+    }
+
+    bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
+};
+}  // namespace
+
+bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+bcostars::FrontServiceClient::getGroupNodeInfo()
+{
+    struct GetGroupNodeInfoAwaitable
+    {
+        struct CompletionState
+        {
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+            bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo;
+        };
+
+        class Callback : public FrontServicePrxCallback
+        {
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncGetGroupNodeInfo(
+                const bcostars::Error& ret, const GroupNodeInfo& groupNodeInfo) override
+            {
+                auto bcosGroupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
+                    [m_groupNodeInfo = groupNodeInfo]() mutable { return &m_groupNodeInfo; });
+                complete(toBcosError(ret), std::move(bcosGroupNodeInfo));
+            }
+            void callback_asyncGetGroupNodeInfo_exception(tars::Int32 ret) override
+            {
+                complete(toBcosError(ret), nullptr);
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error, bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->groupNodeInfo = std::move(groupNodeInfo);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        FrontServiceClient* m_self;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        void await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
+                ->async_asyncGetGroupNodeInfo(new Callback(m_state));
+        }
+
+        std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr> await_resume()
+        {
+            return std::make_tuple(std::move(m_state->error), std::move(m_state->groupNodeInfo));
+        }
+    };
+
+    GetGroupNodeInfoAwaitable awaitable{
+        this, std::make_shared<GetGroupNodeInfoAwaitable::CompletionState>()};
+    co_return co_await awaitable;
+}
+bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveGroupNodeInfo(
+    std::string _groupID, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo)
+{
     auto groupNodeInfoImpl =
         std::dynamic_pointer_cast<bcostars::protocol::GroupNodeInfoImpl>(_groupNodeInfo);
     auto tarsGroupNodeInfo = groupNodeInfoImpl->inner();
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->async_onReceiveGroupNodeInfo(
-            new Callback(_receiveMsgCallback), _groupID, tarsGroupNodeInfo);
+    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+        [proxy = m_proxy, timeout = c_frontServiceTimeout, groupID = std::move(_groupID),
+            tarsGroupNodeInfo](FrontServicePrxCallback* callback) mutable {
+            proxy->tars_set_timeout(timeout)
+                ->async_onReceiveGroupNodeInfo(callback, groupID, tarsGroupNodeInfo);
+        }};
 }
-void bcostars::FrontServiceClient::onReceiveMessage(const std::string& _groupID,
-    const bcos::crypto::NodeIDPtr& _nodeID, bcos::bytesConstRef _data,
-    bcos::front::ReceiveMsgFunc _receiveMsgCallback)
+bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveMessage(
+    std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data)
 {
-    class Callback : public FrontServicePrxCallback
-    {
-    public:
-        Callback(bcos::front::ReceiveMsgFunc callback) : m_callback(callback) {}
-
-        void callback_onReceiveMessage(const bcostars::Error& ret) override
-        {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(toBcosError(ret));
-        }
-
-        void callback_onReceiveMessage_exception(tars::Int32 ret) override
-        {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(toBcosError(ret));
-        }
-
-    private:
-        bcos::front::ReceiveMsgFunc m_callback;
-    };
     auto nodeIDData = _nodeID->data();
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->async_onReceiveMessage(new Callback(_receiveMsgCallback), _groupID,
-            std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
-            std::vector<char>(_data.begin(), _data.end()));
+    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+        [proxy = m_proxy, timeout = c_frontServiceTimeout, groupID = std::move(_groupID),
+            nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
+            data = std::vector<char>(_data.begin(), _data.end())](
+            FrontServicePrxCallback* callback) mutable {
+            proxy->tars_set_timeout(timeout)->async_onReceiveMessage(callback, groupID, nodeID,
+                data);
+        }};
 }
-void bcostars::FrontServiceClient::onReceiveBroadcastMessage(const std::string& _groupID,
-    bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data,
-    bcos::front::ReceiveMsgFunc _receiveMsgCallback)
+bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveBroadcastMessage(
+    std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data)
 {
-    class Callback : public FrontServicePrxCallback
-    {
-    public:
-        Callback(bcos::front::ReceiveMsgFunc callback) : m_callback(callback) {}
-
-        void callback_onReceiveBroadcastMessage(const bcostars::Error& ret) override
-        {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(toBcosError(ret));
-        }
-
-        void callback_onReceiveBroadcastMessage_exception(tars::Int32 ret) override
-        {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(toBcosError(ret));
-        }
-
-    private:
-        bcos::front::ReceiveMsgFunc m_callback;
-    };
     auto nodeIDData = _nodeID->data();
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->async_onReceiveBroadcastMessage(new Callback(_receiveMsgCallback), _groupID,
-            std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
-            std::vector<char>(_data.begin(), _data.end()));
+    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+        [proxy = m_proxy, timeout = c_frontServiceTimeout, groupID = std::move(_groupID),
+            nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
+            data = std::vector<char>(_data.begin(), _data.end())](
+            FrontServicePrxCallback* callback) mutable {
+            proxy->tars_set_timeout(timeout)
+                ->async_onReceiveBroadcastMessage(callback, groupID, nodeID, data);
+        }};
 }
 bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMessageByNodeID(
     int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
@@ -244,14 +283,16 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
         std::make_shared<SendAwaitable::CompletionState>()};
     co_return co_await awaitable;
 }
-void bcostars::FrontServiceClient::asyncSendResponse(const std::string& _id, int _moduleID,
-    bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data,
-    bcos::front::ReceiveMsgFunc _receiveMsgCallback)
+bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::sendResponse(
+    const std::string& _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+    bcos::bytesConstRef _data)
 {
     auto nodeIDData = _nodeID->data();
+    // oneway RPC (no callback): marshal the arguments and fire
     m_proxy->tars_set_timeout(c_frontServiceTimeout)
         ->asyncSendResponse(_id, _moduleID, std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
             std::vector<char>(_data.begin(), _data.end()));
+    co_return nullptr;
 }
 bcos::task::Task<void> bcostars::FrontServiceClient::broadcastMessage(uint16_t _type,
     int _moduleID, ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -284,7 +284,7 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
     co_return co_await awaitable;
 }
 bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::sendResponse(
-    const std::string& _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+    std::string _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
     bcos::bytesConstRef _data)
 {
     auto nodeIDData = _nodeID->data();

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -10,198 +10,183 @@ bcostars::FrontServiceClient::FrontServiceClient(
 {}
 namespace
 {
-// shared awaitable for the Error-returning RPCs (onReceive* and sendResponse): the Callback
-// completes the coroutine exactly once (via exchange) with the tars error converted to a bcos error
-struct ErrorAwaitable
+// One completion state machine for every front RPC. The tars PrxCallback completes the
+// coroutine exactly once (completed dedups the success/exception callback pair). A single
+// atomic rendezvous flag decides which side continues the coroutine: a completion that lands
+// before await_suspend's exchange (a synchronous tars reject/exception fired on the caller's
+// stack, or a fast reply) sets rendezvous first, so await_suspend observes it and returns false
+// and the coroutine continues through await_resume on this stack; a later completion finds
+// rendezvous already set and resumes. Neither side can both resume and decline to suspend, so
+// the coroutine is never resumed from inside await_suspend (undefined behaviour) and never runs
+// on two threads at once.
+template <class Result>
+struct TarsAwaitable
 {
     struct CompletionState
     {
         std::atomic<bool> completed{false};
-        // true only while await_suspend is still executing: complete() must never resume the
-        // coroutine from inside await_suspend — resuming a coroutine that is still executing
-        // await_suspend is undefined behaviour. A synchronous completion (tars local reject /
-        // exception fired on the caller's stack before the request leaves it) only records the
-        // result here; await_suspend then observes the completed state and returns false, so the
-        // coroutine continues through await_resume on this stack instead of being resumed
-        // re-entrantly.
-        std::atomic<bool> inAwaitSuspend{false};
+        std::atomic<bool> rendezvous{false};
         std::coroutine_handle<> handle;
-        bcos::Error::Ptr error;
+        Result result;
     };
 
     class Callback : public bcostars::FrontServicePrxCallback
     {
     public:
-        explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state)) {}
+        using OnError = std::function<Result(const bcostars::Error&)>;
+        using OnException = std::function<Result(tars::Int32)>;
+        using OnGroupNodeInfo =
+            std::function<Result(const bcostars::Error&, const bcostars::GroupNodeInfo&)>;
+        using OnSendResult = std::function<Result(const bcostars::Error&,
+            const std::vector<tars::Char>&, const std::vector<tars::Char>&, const std::string&)>;
+
+        // each call site wires only the converters of the RPC it issues; the rest stay empty and
+        // their overrides can only fire if the invoker issued a different RPC than configured
+        Callback(std::shared_ptr<CompletionState> state, OnError onError, OnException onException,
+            OnGroupNodeInfo onGroupNodeInfo, OnSendResult onSendResult)
+          : m_state(std::move(state)),
+            m_onError(std::move(onError)),
+            m_onException(std::move(onException)),
+            m_onGroupNodeInfo(std::move(onGroupNodeInfo)),
+            m_onSendResult(std::move(onSendResult))
+        {}
 
         void callback_onReceiveGroupNodeInfo(const bcostars::Error& ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onError(ret));
         }
         void callback_onReceiveGroupNodeInfo_exception(tars::Int32 ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onException(ret));
         }
         void callback_onReceiveMessage(const bcostars::Error& ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onError(ret));
         }
         void callback_onReceiveMessage_exception(tars::Int32 ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onException(ret));
         }
         void callback_onReceiveBroadcastMessage(const bcostars::Error& ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onError(ret));
         }
         void callback_onReceiveBroadcastMessage_exception(tars::Int32 ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onException(ret));
         }
         void callback_asyncSendResponse(const bcostars::Error& ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onError(ret));
         }
         void callback_asyncSendResponse_exception(tars::Int32 ret) override
         {
-            complete(bcostars::toBcosError(ret));
+            complete(m_onException(ret));
+        }
+        void callback_asyncGetGroupNodeInfo(
+            const bcostars::Error& ret, const bcostars::GroupNodeInfo& groupNodeInfo) override
+        {
+            complete(m_onGroupNodeInfo(ret, groupNodeInfo));
+        }
+        void callback_asyncGetGroupNodeInfo_exception(tars::Int32 ret) override
+        {
+            complete(m_onException(ret));
+        }
+        void callback_asyncSendMessageByNodeID(const bcostars::Error& ret,
+            const std::vector<tars::Char>& responseNodeID,
+            const std::vector<tars::Char>& responseData, const std::string& seq) override
+        {
+            complete(m_onSendResult(ret, responseNodeID, responseData, seq));
+        }
+        void callback_asyncSendMessageByNodeID_exception(tars::Int32 ret) override
+        {
+            complete(m_onException(ret));
         }
 
     private:
-        void complete(bcos::Error::Ptr error)
+        void complete(Result result)
         {
-            if (!m_state->completed.exchange(true))
+            if (!m_state->completed.exchange(true, std::memory_order_acq_rel))
             {
-                m_state->error = std::move(error);
-                // a completion arriving while await_suspend is still on this stack must not resume
-                // the coroutine re-entrantly (see CompletionState::inAwaitSuspend): await_suspend
-                // observes the completed state and returns false instead
-                if (!m_state->inAwaitSuspend.load(std::memory_order_acquire))
+                m_state->result = std::move(result);
+                // resume only when await_suspend has already exchanged: exactly one side
+                // continues the coroutine, and never from inside await_suspend
+                if (m_state->rendezvous.exchange(true, std::memory_order_acq_rel))
                 {
                     m_state->handle.resume();
                 }
             }
         }
+
         std::shared_ptr<CompletionState> m_state;
+        OnError m_onError;
+        OnException m_onException;
+        OnGroupNodeInfo m_onGroupNodeInfo;
+        OnSendResult m_onSendResult;
     };
 
+    // issues the RPC; adopts the callback at the tars call (release()), so a throw before the
+    // call cannot leak it
+    std::function<void(std::unique_ptr<bcostars::FrontServicePrxCallback>)> m_invoker;
     std::shared_ptr<CompletionState> m_state;
-    // issues the RPC with the given callback (owns the marshaled arguments)
-    std::function<void(bcostars::FrontServicePrxCallback*)> m_invoker;
+    typename Callback::OnError m_onError;
+    typename Callback::OnException m_onException;
+    typename Callback::OnGroupNodeInfo m_onGroupNodeInfo;
+    typename Callback::OnSendResult m_onSendResult;
 
     constexpr static bool await_ready() noexcept { return false; }
 
-    // returns false (no suspension) if the RPC completed synchronously inside await_suspend, so
-    // the coroutine is never resumed from within await_suspend (undefined behaviour) — it then
-    // continues on this stack through await_resume. Returns true once the RPC is in flight and
-    // the completion callback will fire on the tars network thread.
+    // returns false (no suspension) when the RPC completed synchronously inside await_suspend:
+    // the coroutine then continues on this stack through await_resume instead of being resumed
+    // re-entrantly from within await_suspend (undefined behaviour)
     bool await_suspend(std::coroutine_handle<> _handle)
     {
         m_state->handle = _handle;
-        m_state->inAwaitSuspend.store(true, std::memory_order_release);
         try
         {
-            m_invoker(new Callback(m_state));
+            m_invoker(std::make_unique<Callback>(
+                m_state, m_onError, m_onException, m_onGroupNodeInfo, m_onSendResult));
         }
         catch (...)
         {
-            // the RPC was never issued: clear the guard before the exception resumes the coroutine
-            m_state->inAwaitSuspend.store(false, std::memory_order_release);
+            // the RPC never left this stack and no callback can fire: swallow any late
+            // completion and let the exception resume the coroutine here
+            m_state->completed.store(true, std::memory_order_relaxed);
             throw;
         }
-        m_state->inAwaitSuspend.store(false, std::memory_order_release);
-        return !m_state->completed.load(std::memory_order_acquire);
+        // a completion that already landed set rendezvous first: do not suspend, continue
+        // through await_resume on this stack
+        return !m_state->rendezvous.exchange(true, std::memory_order_acq_rel);
     }
 
-    bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
+    Result await_resume() { return std::move(m_state->result); }
 };
+
+// the Error-returning RPCs (onReceive* and sendResponse): the tars error converts directly
+using ErrorAwaitable = TarsAwaitable<bcos::Error::Ptr>;
+using GetGroupNodeInfoAwaitable =
+    TarsAwaitable<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>;
+using SendAwaitable = TarsAwaitable<bcos::front::SendResult>;
 }  // namespace
 
 bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
 bcostars::FrontServiceClient::getGroupNodeInfo()
 {
-    struct GetGroupNodeInfoAwaitable
-    {
-        struct CompletionState
-        {
-            std::atomic<bool> completed{false};
-            // see ErrorAwaitable::CompletionState::inAwaitSuspend: complete() must not resume the
-            // coroutine from inside await_suspend
-            std::atomic<bool> inAwaitSuspend{false};
-            std::coroutine_handle<> handle;
-            bcos::Error::Ptr error;
-            bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo;
-        };
-
-        class Callback : public FrontServicePrxCallback
-        {
-        public:
-            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
-            {}
-
-            void callback_asyncGetGroupNodeInfo(
-                const bcostars::Error& ret, const GroupNodeInfo& groupNodeInfo) override
-            {
-                auto bcosGroupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
-                    [m_groupNodeInfo = groupNodeInfo]() mutable { return &m_groupNodeInfo; });
-                complete(toBcosError(ret), std::move(bcosGroupNodeInfo));
-            }
-            void callback_asyncGetGroupNodeInfo_exception(tars::Int32 ret) override
-            {
-                complete(toBcosError(ret), nullptr);
-            }
-
-        private:
-            void complete(bcos::Error::Ptr error, bcos::gateway::GroupNodeInfo::Ptr groupNodeInfo)
-            {
-                if (!m_state->completed.exchange(true))
-                {
-                    m_state->error = std::move(error);
-                    m_state->groupNodeInfo = std::move(groupNodeInfo);
-                    // see CompletionState::inAwaitSuspend: no resume from inside await_suspend
-                    if (!m_state->inAwaitSuspend.load(std::memory_order_acquire))
-                    {
-                        m_state->handle.resume();
-                    }
-                }
-            }
-            std::shared_ptr<CompletionState> m_state;
-        };
-
-        FrontServiceClient* m_self;
-        std::shared_ptr<CompletionState> m_state;
-
-        constexpr static bool await_ready() noexcept { return false; }
-
-        // see ErrorAwaitable::await_suspend for why this returns false on a synchronous
-        // completion instead of resuming from inside await_suspend
-        bool await_suspend(std::coroutine_handle<> _handle)
-        {
-            m_state->handle = _handle;
-            m_state->inAwaitSuspend.store(true, std::memory_order_release);
-            try
-            {
-                m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
-                    ->async_asyncGetGroupNodeInfo(new Callback(m_state));
-            }
-            catch (...)
-            {
-                m_state->inAwaitSuspend.store(false, std::memory_order_release);
-                throw;
-            }
-            m_state->inAwaitSuspend.store(false, std::memory_order_release);
-            return !m_state->completed.load(std::memory_order_acquire);
-        }
-
-        std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr> await_resume()
-        {
-            return std::make_tuple(std::move(m_state->error), std::move(m_state->groupNodeInfo));
-        }
-    };
-
-    GetGroupNodeInfoAwaitable awaitable{
-        this, std::make_shared<GetGroupNodeInfoAwaitable::CompletionState>()};
-    co_return co_await awaitable;
+    co_return co_await GetGroupNodeInfoAwaitable{
+        [proxy = m_proxy, timeout = c_frontServiceTimeout](
+            std::unique_ptr<FrontServicePrxCallback> callback) mutable {
+            proxy->tars_set_timeout(timeout)->async_asyncGetGroupNodeInfo(callback.release());
+        },
+        std::make_shared<GetGroupNodeInfoAwaitable::CompletionState>(), {},
+        [](tars::Int32 ret) -> std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr> {
+            return {bcostars::toBcosError(ret), nullptr};
+        },
+        [](const bcostars::Error& ret, const bcostars::GroupNodeInfo& groupNodeInfo) {
+            auto bcosGroupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
+                [m_groupNodeInfo = groupNodeInfo]() mutable { return &m_groupNodeInfo; });
+            return std::make_tuple(bcostars::toBcosError(ret), std::move(bcosGroupNodeInfo));
+        },
+        {}};
 }
 bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveGroupNodeInfo(
     std::string _groupID, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo)
@@ -209,175 +194,109 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveGroupN
     auto groupNodeInfoImpl =
         std::dynamic_pointer_cast<bcostars::protocol::GroupNodeInfoImpl>(_groupNodeInfo);
     auto tarsGroupNodeInfo = groupNodeInfoImpl->inner();
-    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+    co_return co_await ErrorAwaitable{
         [proxy = m_proxy, timeout = c_frontServiceTimeout, groupID = std::move(_groupID),
-            tarsGroupNodeInfo](FrontServicePrxCallback* callback) mutable {
+            tarsGroupNodeInfo](std::unique_ptr<FrontServicePrxCallback> callback) mutable {
             proxy->tars_set_timeout(timeout)
-                ->async_onReceiveGroupNodeInfo(callback, groupID, tarsGroupNodeInfo);
-        }};
+                ->async_onReceiveGroupNodeInfo(callback.release(), groupID, tarsGroupNodeInfo);
+        },
+        std::make_shared<ErrorAwaitable::CompletionState>(),
+        [](const bcostars::Error& ret) { return bcostars::toBcosError(ret); },
+        [](tars::Int32 ret) { return bcostars::toBcosError(ret); }, {}, {}};
 }
 bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveMessage(
     std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data)
 {
     auto nodeIDData = _nodeID->data();
-    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+    co_return co_await ErrorAwaitable{
         [proxy = m_proxy, timeout = c_frontServiceTimeout, groupID = std::move(_groupID),
             nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
             data = std::vector<char>(_data.begin(), _data.end())](
-            FrontServicePrxCallback* callback) mutable {
-            proxy->tars_set_timeout(timeout)->async_onReceiveMessage(callback, groupID, nodeID,
-                data);
-        }};
+            std::unique_ptr<FrontServicePrxCallback> callback) mutable {
+            proxy->tars_set_timeout(timeout)->async_onReceiveMessage(
+                callback.release(), groupID, nodeID, data);
+        },
+        std::make_shared<ErrorAwaitable::CompletionState>(),
+        [](const bcostars::Error& ret) { return bcostars::toBcosError(ret); },
+        [](tars::Int32 ret) { return bcostars::toBcosError(ret); }, {}, {}};
 }
 bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::onReceiveBroadcastMessage(
     std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data)
 {
     auto nodeIDData = _nodeID->data();
-    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+    co_return co_await ErrorAwaitable{
         [proxy = m_proxy, timeout = c_frontServiceTimeout, groupID = std::move(_groupID),
             nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
             data = std::vector<char>(_data.begin(), _data.end())](
-            FrontServicePrxCallback* callback) mutable {
+            std::unique_ptr<FrontServicePrxCallback> callback) mutable {
             proxy->tars_set_timeout(timeout)
-                ->async_onReceiveBroadcastMessage(callback, groupID, nodeID, data);
-        }};
+                ->async_onReceiveBroadcastMessage(callback.release(), groupID, nodeID, data);
+        },
+        std::make_shared<ErrorAwaitable::CompletionState>(),
+        [](const bcostars::Error& ret) { return bcostars::toBcosError(ret); },
+        [](tars::Int32 ret) { return bcostars::toBcosError(ret); }, {}, {}};
 }
 bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMessageByNodeID(
     int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
     ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> _payloads,
     uint32_t _timeout)
 {
-    struct SendAwaitable
-    {
-        struct CompletionState
-        {
-            std::atomic<bool> completed{false};
-            // see ErrorAwaitable::CompletionState::inAwaitSuspend: complete() must not resume the
-            // coroutine from inside await_suspend
-            std::atomic<bool> inAwaitSuspend{false};
-            std::coroutine_handle<> handle;
-            bcos::front::SendResult result;
-        };
-
-        class Callback : public FrontServicePrxCallback
-        {
-        public:
-            // owns the keyFactory across the RPC (the callback may fire on the tars network
-            // thread after the client would otherwise be gone): no raw FrontServiceClient* is held
-            Callback(std::shared_ptr<CompletionState> state,
-                bcos::crypto::KeyFactory::Ptr keyFactory)
-              : m_state(std::move(state)), m_keyFactory(std::move(keyFactory))
-            {}
-
-            void callback_asyncSendMessageByNodeID(const bcostars::Error& ret,
-                const std::vector<tars::Char>& responseNodeID,
-                const std::vector<tars::Char>& responseData, const std::string& seq) override
-            {
-                complete(ret, responseNodeID, responseData, seq);
-            }
-
-            void callback_asyncSendMessageByNodeID_exception(tars::Int32 ret) override
-            {
-                bcos::front::SendResult result;
-                result.error = toBcosError(ret);
-                completeResult(std::move(result));
-            }
-
-        private:
-            void complete(const bcostars::Error& ret,
-                const std::vector<tars::Char>& responseNodeID,
-                const std::vector<tars::Char>& responseData, const std::string& seq)
-            {
-                bcos::front::SendResult result;
-                result.error = toBcosError(ret);
-                if (!responseNodeID.empty())
-                {
-                    result.nodeID = m_keyFactory->createKey(bcos::bytesConstRef(
-                        (const bcos::byte*)responseNodeID.data(), responseNodeID.size()));
-                }
-                result.payload.assign(responseData.begin(), responseData.end());
-                result.uuid = seq;
-                completeResult(std::move(result));
-            }
-
-            void completeResult(bcos::front::SendResult result)
-            {
-                if (!m_state->completed.exchange(true))
-                {
-                    m_state->result = std::move(result);
-                    // see CompletionState::inAwaitSuspend: no resume from inside await_suspend
-                    if (!m_state->inAwaitSuspend.load(std::memory_order_acquire))
-                    {
-                        m_state->handle.resume();
-                    }
-                }
-            }
-
-            std::shared_ptr<CompletionState> m_state;
-            bcos::crypto::KeyFactory::Ptr m_keyFactory;
-        };
-
-        FrontServiceClient* m_self;
-        int m_moduleID;
-        bcos::crypto::NodeIDPtr m_nodeID;
-        std::shared_ptr<std::vector<char>> m_buffer;
-        uint32_t m_timeout;
-        std::shared_ptr<CompletionState> m_state;
-
-        constexpr static bool await_ready() noexcept { return false; }
-
-        // see ErrorAwaitable::await_suspend for why this returns false on a synchronous
-        // completion instead of resuming from inside await_suspend
-        bool await_suspend(std::coroutine_handle<> _handle)
-        {
-            m_state->handle = _handle;
-            auto state = m_state;
-            auto nodeIDData = m_nodeID->data();
-            m_state->inAwaitSuspend.store(true, std::memory_order_release);
-            try
-            {
-                m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
-                    ->async_asyncSendMessageByNodeID(
-                        new Callback(state, m_self->m_keyFactory), m_moduleID,
-                        std::vector<char>(nodeIDData.begin(), nodeIDData.end()), *m_buffer,
-                        m_timeout, (m_timeout > 0));
-            }
-            catch (...)
-            {
-                m_state->inAwaitSuspend.store(false, std::memory_order_release);
-                throw;
-            }
-            m_state->inAwaitSuspend.store(false, std::memory_order_release);
-            return !m_state->completed.load(std::memory_order_acquire);
-        }
-
-        bcos::front::SendResult await_resume() { return std::move(m_state->result); }
-    };
-
     // materialise the joined payload directly as the std::vector<char> the RPC argument needs —
-    // a single pass and one allocation, no second copy in await_suspend
-    auto buffer = std::make_shared<std::vector<char>>();
+    // a single pass and one allocation
+    std::vector<char> buffer;
     for (auto const& data : _payloads)
     {
-        buffer->insert(buffer->end(), data.begin(), data.end());
+        buffer.insert(buffer.end(), data.begin(), data.end());
     }
-    SendAwaitable awaitable{this, _moduleID, std::move(_nodeID), std::move(buffer), _timeout,
-        std::make_shared<SendAwaitable::CompletionState>()};
-    co_return co_await awaitable;
+    auto nodeIDData = _nodeID->data();
+    co_return co_await SendAwaitable{
+        [proxy = m_proxy, timeout = c_frontServiceTimeout, _moduleID,
+            nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
+            buffer = std::move(buffer), _timeout](
+            std::unique_ptr<FrontServicePrxCallback> callback) mutable {
+            proxy->tars_set_timeout(timeout)->async_asyncSendMessageByNodeID(callback.release(),
+                _moduleID, nodeID, buffer, _timeout, (_timeout > 0));
+        },
+        std::make_shared<SendAwaitable::CompletionState>(), {},
+        [](tars::Int32 ret) {
+            bcos::front::SendResult result;
+            result.error = bcostars::toBcosError(ret);
+            return result;
+        },
+        {},
+        // owns the keyFactory across the RPC: the callback may fire on the tars network thread
+        // after the client would otherwise be gone
+        [keyFactory = m_keyFactory](const bcostars::Error& ret,
+            const std::vector<tars::Char>& responseNodeID,
+            const std::vector<tars::Char>& responseData, const std::string& seq) {
+            bcos::front::SendResult result;
+            result.error = bcostars::toBcosError(ret);
+            if (!responseNodeID.empty())
+            {
+                result.nodeID = keyFactory->createKey(bcos::bytesConstRef(
+                    (const bcos::byte*)responseNodeID.data(), responseNodeID.size()));
+            }
+            result.payload.assign(responseData.begin(), responseData.end());
+            result.uuid = seq;
+            return result;
+        }};
 }
 bcos::task::Task<bcos::Error::Ptr> bcostars::FrontServiceClient::sendResponse(
     std::string _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
     bcos::bytesConstRef _data)
 {
     auto nodeIDData = _nodeID->data();
-    co_return co_await ErrorAwaitable{std::make_shared<ErrorAwaitable::CompletionState>(),
+    co_return co_await ErrorAwaitable{
         [proxy = m_proxy, timeout = c_frontServiceTimeout, id = std::move(_id), _moduleID,
             nodeID = std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
             data = std::vector<char>(_data.begin(), _data.end())](
-            FrontServicePrxCallback* callback) mutable {
-            proxy->tars_set_timeout(timeout)->async_asyncSendResponse(callback, id, _moduleID,
-                nodeID, data);
-        }};
+            std::unique_ptr<FrontServicePrxCallback> callback) mutable {
+            proxy->tars_set_timeout(timeout)->async_asyncSendResponse(
+                callback.release(), id, _moduleID, nodeID, data);
+        },
+        std::make_shared<ErrorAwaitable::CompletionState>(),
+        [](const bcostars::Error& ret) { return bcostars::toBcosError(ret); },
+        [](tars::Int32 ret) { return bcostars::toBcosError(ret); }, {}, {}};
 }
 bcos::task::Task<void> bcostars::FrontServiceClient::broadcastMessage(uint16_t _type,
     int _moduleID, ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
@@ -30,7 +30,7 @@ public:
     bcos::task::Task<bcos::Error::Ptr> onReceiveBroadcastMessage(std::string _groupID,
         bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data) override;
 
-    bcos::task::Task<bcos::Error::Ptr> sendResponse(const std::string& _id, int _moduleID,
+    bcos::task::Task<bcos::Error::Ptr> sendResponse(std::string _id, int _moduleID,
         bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data) override;
 
     // (coroutine) send message to one node and await the module-level response via the

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
@@ -18,21 +18,20 @@ public:
 
     FrontServiceClient(bcostars::FrontServicePrx proxy, bcos::crypto::KeyFactory::Ptr keyFactory);
 
-    void asyncGetGroupNodeInfo(bcos::front::GetGroupNodeInfoFunc _onGetGroupNodeInfo) override;
+    bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
+    getGroupNodeInfo() override;
 
-    void onReceiveGroupNodeInfo(const std::string& _groupID,
-        bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo,
-        bcos::front::ReceiveMsgFunc _receiveMsgCallback) override;
+    bcos::task::Task<bcos::Error::Ptr> onReceiveGroupNodeInfo(
+        std::string _groupID, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) override;
 
-    void onReceiveMessage(const std::string& _groupID, const bcos::crypto::NodeIDPtr& _nodeID,
-        bcos::bytesConstRef _data, bcos::front::ReceiveMsgFunc _receiveMsgCallback) override;
+    bcos::task::Task<bcos::Error::Ptr> onReceiveMessage(
+        std::string _groupID, bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data) override;
 
-    // Note: the _receiveMsgCallback maybe null in some cases
-    void onReceiveBroadcastMessage(const std::string& _groupID, bcos::crypto::NodeIDPtr _nodeID,
-        bcos::bytesConstRef _data, bcos::front::ReceiveMsgFunc _receiveMsgCallback) override;
+    bcos::task::Task<bcos::Error::Ptr> onReceiveBroadcastMessage(std::string _groupID,
+        bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data) override;
 
-    void asyncSendResponse(const std::string& _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        bcos::bytesConstRef _data, bcos::front::ReceiveMsgFunc _receiveMsgCallback) override;
+    bcos::task::Task<bcos::Error::Ptr> sendResponse(const std::string& _id, int _moduleID,
+        bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data) override;
 
     // (coroutine) send message to one node and await the module-level response via the
     // front-service RPC

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -681,17 +681,22 @@ void TxPool::initSendResponseHandler()
             {
                 return;
             }
-            frontService->asyncSendResponse(
-                _id, _moduleID, _dstNode, _data, [_id, _moduleID, _dstNode](Error::Ptr _error) {
-                    if (_error)
-                    {
-                        TXPOOL_LOG(TRACE) << LOG_DESC("sendResponse failed") << LOG_KV("uuid", _id)
-                                          << LOG_KV("module", std::to_string(_moduleID))
-                                          << LOG_KV("dst", _dstNode->shortHex())
-                                          << LOG_KV("code", _error->errorCode())
-                                          << LOG_KV("msg", _error->errorMessage());
-                    }
-                });
+            // fire-and-forget: the coroutine parameters own the payload copy so nothing
+            // dangles after task::wait detaches
+            task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService, std::string _id,
+                           int _moduleID, NodeIDPtr _dstNode,
+                           bcos::bytes _payload) -> task::Task<void> {
+                auto error = co_await _frontService->sendResponse(
+                    _id, _moduleID, _dstNode, bcos::ref(_payload));
+                if (error)
+                {
+                    TXPOOL_LOG(TRACE) << LOG_DESC("sendResponse failed") << LOG_KV("uuid", _id)
+                                      << LOG_KV("module", std::to_string(_moduleID))
+                                      << LOG_KV("dst", _dstNode->shortHex())
+                                      << LOG_KV("code", error->errorCode())
+                                      << LOG_KV("msg", error->errorMessage());
+                }
+            }(frontService, _id, _moduleID, _dstNode, _data.toBytes()));
         }
         catch (std::exception const& e)
         {

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -556,7 +556,7 @@ void TransactionSync::responseTxsStatus(NodeIDPtr _fromNode)
     auto packetData = txsStatus->encode();
     auto packetSize = packetData->size();
     // owned payload -> zero-copy through the front/gateway coroutine fast path
-    m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+    m_config->frontService()->sendMessageByNodeIDByOwnedPayload(
         ModuleID::TxsSync, _fromNode, std::move(packetData));
     SYNC_LOG(DEBUG) << LOG_DESC("onPeerTxsStatus: receive empty txsStatus and responseTxsStatus")
                     << LOG_KV("to", _fromNode->shortHex()) << LOG_KV("txsSize", txsHash->size())

--- a/fisco-bcos-tars-service/FrontService/FrontServiceServer.cpp
+++ b/fisco-bcos-tars-service/FrontService/FrontServiceServer.cpp
@@ -11,21 +11,33 @@ bcostars::Error FrontServiceServer::asyncGetGroupNodeInfo(
 {
     current->setResponse(false);
 
-    m_frontServiceInitializer->front()->asyncGetGroupNodeInfo(
-        [current](bcos::Error::Ptr _error, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) {
+    bcos::task::wait([](auto _front, auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto [error, groupNodeInfo] = co_await _front->getGroupNodeInfo();
             // Note: the nodeIDs maybe null if no connections
-            std::vector<std::vector<char>> tarsNodeIDs;
-            if (!_groupNodeInfo)
+            if (!groupNodeInfo)
             {
                 async_response_asyncGetGroupNodeInfo(
-                    current, toTarsError(_error), bcostars::GroupNodeInfo());
-                return;
+                    _current, toTarsError(error), bcostars::GroupNodeInfo());
+                co_return;
             }
             auto groupInfoImpl =
-                std::dynamic_pointer_cast<bcostars::protocol::GroupNodeInfoImpl>(_groupNodeInfo);
+                std::dynamic_pointer_cast<bcostars::protocol::GroupNodeInfoImpl>(groupNodeInfo);
             async_response_asyncGetGroupNodeInfo(
-                current, toTarsError(_error), groupInfoImpl->inner());
-        });
+                _current, toTarsError(error), groupInfoImpl->inner());
+        }
+        catch (std::exception const& e)
+        {
+            // ensure the RPC is always answered: current->setResponse(false) already disabled the
+            // automatic reply, so an exception before async_response would leave the caller blocked
+            FRONTSERVICE_LOG(WARNING) << LOG_DESC("asyncGetGroupNodeInfo exception")
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_asyncGetGroupNodeInfo(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))),
+                bcostars::GroupNodeInfo());
+        }
+    }(m_frontServiceInitializer->front(), current));
 
     return bcostars::Error();
 }
@@ -149,13 +161,29 @@ bcostars::Error FrontServiceServer::asyncSendResponse(const std::string& id, tar
 {
     FRONTSERVICE_LOG(TRACE) << LOG_DESC("asyncSendResponse server") << LOG_KV("id", id);
     current->setResponse(false);
-    m_frontServiceInitializer->front()->asyncSendResponse(id, moduleID,
-        m_frontServiceInitializer->keyFactory()->createKey(
-            bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size())),
-        bcos::bytesConstRef((bcos::byte*)data.data(), data.size()),
-        [current](bcos::Error::Ptr error) {
-            async_response_asyncSendResponse(current, toTarsError(error));
-        });
+    auto bcosNodeID = m_frontServiceInitializer->keyFactory()->createKey(
+        bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size()));
+    // copy the payload into an owned coroutine parameter: the tars request buffer may not outlive
+    // the detached coroutine
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
+    bcos::task::wait([](auto _front, auto _id, auto _moduleID, auto _bcosNodeID, auto _payloadData,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _front->sendResponse(_id, _moduleID, _bcosNodeID,
+                bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size()));
+            async_response_asyncSendResponse(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            FRONTSERVICE_LOG(WARNING) << LOG_DESC("asyncSendResponse exception")
+                                      << LOG_KV("id", _id)
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_asyncSendResponse(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(m_frontServiceInitializer->front(), id, moduleID, bcosNodeID, payloadData, current));
     return bcostars::Error();
 }
 
@@ -164,13 +192,29 @@ bcostars::Error FrontServiceServer::onReceiveBroadcastMessage(const std::string&
 {
     current->setResponse(false);
 
-    m_frontServiceInitializer->front()->onReceiveBroadcastMessage(groupID,
-        m_frontServiceInitializer->keyFactory()->createKey(
-            bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size())),
-        bcos::bytesConstRef((bcos::byte*)data.data(), data.size()),
-        [current](bcos::Error::Ptr error) {
-            async_response_onReceiveBroadcastMessage(current, toTarsError(error));
-        });
+    auto bcosNodeID = m_frontServiceInitializer->keyFactory()->createKey(
+        bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size()));
+    // copy the tars request buffer into an owned coroutine parameter (it may not outlive the
+    // detached coroutine)
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
+    bcos::task::wait([](auto _front, auto _groupID, auto _bcosNodeID, auto _payloadData,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _front->onReceiveBroadcastMessage(_groupID, _bcosNodeID,
+                bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size()));
+            async_response_onReceiveBroadcastMessage(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            FRONTSERVICE_LOG(WARNING) << LOG_DESC("onReceiveBroadcastMessage exception")
+                                      << LOG_KV("groupID", _groupID)
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_onReceiveBroadcastMessage(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(m_frontServiceInitializer->front(), groupID, bcosNodeID, payloadData, current));
 
     return bcostars::Error();
 }
@@ -180,13 +224,29 @@ bcostars::Error FrontServiceServer::onReceiveMessage(const std::string& groupID,
 {
     current->setResponse(false);
 
-    m_frontServiceInitializer->front()->onReceiveMessage(groupID,
-        m_frontServiceInitializer->keyFactory()->createKey(
-            bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size())),
-        bcos::bytesConstRef((bcos::byte*)data.data(), data.size()),
-        [current](bcos::Error::Ptr error) {
-            async_response_onReceiveMessage(current, toTarsError(error));
-        });
+    auto bcosNodeID = m_frontServiceInitializer->keyFactory()->createKey(
+        bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size()));
+    // copy the tars request buffer into an owned coroutine parameter (it may not outlive the
+    // detached coroutine)
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
+    bcos::task::wait([](auto _front, auto _groupID, auto _bcosNodeID, auto _payloadData,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _front->onReceiveMessage(_groupID, _bcosNodeID,
+                bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size()));
+            async_response_onReceiveMessage(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            FRONTSERVICE_LOG(WARNING) << LOG_DESC("onReceiveMessage exception")
+                                      << LOG_KV("groupID", _groupID)
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_onReceiveMessage(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(m_frontServiceInitializer->front(), groupID, bcosNodeID, payloadData, current));
 
     return bcostars::Error();
 }
@@ -197,9 +257,21 @@ bcostars::Error FrontServiceServer::onReceiveGroupNodeInfo(const std::string& gr
     current->setResponse(false);
     auto bcosGroupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>(
         [m_groupNodeInfo = _groupNodeInfo]() mutable { return &m_groupNodeInfo; });
-    m_frontServiceInitializer->front()->onReceiveGroupNodeInfo(
-        groupID, bcosGroupNodeInfo, [current](bcos::Error::Ptr error) {
-            async_response_onReceiveGroupNodeInfo(current, toTarsError(error));
-        });
+    bcos::task::wait([](auto _front, auto _groupID, auto _bcosGroupNodeInfo,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _front->onReceiveGroupNodeInfo(_groupID, _bcosGroupNodeInfo);
+            async_response_onReceiveGroupNodeInfo(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            FRONTSERVICE_LOG(WARNING) << LOG_DESC("onReceiveGroupNodeInfo exception")
+                                      << LOG_KV("groupID", _groupID)
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_onReceiveGroupNodeInfo(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(m_frontServiceInitializer->front(), groupID, bcosGroupNodeInfo, current));
     return bcostars::Error();
 }

--- a/libinitializer/LightNodeInitializer.h
+++ b/libinitializer/LightNodeInitializer.h
@@ -80,9 +80,14 @@ public:
 
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    (void)co_await front->sendResponse(id,
+                    auto error = co_await front->sendResponse(id,
                         bcos::protocol::LIGHTNODE_GET_TRANSACTIONS, nodeID,
                         bcos::ref(responseBuffer));
+                    if (error)
+                    {
+                        LIGHTNODE_LOG(ERROR) << "send getTransactionsResponse failed "
+                                             << LOG_KV("id", id);
+                    }
                 }(ledger, front, std::move(nodeID), id, data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_GET_RECEIPTS,
@@ -116,9 +121,14 @@ public:
 
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    (void)co_await front->sendResponse(
+                    auto error = co_await front->sendResponse(
                         id, bcos::protocol::LIGHTNODE_GET_RECEIPTS, nodeID,
                         bcos::ref(responseBuffer));
+                    if (error)
+                    {
+                        LIGHTNODE_LOG(ERROR) << "send getReceiptsResponse failed "
+                                             << LOG_KV("id", id);
+                    }
                 }(ledger, weakFront, id, std::move(nodeID), data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_GET_STATUS,
@@ -152,8 +162,13 @@ public:
                     }
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    (void)co_await front->sendResponse(messageID,
+                    auto error = co_await front->sendResponse(messageID,
                         bcos::protocol::LIGHTNODE_GET_STATUS, nodeID, bcos::ref(responseBuffer));
+                    if (error)
+                    {
+                        LIGHTNODE_LOG(ERROR) << "send getStatusResponse failed "
+                                             << LOG_KV("id", messageID);
+                    }
                 }(ledger, std::move(front), std::move(nodeID), std::string(messageID), data));
             });
         front->registerModuleMessageDispatcher(
@@ -184,8 +199,12 @@ public:
                     }
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    (void)co_await front->sendResponse(
+                    auto error = co_await front->sendResponse(
                         id, bcos::protocol::LIGHTNODE_GET_ABI, nodeID, bcos::ref(responseBuffer));
+                    if (error)
+                    {
+                        LIGHTNODE_LOG(ERROR) << "send getABIResponse failed " << LOG_KV("id", id);
+                    }
                 }(ledger, std::move(front), std::move(nodeID), std::string(id), data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_SEND_TRANSACTION,
@@ -247,8 +266,13 @@ private:
             task::wait([](std::shared_ptr<bcos::front::FrontService> _front, std::string _id,
                            bcos::protocol::ModuleID _moduleID, bcos::crypto::NodeIDPtr _nodeID,
                            bcos::bytes _payload) -> task::Task<void> {
-                (void)co_await _front->sendResponse(
+                auto error = co_await _front->sendResponse(
                     _id, _moduleID, std::move(_nodeID), bcos::ref(_payload));
+                if (error)
+                {
+                    LIGHTNODE_LOG(ERROR) << "send decodeErrorResponse failed "
+                                         << LOG_KV("id", _id) << LOG_KV("moduleID", _moduleID);
+                }
             }(front, std::string(id), moduleID, std::move(nodeID), std::move(responseBuffer)));
         }
 
@@ -324,8 +348,12 @@ private:
         LIGHTNODE_LOG(INFO) << "Response submit transaction: " << id << " | "
                             << responseBuffer.size();
 
-        (void)co_await front->sendResponse(id, bcos::protocol::LIGHTNODE_SEND_TRANSACTION, nodeID,
-            bcos::ref(responseBuffer));
+        auto error = co_await front->sendResponse(
+            id, bcos::protocol::LIGHTNODE_SEND_TRANSACTION, nodeID, bcos::ref(responseBuffer));
+        if (error)
+        {
+            LIGHTNODE_LOG(ERROR) << "send sendTransactionResponse failed " << LOG_KV("id", id);
+        }
     }
 
     task::Task<void> call(std::shared_ptr<bcos::front::FrontService> front,
@@ -347,8 +375,12 @@ private:
 
         bcos::bytes responseBuffer;
         bcos::concepts::serialize::encode(response, responseBuffer);
-        (void)co_await front->sendResponse(
+        auto error = co_await front->sendResponse(
             id, bcos::protocol::LIGHTNODE_CALL, nodeID, bcos::ref(responseBuffer));
+        if (error)
+        {
+            LIGHTNODE_LOG(ERROR) << "send callResponse failed " << LOG_KV("id", id);
+        }
     }
 };
 }  // namespace bcos::initializer

--- a/libinitializer/LightNodeInitializer.h
+++ b/libinitializer/LightNodeInitializer.h
@@ -80,8 +80,8 @@ public:
 
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    front->asyncSendResponse(id, bcos::protocol::LIGHTNODE_GET_TRANSACTIONS, nodeID,
-                        bcos::ref(responseBuffer), []([[maybe_unused]] Error::Ptr _error) {});
+                    (void)co_await front->sendResponse(id, bcos::protocol::LIGHTNODE_GET_TRANSACTIONS,
+                        nodeID, bcos::ref(responseBuffer));
                 }(ledger, front, std::move(nodeID), id, data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_GET_RECEIPTS,
@@ -115,8 +115,8 @@ public:
 
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    front->asyncSendResponse(id, bcos::protocol::LIGHTNODE_GET_RECEIPTS, nodeID,
-                        bcos::ref(responseBuffer), {});
+                    (void)co_await front->sendResponse(
+                        id, bcos::protocol::LIGHTNODE_GET_RECEIPTS, nodeID, bcos::ref(responseBuffer));
                 }(ledger, weakFront, id, std::move(nodeID), data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_GET_STATUS,
@@ -150,9 +150,8 @@ public:
                     }
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    front->asyncSendResponse(messageID, bcos::protocol::LIGHTNODE_GET_STATUS,
-                        nodeID, bcos::ref(responseBuffer),
-                        []([[maybe_unused]] const Error::Ptr& error) {});
+                    (void)co_await front->sendResponse(messageID, bcos::protocol::LIGHTNODE_GET_STATUS,
+                        nodeID, bcos::ref(responseBuffer));
                 }(ledger, std::move(front), std::move(nodeID), std::string(messageID), data));
             });
         front->registerModuleMessageDispatcher(
@@ -183,8 +182,8 @@ public:
                     }
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    front->asyncSendResponse(id, bcos::protocol::LIGHTNODE_GET_ABI, nodeID,
-                        bcos::ref(responseBuffer), []([[maybe_unused]] const Error::Ptr& error) {});
+                    (void)co_await front->sendResponse(
+                        id, bcos::protocol::LIGHTNODE_GET_ABI, nodeID, bcos::ref(responseBuffer));
                 }(ledger, std::move(front), std::move(nodeID), std::string(id), data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_SEND_TRANSACTION,
@@ -241,8 +240,14 @@ private:
 
             bcos::bytes responseBuffer;
             bcos::concepts::serialize::encode(response, responseBuffer);
-            front->asyncSendResponse(
-                std::string(id), moduleID, nodeID, bcos::ref(responseBuffer), [](Error::Ptr) {});
+            // fire-and-forget bridge: the payload is moved into the coroutine as an owned copy
+            // so it stays alive after task::wait detaches
+            task::wait([](std::shared_ptr<bcos::front::FrontService> _front, std::string _id,
+                           bcos::protocol::ModuleID _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+                           bcos::bytes _payload) -> task::Task<void> {
+                (void)co_await _front->sendResponse(
+                    _id, _moduleID, std::move(_nodeID), bcos::ref(_payload));
+            }(front, std::string(id), moduleID, std::move(nodeID), std::move(responseBuffer)));
         }
 
         return success;
@@ -279,15 +284,14 @@ private:
         bcos::bytes responseBuffer;
         bcos::concepts::serialize::encode(response, responseBuffer);
         auto blockNumber = request.blockNumber;
-        front->asyncSendResponse(messageID, bcos::protocol::LIGHTNODE_GET_BLOCK, nodeID,
-            bcos::ref(responseBuffer), [blockNumber](Error::Ptr _error) {
-                if (_error)
-                {
-                    LIGHTNODE_LOG(ERROR)
-                        << "send getblockResponse failed " << LOG_KV("blockNumber", blockNumber);
-                }
-            });
-        LIGHTNODE_LOG(DEBUG) << "asyncSendResponse: sendResponseMessage to dstNode:"
+        auto error = co_await front->sendResponse(
+            messageID, bcos::protocol::LIGHTNODE_GET_BLOCK, nodeID, bcos::ref(responseBuffer));
+        if (error)
+        {
+            LIGHTNODE_LOG(ERROR)
+                << "send getblockResponse failed " << LOG_KV("blockNumber", blockNumber);
+        }
+        LIGHTNODE_LOG(DEBUG) << "sendResponse: sendResponseMessage to dstNode:"
                              << nodeID->hex() << LOG_KV("blockNUmber", blockNumber)
                              << LOG_KV("moduleID", bcos::protocol::LIGHTNODE_GET_BLOCK)
                              << LOG_KV("responseBuffer size", responseBuffer.size());
@@ -318,8 +322,8 @@ private:
         LIGHTNODE_LOG(INFO) << "Response submit transaction: " << id << " | "
                             << responseBuffer.size();
 
-        front->asyncSendResponse(id, bcos::protocol::LIGHTNODE_SEND_TRANSACTION, nodeID,
-            bcos::ref(responseBuffer), [](const Error::Ptr&) {});
+        (void)co_await front->sendResponse(id, bcos::protocol::LIGHTNODE_SEND_TRANSACTION, nodeID,
+            bcos::ref(responseBuffer));
     }
 
     task::Task<void> call(std::shared_ptr<bcos::front::FrontService> front,
@@ -341,8 +345,8 @@ private:
 
         bcos::bytes responseBuffer;
         bcos::concepts::serialize::encode(response, responseBuffer);
-        front->asyncSendResponse(id, bcos::protocol::LIGHTNODE_CALL, nodeID,
-            bcos::ref(responseBuffer), [](const Error::Ptr&) {});
+        (void)co_await front->sendResponse(
+            id, bcos::protocol::LIGHTNODE_CALL, nodeID, bcos::ref(responseBuffer));
     }
 };
 }  // namespace bcos::initializer

--- a/libinitializer/LightNodeInitializer.h
+++ b/libinitializer/LightNodeInitializer.h
@@ -48,8 +48,13 @@ public:
                 }
 
                 bcostars::RequestBlock request;
-                init->decodeRequest<bcostars::ResponseBlock>(
-                    request, front, protocol::LIGHTNODE_GET_BLOCK, nodeID, messageID, data);
+                // a decode failure already sent an error response inside decodeRequest: do not
+                // also run getBlock on the default-constructed request and send a second response
+                if (!init->decodeRequest<bcostars::ResponseBlock>(
+                        request, front, protocol::LIGHTNODE_GET_BLOCK, nodeID, messageID, data))
+                {
+                    return;
+                }
                 bcos::task::wait(init->getBlock(std::move(front), ledger, std::move(nodeID),
                     std::string(messageID), std::move(request)));
             });
@@ -217,8 +222,13 @@ public:
                     return;
                 }
                 bcostars::RequestSendTransaction request;
-                init->decodeRequest<bcostars::ResponseSendTransaction>(
-                    request, front, protocol::LIGHTNODE_SEND_TRANSACTION, nodeID, id, data);
+                // a decode failure already sent an error response inside decodeRequest: do not
+                // also submitTransaction on the default-constructed request
+                if (!init->decodeRequest<bcostars::ResponseSendTransaction>(request, front,
+                        protocol::LIGHTNODE_SEND_TRANSACTION, nodeID, id, data))
+                {
+                    return;
+                }
                 bcos::task::wait(init->submitTransaction(
                     front, transactionPool, nodeID, id, std::move(request)));
             });
@@ -234,8 +244,13 @@ public:
                 }
 
                 bcostars::RequestSendTransaction request;
-                init->decodeRequest<bcostars::ResponseSendTransaction>(
-                    request, front, protocol::LIGHTNODE_CALL, nodeID, id, data);
+                // a decode failure already sent an error response inside decodeRequest: do not
+                // also run call on the default-constructed request
+                if (!init->decodeRequest<bcostars::ResponseSendTransaction>(request, front,
+                        protocol::LIGHTNODE_CALL, nodeID, id, data))
+                {
+                    return;
+                }
                 bcos::task::wait(init->call(front, scheduler, nodeID, id, std::move(request)));
             });
     }

--- a/libinitializer/LightNodeInitializer.h
+++ b/libinitializer/LightNodeInitializer.h
@@ -80,8 +80,9 @@ public:
 
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    (void)co_await front->sendResponse(id, bcos::protocol::LIGHTNODE_GET_TRANSACTIONS,
-                        nodeID, bcos::ref(responseBuffer));
+                    (void)co_await front->sendResponse(id,
+                        bcos::protocol::LIGHTNODE_GET_TRANSACTIONS, nodeID,
+                        bcos::ref(responseBuffer));
                 }(ledger, front, std::move(nodeID), id, data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_GET_RECEIPTS,
@@ -116,7 +117,8 @@ public:
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
                     (void)co_await front->sendResponse(
-                        id, bcos::protocol::LIGHTNODE_GET_RECEIPTS, nodeID, bcos::ref(responseBuffer));
+                        id, bcos::protocol::LIGHTNODE_GET_RECEIPTS, nodeID,
+                        bcos::ref(responseBuffer));
                 }(ledger, weakFront, id, std::move(nodeID), data));
             });
         front->registerModuleMessageDispatcher(bcos::protocol::LIGHTNODE_GET_STATUS,
@@ -150,8 +152,8 @@ public:
                     }
                     bcos::bytes responseBuffer;
                     bcos::concepts::serialize::encode(response, responseBuffer);
-                    (void)co_await front->sendResponse(messageID, bcos::protocol::LIGHTNODE_GET_STATUS,
-                        nodeID, bcos::ref(responseBuffer));
+                    (void)co_await front->sendResponse(messageID,
+                        bcos::protocol::LIGHTNODE_GET_STATUS, nodeID, bcos::ref(responseBuffer));
                 }(ledger, std::move(front), std::move(nodeID), std::string(messageID), data));
             });
         front->registerModuleMessageDispatcher(

--- a/libinitializer/PBFTInitializer.cpp
+++ b/libinitializer/PBFTInitializer.cpp
@@ -532,53 +532,54 @@ void PBFTInitializer::syncGroupNodeInfo()
 {
     // Note: In air mode, the groupNodeInfo must be successful
     auto self = std::weak_ptr<PBFTInitializer>(shared_from_this());
-    m_frontService->asyncGetGroupNodeInfo(
-        [self](Error::Ptr _error, bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo) {
-            auto pbftInit = self.lock();
-            if (!pbftInit)
+    task::wait([](std::weak_ptr<PBFTInitializer> _self,
+                   front::FrontServiceInterface::Ptr _frontService) -> task::Task<void> {
+        auto pbftInit = _self.lock();
+        if (!pbftInit)
+        {
+            co_return;
+        }
+        auto [_error, _groupNodeInfo] = co_await _frontService->getGroupNodeInfo();
+        if (_error != nullptr)
+        {
+            INITIALIZER_LOG(WARNING)
+                << LOG_DESC("getGroupNodeInfo failed")
+                << LOG_KV("code", _error->errorCode()) << LOG_KV("msg", _error->errorMessage());
+            co_return;
+        }
+        try
+        {
+            if (!_groupNodeInfo || _groupNodeInfo->nodeIDList().empty())
             {
-                return;
+                co_return;
             }
-            if (_error != nullptr)
+            NodeIDSet nodeIdSet;
+            auto const& nodeIDList = _groupNodeInfo->nodeIDList();
+            if (nodeIDList.empty())
             {
-                INITIALIZER_LOG(WARNING)
-                    << LOG_DESC("asyncGetGroupNodeInfo failed")
-                    << LOG_KV("code", _error->errorCode()) << LOG_KV("msg", _error->errorMessage());
-                return;
+                co_return;
             }
-            try
+            for (auto const& nodeIDStr : nodeIDList)
             {
-                if (!_groupNodeInfo || _groupNodeInfo->nodeIDList().empty())
-                {
-                    return;
-                }
-                NodeIDSet nodeIdSet;
-                auto const& nodeIDList = _groupNodeInfo->nodeIDList();
-                if (nodeIDList.empty())
-                {
-                    return;
-                }
-                for (auto const& nodeIDStr : nodeIDList)
-                {
-                    auto nodeID =
-                        pbftInit->m_protocolInitializer->cryptoSuite()->keyFactory()->createKey(
-                            fromHex(nodeIDStr));
-                    nodeIdSet.insert(nodeID);
-                }
-                // the blockSync module set the connected node list
-                pbftInit->m_blockSync->config()->setConnectedNodeList(nodeIdSet);
-                // the txpool module set the connected node list
-                auto txpool = std::dynamic_pointer_cast<bcos::txpool::TxPool>(pbftInit->m_txpool);
-                INITIALIZER_LOG(INFO) << LOG_DESC("syncGroupNodeInfo for block sync and txpool")
-                                      << LOG_KV("connectedSize", nodeIdSet.size());
-                txpool->transactionSync()->config()->setConnectedNodeList(std::move(nodeIdSet));
+                auto nodeID =
+                    pbftInit->m_protocolInitializer->cryptoSuite()->keyFactory()->createKey(
+                        fromHex(nodeIDStr));
+                nodeIdSet.insert(nodeID);
             }
-            catch (std::exception const& e)
-            {
-                INITIALIZER_LOG(WARNING) << LOG_DESC("asyncGetGroupNodeInfo exception")
-                                         << LOG_KV("message", boost::diagnostic_information(e));
-            }
-        });
+            // the blockSync module set the connected node list
+            pbftInit->m_blockSync->config()->setConnectedNodeList(nodeIdSet);
+            // the txpool module set the connected node list
+            auto txpool = std::dynamic_pointer_cast<bcos::txpool::TxPool>(pbftInit->m_txpool);
+            INITIALIZER_LOG(INFO) << LOG_DESC("syncGroupNodeInfo for block sync and txpool")
+                                  << LOG_KV("connectedSize", nodeIdSet.size());
+            txpool->transactionSync()->config()->setConnectedNodeList(std::move(nodeIdSet));
+        }
+        catch (std::exception const& e)
+        {
+            INITIALIZER_LOG(WARNING) << LOG_DESC("getGroupNodeInfo exception")
+                                     << LOG_KV("message", boost::diagnostic_information(e));
+        }
+    }(self, m_frontService));
 }
 
 void PBFTInitializer::onGroupInfoChanged()


### PR DESCRIPTION
## 概述

本 PR 是网关/AMOP 网络路径协程化（#5519、#5541）的延续，将 **front（FrontService）层接口及全部实现/调用方**从「异步回调」风格整体收敛为「协程（`bcos-task`）」风格，删除残留的 `async*`/回调风格桥接，使模块间消息路径（front → gateway → p2p）在接口层面统一为单出口的协程调用。

共改动 27 个文件，+760 / −707。

## 接口变更（`bcos-framework/front/FrontServiceInterface.h`）

| 旧（回调式） | 新（协程式） |
| --- | --- |
| `asyncGetGroupNodeInfo(GetGroupNodeInfoFunc)` | `Task<tuple<Error::Ptr, GroupNodeInfo::Ptr>> getGroupNodeInfo()` |
| `onReceiveGroupNodeInfo(..., ReceiveMsgFunc)` | `Task<Error::Ptr> onReceiveGroupNodeInfo(...)` |
| `onReceiveMessage(..., ReceiveMsgFunc)` | `Task<Error::Ptr> onReceiveMessage(...)` |
| `onReceiveBroadcastMessage(..., ReceiveMsgFunc)` | `Task<Error::Ptr> onReceiveBroadcastMessage(...)` |
| `asyncSendResponse(..., ReceiveMsgFunc)` | `Task<Error::Ptr> sendResponse(...)` |
| `asyncBroadcastMessageByOwnedPayload` | `broadcastMessageByOwnedPayload`（更名，语义不变） |
| `asyncSendMessageByNodeIDByOwnedPayload` | `sendMessageByNodeIDByOwnedPayload`（更名，语义不变） |

- 移除回调类型 `GetGroupNodeInfoFunc`、`ReceiveMsgFunc`，以及 `FrontService::sendMessage(...)` 回调桥接实现。
- `bytesConstRef` 参数语义明确为**视图**：调用方须保证缓冲在 `co_await` 期间存活。延迟派发通过 **owner 参数**保活且零拷贝：入站 p2p/broadcast 把 `P2PMessage` 本身作为协程参数传入（协程帧持有它，payload 视图指向其缓冲）；TARS 请求缓冲 marshal 时拷贝进 owned 协程参数；纯 fire-and-forget 触发点把 payload 拷贝进 owned 协程参数。

## 实现层

- **FrontService**：`getGroupNodeInfo` / `onReceive*` / `sendResponse` 改为协程实现。`sendResponse` 在协程帧内构造 header，以零拷贝方式组合 header + payload 调用网关 `sendMessageByNodeID`（删除了原先 `sendMessage` 的 shared_ptr 拷贝桥）；`handleCallback` 的响应发送改为 `task::wait` + 拷贝 payload 的 fire-and-forget。
- **LocalRouterTable**：
  - `asyncBroadcastMsg` → `broadcastMsg`，本地广播内部对每个 front 以 `task::wait` 派发 `onReceiveMessage`；入站 `P2PMessage` 作为 owner 传入每个派发协程，payload 视图零拷贝；
  - `sendMessage` 由「`bool` + `ErrorRespFunc` 回调」改为 `Task<Error::Ptr>`，找不到目标 front 时返回 `NotFoundFrontServiceSendMsg`。由此删除了 `Gateway::sendMessageByNodeID` 中手写的 `LocalSendAwaitable` 桥（本地投递结果直接作为协程返回值）。
- **Gateway / GatewayNodeManager**：`onReceiveP2PMessage`、广播、`syncLatestNodeIDList` 对 front 的调用改为协程；入站 p2p/broadcast 的 `P2PMessage` 由派发协程持有（owner），payload 以视图零拷贝派发（评审后移除原先的防御性全量拷贝）。
- **TARS 客户端（FrontServiceClient）**：新增共享 `ErrorAwaitable` / `GetGroupNodeInfoAwaitable`，把 tars `PrxCallback` 包装为「恰好完成一次」的协程 awaitable（`completed.exchange` 判重 + resume）；`sendResponse` 同样经 `ErrorAwaitable` 走带回调的异步代理形式，`co_return` 真实的 tars 错误（Round-2 评审后修复，原先误用无回调的同步代理形式并丢弃返回值）。
- **TARS 服务端（FrontServiceServer）**：各 RPC 在 `task::wait` 协程内 `co_await` front 方法并加 try/catch——因 `current->setResponse(false)` 已禁用自动应答，异常时仍手动 `async_response_*` 回复，避免调用方永久阻塞；tars 请求缓冲拷贝进 owned 协程参数。
- **模块调用方**（PBFTEngine / PBFTCache / PBFTCacheProcessor、BlockSync、TxPool、TransactionSync、LightNodeInitializer、PBFTInitializer）：
  - 原「sendResponse 响应回调」统一改为 `task::wait` + owned payload 拷贝的 fire-and-forget 协程，失败日志保持一致；
  - `asyncBroadcastMessageByOwnedPayload` / `asyncSendMessageByNodeIDByOwnedPayload` 调用点全部更名；
  - `PBFTInitializer::syncGroupNodeInfo` 由回调改为 `task::wait` + `co_await getGroupNodeInfo()`。

## 附带清理

- `NodeInfoDef.h` 的缩进 / `virtual` 杂项修正已在 Round-1 评审后**回退**（去掉 `virtual ~NodeIPEndpoint()` 属与协程化无关的 ABI/布局变更，移出本 PR 另行处理）；`SchedulerInterface.h` 注释引用同步更名。

## Round-1 评审处理（kyonRay，2026-09-03）

- **[F1] 入站 payload 零拷贝化**：`Gateway::onReceiveP2PMessage` 与 `LocalRouterTable::broadcastMsg` 移除对入站 payload 的 `bcos::bytes` 全量拷贝；派发协程持有 `P2PMessage`（owner），payload 视图指向其缓冲，跨（可能延迟的）派发生命周期由 owner 保证。
- **[F2] 回退 `NodeInfoDef.h` 无关改动**：删除 `virtual ~NodeIPEndpoint()` 会改变结构体布局（ABI），与本 PR 主题无关，已整体回退（该文件相对 base 无差异）并另行处理。
- **[F3] 格式**：`LightNodeInitializer.h` 三处 `sendResponse` 调用超 100 列，已按行宽重排。
- **[F5] `sendResponse` 请求 id 按值传递**：接口与全部 override（`FrontService` / `FrontServiceClient` / `FakeFrontService`）统一为 `std::string _id`，与兄弟协程签名一致。
- **[F4] 记录为 follow-up**：`FrontServiceClient` 三份手写 tars 完成状态机（`ErrorAwaitable` / `GetGroupNodeInfoAwaitable` / `SendAwaitable`）计划模板化为单一 `TarsAwaitable`，不在本 PR 处理。

## 测试

- `FakeFrontService` / `FakeGateway` / `FrontServiceTest` / `FIB185_AsyncSendOffCallerThreadTest` / `GatewayTest` / gateway `main.cpp` 全部适配新接口签名；
- front/gateway 测试用 `task::syncWait` / `task::wait` 驱动协程路径；sendResponse 回环测试改为走真实协程响应路径（模块 dispatcher → `sendResponse` → fake gateway 回环 → `handleCallback`）。

## Round-2 评审处理（kyonRay / ywy2090，2026-09-04，commit cac7becfb）

- **[R2-1] `FrontServiceClient::sendResponse` 改走异步代理形式**：原实现用无回调的 tars 同步代理调用（阻塞至服务端应答或超时）并丢弃返回值，恒 `co_return nullptr`，注释误称 oneway。现 `ErrorAwaitable::Callback` 新增 `callback_asyncSendResponse` / `_exception` 两个 override，`sendResponse` 以带回调的异步形式发起并 `co_return` 真实错误，兑现接口契约「失败返回 Error」。
- **[R2-2] 解码失败不再 ACK SUCCESS**：`FrontService::onReceiveMessage` 的解码异常 catch 分支由 `co_return nullptr` 改为返回 `BCOS_ERROR_PTR(CommonError::MessageDecodeFailed, ...)`（`CommonError.h` 新增 1006），网关 ack 回调携带真实错误码；广播路径复用 `onReceiveMessage`，自动覆盖。
- **[R2-3] LightNode 七处 `(void)co_await sendResponse` 补错误日志**：六个 dispatcher/协程站点与 `decodeRequest` 的 detach 桥全部按 `getBlock` 既有模式检查并 `LIGHTNODE_LOG(ERROR)` 记录失败。
- **[R2-4] 记录为 follow-up**：五处手写 fire-and-forget `sendResponse` 桥（PBFTEngine / BlockSync / TxPool / FrontService / LightNodeInitializer）计划在接口加默认实现 `sendResponseByOwnedPayload`（镜像现有 `*ByOwnedPayload` 桥）后迁移，与 F4 `TarsAwaitable` 模板化一并处理，不在本 PR。


## Round-4 评审处理（kyonRay，2026-09-05，commit a51a11e9f）

- **[R4-1] 修复 awaitable 双 resume 竞态（F1，HIGH）**：原 `await_suspend` 先清 `inAwaitSuspend` 再读 `completed`，落入窗口的 tars 完成会在回调线程 resume 仍在栈上的协程，且 `await_suspend` 随后返回 false 使协程在原线程也继续（同一帧两线程并发驱动，fire-and-forget 路径 double destroy）。改为单个原子 `rendezvous` exchange 定夺：`await_suspend` 发 RPC 后 `return !rendezvous.exchange(true, acq_rel)`，`complete()` 判重写结果后仅在 rendezvous 已置位时 resume——同步完成走当前栈 `await_resume`，异步完成由回调 resume，恰好一方继续，`inAwaitSuspend` 整体删除。callback 改 `unique_ptr` 构造、invoker 内 tars 调用点 `release()` 移交所有权（接管前抛异常不泄漏）。
- **[R4-2] 三份 tars 完成状态机合并（F2，原 follow-up 提前落地）**：`ErrorAwaitable` / `GetGroupNodeInfoAwaitable` / `SendAwaitable` 合并为单一 `template <class Result> TarsAwaitable`（invoker + 结果转换回调参数化），三名保留为别名，六个 RPC 调用点全部迁移；残留的裸 `FrontServiceClient* m_self` 随重复删除（proxy / keyFactory 均由 lambda 持有）。
- **[R4-3] 网关侧 1006 终态分支测试（F3）**：记为 follow-up 并显式声明——双 gateway 集成夹具对本 PR 过重，deadline 绑定下一次改动 `Gateway::sendMessageByNodeID`；front 侧 1006 产出已有 `testFrontService_onReceiveMessage_decodeFailed` pin 住。
- **[R4-4] `LocalRouterTable::sendMessage` 的 `_groupID` 改按值传递（F4）**：声明与定义统一，与兄弟协程签名一致。
- **[R4-5] `FakeFrontService::sendResponse` 透传 fake gateway 错误（F5）**：fake 兑现「失败返回 Error」契约，测试可经 override `FakeGateWay::asyncSendResponse` 注入失败。
- **[R4-6] `diagnostic_information` 每条畸形帧只构造一次（F6/F7）**：算入局部变量，日志与 Error 复用。

验证：protocol-tars / front / gateway / framework 及 pbft / sync / txpool 测试目标编译通过；test-bcos-tars-protocol / test-bcos-front / test-bcos-sync / test-bcos-txpool 全绿；test-bcos-gateway 的 10 个失败与 test-bcos-pbft 的 ASan container-overflow 经 stash 基线对比为环境/预存在问题（缺 ini 配置、libproviders.so、protobuf 容器注解），与本改动无关。