### PR TITLE
feat(engine): add EthEngineService beside EngineServiceImpl

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -33,4 +33,5 @@ include(GNUInstallDirs)
 install(TARGETS engine EXPORT fiscobcosTargets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 install(DIRECTORY "bcos-engine" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" FILES_MATCHING
     PATTERN "*.h"
-    PATTERN "OpEngineService.inl")
+    PATTERN "OpEngineService.inl"
+    PATTERN "EthEngineService.inl")

--- a/engine/bcos-engine/EthEngineService.cpp
+++ b/engine/bcos-engine/EthEngineService.cpp
@@ -1,6 +1,20 @@
 /**
  *  Copyright (C) 2026 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthEngineService.cpp
+ * @brief Ethereum Engine API service non-template definitions
  */
 
 #include "EthEngineService.h"

--- a/engine/bcos-engine/EthEngineService.cpp
+++ b/engine/bcos-engine/EthEngineService.cpp
@@ -1,0 +1,9 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "EthEngineService.h"
+
+// Production Eth validation/encode helpers live in engine::detail
+// (EngineServiceCommon.cpp). This TU remains so the engine library glob stays stable.

--- a/engine/bcos-engine/EthEngineService.h
+++ b/engine/bcos-engine/EthEngineService.h
@@ -82,9 +82,19 @@ void commitRetainedPayload(Guard& guard, ArtifactsMap& artifacts, PayloadID cons
 
 /// Terminal-SYNCING visibility: the CL keeps retrying an answer it cannot move
 /// past without EL sync; keep the fail-closed answer but make the gap visible
-/// (rate-limited log naming it). One shared CAS gate (10 s) across this
-/// service's SYNCING sites — same shape as EngineServiceImpl's cache-miss
-/// warning. The desc names the specific gap at each call site.
+/// (rate-limited log naming it). One CAS gate (10 s) PER call site (template
+/// parameter, one static per instantiation) so a noisy routine site cannot
+/// suppress another site's window. The desc names the specific gap at each
+/// call site.
+enum SyncingWarnSite : std::size_t
+{
+    c_forkchoiceHeadUnknown,
+    c_newPayloadParentUnknown,
+    c_newPayloadNotBuiltHere,
+    c_newPayloadCacheMiss,
+};
+
+template <SyncingWarnSite kSiteV>
 inline void warnSyncingRateLimited(const char* desc, h256 const& blockHash)
 {
     static std::atomic<std::chrono::steady_clock::time_point> lastWarn{
@@ -98,6 +108,14 @@ inline void warnSyncingRateLimited(const char* desc, h256 const& blockHash)
         BCOS_LOG(WARNING) << LOG_BADGE("EthEngineService") << LOG_DESC(desc)
                           << LOG_KV("blockHash", blockHash.hex());
     }
+}
+
+/// Unlimited variant for the mid-persist alarm: a fully built block lost
+/// mid-commit must never be dropped by another site's 10 s window.
+inline void warnSyncingUnlimited(const char* desc, h256 const& blockHash)
+{
+    BCOS_LOG(WARNING) << LOG_BADGE("EthEngineService") << LOG_DESC(desc)
+                      << LOG_KV("blockHash", blockHash.hex());
 }
 }  // namespace detail
 

--- a/engine/bcos-engine/EthEngineService.h
+++ b/engine/bcos-engine/EthEngineService.h
@@ -1,6 +1,20 @@
 /**
  *  Copyright (C) 2026 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthEngineService.h
+ * @brief Ethereum Engine API service beside the legacy EngineServiceImpl
  */
 
 #pragma once
@@ -43,7 +57,7 @@
 namespace bcos::engine
 {
 
-namespace eth_detail
+namespace detail
 {
 template <class Guard, class ArtifactsMap>
 void commitRetainedPayload(Guard& guard, ArtifactsMap& artifacts, PayloadID const& payloadId,
@@ -63,7 +77,7 @@ void commitRetainedPayload(Guard& guard, ArtifactsMap& artifacts, PayloadID cons
         throw;
     }
 }
-}  // namespace eth_detail
+}  // namespace detail
 
 template <class ViewType>
 struct EthPayloadArtifacts

--- a/engine/bcos-engine/EthEngineService.h
+++ b/engine/bcos-engine/EthEngineService.h
@@ -1,0 +1,182 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "EngineServiceCommon.h"
+#include "EngineTracker.h"
+
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/merkle/Merkle.h>
+#include <bcos-framework/engine/EngineService.h>
+#include <bcos-framework/engine/Errors.h>
+#include <bcos-framework/engine/Types.h>
+#include <bcos-framework/ledger/Ledger.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/protocol/BlockFactory.h>
+#include <bcos-framework/protocol/Transaction.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-framework/transaction-executor/TransactionExecutor.h>
+#include <bcos-framework/transaction-scheduler/TransactionScheduler.h>
+#include <bcos-ledger/LedgerMethods.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/Web3RawTransaction.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Bloom.h>
+#include <bcos-utilities/BoostLog.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Exceptions.h>
+#include <boost/lexical_cast.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace bcos::engine
+{
+
+namespace eth_detail
+{
+template <class Guard, class ArtifactsMap>
+void commitRetainedPayload(Guard& guard, ArtifactsMap& artifacts, PayloadID const& payloadId,
+    h256 const& blockHash, BuiltPayloadPtr entry)
+{
+    PayloadCache cacheRollback = guard.snapshotPayloadCache();
+    ArtifactsMap artifactsRollback = artifacts;
+    try
+    {
+        guard.putAndRetainPayload(payloadId, blockHash, std::move(entry));
+        artifacts.clear();
+    }
+    catch (...)
+    {
+        guard.restorePayloadCache(std::move(cacheRollback));
+        artifacts = std::move(artifactsRollback);
+        throw;
+    }
+}
+}  // namespace eth_detail
+
+template <class ViewType>
+struct EthPayloadArtifacts
+{
+    std::shared_ptr<ViewType> view;
+    bcos::protocol::BlockHeader::Ptr header;
+    std::vector<protocol::TransactionReceipt::Ptr> receipts;
+};
+
+template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
+    requires executor_v1::TransactionExecutor<ExecutorType,
+                 typename GlobalStateStorageType::ViewType> &&
+             scheduler_v1::TransactionScheduler<SchedulerType,
+                 typename GlobalStateStorageType::ViewType, ExecutorType,
+                 std::vector<protocol::Transaction::Ptr>>
+class EthEngineService
+{
+public:
+    using ViewType = typename GlobalStateStorageType::ViewType;
+
+    EthEngineService(MemPoolType& memPool, GlobalStateStorageType& globalStateStorage,
+        ExecutorType& executor, SchedulerType& scheduler,
+        bcos::protocol::BlockFactory::Ptr blockFactory,
+        bcos::ledger::LedgerInterface::Ptr ledger = nullptr,
+        int64_t blockTxCountLimit = c_defaultBlockTxCountLimit,
+        std::uint32_t maxEngineVersion = static_cast<std::uint32_t>(ApiVersion::V3))
+      : m_memPool(memPool),
+        m_globalStateStorage(globalStateStorage),
+        m_executor(executor),
+        m_scheduler(scheduler),
+        m_blockFactory(std::move(blockFactory)),
+        m_ledger(std::move(ledger)),
+        m_blockTxCountLimit(blockTxCountLimit),
+        m_maxEngineVersion(maxEngineVersion)
+    {
+        if (!m_blockFactory)
+        {
+            BOOST_THROW_EXCEPTION(std::invalid_argument{"blockFactory must not be null"});
+        }
+    }
+    ~EthEngineService() = default;
+    EthEngineService(const EthEngineService&) = delete;
+    EthEngineService(EthEngineService&&) = delete;
+    EthEngineService& operator=(const EthEngineService&) = delete;
+    EthEngineService& operator=(EthEngineService&&) = delete;
+
+    task::Task<std::vector<std::string>> exchangeCapabilities(
+        std::vector<std::string> remoteCapabilities)
+    {
+        (void)remoteCapabilities;
+        co_return engine_common::supportedCapabilities();
+    }
+
+    task::Task<ForkchoiceUpdatedResult> updateForkchoice(const ForkchoiceState& forkchoiceState,
+        const PayloadAttributes* payloadAttributes, std::uint32_t version);
+
+    task::Task<GetPayloadResult> getPayload(const PayloadID& payloadId, std::uint32_t version)
+    {
+        co_return m_tracker.getPayload(payloadId, version);
+    }
+
+    task::Task<PayloadStatus> newPayload(const NewPayloadRequest& request, std::uint32_t version);
+
+    std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() const
+    {
+        return m_tracker.safeBlockNumber();
+    }
+
+    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const
+    {
+        return m_tracker.finalizedBlockNumber();
+    }
+
+private:
+    struct BuildPayloadResult
+    {
+        ExecutionPayload executionPayload;
+        bcos::protocol::BlockHeader::Ptr header;
+        std::vector<protocol::TransactionReceipt::Ptr> receipts;
+    };
+
+    bool isForkchoiceVersionSupported(std::uint32_t version) const
+    {
+        return version >= static_cast<std::uint32_t>(ApiVersion::V1) &&
+               version <= m_maxEngineVersion;
+    }
+
+    static bool isNewPayloadVersionSupported(std::uint32_t version)
+    {
+        return version >= static_cast<std::uint32_t>(ApiVersion::V1) &&
+               version <= static_cast<std::uint32_t>(ApiVersion::V4);
+    }
+
+    task::Task<BuildPayloadResult> buildPayload(const ForkchoiceState& forkchoiceState,
+        const PayloadAttributes& payloadAttributes, const PayloadID& payloadId,
+        std::uint32_t version, bcos::protocol::BlockNumber nextBlockNumber,
+        std::vector<protocol::Transaction::Ptr> sealedTxs, ViewType& view,
+        std::vector<bcos::bytes> const& decodedForcedTxs) const;
+
+    task::Task<h256> calculateStateRoot(ViewType& view, uint32_t blockVersion) const;
+
+    EngineTracker m_tracker;
+    std::unordered_map<PayloadID, EthPayloadArtifacts<ViewType>> m_artifacts;
+    MemPoolType& m_memPool;
+    GlobalStateStorageType& m_globalStateStorage;
+    ExecutorType& m_executor;
+    SchedulerType& m_scheduler;
+    bcos::protocol::BlockFactory::Ptr m_blockFactory;
+    bcos::ledger::LedgerInterface::Ptr m_ledger;
+    int64_t m_blockTxCountLimit;
+    std::uint32_t m_maxEngineVersion;
+};
+
+}  // namespace bcos::engine
+
+#include "EthEngineService.inl"

--- a/engine/bcos-engine/EthEngineService.h
+++ b/engine/bcos-engine/EthEngineService.h
@@ -47,6 +47,8 @@
 #include <boost/lexical_cast.hpp>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -75,6 +77,26 @@ void commitRetainedPayload(Guard& guard, ArtifactsMap& artifacts, PayloadID cons
         guard.restorePayloadCache(std::move(cacheRollback));
         artifacts = std::move(artifactsRollback);
         throw;
+    }
+}
+
+/// Terminal-SYNCING visibility: the CL keeps retrying an answer it cannot move
+/// past without EL sync; keep the fail-closed answer but make the gap visible
+/// (rate-limited log naming it). One shared CAS gate (10 s) across this
+/// service's SYNCING sites — same shape as EngineServiceImpl's cache-miss
+/// warning. The desc names the specific gap at each call site.
+inline void warnSyncingRateLimited(const char* desc, h256 const& blockHash)
+{
+    static std::atomic<std::chrono::steady_clock::time_point> lastWarn{
+        std::chrono::steady_clock::time_point{}};
+    auto const now = std::chrono::steady_clock::now();
+    auto prev = lastWarn.load(std::memory_order_relaxed);
+    if (now - prev >= std::chrono::seconds(10) &&
+        lastWarn.compare_exchange_strong(
+            prev, now, std::memory_order_relaxed, std::memory_order_relaxed))
+    {
+        BCOS_LOG(WARNING) << LOG_BADGE("EthEngineService") << LOG_DESC(desc)
+                          << LOG_KV("blockHash", blockHash.hex());
     }
 }
 }  // namespace detail
@@ -124,6 +146,16 @@ public:
     EthEngineService& operator=(const EthEngineService&) = delete;
     EthEngineService& operator=(EthEngineService&&) = delete;
 
+    /// Version-window contract (the four surfaces deliberately differ, matching
+    /// op-geth's by-design ceiling split; do not "fix" them to agree):
+    /// - exchangeCapabilities: the FULL supported list regardless of
+    ///   m_maxEngineVersion — capability advertisement is static, method windows
+    ///   are what gate actual dispatch.
+    /// - updateForkchoice (FCU): instance-gated by m_maxEngineVersion (V1–V3 for
+    ///   the default-constructed service).
+    /// - newPayload: V1–V4 (Isthmus V4 empty-lists shape).
+    /// - getPayload: V1–V5 via the tracker's window (the V2 build answers V1–V2,
+    ///   the V3 build answers V1–V5).
     task::Task<std::vector<std::string>> exchangeCapabilities(
         std::vector<std::string> remoteCapabilities)
     {

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -305,50 +305,90 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
         co_return engine_common::makeStatus(
             PayloadValidationStatus::InvalidBlockHash, std::nullopt, mismatch);
     }
+    bool viewPushed = false;
     {
         auto guard = m_tracker.lockExclusive();
         auto artifactIt = m_artifacts.find(payloadId);
-        if (artifactIt != m_artifacts.end() && artifactIt->second.view)
+        // Commit contract (mirrors EngineServiceImpl; finding F22 there): the branch
+        // runs only when PENDING DURABLE WORK exists — a view to push, or artifacts
+        // to persist. The entry stays in m_artifacts until the durable write
+        // succeeds (commitRetainedPayload clears it below): moving/erasing it here
+        // turned a transient merge failure into a terminal SYNCING — the retry
+        // found no artifact and no ledger row, stranding a fully built block.
+        // pushView + view.reset() happen under the lock so a concurrent duplicate
+        // newPayload never pushes the same view twice; header/receipts are only
+        // read here and consumed after the I/O succeeds, so their presence is the
+        // retry discriminator.
+        if (artifactIt != m_artifacts.end() &&
+            (artifactIt->second.view || artifactIt->second.header))
         {
-            localArtifact = std::move(artifactIt->second);
-            m_artifacts.erase(artifactIt);
+            if (artifactIt->second.view)
+            {
+                m_globalStateStorage.pushView(std::move(*artifactIt->second.view));
+                artifactIt->second.view.reset();
+                viewPushed = true;
+            }
+            if (m_ledger && artifactIt->second.header)
+            {
+                localArtifact = artifactIt->second;
+            }
         }
     }
 
-    if (localArtifact && localArtifact->view)
+    if (localArtifact)
     {
-        m_globalStateStorage.pushView(std::move(*localArtifact->view));
-        if (m_ledger && localArtifact->header)
+        typename GlobalStateStorageType::MutableStorage prewriteStorage;
+        auto block = m_blockFactory->createBlock();
+        block->setBlockHeader(localArtifact->header);
+        auto const& bloom = cached->executionPayload.logsBloom;
+        block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+        for (auto const& tx : cached->executionPayload.transactions)
         {
-            typename GlobalStateStorageType::MutableStorage prewriteStorage;
-            auto block = m_blockFactory->createBlock();
-            block->setBlockHeader(localArtifact->header);
-            auto const& bloom = cached->executionPayload.logsBloom;
-            block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
-            for (auto const& tx : cached->executionPayload.transactions)
+            if (tx.decoded)
             {
-                if (tx.decoded)
-                {
-                    block->appendTransaction(tx.decoded);
-                }
+                block->appendTransaction(tx.decoded);
             }
-            for (auto const& receipt : localArtifact->receipts)
-            {
-                block->appendReceipt(receipt);
-            }
-            auto blockTxs = std::make_shared<protocol::ConstTransactions>(
-                cached->executionPayload.transactions |
-                ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
-                ::ranges::views::transform(
-                    [](auto const& tx) { return protocol::Transaction::ConstPtr(tx.decoded); }) |
-                ::ranges::to<std::vector>());
-            co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
+        }
+        for (auto const& receipt : localArtifact->receipts)
+        {
+            block->appendReceipt(receipt);
+        }
+        auto blockTxs = std::make_shared<protocol::ConstTransactions>(
+            cached->executionPayload.transactions |
+            ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
+            ::ranges::views::transform(
+                [](auto const& tx) { return protocol::Transaction::ConstPtr(tx.decoded); }) |
+            ::ranges::to<std::vector>());
+        co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
+        // Land the prewritten rows together with the queued view layer, then let a
+        // later commit drain any layer a previously failed attempt left queued.
+        // mergeBackStorage throws NotExistsImmutableStorageError on an empty deque;
+        // the empty case is NOT an error — a concurrent duplicate may have drained
+        // the layer between the attempts, and its rows are identical to ours, so
+        // the prewritten rows land directly via mergeToBackends (idempotent) instead
+        // of surfacing a spurious internal error where the Engine API requires the
+        // idempotent VALID. Awaits stay OUT of the catch handlers (C++20 forbids
+        // them there) — the handler only records whether the rows still need landing.
+        bool rowsLanded = false;
+        try
+        {
             co_await m_globalStateStorage.mergeBackStorage(prewriteStorage);
+            rowsLanded = true;
         }
-        else
+        catch (bcos::storage2::NotExistsImmutableStorageError const&)
         {
-            co_await m_globalStateStorage.mergeBackStorage();
+            // Queue already empty — nothing to pair with; land the rows below.
         }
+        if (!rowsLanded)
+        {
+            co_await m_globalStateStorage.mergeToBackends(prewriteStorage);
+        }
+    }
+    else if (viewPushed)
+    {
+        // A pushed view without durable work: the queued state layer must still
+        // drain into the backends — the merge must not depend on ledger persistence.
+        co_await m_globalStateStorage.mergeBackStorage();
     }
 
     // Fail-closed guard (finding AI): if no local artifact was available above, either

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -191,10 +191,13 @@ task::Task<ForkchoiceUpdatedResult> EthEngineService<MemPoolType, GlobalStateSto
     };
 
     {
+        // Copy the hash before the entry is moved: publishBuiltPayload stores the
+        // payload by move, which leaves the original object's blockHash member
+        // moved-from, and putStaged then hashes that reference into hashToId.
+        const auto blockHash = commonEntry->executionPayload.blockHash;
         auto guard = m_tracker.lockExclusive();
-        publishBuiltPayload(guard, m_artifacts, payloadId,
-            commonEntry->executionPayload.blockHash, std::move(commonEntry),
-            std::move(stagedArtifact));
+        publishBuiltPayload(guard, m_artifacts, payloadId, blockHash,
+            std::move(commonEntry), std::move(stagedArtifact));
     }
     result.payloadId = payloadId;
     co_return result;

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -79,6 +79,8 @@ task::Task<ForkchoiceUpdatedResult> EthEngineService<MemPoolType, GlobalStateSto
 
     if (!headBlockNumber.has_value())
     {
+        detail::warnSyncingRateLimited("forkchoice head unknown; answering SYNCING (no EL sync)",
+            forkchoiceState.headBlockHash);
         co_return ForkchoiceUpdatedResult{
             .payloadStatus = engine_common::makeStatus(
                 PayloadValidationStatus::Syncing, std::nullopt, std::nullopt),
@@ -277,6 +279,8 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
                            guard.payloadIdForHash(request.executionPayload.parentHash).has_value();
         if (!parentKnown)
         {
+            detail::warnSyncingRateLimited("newPayload parent unknown; answering SYNCING",
+                request.executionPayload.parentHash);
             co_return engine_common::makeStatus(
                 PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
         }
@@ -286,6 +290,9 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
         {
             // #5468 / finding E: op-geth executes (InsertBlockWithoutSetHead) before VALID.
             // An external payload this node did not build is not executed here yet.
+            detail::warnSyncingRateLimited(
+                "newPayload block not built here; answering SYNCING",
+                request.executionPayload.blockHash);
             co_return engine_common::makeStatus(
                 PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
         }
@@ -294,6 +301,8 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
     }
     if (!cached)
     {
+        detail::warnSyncingRateLimited("newPayload cache miss; answering SYNCING",
+            request.executionPayload.blockHash);
         co_return engine_common::makeStatus(
             PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
     }
@@ -403,6 +412,10 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
         if (!co_await bcos::ledger::getBlockNumber(
                 checkView, cached->executionPayload.blockHash, bcos::ledger::fromStorage))
         {
+            detail::warnSyncingRateLimited(
+                "newPayload has no ledger row and no retryable artifact; answering SYNCING "
+                "(a previous attempt died mid-persist)",
+                cached->executionPayload.blockHash);
             co_return engine_common::makeStatus(
                 PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
         }
@@ -656,11 +669,7 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
     Bloom logsBloom{};
     for (auto& receipt : receipts)
     {
-        if (!receipt)
-        {
-            BOOST_THROW_EXCEPTION(OpExecutionInternalError{} << bcos::errinfo_comment{
-                                      "Null receipt returned by scheduler"});
-        }
+        // Null receipts were rejected by the any_of guard above the merkle.
         totalGasUsed += receipt->gasUsed();
         if (!receipt->logsBloom().empty())
         {

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -1,0 +1,667 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/indirect.hpp>
+#include <range/v3/view/transform.hpp>
+
+#include <bcos-ledger/mpt/Constants.h>
+#include <optional>
+
+namespace bcos::engine
+{
+
+template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
+    requires executor_v1::TransactionExecutor<ExecutorType,
+                 typename GlobalStateStorageType::ViewType> &&
+             scheduler_v1::TransactionScheduler<SchedulerType,
+                 typename GlobalStateStorageType::ViewType, ExecutorType,
+                 std::vector<protocol::Transaction::Ptr>>
+task::Task<ForkchoiceUpdatedResult> EthEngineService<MemPoolType, GlobalStateStorageType,
+    ExecutorType, SchedulerType>::updateForkchoice(const ForkchoiceState& forkchoiceState,
+    const PayloadAttributes* payloadAttributes, std::uint32_t version)
+{
+    if (!isForkchoiceVersionSupported(version))
+    {
+        BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
+                              << bcos::errinfo_comment{"Unsupported Engine API version"});
+    }
+    std::vector<bcos::bytes> decodedForcedTxs;
+    if (payloadAttributes != nullptr)
+    {
+        if (auto validationError = engine_common::validatePayloadAttributes(
+                *payloadAttributes, version, &decodedForcedTxs);
+            validationError.has_value())
+        {
+            co_return ForkchoiceUpdatedResult{
+                .payloadStatus = engine_common::makeStatus(
+                    PayloadValidationStatus::Invalid, std::nullopt, validationError),
+                .payloadId = std::nullopt,
+            };
+        }
+    }
+
+    auto view = m_globalStateStorage.fork();
+    auto headBlockNumber = co_await bcos::ledger::getBlockNumber(
+        view, forkchoiceState.headBlockHash, bcos::ledger::fromStorage);
+    // All-zero safe/finalized hashes are the Engine-API "not set" value: skip number
+    // resolution and canonical checks for that field (op-geth SetSafe/SetFinalized are
+    // only called for non-zero hashes). A missing HEAD is SYNCING; a non-zero
+    // unresolvable safe/finalized is InvalidForkchoiceState (op-geth, finding BJ).
+    bool const safeSet = forkchoiceState.safeBlockHash != bcos::h256{};
+    bool const finalizedSet = forkchoiceState.finalizedBlockHash != bcos::h256{};
+    auto safeBlockNumber = safeSet ? co_await bcos::ledger::getBlockNumber(view,
+                                         forkchoiceState.safeBlockHash, bcos::ledger::fromStorage) :
+                                     std::nullopt;
+    auto finalizedBlockNumber =
+        finalizedSet ? co_await bcos::ledger::getBlockNumber(
+                           view, forkchoiceState.finalizedBlockHash, bcos::ledger::fromStorage) :
+                       std::nullopt;
+
+    if (!headBlockNumber.has_value())
+    {
+        co_return ForkchoiceUpdatedResult{
+            .payloadStatus = engine_common::makeStatus(
+                PayloadValidationStatus::Syncing, std::nullopt, std::nullopt),
+            .payloadId = std::nullopt,
+        };
+    }
+    if ((safeSet && !safeBlockNumber.has_value()) ||
+        (finalizedSet && !finalizedBlockNumber.has_value()))
+    {
+        BOOST_THROW_EXCEPTION(InvalidForkchoiceState{} << bcos::errinfo_comment{
+                                  "Forkchoice safe or finalized block is unknown"});
+    }
+    if (safeBlockNumber.has_value() && *safeBlockNumber > *headBlockNumber)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidForkchoiceState{} << bcos::errinfo_comment{
+                "Forkchoice safe block number must not exceed head block number"});
+    }
+    if (finalizedBlockNumber.has_value() && *finalizedBlockNumber > *headBlockNumber)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidForkchoiceState{} << bcos::errinfo_comment{
+                "Forkchoice finalized block number must not exceed head block number"});
+    }
+    if (finalizedBlockNumber.has_value() && safeBlockNumber.has_value() &&
+        *finalizedBlockNumber > *safeBlockNumber)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidForkchoiceState{} << bcos::errinfo_comment{
+                "Forkchoice finalized block number must not exceed safe block number"});
+    }
+
+    auto canonicalHeadHash =
+        co_await bcos::ledger::getBlockHash(view, *headBlockNumber, bcos::ledger::fromStorage);
+    bool const headCanonical =
+        canonicalHeadHash.has_value() && *canonicalHeadHash == forkchoiceState.headBlockHash;
+    // Same-number safe/finalized already resolved above: their canonical hash is the
+    // head's (one NUMBER_2_HASH row per height), so reuse it instead of a second storage
+    // read; zero (unset) fields skip resolution entirely. Heartbeat FCUs (all three
+    // hashes equal) drop from 3 to 1 sequential reads.
+    auto canonicalSafeHash =
+        (!safeSet || *safeBlockNumber == *headBlockNumber) ?
+            canonicalHeadHash :
+            co_await bcos::ledger::getBlockHash(view, *safeBlockNumber, bcos::ledger::fromStorage);
+    auto canonicalFinalizedHash = (!finalizedSet || *finalizedBlockNumber == *headBlockNumber) ?
+                                      canonicalHeadHash :
+                                      co_await bcos::ledger::getBlockHash(
+                                          view, *finalizedBlockNumber, bcos::ledger::fromStorage);
+
+    ResolvedForkchoice resolved{
+        .state = forkchoiceState,
+        .headNumber = *headBlockNumber,
+        .safeNumber = safeBlockNumber,
+        .finalizedNumber = finalizedBlockNumber,
+        .headCanonical = headCanonical,
+        .payloadAttributesPresent = payloadAttributes != nullptr,
+        .safeCanonical = engine_common::forkchoiceHashIsCanonical(
+            forkchoiceState.safeBlockHash, canonicalSafeHash),
+        .finalizedCanonical = engine_common::forkchoiceHashIsCanonical(
+            forkchoiceState.finalizedBlockHash, canonicalFinalizedHash),
+    };
+    if (m_tracker.applyForkchoice(resolved) == ForkchoiceApplyResult::Swallowed)
+    {
+        co_return ForkchoiceUpdatedResult{
+            .payloadStatus = engine_common::makeStatus(
+                PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt),
+            .payloadId = std::nullopt,
+        };
+    }
+
+    ForkchoiceUpdatedResult result{
+        .payloadStatus = engine_common::makeStatus(
+            PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt),
+        .payloadId = std::nullopt,
+    };
+    if (payloadAttributes == nullptr)
+    {
+        co_return result;
+    }
+
+    std::vector<protocol::Transaction::Ptr> sealedTxs;
+    view.newMutable();
+    if (!payloadAttributes->noTxPool.value_or(false))
+    {
+        m_memPool.remove(view);
+        m_memPool.seal(m_blockTxCountLimit, view, std::back_inserter(sealedTxs));
+    }
+
+    // Payload ID: deterministic derive from attributes + parent (op-geth-aligned). Do not
+    // switch back to a process-local sequence counter — that was release EngineServiceImpl
+    // only and is not the EthEngineService cutover contract (option B).
+    auto payloadIdOpt = engine_common::derivePayloadId(
+        *payloadAttributes, forkchoiceState.headBlockHash, version, decodedForcedTxs);
+    if (!payloadIdOpt.has_value())
+    {
+        co_return ForkchoiceUpdatedResult{
+            .payloadStatus =
+                engine_common::makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
+                    std::string("payloadAttributes.transactions contains undecodable hex")),
+            .payloadId = std::nullopt,
+        };
+    }
+    auto payloadId = *payloadIdOpt;
+    auto nextBlockNumber = *headBlockNumber + 1;
+    auto built = co_await buildPayload(forkchoiceState, *payloadAttributes, payloadId, version,
+        nextBlockNumber, std::move(sealedTxs), view, decodedForcedTxs);
+
+    auto commonEntry = std::make_shared<BuiltPayload>();
+    commonEntry->version = engine_common::payloadShapeVersion(version);
+    commonEntry->executionPayload = std::move(built.executionPayload);
+    commonEntry->blockValue = 0;
+    commonEntry->blobsBundle = std::nullopt;
+    commonEntry->shouldOverrideBuilder = false;
+    commonEntry->parentBeaconBlockRoot = payloadAttributes->parentBeaconBlockRoot;
+    if (version == static_cast<std::uint32_t>(ApiVersion::V3))
+    {
+        commonEntry->blobsBundle = BlobsBundleV1{};
+    }
+
+    auto stagedArtifact = EthPayloadArtifacts<ViewType>{
+        .view = std::make_shared<ViewType>(std::move(view)),
+        .header = std::move(built.header),
+        .receipts = std::move(built.receipts),
+    };
+
+    {
+        auto guard = m_tracker.lockExclusive();
+        publishBuiltPayload(guard, m_artifacts, payloadId,
+            commonEntry->executionPayload.blockHash, std::move(commonEntry),
+            std::move(stagedArtifact));
+    }
+    result.payloadId = payloadId;
+    co_return result;
+}
+
+template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
+    requires executor_v1::TransactionExecutor<ExecutorType,
+                 typename GlobalStateStorageType::ViewType> &&
+             scheduler_v1::TransactionScheduler<SchedulerType,
+                 typename GlobalStateStorageType::ViewType, ExecutorType,
+                 std::vector<protocol::Transaction::Ptr>>
+task::Task<PayloadStatus>
+EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerType>::newPayload(
+    const NewPayloadRequest& request, std::uint32_t version)
+{
+    if (!isNewPayloadVersionSupported(version))
+    {
+        BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
+                              << bcos::errinfo_comment{"Unsupported Engine API version"});
+    }
+    if (auto validationError = detail::validateExecutionPayload(request.executionPayload, version);
+        validationError.has_value())
+    {
+        auto status = validationError->find("blockHash") != std::string::npos ?
+                          PayloadValidationStatus::InvalidBlockHash :
+                          PayloadValidationStatus::Invalid;
+        co_return engine_common::makeStatus(status, std::nullopt, validationError);
+    }
+    if (version <= 2 && request.parentBeaconBlockRoot.has_value())
+    {
+        co_return engine_common::makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
+            std::string("parentBeaconBlockRoot is only valid for newPayloadV3 and later"));
+    }
+    if (version >= 3 && !request.parentBeaconBlockRoot.has_value())
+    {
+        co_return engine_common::makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
+            std::string("parentBeaconBlockRoot must be a 32-byte hash for newPayloadV3 and "
+                        "later"));
+    }
+    if (version >= 3 && !request.expectedBlobVersionedHashes.empty())
+    {
+        co_return engine_common::makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
+            std::string("expectedBlobVersionedHashes must be empty (L2 forbids blob "
+                        "transactions)"));
+    }
+    if (version >= 4)
+    {
+        if (!request.executionRequests.has_value() || !request.executionRequests->empty())
+        {
+            co_return engine_common::makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
+                std::string("executionRequests must be a present-but-empty list on this "
+                            "chain"));
+        }
+    }
+
+    BuiltPayloadPtr cached;
+    PayloadID payloadId;
+    std::optional<EthPayloadArtifacts<ViewType>> localArtifact;
+    {
+        auto guard = m_tracker.lockExclusive();
+        auto const& forkchoiceState = guard.forkchoiceState();
+        auto parentKnown = request.executionPayload.parentHash == forkchoiceState.headBlockHash ||
+                           guard.payloadIdForHash(request.executionPayload.parentHash).has_value();
+        if (!parentKnown)
+        {
+            co_return engine_common::makeStatus(
+                PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+        }
+
+        auto existingId = guard.payloadIdForHash(request.executionPayload.blockHash);
+        if (!existingId)
+        {
+            // #5468 / finding E: op-geth executes (InsertBlockWithoutSetHead) before VALID.
+            // An external payload this node did not build is not executed here yet.
+            co_return engine_common::makeStatus(
+                PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+        }
+        payloadId = *existingId;
+        cached = guard.findPayload(payloadId);
+    }
+    if (!cached)
+    {
+        co_return engine_common::makeStatus(
+            PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+    }
+    // Finding AV: compare (O(tx bytes) memcmp) runs on the immutable shared
+    // entry after releasing the exclusive tracker lock.
+    if (auto mismatch =
+            detail::compareWithBuiltPayload(request.executionPayload, cached->executionPayload))
+    {
+        co_return engine_common::makeStatus(
+            PayloadValidationStatus::InvalidBlockHash, std::nullopt, mismatch);
+    }
+    {
+        auto guard = m_tracker.lockExclusive();
+        auto artifactIt = m_artifacts.find(payloadId);
+        if (artifactIt != m_artifacts.end() && artifactIt->second.view)
+        {
+            localArtifact = std::move(artifactIt->second);
+            m_artifacts.erase(artifactIt);
+        }
+    }
+
+    if (localArtifact && localArtifact->view)
+    {
+        m_globalStateStorage.pushView(std::move(*localArtifact->view));
+        if (m_ledger && localArtifact->header)
+        {
+            typename GlobalStateStorageType::MutableStorage prewriteStorage;
+            auto block = m_blockFactory->createBlock();
+            block->setBlockHeader(localArtifact->header);
+            auto const& bloom = cached->executionPayload.logsBloom;
+            block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+            for (auto const& tx : cached->executionPayload.transactions)
+            {
+                if (tx.decoded)
+                {
+                    block->appendTransaction(tx.decoded);
+                }
+            }
+            for (auto const& receipt : localArtifact->receipts)
+            {
+                block->appendReceipt(receipt);
+            }
+            auto blockTxs = std::make_shared<protocol::ConstTransactions>(
+                cached->executionPayload.transactions |
+                ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
+                ::ranges::views::transform(
+                    [](auto const& tx) { return protocol::Transaction::ConstPtr(tx.decoded); }) |
+                ::ranges::to<std::vector>());
+            co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
+            co_await m_globalStateStorage.mergeBackStorage(prewriteStorage);
+        }
+        else
+        {
+            co_await m_globalStateStorage.mergeBackStorage();
+        }
+    }
+
+    // Fail-closed guard (finding AI): if no local artifact was available above, either
+    // the block was already committed by an earlier call (artifacts.clear() in
+    // commitRetainedPayload) or a previous commit attempt died mid-persist. Only the
+    // former may answer VALID - a ledger row proves the persist actually happened. When
+    // the ledger has no row for this blockHash, answering VALID would fabricate a
+    // committed block (the retry previously skipped the merge and still returned VALID).
+    if (!localArtifact && m_ledger)
+    {
+        auto checkView = m_globalStateStorage.fork();
+        if (!co_await bcos::ledger::getBlockNumber(
+                checkView, cached->executionPayload.blockHash, bcos::ledger::fromStorage))
+        {
+            co_return engine_common::makeStatus(
+                PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+        }
+    }
+
+    {
+        auto guard = m_tracker.lockExclusive();
+        // Keep the locally built body (executed at FCU). Do not rewrite from the CL request.
+        eth_detail::commitRetainedPayload(
+            guard, m_artifacts, payloadId, cached->executionPayload.blockHash, cached);
+    }
+
+    co_return engine_common::makeStatus(
+        PayloadValidationStatus::Valid, cached->executionPayload.blockHash, std::nullopt);
+}
+
+template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
+    requires executor_v1::TransactionExecutor<ExecutorType,
+                 typename GlobalStateStorageType::ViewType> &&
+             scheduler_v1::TransactionScheduler<SchedulerType,
+                 typename GlobalStateStorageType::ViewType, ExecutorType,
+                 std::vector<protocol::Transaction::Ptr>>
+task::Task<typename EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType,
+    SchedulerType>::BuildPayloadResult>
+EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerType>::buildPayload(
+    const ForkchoiceState& forkchoiceState, const PayloadAttributes& payloadAttributes,
+    const PayloadID& payloadId, std::uint32_t version, bcos::protocol::BlockNumber nextBlockNumber,
+    std::vector<protocol::Transaction::Ptr> sealedTxs, ViewType& view,
+    std::vector<bcos::bytes> const& decodedForcedTxs) const
+{
+    std::vector<EngineTransaction> engineTransactions;
+    engineTransactions.reserve(
+        payloadAttributes.transactions.value_or(std::vector<std::string>{}).size() +
+        sealedTxs.size());
+    if (payloadAttributes.transactions.has_value())
+    {
+        for (auto const& raw : decodedForcedTxs)
+        {
+            engineTransactions.push_back(EngineTransaction{
+                .raw = raw,
+                .decoded = nullptr,
+            });
+        }
+    }
+    for (auto& sealedTx : sealedTxs)
+    {
+        if (sealedTx->type() !=
+            static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
+        {
+            BCOS_LOG(WARNING) << LOG_BADGE("EthEngineService")
+                              << LOG_DESC(
+                                     "buildPayload: excluding transaction without an EIP-2718 "
+                                     "wire form from the OP payload")
+                              << LOG_KV("hash", sealedTx->hash().hex())
+                              << LOG_KV("type", static_cast<int>(sealedTx->type()));
+            continue;
+        }
+        engineTransactions.push_back(EngineTransaction{
+            .raw = bcostars::protocol::reassembleWeb3RawTransaction(
+                sealedTx->extraTransactionBytes(), sealedTx->signatureData()),
+            .decoded = std::move(sealedTx),
+        });
+    }
+
+    // Match release EngineServiceImpl: stamp OP extraData and derive the Eth header fork
+    // from the on-chain EVM revision, not from the Engine API method version.
+    bytes extraData = detail::encodeOptimismExtraData(payloadAttributes);
+
+    ExecutionPayload executionPayload{
+        .logsBloom = Bloom{},
+        .parentHash = forkchoiceState.headBlockHash,
+        .stateRoot = h256{},
+        .receiptsRoot = h256{},
+        .prevRandao = payloadAttributes.prevRandao,
+        .gasLimit = 0,
+        .gasUsed = 0,
+        .baseFeePerGas = 0,
+        .blockHash = h256{},
+        .transactions = std::move(engineTransactions),
+        .extraData = extraData,
+        .feeRecipient = payloadAttributes.suggestedFeeRecipient,
+        .timestamp = payloadAttributes.timestamp,
+        .blockNumber = nextBlockNumber,
+        .withdrawals = std::nullopt,
+        .blobGasUsed = std::nullopt,
+        .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
+        .withdrawalsRoot = std::nullopt,
+    };
+
+    ledger::LedgerConfig ledgerConfig;
+    co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
+    auto blockVersion = ledgerConfig.compatibilityVersion();
+
+    auto chainRevision = ledgerConfig.evmcRevisionForBlock(nextBlockNumber);
+    if (!chainRevision.has_value())
+    {
+        BOOST_THROW_EXCEPTION(
+            UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: no on-chain EVM revision configured for block " +
+                std::to_string(nextBlockNumber) +
+                "; cannot derive the Eth header fork era (a v2 chain persists evmc_revision "
+                "at genesis)"});
+    }
+    auto forkVersion = detail::ethBlockVersionFor(*chainRevision);
+
+    if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN &&
+        !payloadAttributes.parentBeaconBlockRoot.has_value())
+    {
+        BOOST_THROW_EXCEPTION(
+            UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: chain EVM revision requires the V3 payload attributes "
+                "(parentBeaconBlockRoot); forkchoiceUpdated must be called at version >= 3"});
+    }
+    if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI &&
+        !payloadAttributes.withdrawals.has_value())
+    {
+        BOOST_THROW_EXCEPTION(
+            UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: chain EVM revision requires the V2 payload attributes "
+                "(withdrawals); forkchoiceUpdated must be called at version >= 2"});
+    }
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V3) &&
+        forkVersion < bcos::protocol::EthBlockVersion::CANCUN)
+    {
+        BOOST_THROW_EXCEPTION(
+            UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: forkchoiceUpdatedV3 requires a CANCUN-or-later chain fork; "
+                "chain EVM revision maps to " +
+                std::to_string(static_cast<int>(forkVersion))});
+    }
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V2) &&
+        forkVersion < bcos::protocol::EthBlockVersion::SHANGHAI)
+    {
+        BOOST_THROW_EXCEPTION(
+            UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: forkchoiceUpdatedV2 requires a SHANGHAI-or-later chain "
+                "fork; chain EVM revision maps to " +
+                std::to_string(static_cast<int>(forkVersion))});
+    }
+
+    if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI)
+    {
+        executionPayload.withdrawals =
+            payloadAttributes.withdrawals.value_or(std::vector<WithdrawalV1>{});
+    }
+    if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN)
+    {
+        executionPayload.blobGasUsed = u256(0);
+        executionPayload.excessBlobGas = u256(0);
+        executionPayload.withdrawalsRoot = detail::withdrawalsRootFor(executionPayload);
+    }
+
+    executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
+
+    if (executionPayload.transactions.empty())
+    {
+        auto emptyHeader = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+        bcos::protocol::ParentInfo parentInfo{
+            .blockNumber = nextBlockNumber - 1, .blockHash = forkchoiceState.headBlockHash};
+        emptyHeader->setParentInfo(parentInfo);
+        emptyHeader->setNumber(nextBlockNumber);
+        emptyHeader->setVersion(blockVersion);
+        emptyHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
+        emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
+        emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
+        emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
+        emptyHeader->setExtraData(std::move(extraData));
+        emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
+        emptyHeader->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
+        emptyHeader->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
+        emptyHeader->setGasUsed(0);
+        detail::finalizeEthBlockHeader(
+            *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, forkVersion);
+        executionPayload.stateRoot = emptyHeader->stateRoot();
+        executionPayload.receiptsRoot = bcos::ledger::mpt::emptyRootHash();
+        executionPayload.gasUsed = 0;
+        executionPayload.blockHash = emptyHeader->hash();
+        co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
+            .header = std::move(emptyHeader),
+            .receipts = {}};
+    }
+
+    auto blockHeader = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    bcos::protocol::ParentInfo parentInfo{
+        .blockNumber = nextBlockNumber - 1, .blockHash = forkchoiceState.headBlockHash};
+    blockHeader->setParentInfo(parentInfo);
+    blockHeader->setNumber(nextBlockNumber);
+    blockHeader->setVersion(blockVersion);
+    blockHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
+    blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
+    blockHeader->setPrevRandao(payloadAttributes.prevRandao);
+    blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
+    blockHeader->setExtraData(std::move(extraData));
+
+    auto executableTransactions =
+        executionPayload.transactions | ::ranges::views::filter([](auto const& transaction) {
+            return transaction.decoded != nullptr;
+        }) |
+        ::ranges::views::transform([](auto const& transaction) { return transaction.decoded; }) |
+        ::ranges::to<std::vector>();
+    auto receipts = co_await m_scheduler.executeBlock(view, m_executor, *blockHeader,
+        executableTransactions | ::ranges::views::indirect, ledgerConfig);
+
+    h256 txRoot = bcos::ledger::mpt::emptyRootHash();
+    {
+        auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
+        auto hasher = hashImpl.hasher();
+        crypto::merkle::Merkle<std::remove_reference_t<decltype(hasher)>> merkle(hasher.clone());
+        if (!executionPayload.transactions.empty())
+        {
+            auto txHashes =
+                executionPayload.transactions | ::ranges::views::transform([](auto& tx) {
+                    return tx.decoded ? tx.decoded->hash() :
+                                        bcos::crypto::keccak256Hash(bcos::ref(tx.raw));
+                });
+            std::vector<h256> merkleTrie;
+            merkle.generateMerkle(txHashes, merkleTrie);
+            if (!merkleTrie.empty())
+            {
+                txRoot = merkleTrie.back();
+            }
+        }
+    }
+
+    h256 receiptRoot = bcos::ledger::mpt::emptyRootHash();
+    {
+        if (::ranges::any_of(receipts, [](auto& r) { return !r; }))
+        {
+            BOOST_THROW_EXCEPTION(OpExecutionInternalError{} << bcos::errinfo_comment{
+                                      "Null receipt returned by scheduler"});
+        }
+        auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
+        auto hasher = hashImpl.hasher();
+        crypto::merkle::Merkle<std::remove_reference_t<decltype(hasher)>> merkle(hasher.clone());
+        if (!receipts.empty())
+        {
+            auto receiptHashes =
+                receipts | ::ranges::views::transform([](auto& r) { return r->hash(); });
+            std::vector<h256> merkleTrie;
+            merkle.generateMerkle(receiptHashes, merkleTrie);
+            if (!merkleTrie.empty())
+            {
+                receiptRoot = merkleTrie.back();
+            }
+        }
+    }
+
+    u256 totalGasUsed;
+    Bloom logsBloom{};
+    for (auto& receipt : receipts)
+    {
+        if (!receipt)
+        {
+            BOOST_THROW_EXCEPTION(OpExecutionInternalError{} << bcos::errinfo_comment{
+                                      "Null receipt returned by scheduler"});
+        }
+        totalGasUsed += receipt->gasUsed();
+        if (!receipt->logsBloom().empty())
+        {
+            orBloom(logsBloom, receipt->logsBloom());
+        }
+    }
+
+    h256 stateRoot = co_await calculateStateRoot(view, blockHeader->version());
+    blockHeader->setStateRoot(stateRoot);
+    blockHeader->setReceiptsRoot(receiptRoot);
+    blockHeader->setTxsRoot(txRoot);
+    blockHeader->setGasUsed(totalGasUsed);
+
+    executionPayload.logsBloom = logsBloom;
+    detail::finalizeEthBlockHeader(
+        *blockHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, forkVersion);
+
+    executionPayload.stateRoot = stateRoot;
+    executionPayload.receiptsRoot = receiptRoot;
+    executionPayload.gasUsed = totalGasUsed;
+    executionPayload.blockHash = blockHeader->hash();
+    executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
+
+    co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
+        .header = std::move(blockHeader),
+        .receipts = std::move(receipts)};
+}
+
+template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
+    requires executor_v1::TransactionExecutor<ExecutorType,
+                 typename GlobalStateStorageType::ViewType> &&
+             scheduler_v1::TransactionScheduler<SchedulerType,
+                 typename GlobalStateStorageType::ViewType, ExecutorType,
+                 std::vector<protocol::Transaction::Ptr>>
+task::Task<h256> EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType,
+    SchedulerType>::calculateStateRoot(ViewType& view, uint32_t blockVersion) const
+{
+    auto range = co_await storage2::range(view);
+    h256 totalHash;
+    while (auto keyValue = co_await range.next())
+    {
+        auto& [key, value] = *keyValue;
+        executor_v1::StateKeyView viewKey(key);
+        auto [tableName, keyName] = viewKey.get();
+
+        storage::Entry entry;
+        if (auto* e = std::get_if<storage::Entry>(std::addressof(value)))
+        {
+            entry = *e;
+        }
+        else
+        {
+            entry.setStatus(storage::Entry::DELETED);
+        }
+        totalHash ^= entry.hash(
+            tableName, keyName, *m_blockFactory->cryptoSuite()->hashImpl(), blockVersion);
+    }
+    co_return totalHash;
+}
+
+}  // namespace bcos::engine

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -1,6 +1,20 @@
 /**
  *  Copyright (C) 2026 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthEngineService.inl
+ * @brief Ethereum Engine API service implementation (template bodies)
  */
 
 #pragma once
@@ -357,7 +371,7 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
     {
         auto guard = m_tracker.lockExclusive();
         // Keep the locally built body (executed at FCU). Do not rewrite from the CL request.
-        eth_detail::commitRetainedPayload(
+        detail::commitRetainedPayload(
             guard, m_artifacts, payloadId, cached->executionPayload.blockHash, cached);
     }
 

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -25,6 +25,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <bcos-ledger/mpt/Constants.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <optional>
 
 namespace bcos::engine

--- a/engine/bcos-engine/EthEngineService.inl
+++ b/engine/bcos-engine/EthEngineService.inl
@@ -80,7 +80,8 @@ task::Task<ForkchoiceUpdatedResult> EthEngineService<MemPoolType, GlobalStateSto
 
     if (!headBlockNumber.has_value())
     {
-        detail::warnSyncingRateLimited("forkchoice head unknown; answering SYNCING (no EL sync)",
+        detail::warnSyncingRateLimited<detail::c_forkchoiceHeadUnknown>(
+            "forkchoice head unknown; answering SYNCING (no EL sync)",
             forkchoiceState.headBlockHash);
         co_return ForkchoiceUpdatedResult{
             .payloadStatus = engine_common::makeStatus(
@@ -208,9 +209,10 @@ task::Task<ForkchoiceUpdatedResult> EthEngineService<MemPoolType, GlobalStateSto
     };
 
     {
-        // Copy the hash before the entry is moved: publishBuiltPayload stores the
-        // payload by move, which leaves the original object's blockHash member
-        // moved-from, and putStaged then hashes that reference into hashToId.
+        // commonEntry is null after the move, so capture the hash before the
+        // argument list is evaluated — argument evaluation order is unspecified and
+        // publishBuiltPayload stores the payload by move, needing the hash
+        // independently of the moved pointer.
         const auto blockHash = commonEntry->executionPayload.blockHash;
         auto guard = m_tracker.lockExclusive();
         publishBuiltPayload(guard, m_artifacts, payloadId, blockHash,
@@ -238,9 +240,10 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
     if (auto validationError = detail::validateExecutionPayload(request.executionPayload, version);
         validationError.has_value())
     {
-        auto status = validationError->find("blockHash") != std::string::npos ?
-                          PayloadValidationStatus::InvalidBlockHash :
-                          PayloadValidationStatus::Invalid;
+        // validateExecutionPayload only checks shape/semantic rules — a failure
+        // there is a malformed payload, never a blockHash mismatch (that path is
+        // compareWithBuiltPayload's and returns InvalidBlockHash directly).
+        auto status = PayloadValidationStatus::Invalid;
         co_return engine_common::makeStatus(status, std::nullopt, validationError);
     }
     if (version <= 2 && request.parentBeaconBlockRoot.has_value())
@@ -280,7 +283,8 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
                            guard.payloadIdForHash(request.executionPayload.parentHash).has_value();
         if (!parentKnown)
         {
-            detail::warnSyncingRateLimited("newPayload parent unknown; answering SYNCING",
+            detail::warnSyncingRateLimited<detail::c_newPayloadParentUnknown>(
+                "newPayload parent unknown; answering SYNCING",
                 request.executionPayload.parentHash);
             co_return engine_common::makeStatus(
                 PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
@@ -291,7 +295,7 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
         {
             // #5468 / finding E: op-geth executes (InsertBlockWithoutSetHead) before VALID.
             // An external payload this node did not build is not executed here yet.
-            detail::warnSyncingRateLimited(
+            detail::warnSyncingRateLimited<detail::c_newPayloadNotBuiltHere>(
                 "newPayload block not built here; answering SYNCING",
                 request.executionPayload.blockHash);
             co_return engine_common::makeStatus(
@@ -302,8 +306,8 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
     }
     if (!cached)
     {
-        detail::warnSyncingRateLimited("newPayload cache miss; answering SYNCING",
-            request.executionPayload.blockHash);
+        detail::warnSyncingRateLimited<detail::c_newPayloadCacheMiss>(
+            "newPayload cache miss; answering SYNCING", request.executionPayload.blockHash);
         co_return engine_common::makeStatus(
             PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
     }
@@ -393,12 +397,51 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
         {
             co_await m_globalStateStorage.mergeToBackends(prewriteStorage);
         }
+        // The drain loop then removes every remaining queued layer: one left behind
+        // by an abandoned failed merge would otherwise make every later commit merge
+        // one-behind, leaving the newest payload's state queued in-memory — lost on
+        // restart — though it answered VALID.
+        for (;;)
+        {
+            bool drained = false;
+            try
+            {
+                co_await m_globalStateStorage.mergeBackStorage();
+                drained = true;
+            }
+            catch (bcos::storage2::NotExistsImmutableStorageError const&)
+            {
+                // Queue empty — the drain is complete.
+            }
+            if (!drained)
+            {
+                break;
+            }
+        }
     }
     else if (viewPushed)
     {
         // A pushed view without durable work: the queued state layer must still
-        // drain into the backends — the merge must not depend on ledger persistence.
-        co_await m_globalStateStorage.mergeBackStorage();
+        // drain into the backends — the merge must not depend on ledger persistence
+        // (CI-found: the pushed view stayed queued in memory and every committed
+        // balance was lost).
+        for (;;)
+        {
+            bool drained = false;
+            try
+            {
+                co_await m_globalStateStorage.mergeBackStorage();
+                drained = true;
+            }
+            catch (bcos::storage2::NotExistsImmutableStorageError const&)
+            {
+                // Queue empty — the drain is complete.
+            }
+            if (!drained)
+            {
+                break;
+            }
+        }
     }
 
     // Fail-closed guard (finding AI): if no local artifact was available above, either
@@ -413,7 +456,7 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
         if (!co_await bcos::ledger::getBlockNumber(
                 checkView, cached->executionPayload.blockHash, bcos::ledger::fromStorage))
         {
-            detail::warnSyncingRateLimited(
+            detail::warnSyncingUnlimited(
                 "newPayload has no ledger row and no retryable artifact; answering SYNCING "
                 "(a previous attempt died mid-persist)",
                 cached->executionPayload.blockHash);
@@ -449,7 +492,7 @@ EthEngineService<MemPoolType, GlobalStateStorageType, ExecutorType, SchedulerTyp
 {
     std::vector<EngineTransaction> engineTransactions;
     engineTransactions.reserve(
-        payloadAttributes.transactions.value_or(std::vector<std::string>{}).size() +
+        (payloadAttributes.transactions ? payloadAttributes.transactions->size() : 0) +
         sealedTxs.size());
     if (payloadAttributes.transactions.has_value())
     {

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -42,5 +42,9 @@ set_source_files_properties(
     "unittests/engine/OpEngineServiceExecParityTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties(
     "unittests/engine/OpEngineReviewFixTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_source_files_properties(
+    "unittests/engine/EthEngineServiceParityTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_source_files_properties(
+    "unittests/engine/EthEngineServiceTransactionalTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" ${TEST_BINARY_NAME} "" "")

--- a/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
@@ -1015,7 +1015,8 @@ BOOST_AUTO_TEST_CASE(generic_validation_error_table_matches)
             },
             4, "executionRequests must be a present-but-empty list on this chain"},
         // Matrix: E6 — wide/bad in-process payloads. JSON-null blob fields are a parse
-        // concern below this layer (the RPC dialect tests); these rows hit validateExecutionPayload.
+        // concern below this layer (the RPC dialect tests); these rows hit
+        // validateExecutionPayload.
         {"v2_with_blob_gas",
             [&] {
                 NewPayloadRequest r;
@@ -1558,8 +1559,72 @@ BOOST_AUTO_TEST_CASE(matrix_new_payload_v4_empty_lists_match)
         task::syncWait(pair.fresh.newPayload(newRequest, 4)));
 }
 
-// Matrix: S7 — Eth publish under shared guard blocks exclusive writer (same handshake as OP).
+BOOST_AUTO_TEST_CASE(eth_nonempty_withdrawals_rejected_with_pinned_message)
+{
+    // Pin the non-empty-withdrawals gate (validateExecutionPayload): a non-empty
+    // list is uncommittable at every version that carries the field, because this
+    // node cannot compute the withdrawals trie root. The tests around it route
+    // around this gate with empty lists; this is the negative half, with the
+    // message pinned so the reason stays greppable.
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto attrs = makeKarstPayloadAttributes();
+    auto legacyBuild = task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto newBuild = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+    BOOST_REQUIRE(legacyBuild.payloadId.has_value());
+    BOOST_REQUIRE(newBuild.payloadId.has_value());
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 5));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 5));
+    BOOST_REQUIRE(legacyPayload);
+    BOOST_REQUIRE(newPayload);
 
+    auto checkNonEmptyWithdrawalsInvalid =
+        [](PayloadStatus const& status, const char* what)
+    {
+        BOOST_CHECK_EQUAL(static_cast<int>(status.status),
+            static_cast<int>(PayloadValidationStatus::Invalid));
+        BOOST_REQUIRE(status.validationError.has_value());
+        BOOST_CHECK_MESSAGE(status.validationError->find("non-empty withdrawals") !=
+                                std::string::npos,
+            what << ": unexpected validationError: " << *status.validationError);
+    };
+
+    // V2: the first version that carries withdrawals.
+    NewPayloadRequest legacyV2;
+    legacyV2.executionPayload = legacyPayload->executionPayload;
+    legacyV2.executionPayload.withdrawals =
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+    auto legacyV2Status = task::syncWait(pair.legacy.newPayload(legacyV2, 2));
+    checkNonEmptyWithdrawalsInvalid(legacyV2Status, "legacy V2");
+
+    NewPayloadRequest newV2;
+    newV2.executionPayload = newPayload->executionPayload;
+    newV2.executionPayload.withdrawals =
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+    auto newV2Status = task::syncWait(pair.fresh.newPayload(newV2, 2));
+    checkNonEmptyWithdrawalsInvalid(newV2Status, "fresh V2");
+
+    // V4 (Isthmus): the advertised newPayload ceiling.
+    NewPayloadRequest legacyV4 = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+    legacyV4.executionRequests = std::vector<bytes>{};
+    legacyV4.executionPayload.withdrawals =
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+    auto legacyV4Status = task::syncWait(pair.legacy.newPayload(legacyV4, 4));
+    checkNonEmptyWithdrawalsInvalid(legacyV4Status, "legacy V4");
+
+    NewPayloadRequest newV4 = makeNewPayloadRequestV3(newPayload->executionPayload);
+    newV4.executionRequests = std::vector<bytes>{};
+    newV4.executionPayload.withdrawals =
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+    auto newV4Status = task::syncWait(pair.fresh.newPayload(newV4, 4));
+    checkNonEmptyWithdrawalsInvalid(newV4Status, "fresh V4");
+}
+
+// Matrix: S7 — Eth publish under shared guard blocks exclusive writer (same handshake as OP).
 BOOST_AUTO_TEST_CASE(eth_publish_blocks_behind_shared_guard)
 {
     EngineTracker tracker;
@@ -1684,8 +1749,8 @@ BOOST_AUTO_TEST_CASE(wire_round_trip_through_engine_helper)
         }
         auto parsed = bcos::rpc::parseNewPayloadRequest(params, version);
         BOOST_REQUIRE(parsed.parentBeaconBlockRoot.has_value());
-        BOOST_CHECK_EQUAL(
-            parsed.parentBeaconBlockRoot->hexPrefixed(), built->parentBeaconBlockRoot->hexPrefixed());
+        BOOST_CHECK_EQUAL(parsed.parentBeaconBlockRoot->hexPrefixed(),
+            built->parentBeaconBlockRoot->hexPrefixed());
         auto mismatch =
             detail::compareWithBuiltPayload(parsed.executionPayload, built->executionPayload);
         BOOST_CHECK_MESSAGE(!mismatch, label << " wire round-trip diverged: " << *mismatch);

--- a/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
@@ -21,6 +21,7 @@
 #include "engine/bcos-engine/EthEngineService.h"
 #include "engine/test/unittests/engine/EthServiceStubs.h"
 
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-concepts/ByteBuffer.h>
@@ -1646,6 +1647,63 @@ BOOST_AUTO_TEST_CASE(eth_publish_blocks_behind_shared_guard)
         BOOST_CHECK_EQUAL(it->second.header->number(), c_targetNumber);
         BOOST_CHECK_EQUAL(it->second.header.get(), initialHeader.get());
     }
+}
+
+BOOST_AUTO_TEST_CASE(wire_round_trip_through_engine_helper)
+{
+    // Parity must cross the production JSON wire dialect: build a real payload via
+    // FCU -> getPayload, serialize it with EngineHelper, parse it back into a
+    // NewPayloadRequest, and require the parsed struct to equal the built one under
+    // the production comparator — at every advertised version pair.
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+
+    auto build =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(build.payloadId.has_value());
+    auto built = task::syncWait(pair.fresh.getPayload(*build.payloadId, 5));
+    BOOST_REQUIRE(built);
+    BOOST_REQUIRE(built->parentBeaconBlockRoot.has_value());
+
+    for (auto const [version, label] :
+        {std::pair{ApiVersion::V3, "V3"}, std::pair{ApiVersion::V5, "V5"}})
+    {
+        auto ep = bcos::rpc::serializeExecutionPayload(built->executionPayload, version);
+        Json::Value params(Json::arrayValue);
+        params.append(ep);
+        params.append(Json::Value(Json::arrayValue));  // expectedBlobVersionedHashes (empty)
+        params.append(built->parentBeaconBlockRoot->hexPrefixed());
+        if (version >= ApiVersion::V4)
+        {
+            params.append(Json::Value(Json::arrayValue));  // executionRequests (empty)
+        }
+        auto parsed = bcos::rpc::parseNewPayloadRequest(params, version);
+        BOOST_REQUIRE(parsed.parentBeaconBlockRoot.has_value());
+        BOOST_CHECK_EQUAL(
+            parsed.parentBeaconBlockRoot->hexPrefixed(), built->parentBeaconBlockRoot->hexPrefixed());
+        auto mismatch =
+            detail::compareWithBuiltPayload(parsed.executionPayload, built->executionPayload);
+        BOOST_CHECK_MESSAGE(!mismatch, label << " wire round-trip diverged: " << *mismatch);
+    }
+
+    // V2 shape: the Shanghai payload drops the Cancun blob fields, but the dialect
+    // must still carry the withdrawals list end to end.
+    auto shanghai = built->executionPayload;
+    shanghai.blobGasUsed = std::nullopt;
+    shanghai.excessBlobGas = std::nullopt;
+    auto ep = bcos::rpc::serializeExecutionPayload(shanghai, ApiVersion::V2);
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    auto parsed = bcos::rpc::parseNewPayloadRequest(params, ApiVersion::V2);
+    BOOST_REQUIRE(parsed.executionPayload.withdrawals.has_value());
+    BOOST_CHECK_EQUAL(parsed.executionPayload.withdrawals->size(), shanghai.withdrawals->size());
+    BOOST_CHECK(!parsed.executionPayload.blobGasUsed.has_value());
+    BOOST_CHECK(!parsed.executionPayload.excessBlobGas.has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
@@ -1,0 +1,1698 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "engine/bcos-engine/EngineServiceImpl.h"
+#include "engine/bcos-engine/EthEngineService.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/engine/EngineService.h>
+#include <bcos-framework/engine/Errors.h>
+#include <bcos-framework/engine/RawTransactionDispatch.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage/Serialize.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/testutils/faker/FakeBlock.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-mempool/MemPoolImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <evmc/evmc.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/test/unit_test.hpp>
+#include <magic_enum/magic_enum.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <exception>
+#include <functional>
+#include <latch>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::engine;
+using namespace bcos::txpool;
+using namespace bcos::protocol;
+using namespace bcos::crypto;
+
+namespace eth_parity_test
+{
+// Whole-second milliseconds: finalizeEthBlockHeader / validateHeader require a whole
+// number of seconds at the Eth RLP boundary.
+constexpr std::uint64_t c_timestamp = 1700000000ULL * 1000ULL;
+constexpr bcos::protocol::BlockNumber c_initialBlockNumber = 5;
+constexpr bcos::protocol::BlockNumber c_trackedInitialBlockNumber = 10;
+constexpr bcos::protocol::BlockNumber c_trackedNextBlockNumber = 11;
+constexpr bcos::protocol::BlockNumber c_validationBlockNumber = 20;
+constexpr bcos::protocol::BlockNumber c_headOrderingBlockNumber = 40;
+constexpr bcos::protocol::BlockNumber c_safeOrderingBlockNumber = 41;
+constexpr bcos::protocol::BlockNumber c_staleInitialBlockNumber = 50;
+constexpr bcos::protocol::BlockNumber c_staleNextBlockNumber = 51;
+constexpr bcos::protocol::BlockNumber c_staleThirdBlockNumber = 52;
+constexpr bcos::protocol::BlockNumber c_rebuildBaseBlockNumber = 60;
+
+using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
+    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
+    bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
+                                              bcos::storage2::memory_storage::LOGICAL_DELETION)>;
+using RealGlobalStateBackendStorage =
+    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+        bcos::executor_v1::StateValue,
+        bcos::storage2::memory_storage::Attribute(
+            bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::CONCURRENT),
+        std::hash<bcos::executor_v1::StateKey>>;
+
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& s) : m_storage(s) {}
+    Storage& open() { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const&) { std::abort(); }
+    void createCheckpoint(Storage&, CheckpointName const&) {}
+    void deleteCheckpoint(CheckpointName const&) {}
+    std::optional<CheckpointName> latestCheckpointName() const { return std::nullopt; }
+    std::optional<CheckpointName> oldestCheckpointName() const { return std::nullopt; }
+};
+
+using RealGlobalCheckpointBackend = TrivialCheckpointStorage<bcos::executor_v1::StateKey,
+    bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
+using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
+    void, RealGlobalCheckpointBackend>;
+
+struct StubExecutor
+{
+    template <class Storage>
+    struct ExecuteContext
+    {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
+    };
+
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
+        const protocol::BlockHeader&, const protocol::Transaction&, int,
+        const ledger::LedgerConfig&, bool)
+    {
+        co_return nullptr;
+    }
+
+    template <class Storage>
+    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&, const protocol::BlockHeader&,
+        const protocol::Transaction&, int, const ledger::LedgerConfig&, bool)
+    {
+        co_return ExecuteContext<Storage>{};
+    }
+};
+
+struct StubScheduler
+{
+    template <class Storage, class Executor>
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
+    {
+        co_return {};
+    }
+};
+
+using LegacyService =
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
+using NewService =
+    EthEngineService<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
+
+static_assert(EngineServiceConcept<LegacyService>);
+static_assert(EngineServiceConcept<NewService>);
+
+class TestTransactionImpl : public bcostars::protocol::TransactionImpl
+{
+public:
+    void markClean() { setTainted(false); }
+};
+
+static bytes toBytes(std::string_view input)
+{
+    return {reinterpret_cast<const byte*>(input.data()),
+        reinterpret_cast<const byte*>(input.data()) + input.size()};
+}
+
+static protocol::Transaction::Ptr makeWeb3Tx(std::string_view senderBytes, uint64_t nonce)
+{
+    bytes body;
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));
+    bcos::codec::rlp::encode(body, nonce);
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(21000));
+    bcos::codec::rlp::encode(body, Address("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"));
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));
+    bcos::codec::rlp::encode(body, bytes{});
+    body.push_back(bcos::codec::rlp::LIST_HEAD_BASE);
+    bytes payload;
+    payload.push_back(0x02);
+    bcos::codec::rlp::encodeHeader(
+        payload, bcos::codec::rlp::Header{.isList = true, .payloadLength = body.size()});
+    payload.insert(payload.end(), body.begin(), body.end());
+
+    auto tx = std::make_shared<TestTransactionImpl>();
+    tx->mutableInner().type = static_cast<int>(bcos::protocol::TransactionType::Web3Transaction);
+    tx->mutableInner().extraTransactionBytes.assign(payload.begin(), payload.end());
+    bytes signature(65, 0);
+    signature[31] = 0x12;
+    signature[63] = 0x34;
+    signature[64] = 0x01;
+    tx->mutableInner().signature.assign(signature.begin(), signature.end());
+    tx->setNonce("0x" + std::to_string(nonce));
+    tx->forceSender(toBytes(senderBytes));
+    Keccak256 hasher;
+    tx->calculateHash(hasher);
+    tx->markClean();
+    tx->setImportTime(static_cast<int64_t>(nonce));
+    return tx;
+}
+
+task::Task<void> writeBlockNumberToStorage(RealGlobalStateBackendStorage& backendStorage,
+    const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
+{
+    storage::Entry entry;
+    entry.set(boost::lexical_cast<std::string>(blockNumber));
+    co_await bcos::storage2::writeOne(backendStorage,
+        bcos::executor_v1::StateKey{
+            ledger::SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(blockHash)},
+        std::move(entry));
+}
+
+task::Task<void> writeCanonicalHashToStorage(RealGlobalStateBackendStorage& backendStorage,
+    bcos::protocol::BlockNumber blockNumber, const h256& blockHash)
+{
+    storage::Entry entry;
+    entry.set(blockHash.asBytes());
+    co_await bcos::storage2::writeOne(backendStorage,
+        bcos::executor_v1::StateKey{
+            ledger::SYS_NUMBER_2_HASH, boost::lexical_cast<std::string>(blockNumber)},
+        std::move(entry));
+}
+
+struct RealGlobalStateStorageFixture
+{
+    RealGlobalStateBackendStorage backendStorage;
+    RealGlobalCheckpointBackend checkpointBackend{backendStorage};
+    RealGlobalStateStorage storage{checkpointBackend};
+
+    explicit RealGlobalStateStorageFixture(
+        evmc_revision rev = EVMC_CANCUN, bool writeEvmcRevision = true)
+    {
+        writeSysConfig(magic_enum::enum_name(ledger::SystemConfig::executor_version),
+            std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION));
+        if (writeEvmcRevision)
+        {
+            writeSysConfig(
+                ledger::SYSTEM_KEY_EVMC_REVISION, ledger::encodeEVMCRevisionConfig(rev, {}));
+        }
+    }
+
+    void setBlockNumber(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
+    {
+        task::syncWait(writeBlockNumberToStorage(backendStorage, blockHash, blockNumber));
+    }
+
+    void setCanonicalBlock(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
+    {
+        setBlockNumber(blockHash, blockNumber);
+        task::syncWait(writeCanonicalHashToStorage(backendStorage, blockNumber, blockHash));
+    }
+
+    void setNonce(std::string_view sender, std::string nonce)
+    {
+        evmc_address addr{};
+        std::copy_n(sender.begin(), std::min(sender.size(), sizeof(addr.bytes)), addr.bytes);
+        ledger::account::EVMAccount account{backendStorage, addr, false};
+        task::syncWait(account.setNonce(std::move(nonce)));
+    }
+
+private:
+    void writeSysConfig(std::string_view key, std::string value)
+    {
+        storage::Entry entry;
+        entry.set(bcos::storage::serialize::encode(ledger::SystemConfigEntry{std::move(value), 0}));
+        task::syncWait(storage2::writeOne(backendStorage,
+            bcos::executor_v1::StateKey{ledger::SYS_CONFIG, key}, std::move(entry)));
+    }
+};
+
+void setForkchoiceBlockNumbers(RealGlobalStateStorageFixture& storageFixture,
+    const ForkchoiceState& forkchoiceState, bcos::protocol::BlockNumber headBlockNumber,
+    bcos::protocol::BlockNumber safeBlockNumber, bcos::protocol::BlockNumber finalizedBlockNumber)
+{
+    // One number → one canonical hash. Distinct hashes at the same height overwrite
+    // NUMBER_2_HASH and fail R3-F4's fail-closed check. Legacy fixtures that reused a
+    // height for makeForkchoiceState()'s three hashes get finalized < safe < head.
+    if (forkchoiceState.headBlockHash != forkchoiceState.safeBlockHash &&
+        headBlockNumber == safeBlockNumber)
+    {
+        BOOST_REQUIRE_GE(headBlockNumber, 1);
+        safeBlockNumber = headBlockNumber - 1;
+    }
+    if (forkchoiceState.headBlockHash != forkchoiceState.finalizedBlockHash &&
+        (headBlockNumber == finalizedBlockNumber || safeBlockNumber == finalizedBlockNumber))
+    {
+        BOOST_REQUIRE_GE(std::min(safeBlockNumber, headBlockNumber), 1);
+        finalizedBlockNumber = std::min(safeBlockNumber, headBlockNumber) - 1;
+    }
+    storageFixture.setCanonicalBlock(forkchoiceState.headBlockHash, headBlockNumber);
+    storageFixture.setCanonicalBlock(forkchoiceState.safeBlockHash, safeBlockNumber);
+    storageFixture.setCanonicalBlock(forkchoiceState.finalizedBlockHash, finalizedBlockNumber);
+}
+
+struct ServicePair
+{
+    MemPoolImpl legacyMemPool;
+    MemPoolImpl newMemPool;
+    RealGlobalStateStorageFixture legacyStorage;
+    RealGlobalStateStorageFixture newStorage;
+    StubExecutor legacyExecutor;
+    StubExecutor newExecutor;
+    StubScheduler legacyScheduler;
+    StubScheduler newScheduler;
+    LegacyService legacy;
+    NewService fresh;
+
+    explicit ServicePair(evmc_revision rev = EVMC_CANCUN, bool writeEvmcRevision = true)
+      : legacyStorage(rev, writeEvmcRevision),
+        newStorage(rev, writeEvmcRevision),
+        legacy(legacyMemPool, legacyStorage.storage, legacyExecutor, legacyScheduler,
+            bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite())),
+        fresh(newMemPool, newStorage.storage, newExecutor, newScheduler,
+            bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite()))
+    {}
+};
+
+ForkchoiceState makeForkchoiceState()
+{
+    return {h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        h256("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        h256("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")};
+}
+
+PayloadAttributes makePayloadAttributesV2()
+{
+    PayloadAttributes payloadAttributes;
+    payloadAttributes.timestamp = c_timestamp;
+    payloadAttributes.prevRandao =
+        h256("1111111111111111111111111111111111111111111111111111111111111111");
+    payloadAttributes.suggestedFeeRecipient = Address("1234567890abcdef1234567890abcdef12345678");
+    // release validatePayloadAttributes rejects non-empty withdrawals until the trie root
+    // is computed; match EngineServiceTest / Karst fixtures with an empty list.
+    payloadAttributes.withdrawals = std::vector<WithdrawalV1>{};
+    return payloadAttributes;
+}
+
+PayloadAttributes makePayloadAttributesV3()
+{
+    auto payloadAttributes = makePayloadAttributesV2();
+    payloadAttributes.parentBeaconBlockRoot =
+        h256("2222222222222222222222222222222222222222222222222222222222222222");
+    return payloadAttributes;
+}
+
+PayloadAttributes makeKarstPayloadAttributes()
+{
+    auto payloadAttributes = makePayloadAttributesV3();
+    payloadAttributes.withdrawals = std::vector<WithdrawalV1>{};
+    return payloadAttributes;
+}
+
+NewPayloadRequest makeNewPayloadRequestV3(const ExecutionPayload& executionPayload)
+{
+    NewPayloadRequest request;
+    request.executionPayload = executionPayload;
+    request.parentBeaconBlockRoot =
+        h256("5555555555555555555555555555555555555555555555555555555555555555");
+    return request;
+}
+
+void checkForkchoiceParity(
+    ForkchoiceUpdatedResult const& legacyResult, ForkchoiceUpdatedResult const& newResult)
+{
+    BOOST_CHECK_EQUAL(static_cast<int>(legacyResult.payloadStatus.status),
+        static_cast<int>(newResult.payloadStatus.status));
+    BOOST_CHECK(
+        legacyResult.payloadStatus.latestValidHash == newResult.payloadStatus.latestValidHash);
+    BOOST_CHECK(
+        legacyResult.payloadStatus.validationError == newResult.payloadStatus.validationError);
+    // Payload ID policy (option B): EthEngineService uses deterministic derivePayloadId
+    // (op-geth-aligned). release EngineServiceImpl still uses nextPayloadID(). Parity
+    // requires matching presence only — ID strings are not part of the cutover contract.
+    BOOST_CHECK_EQUAL(legacyResult.payloadId.has_value(), newResult.payloadId.has_value());
+}
+
+void checkStatusParity(PayloadStatus const& legacyStatus, PayloadStatus const& newStatus)
+{
+    BOOST_CHECK_EQUAL(static_cast<int>(legacyStatus.status), static_cast<int>(newStatus.status));
+    BOOST_CHECK(legacyStatus.latestValidHash == newStatus.latestValidHash);
+    BOOST_CHECK(legacyStatus.validationError == newStatus.validationError);
+}
+
+void checkEngineTransactionParity(EngineTransaction const& legacyTx, EngineTransaction const& newTx)
+{
+    BOOST_CHECK(legacyTx.raw == newTx.raw);
+    if (legacyTx.decoded && newTx.decoded)
+    {
+        BOOST_CHECK_EQUAL(legacyTx.decoded->hash(), newTx.decoded->hash());
+        BOOST_CHECK_EQUAL(legacyTx.decoded->type(), newTx.decoded->type());
+    }
+    else
+    {
+        BOOST_CHECK(legacyTx.decoded == newTx.decoded);
+    }
+}
+
+void checkExecutionPayloadParity(
+    ExecutionPayload const& legacyPayload, ExecutionPayload const& newPayload)
+{
+    BOOST_CHECK(legacyPayload.logsBloom == newPayload.logsBloom);
+    BOOST_CHECK_EQUAL(legacyPayload.parentHash, newPayload.parentHash);
+    BOOST_CHECK_EQUAL(legacyPayload.stateRoot, newPayload.stateRoot);
+    BOOST_CHECK_EQUAL(legacyPayload.receiptsRoot, newPayload.receiptsRoot);
+    BOOST_CHECK_EQUAL(legacyPayload.prevRandao, newPayload.prevRandao);
+    BOOST_CHECK_EQUAL(legacyPayload.gasLimit, newPayload.gasLimit);
+    BOOST_CHECK_EQUAL(legacyPayload.gasUsed, newPayload.gasUsed);
+    BOOST_CHECK_EQUAL(legacyPayload.baseFeePerGas, newPayload.baseFeePerGas);
+    BOOST_CHECK_EQUAL(legacyPayload.blockHash, newPayload.blockHash);
+    BOOST_REQUIRE_EQUAL(legacyPayload.transactions.size(), newPayload.transactions.size());
+    for (std::size_t i = 0; i < legacyPayload.transactions.size(); ++i)
+    {
+        checkEngineTransactionParity(legacyPayload.transactions[i], newPayload.transactions[i]);
+    }
+    BOOST_CHECK(legacyPayload.extraData == newPayload.extraData);
+    BOOST_CHECK_EQUAL(legacyPayload.feeRecipient, newPayload.feeRecipient);
+    BOOST_CHECK_EQUAL(legacyPayload.timestamp, newPayload.timestamp);
+    BOOST_CHECK_EQUAL(legacyPayload.blockNumber, newPayload.blockNumber);
+    BOOST_CHECK_EQUAL(legacyPayload.withdrawals.has_value(), newPayload.withdrawals.has_value());
+    if (legacyPayload.withdrawals.has_value())
+    {
+        BOOST_REQUIRE(newPayload.withdrawals.has_value());
+        BOOST_REQUIRE_EQUAL(legacyPayload.withdrawals->size(), newPayload.withdrawals->size());
+        for (std::size_t i = 0; i < legacyPayload.withdrawals->size(); ++i)
+        {
+            BOOST_CHECK_EQUAL(
+                (*legacyPayload.withdrawals)[i].index, (*newPayload.withdrawals)[i].index);
+            BOOST_CHECK_EQUAL((*legacyPayload.withdrawals)[i].validatorIndex,
+                (*newPayload.withdrawals)[i].validatorIndex);
+            BOOST_CHECK_EQUAL(
+                (*legacyPayload.withdrawals)[i].address, (*newPayload.withdrawals)[i].address);
+            BOOST_CHECK_EQUAL(
+                (*legacyPayload.withdrawals)[i].amount, (*newPayload.withdrawals)[i].amount);
+        }
+    }
+    BOOST_CHECK(legacyPayload.blobGasUsed == newPayload.blobGasUsed);
+    BOOST_CHECK(legacyPayload.excessBlobGas == newPayload.excessBlobGas);
+    BOOST_CHECK(legacyPayload.withdrawalsRoot == newPayload.withdrawalsRoot);
+}
+
+void checkGetPayloadParity(GetPayloadData const& legacyPayload, GetPayloadData const& newPayload)
+{
+    checkExecutionPayloadParity(legacyPayload.executionPayload, newPayload.executionPayload);
+    BOOST_CHECK_EQUAL(legacyPayload.blockValue, newPayload.blockValue);
+    BOOST_CHECK(legacyPayload.blobsBundle.has_value() == newPayload.blobsBundle.has_value());
+    if (legacyPayload.blobsBundle.has_value())
+    {
+        BOOST_REQUIRE(newPayload.blobsBundle.has_value());
+        BOOST_CHECK(legacyPayload.blobsBundle->commitments == newPayload.blobsBundle->commitments);
+        BOOST_CHECK(legacyPayload.blobsBundle->proofs == newPayload.blobsBundle->proofs);
+        BOOST_CHECK(legacyPayload.blobsBundle->blobs == newPayload.blobsBundle->blobs);
+    }
+    BOOST_CHECK_EQUAL(legacyPayload.shouldOverrideBuilder, newPayload.shouldOverrideBuilder);
+    BOOST_CHECK(
+        legacyPayload.executionRequests.has_value() == newPayload.executionRequests.has_value());
+    if (legacyPayload.executionRequests.has_value())
+    {
+        BOOST_REQUIRE(newPayload.executionRequests.has_value());
+        BOOST_REQUIRE_EQUAL(
+            legacyPayload.executionRequests->size(), newPayload.executionRequests->size());
+        for (std::size_t i = 0; i < legacyPayload.executionRequests->size(); ++i)
+        {
+            BOOST_CHECK(
+                (*legacyPayload.executionRequests)[i] == (*newPayload.executionRequests)[i]);
+        }
+    }
+    BOOST_CHECK(legacyPayload.parentBeaconBlockRoot == newPayload.parentBeaconBlockRoot);
+}
+
+template <typename Exception>
+void checkBothThrow(auto&& legacyAction, auto&& newAction)
+{
+    BOOST_CHECK_THROW(legacyAction(), Exception);
+    BOOST_CHECK_THROW(newAction(), Exception);
+}
+
+}  // namespace eth_parity_test
+
+BOOST_AUTO_TEST_SUITE(EthEngineServiceParityTest)
+
+using namespace eth_parity_test;
+
+BOOST_AUTO_TEST_CASE(generic_capabilities_match)
+{
+    ServicePair pair;
+    auto legacyCaps = task::syncWait(pair.legacy.exchangeCapabilities({}));
+    auto newCaps = task::syncWait(pair.fresh.exchangeCapabilities({}));
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        legacyCaps.begin(), legacyCaps.end(), newCaps.begin(), newCaps.end());
+}
+
+BOOST_AUTO_TEST_CASE(generic_unknown_head_matches)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    pair.legacyStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_validationBlockNumber);
+    pair.legacyStorage.setBlockNumber(forkchoiceState.finalizedBlockHash, c_validationBlockNumber);
+    pair.newStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_validationBlockNumber);
+    pair.newStorage.setBlockNumber(forkchoiceState.finalizedBlockHash, c_validationBlockNumber);
+
+    auto legacyResult = task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, nullptr, 3));
+    auto newResult = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, nullptr, 3));
+    checkForkchoiceParity(legacyResult, newResult);
+}
+
+BOOST_AUTO_TEST_CASE(eth_unknown_nonzero_safe_is_invalid_forkchoice)
+{
+    // BJ — known head + unresolved non-zero safe is InvalidForkchoiceState (not SYNCING).
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    pair.newStorage.setBlockNumber(forkchoiceState.headBlockHash, c_validationBlockNumber);
+    pair.newStorage.setCanonicalBlock(forkchoiceState.headBlockHash, c_validationBlockNumber);
+    BOOST_CHECK_THROW(task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, nullptr, 3)),
+        InvalidForkchoiceState);
+}
+
+BOOST_AUTO_TEST_CASE(eth_resolvable_non_canonical_safe_is_invalid_forkchoice)
+{
+    // BV — HASH_2_NUMBER finds safe, but NUMBER_2_HASH at that height differs.
+    ServicePair pair;
+    ForkchoiceState forkchoice{
+        h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        h256("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        h256("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")};
+    auto const canonicalSafe =
+        h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
+    pair.newStorage.setCanonicalBlock(forkchoice.headBlockHash, 10);
+    pair.newStorage.setCanonicalBlock(canonicalSafe, 8);
+    pair.newStorage.setBlockNumber(forkchoice.safeBlockHash, 8);
+    pair.newStorage.setCanonicalBlock(forkchoice.finalizedBlockHash, 7);
+    BOOST_CHECK_EXCEPTION(task::syncWait(pair.fresh.updateForkchoice(forkchoice, nullptr, 3)),
+        InvalidForkchoiceState, [&](InvalidForkchoiceState const& e) {
+            auto const* comment = boost::get_error_info<bcos::errinfo_comment>(e);
+            return comment != nullptr && *comment == "Forkchoice safe block not in canonical chain";
+        });
+}
+
+BOOST_AUTO_TEST_CASE(generic_safe_finalized_validation_matches)
+{
+    ServicePair pair;
+    ForkchoiceState forkchoiceState{
+        h256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+        h256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+        h256("0000000000000000000000000000000000000000000000000000000000000011")};
+    pair.legacyStorage.setBlockNumber(forkchoiceState.headBlockHash, c_headOrderingBlockNumber);
+    pair.legacyStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_safeOrderingBlockNumber);
+    pair.legacyStorage.setBlockNumber(
+        forkchoiceState.finalizedBlockHash, c_headOrderingBlockNumber);
+    pair.newStorage.setBlockNumber(forkchoiceState.headBlockHash, c_headOrderingBlockNumber);
+    pair.newStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_safeOrderingBlockNumber);
+    pair.newStorage.setBlockNumber(forkchoiceState.finalizedBlockHash, c_headOrderingBlockNumber);
+
+    checkBothThrow<InvalidForkchoiceState>(
+        [&] { return task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, nullptr, 3)); },
+        [&] { return task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, nullptr, 3)); });
+}
+
+BOOST_AUTO_TEST_CASE(generic_stale_head_swallow_matches)
+{
+    ServicePair pair;
+    ForkchoiceState firstForkchoice{
+        h256("1515151515151515151515151515151515151515151515151515151515151515"),
+        h256("1515151515151515151515151515151515151515151515151515151515151515"),
+        h256("1515151515151515151515151515151515151515151515151515151515151515")};
+    ForkchoiceState secondForkchoice{
+        h256("1616161616161616161616161616161616161616161616161616161616161616"),
+        h256("1616161616161616161616161616161616161616161616161616161616161616"),
+        h256("1616161616161616161616161616161616161616161616161616161616161616")};
+
+    setForkchoiceBlockNumbers(pair.legacyStorage, firstForkchoice, c_staleInitialBlockNumber,
+        c_staleInitialBlockNumber, c_staleInitialBlockNumber);
+    setForkchoiceBlockNumbers(pair.legacyStorage, secondForkchoice, c_staleNextBlockNumber,
+        c_staleNextBlockNumber, c_staleNextBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, firstForkchoice, c_staleInitialBlockNumber,
+        c_staleInitialBlockNumber, c_staleInitialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, secondForkchoice, c_staleNextBlockNumber,
+        c_staleNextBlockNumber, c_staleNextBlockNumber);
+
+    task::syncWait(pair.legacy.updateForkchoice(firstForkchoice, nullptr, 3));
+    task::syncWait(pair.fresh.updateForkchoice(firstForkchoice, nullptr, 3));
+    task::syncWait(pair.legacy.updateForkchoice(secondForkchoice, nullptr, 3));
+    task::syncWait(pair.fresh.updateForkchoice(secondForkchoice, nullptr, 3));
+
+    auto legacyStale = task::syncWait(pair.legacy.updateForkchoice(firstForkchoice, nullptr, 3));
+    auto newStale = task::syncWait(pair.fresh.updateForkchoice(firstForkchoice, nullptr, 3));
+    checkForkchoiceParity(legacyStale, newStale);
+}
+
+BOOST_AUTO_TEST_CASE(generic_rebuild_on_parent_matches)
+{
+    ServicePair pair;
+    auto parentForkchoice = makeForkchoiceState();
+    // op-geth: safe/finalized must match ReadCanonicalHash(number). Three distinct
+    // hashes cannot all be canonical at the same height.
+    parentForkchoice.safeBlockHash = parentForkchoice.headBlockHash;
+    parentForkchoice.finalizedBlockHash = parentForkchoice.headBlockHash;
+    setForkchoiceBlockNumbers(pair.legacyStorage, parentForkchoice, c_rebuildBaseBlockNumber,
+        c_rebuildBaseBlockNumber, c_rebuildBaseBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, parentForkchoice, c_rebuildBaseBlockNumber,
+        c_rebuildBaseBlockNumber, c_rebuildBaseBlockNumber);
+    pair.legacyStorage.setCanonicalBlock(parentForkchoice.headBlockHash, c_rebuildBaseBlockNumber);
+    pair.newStorage.setCanonicalBlock(parentForkchoice.headBlockHash, c_rebuildBaseBlockNumber);
+
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto legacyBuild =
+        task::syncWait(pair.legacy.updateForkchoice(parentForkchoice, &payloadAttributes, 3));
+    auto newBuild =
+        task::syncWait(pair.fresh.updateForkchoice(parentForkchoice, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+    BOOST_REQUIRE(legacyBuild.payloadId.has_value());
+    BOOST_REQUIRE(newBuild.payloadId.has_value());
+
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+
+    pair.legacyStorage.setBlockNumber(
+        legacyPayload->executionPayload.blockHash, c_rebuildBaseBlockNumber + 1);
+    pair.newStorage.setBlockNumber(
+        newPayload->executionPayload.blockHash, c_rebuildBaseBlockNumber + 1);
+    pair.legacyStorage.setCanonicalBlock(
+        legacyPayload->executionPayload.blockHash, c_rebuildBaseBlockNumber + 1);
+    pair.newStorage.setCanonicalBlock(
+        newPayload->executionPayload.blockHash, c_rebuildBaseBlockNumber + 1);
+
+    auto request = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(request, 3)),
+        task::syncWait(
+            pair.fresh.newPayload(makeNewPayloadRequestV3(newPayload->executionPayload), 3)));
+
+    ForkchoiceState tipForkchoice{legacyPayload->executionPayload.blockHash,
+        legacyPayload->executionPayload.blockHash, legacyPayload->executionPayload.blockHash};
+    task::syncWait(pair.legacy.updateForkchoice(tipForkchoice, nullptr, 3));
+    task::syncWait(pair.fresh.updateForkchoice(
+        ForkchoiceState{newPayload->executionPayload.blockHash,
+            newPayload->executionPayload.blockHash, newPayload->executionPayload.blockHash},
+        nullptr, 3));
+
+    auto rebuildAttributes = makePayloadAttributesV3();
+    rebuildAttributes.timestamp = c_timestamp + 1000;
+    auto legacyRebuild =
+        task::syncWait(pair.legacy.updateForkchoice(parentForkchoice, &rebuildAttributes, 3));
+    auto newRebuild =
+        task::syncWait(pair.fresh.updateForkchoice(parentForkchoice, &rebuildAttributes, 3));
+    // Matrix: S2 — both swallow older head (VALID, no payloadId); no rebuild-on-parent.
+    checkForkchoiceParity(legacyRebuild, newRebuild);
+    BOOST_CHECK(!legacyRebuild.payloadId.has_value());
+    BOOST_CHECK(!newRebuild.payloadId.has_value());
+    BOOST_CHECK_EQUAL(static_cast<int>(legacyRebuild.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+}
+
+BOOST_AUTO_TEST_CASE(generic_payload_id_and_get_payload_match)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("dddddddddddddddddddd", 20);
+    auto legacyTx = makeWeb3Tx(sender, 0);
+    auto newTx = makeWeb3Tx(sender, 0);
+    pair.legacyMemPool.add(std::vector{legacyTx});
+    pair.newMemPool.add(std::vector{newTx});
+    pair.legacyStorage.setNonce(sender, "0");
+    pair.newStorage.setNonce(sender, "0");
+
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto legacyResult =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newResult =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyResult, newResult);
+
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newResult.payloadId, 3));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+}
+
+BOOST_AUTO_TEST_CASE(generic_bounded_cache_evicts_front_after_sixty_five_builds)
+{
+    // Matrix: S2 — both sides use a 64-entry FIFO; distinct attrs → distinct IDs → front evicted.
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    std::vector<PayloadID> legacyIds;
+    std::vector<PayloadID> newIds;
+    for (int i = 0; i < 65; ++i)
+    {
+        auto attrs = makePayloadAttributesV3();
+        // derivePayloadId hashes timestamp/1000; step by whole seconds so each build gets a
+        // distinct payload ID. release nextPayloadID() also yields a distinct ID each call.
+        attrs.timestamp = (c_timestamp + static_cast<std::uint64_t>(i) * 1000);
+        auto legacyResult =
+            task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+        auto newResult = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+        checkForkchoiceParity(legacyResult, newResult);
+        BOOST_REQUIRE(legacyResult.payloadId.has_value());
+        BOOST_REQUIRE(newResult.payloadId.has_value());
+        legacyIds.push_back(*legacyResult.payloadId);
+        newIds.push_back(*newResult.payloadId);
+
+        auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, 3));
+        auto newPayload = task::syncWait(pair.fresh.getPayload(*newResult.payloadId, 3));
+        checkGetPayloadParity(*legacyPayload, *newPayload);
+    }
+
+    BOOST_CHECK_NE(legacyIds.front(), legacyIds.back());
+    BOOST_CHECK_NE(newIds.front(), newIds.back());
+
+    BOOST_CHECK_THROW(
+        task::syncWait(pair.legacy.getPayload(legacyIds.front(), 3)), bcos::engine::UnknownPayload);
+    BOOST_CHECK_THROW(
+        task::syncWait(pair.fresh.getPayload(newIds.front(), 3)), bcos::engine::UnknownPayload);
+    BOOST_CHECK_NO_THROW(task::syncWait(pair.legacy.getPayload(legacyIds[1], 3)));
+    BOOST_CHECK_NO_THROW(task::syncWait(pair.fresh.getPayload(newIds[1], 3)));
+    auto legacySecond = task::syncWait(pair.legacy.getPayload(legacyIds[1], 3));
+    auto newSecond = task::syncWait(pair.fresh.getPayload(newIds[1], 3));
+    checkGetPayloadParity(*legacySecond, *newSecond);
+    BOOST_CHECK_NO_THROW(task::syncWait(pair.legacy.getPayload(legacyIds.back(), 3)));
+    BOOST_CHECK_NO_THROW(task::syncWait(pair.fresh.getPayload(newIds.back(), 3)));
+    auto legacyLast = task::syncWait(pair.legacy.getPayload(legacyIds.back(), 3));
+    auto newLast = task::syncWait(pair.fresh.getPayload(newIds.back(), 3));
+    checkGetPayloadParity(*legacyLast, *newLast);
+}
+
+BOOST_AUTO_TEST_CASE(eth_derive_payload_id_stable_under_identical_attrs)
+{
+    // Matrix: E4 — presence-only FCU ID comparison is option B (checkForkchoiceParity).
+    // This case is the same-attrs overwrite contract, not an ID-string equality vs Impl.
+    // Option B: Eth contract is derivePayloadId — identical attrs → identical id and cache
+    // overwrite (no FIFO growth). Legacy nextPayloadID characterization kept alongside for
+    // cutover awareness; it is not a defect on the Eth path.
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    std::vector<PayloadID> legacyIds;
+    std::vector<PayloadID> newIds;
+    auto attrs = makePayloadAttributesV3();
+    for (int i = 0; i < 65; ++i)
+    {
+        auto legacyResult =
+            task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+        auto newResult = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+        checkForkchoiceParity(legacyResult, newResult);
+        BOOST_REQUIRE(legacyResult.payloadId.has_value());
+        BOOST_REQUIRE(newResult.payloadId.has_value());
+        legacyIds.push_back(*legacyResult.payloadId);
+        newIds.push_back(*newResult.payloadId);
+        if (i > 0)
+        {
+            BOOST_CHECK_EQUAL(newIds[i], newIds.front());
+        }
+    }
+
+    // Legacy characterization (sequential ids + FIFO eviction) — pre-cutover only.
+    BOOST_CHECK_NE(legacyIds.front(), legacyIds.back());
+    BOOST_CHECK_THROW(
+        task::syncWait(pair.legacy.getPayload(legacyIds.front(), 3)), bcos::engine::UnknownPayload);
+    BOOST_CHECK_NO_THROW(task::syncWait(pair.legacy.getPayload(legacyIds.back(), 3)));
+
+    // Eth contract under option B.
+    BOOST_CHECK_EQUAL(newIds.front(), newIds.back());
+    auto ethPayload = task::syncWait(pair.fresh.getPayload(newIds.front(), 3));
+    BOOST_REQUIRE(ethPayload);
+    BOOST_CHECK_EQUAL(ethPayload->executionPayload.timestamp, attrs.timestamp);
+
+    auto otherAttrs = attrs;
+    otherAttrs.timestamp += 1000;
+    auto otherFcu = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &otherAttrs, 3));
+    BOOST_REQUIRE(otherFcu.payloadId.has_value());
+    BOOST_CHECK_NE(*otherFcu.payloadId, newIds.front());
+    BOOST_CHECK_NO_THROW(task::syncWait(pair.fresh.getPayload(newIds.front(), 3)));
+}
+
+BOOST_AUTO_TEST_CASE(generic_v3_v5_v4_round_trip_matches)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+
+    auto legacyBuild =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newBuild =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 5));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 5));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+
+    NewPayloadRequest legacyRequest;
+    legacyRequest.executionPayload = legacyPayload->executionPayload;
+    legacyRequest.parentBeaconBlockRoot = legacyPayload->parentBeaconBlockRoot;
+    legacyRequest.executionRequests = std::vector<bytes>{};
+    NewPayloadRequest newRequest;
+    newRequest.executionPayload = newPayload->executionPayload;
+    newRequest.parentBeaconBlockRoot = newPayload->parentBeaconBlockRoot;
+    newRequest.executionRequests = std::vector<bytes>{};
+
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(legacyRequest, 4)),
+        task::syncWait(pair.fresh.newPayload(newRequest, 4)));
+}
+
+BOOST_AUTO_TEST_CASE(generic_new_payload_validation_errors_match)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto legacyBuild =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newBuild =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+
+    NewPayloadRequest missingBeacon;
+    missingBeacon.executionPayload = legacyPayload->executionPayload;
+    NewPayloadRequest missingBeaconNew;
+    missingBeaconNew.executionPayload = newPayload->executionPayload;
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(missingBeacon, 3)),
+        task::syncWait(pair.fresh.newPayload(missingBeaconNew, 3)));
+
+    auto blobAttributes = makePayloadAttributesV3();
+    blobAttributes.transactions = std::vector<std::string>{"0x03aabb"};
+    auto legacyBlobFcu =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &blobAttributes, 3));
+    auto newBlobFcu =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &blobAttributes, 3));
+    checkForkchoiceParity(legacyBlobFcu, newBlobFcu);
+
+    NewPayloadRequest blobRequest;
+    blobRequest.executionPayload.transactions.push_back(
+        {.raw = bytes{0x03, 0xaa, 0xbb}, .decoded = nullptr});
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(blobRequest, 1)),
+        task::syncWait(pair.fresh.newPayload(blobRequest, 1)));
+
+    auto request = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+    request.expectedBlobVersionedHashes = {
+        h256("3333333333333333333333333333333333333333333333333333333333333333")};
+    auto newBlobRequest = makeNewPayloadRequestV3(newPayload->executionPayload);
+    newBlobRequest.expectedBlobVersionedHashes = request.expectedBlobVersionedHashes;
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(request, 3)),
+        task::syncWait(pair.fresh.newPayload(newBlobRequest, 3)));
+}
+
+BOOST_AUTO_TEST_CASE(generic_cache_only_parent_known_matches)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    auto attrs = makePayloadAttributesV3();
+    auto legacyBuild = task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto newBuild = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+    auto legacyBuilt = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newBuilt = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+
+    // FCU head stays at the original head; parentKnown resolves via cached block hash only.
+    NewPayloadRequest legacyRequest = makeNewPayloadRequestV3(legacyBuilt->executionPayload);
+    legacyRequest.executionPayload.parentHash = legacyBuilt->executionPayload.blockHash;
+    legacyRequest.executionPayload.blockHash =
+        h256("6666666666666666666666666666666666666666666666666666666666666666");
+    NewPayloadRequest newRequest = makeNewPayloadRequestV3(newBuilt->executionPayload);
+    newRequest.executionPayload.parentHash = newBuilt->executionPayload.blockHash;
+    newRequest.executionPayload.blockHash = legacyRequest.executionPayload.blockHash;
+
+    auto legacyStatus = task::syncWait(pair.legacy.newPayload(legacyRequest, 3));
+    auto newStatus = task::syncWait(pair.fresh.newPayload(newRequest, 3));
+    checkStatusParity(legacyStatus, newStatus);
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(newStatus.status), static_cast<int>(PayloadValidationStatus::Syncing));
+}
+
+BOOST_AUTO_TEST_CASE(generic_unknown_parent_syncing_matches)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    NewPayloadRequest legacyRequest;
+    legacyRequest.executionPayload.parentHash =
+        h256("7777777777777777777777777777777777777777777777777777777777777777");
+    legacyRequest.executionPayload.blockHash =
+        h256("8888888888888888888888888888888888888888888888888888888888888888");
+    legacyRequest.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+    legacyRequest.executionPayload.blobGasUsed = u256(0);
+    legacyRequest.executionPayload.excessBlobGas = u256(0);
+    legacyRequest.executionPayload.withdrawalsRoot = h256{};
+    legacyRequest.parentBeaconBlockRoot =
+        h256("9999999999999999999999999999999999999999999999999999999999999999");
+
+    NewPayloadRequest newRequest = legacyRequest;
+    auto legacyStatus = task::syncWait(pair.legacy.newPayload(legacyRequest, 3));
+    auto newStatus = task::syncWait(pair.fresh.newPayload(newRequest, 3));
+    checkStatusParity(legacyStatus, newStatus);
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(legacyStatus.status), static_cast<int>(PayloadValidationStatus::Syncing));
+}
+
+template <typename Exception>
+void checkBothExceptionMessages(auto&& legacyAction, auto&& newAction, char const* expectedMessage)
+{
+    BOOST_CHECK_EXCEPTION(legacyAction(), Exception, [&](Exception const& e) {
+        auto const* comment = boost::get_error_info<errinfo_comment>(e);
+        return comment != nullptr && *comment == expectedMessage;
+    });
+    BOOST_CHECK_EXCEPTION(newAction(), Exception, [&](Exception const& e) {
+        auto const* comment = boost::get_error_info<errinfo_comment>(e);
+        return comment != nullptr && *comment == expectedMessage;
+    });
+}
+
+BOOST_AUTO_TEST_CASE(generic_exception_messages_match)
+{
+    ServicePair pair;
+    NewPayloadRequest request;
+
+    checkBothExceptionMessages<UnsupportedEngineApiVersion>(
+        [&] { return task::syncWait(pair.legacy.newPayload(request, 5)); },
+        [&] { return task::syncWait(pair.fresh.newPayload(request, 5)); },
+        "Unsupported Engine API version");
+
+    checkBothExceptionMessages<UnknownPayload>(
+        [&] { return task::syncWait(pair.legacy.getPayload("0xdeadbeefdeadbeef", 3)); },
+        [&] { return task::syncWait(pair.fresh.getPayload("0xdeadbeefdeadbeef", 3)); },
+        "Unknown payload");
+}
+
+BOOST_AUTO_TEST_CASE(generic_validation_error_table_matches)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    struct Case
+    {
+        char const* name;
+        std::function<NewPayloadRequest()> makeLegacy;
+        std::function<NewPayloadRequest()> makeNew;
+        std::uint32_t version;
+        char const* expectedError;
+    };
+
+    auto attrs = makePayloadAttributesV3();
+    auto legacyBuild = task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto newBuild = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+
+    std::vector<Case> cases{
+        {"empty_tx",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.transactions.push_back({.raw = bytes{}, .decoded = nullptr});
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.transactions.push_back({.raw = bytes{}, .decoded = nullptr});
+                return r;
+            },
+            1, "executionPayload.transactions[0] is empty"},
+        {"unsupported_type",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.transactions.push_back(
+                    {.raw = bytes{0x00, 0x01}, .decoded = nullptr});
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.transactions.push_back(
+                    {.raw = bytes{0x00, 0x01}, .decoded = nullptr});
+                return r;
+            },
+            1, "unsupported transaction type (transaction index 0)"},
+        {"blob_tx",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.transactions.push_back(
+                    {.raw = bytes{0x03, 0xaa}, .decoded = nullptr});
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.transactions.push_back(
+                    {.raw = bytes{0x03, 0xaa}, .decoded = nullptr});
+                return r;
+            },
+            1, "blob transactions are not allowed (transaction index 0)"},
+        {"v1_withdrawals",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                return r;
+            },
+            1, "withdrawals are not part of ExecutionPayloadV1"},
+        {"v2_missing_withdrawals",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.parentHash = forkchoiceState.headBlockHash;
+                r.executionPayload.blockHash =
+                    h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1");
+                r.executionPayload.blockNumber = c_initialBlockNumber + 1;
+                r.executionPayload.timestamp = c_timestamp;
+                r.executionPayload.prevRandao = makePayloadAttributesV3().prevRandao;
+                r.executionPayload.feeRecipient = makePayloadAttributesV3().suggestedFeeRecipient;
+                r.executionPayload.gasLimit = 1;
+                r.executionPayload.gasUsed = 0;
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.parentHash = forkchoiceState.headBlockHash;
+                r.executionPayload.blockHash =
+                    h256("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb1");
+                r.executionPayload.blockNumber = c_initialBlockNumber + 1;
+                r.executionPayload.timestamp = c_timestamp;
+                r.executionPayload.prevRandao = makePayloadAttributesV3().prevRandao;
+                r.executionPayload.feeRecipient = makePayloadAttributesV3().suggestedFeeRecipient;
+                r.executionPayload.gasLimit = 1;
+                r.executionPayload.gasUsed = 0;
+                return r;
+            },
+            2, "withdrawals are required for ExecutionPayloadV2 and later"},
+        {"v4_nonempty_execution_requests",
+            [&] {
+                NewPayloadRequest r = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+                // V3 builds inherit non-empty withdrawals from makePayloadAttributesV3; Isthmus
+                // requires an empty list so executionRequests validation is reached.
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionRequests = std::vector<bytes>{bytes{0x01}};
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r = makeNewPayloadRequestV3(newPayload->executionPayload);
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionRequests = std::vector<bytes>{bytes{0x01}};
+                return r;
+            },
+            4, "executionRequests must be a present-but-empty list on this chain"},
+        // Matrix: E6 — wide/bad in-process payloads. JSON-null blob fields are a parse
+        // concern (OpEngineReviewFixTest); these rows hit validateExecutionPayload.
+        {"v2_with_blob_gas",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionPayload.blobGasUsed = u256(0);
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionPayload.blobGasUsed = u256(0);
+                return r;
+            },
+            2, "blob gas fields are only valid for ExecutionPayloadV3 and later"},
+        {"v3_missing_blob_gas",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                return r;
+            },
+            3, "blob gas fields are required for ExecutionPayloadV3 and later"},
+        {"v3_missing_excess_blob_gas",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionPayload.blobGasUsed = u256(0);
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionPayload.blobGasUsed = u256(0);
+                return r;
+            },
+            3, "blob gas fields are required for ExecutionPayloadV3 and later"},
+        {"v4_missing_withdrawals_root",
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionPayload.blobGasUsed = u256(0);
+                r.executionPayload.excessBlobGas = u256(0);
+                return r;
+            },
+            [&] {
+                NewPayloadRequest r;
+                r.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+                r.executionPayload.blobGasUsed = u256(0);
+                r.executionPayload.excessBlobGas = u256(0);
+                return r;
+            },
+            4, "withdrawalsRoot is required for ExecutionPayloadV4 and later"},
+    };
+
+    for (auto const& c : cases)
+    {
+        auto legacyStatus = task::syncWait(pair.legacy.newPayload(c.makeLegacy(), c.version));
+        auto newStatus = task::syncWait(pair.fresh.newPayload(c.makeNew(), c.version));
+        checkStatusParity(legacyStatus, newStatus);
+        BOOST_REQUIRE(legacyStatus.validationError.has_value());
+        BOOST_REQUIRE(newStatus.validationError.has_value());
+        BOOST_CHECK_EQUAL(*legacyStatus.validationError, c.expectedError);
+        BOOST_CHECK_EQUAL(*newStatus.validationError, c.expectedError);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(generic_multi_error_precedence_matches)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    auto attrs = makePayloadAttributesV3();
+    auto legacyBuild = task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto newBuild = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+
+    auto makeMultiError = [&](ExecutionPayload const& executionPayload) {
+        NewPayloadRequest request = makeNewPayloadRequestV3(executionPayload);
+        request.executionPayload.transactions.push_back({.raw = bytes{}, .decoded = nullptr});
+        request.expectedBlobVersionedHashes = {
+            h256("3333333333333333333333333333333333333333333333333333333333333333")};
+        request.executionRequests = std::vector<bytes>{bytes{0x01}};
+        request.parentBeaconBlockRoot = std::nullopt;
+        return request;
+    };
+
+    auto legacyStatus =
+        task::syncWait(pair.legacy.newPayload(makeMultiError(legacyPayload->executionPayload), 4));
+    auto newStatus =
+        task::syncWait(pair.fresh.newPayload(makeMultiError(newPayload->executionPayload), 4));
+    checkStatusParity(legacyStatus, newStatus);
+    constexpr char const* c_expectedFirstError = "executionPayload.transactions[0] is empty";
+    BOOST_REQUIRE(legacyStatus.validationError.has_value());
+    BOOST_REQUIRE(newStatus.validationError.has_value());
+    BOOST_CHECK_EQUAL(*legacyStatus.validationError, c_expectedFirstError);
+    BOOST_CHECK_EQUAL(*newStatus.validationError, c_expectedFirstError);
+
+    auto makeRequestLevelMultiError = [&](ExecutionPayload const& executionPayload) {
+        NewPayloadRequest request = makeNewPayloadRequestV3(executionPayload);
+        request.executionPayload.withdrawals = std::vector<WithdrawalV1>{};
+        request.expectedBlobVersionedHashes = {
+            h256("4444444444444444444444444444444444444444444444444444444444444444")};
+        request.executionRequests = std::vector<bytes>{bytes{0x01}};
+        request.parentBeaconBlockRoot = std::nullopt;
+        return request;
+    };
+
+    auto legacyRequestError = task::syncWait(
+        pair.legacy.newPayload(makeRequestLevelMultiError(legacyPayload->executionPayload), 4));
+    auto newRequestError = task::syncWait(
+        pair.fresh.newPayload(makeRequestLevelMultiError(newPayload->executionPayload), 4));
+    checkStatusParity(legacyRequestError, newRequestError);
+    constexpr char const* c_expectedRequestError =
+        "parentBeaconBlockRoot must be a 32-byte hash for newPayloadV3 and later";
+    BOOST_REQUIRE(legacyRequestError.validationError.has_value());
+    BOOST_REQUIRE(newRequestError.validationError.has_value());
+    BOOST_CHECK_EQUAL(*legacyRequestError.validationError, c_expectedRequestError);
+    BOOST_CHECK_EQUAL(*newRequestError.validationError, c_expectedRequestError);
+}
+
+// Matrix: S1 — mirror high-risk EngineServiceTest behaviors as dual-run parity.
+
+BOOST_AUTO_TEST_CASE(mirror_v2_rejected_on_cancun_chain)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV2();
+    auto expectV3Attrs = [](UnsupportedFork const& e) {
+        return std::string(e.what()).find("requires the V3 payload attributes") !=
+               std::string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        UnsupportedFork, expectV3Attrs);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        UnsupportedFork, expectV3Attrs);
+}
+
+BOOST_AUTO_TEST_CASE(mirror_v3_rejected_on_shanghai_chain)
+{
+    ServicePair pair(EVMC_SHANGHAI);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto expectCancun = [](UnsupportedFork const& e) {
+        return std::string(e.what()).find("requires a CANCUN-or-later chain fork") !=
+               std::string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3)),
+        UnsupportedFork, expectCancun);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3)),
+        UnsupportedFork, expectCancun);
+}
+
+BOOST_AUTO_TEST_CASE(mirror_rejected_when_evm_revision_missing)
+{
+    ServicePair pair(EVMC_CANCUN, /*writeEvmcRevision=*/false);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto expectMissing = [](UnsupportedFork const& e) {
+        return std::string(e.what()).find("no on-chain EVM revision") != std::string::npos;
+    };
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3)),
+        UnsupportedFork, expectMissing);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3)),
+        UnsupportedFork, expectMissing);
+}
+
+BOOST_AUTO_TEST_CASE(mirror_rejects_non_empty_withdrawals)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    payloadAttributes.withdrawals = std::vector<WithdrawalV1>{
+        WithdrawalV1{.index = 1, .validatorIndex = 2, .amount = 3, .address = Address{}}};
+    auto legacyResult =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newResult =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyResult, newResult);
+    BOOST_CHECK_EQUAL(static_cast<int>(legacyResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_REQUIRE(legacyResult.payloadStatus.validationError.has_value());
+    BOOST_CHECK_NE(legacyResult.payloadStatus.validationError->find("non-empty withdrawals"),
+        std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(mirror_forced_transactions_enter_payload_first)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("abababababababababab", 20);
+    auto legacyTx = makeWeb3Tx(sender, 0);
+    auto newTx = makeWeb3Tx(sender, 0);
+    pair.legacyMemPool.add(std::vector{legacyTx});
+    pair.newMemPool.add(std::vector{newTx});
+    pair.legacyStorage.setNonce(sender, "0");
+    pair.newStorage.setNonce(sender, "0");
+
+    auto attributes = makePayloadAttributesV3();
+    attributes.transactions = std::vector<std::string>{"0x7e0102030405", "0x02f8aabb"};
+    auto legacyResult =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attributes, 3));
+    auto newResult = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attributes, 3));
+    checkForkchoiceParity(legacyResult, newResult);
+    BOOST_REQUIRE(legacyResult.payloadId.has_value());
+    BOOST_REQUIRE(newResult.payloadId.has_value());
+
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newResult.payloadId, 3));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+    BOOST_REQUIRE_EQUAL(legacyPayload->executionPayload.transactions.size(), 3);
+    BOOST_CHECK(legacyPayload->executionPayload.transactions[0].raw ==
+                (bytes{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05}));
+    BOOST_CHECK(
+        legacyPayload->executionPayload.transactions[1].raw == (bytes{0x02, 0xf8, 0xaa, 0xbb}));
+    BOOST_CHECK(legacyPayload->executionPayload.transactions[2].decoded == legacyTx);
+    BOOST_CHECK(newPayload->executionPayload.transactions[2].decoded == newTx);
+}
+
+BOOST_AUTO_TEST_CASE(mirror_no_tx_pool_excludes_mempool)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("cdcdcdcdcdcdcdcdcdcd", 20);
+    auto legacyTx = makeWeb3Tx(sender, 0);
+    auto newTx = makeWeb3Tx(sender, 0);
+    pair.legacyMemPool.add(std::vector{legacyTx});
+    pair.newMemPool.add(std::vector{newTx});
+    pair.legacyStorage.setNonce(sender, "0");
+    pair.newStorage.setNonce(sender, "0");
+
+    auto attributes = makePayloadAttributesV3();
+    attributes.noTxPool = true;
+    attributes.transactions = std::vector<std::string>{"0x7e010203"};
+    auto legacyResult =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attributes, 3));
+    auto newResult = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attributes, 3));
+    checkForkchoiceParity(legacyResult, newResult);
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newResult.payloadId, 3));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+    BOOST_REQUIRE_EQUAL(legacyPayload->executionPayload.transactions.size(), 1);
+    BOOST_CHECK(legacyPayload->executionPayload.transactions.front().raw ==
+                (bytes{0x7e, 0x01, 0x02, 0x03}));
+
+    auto emptyAttributes = makePayloadAttributesV3();
+    emptyAttributes.noTxPool = true;
+    auto legacyEmpty =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &emptyAttributes, 3));
+    auto newEmpty =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &emptyAttributes, 3));
+    checkForkchoiceParity(legacyEmpty, newEmpty);
+    auto legacyEmptyPayload = task::syncWait(pair.legacy.getPayload(*legacyEmpty.payloadId, 3));
+    auto newEmptyPayload = task::syncWait(pair.fresh.getPayload(*newEmpty.payloadId, 3));
+    checkGetPayloadParity(*legacyEmptyPayload, *newEmptyPayload);
+    BOOST_CHECK(legacyEmptyPayload->executionPayload.transactions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(mirror_jovian_extra_data_on_payload)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    payloadAttributes.eip1559Params = bytes(8, 0);
+    payloadAttributes.minBaseFee = 0;
+
+    auto legacyResult =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newResult =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyResult, newResult);
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newResult.payloadId, 3));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(legacyPayload->executionPayload.extraData),
+        "0x01000000fa000000060000000000000000");
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(newPayload->executionPayload.extraData),
+        "0x01000000fa000000060000000000000000");
+
+    auto holoceneAttributes = makeKarstPayloadAttributes();
+    holoceneAttributes.eip1559Params = fromHexWithPrefix("0x000000fa00000006");
+    auto legacyHolocene =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &holoceneAttributes, 3));
+    auto newHolocene =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &holoceneAttributes, 3));
+    checkForkchoiceParity(legacyHolocene, newHolocene);
+    auto legacyHolocenePayload =
+        task::syncWait(pair.legacy.getPayload(*legacyHolocene.payloadId, 3));
+    auto newHolocenePayload = task::syncWait(pair.fresh.getPayload(*newHolocene.payloadId, 3));
+    checkGetPayloadParity(*legacyHolocenePayload, *newHolocenePayload);
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(legacyHolocenePayload->executionPayload.extraData),
+        "0x00000000fa00000006");
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(newHolocenePayload->executionPayload.extraData),
+        "0x00000000fa00000006");
+}
+
+BOOST_AUTO_TEST_CASE(mirror_new_payload_rejects_altered_extra_data)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    payloadAttributes.eip1559Params = bytes(8, 0);
+    payloadAttributes.minBaseFee = 0;
+
+    auto legacyBuild =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newBuild =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+    BOOST_REQUIRE(legacyPayload);
+    BOOST_REQUIRE(newPayload);
+
+    pair.legacyStorage.setBlockNumber(
+        legacyPayload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    pair.newStorage.setBlockNumber(
+        newPayload->executionPayload.blockHash, c_initialBlockNumber + 1);
+
+    auto legacyAltered = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+    legacyAltered.executionPayload.extraData =
+        fromHexWithPrefix("0x01000000fa000000060000000000000009");
+    auto newAltered = makeNewPayloadRequestV3(newPayload->executionPayload);
+    newAltered.executionPayload.extraData =
+        fromHexWithPrefix("0x01000000fa000000060000000000000009");
+
+    auto legacyStatus = task::syncWait(pair.legacy.newPayload(legacyAltered, 3));
+    auto newStatus = task::syncWait(pair.fresh.newPayload(newAltered, 3));
+    checkStatusParity(legacyStatus, newStatus);
+    BOOST_CHECK_EQUAL(static_cast<int>(newStatus.status),
+        static_cast<int>(PayloadValidationStatus::InvalidBlockHash));
+
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(
+                          makeNewPayloadRequestV3(legacyPayload->executionPayload), 3)),
+        task::syncWait(
+            pair.fresh.newPayload(makeNewPayloadRequestV3(newPayload->executionPayload), 3)));
+}
+
+BOOST_AUTO_TEST_CASE(mirror_new_payload_rejects_altered_state_root)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+
+    auto legacyBuild =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newBuild =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+
+    auto legacyAltered = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+    legacyAltered.executionPayload.stateRoot = h256(1);
+    auto newAltered = makeNewPayloadRequestV3(newPayload->executionPayload);
+    newAltered.executionPayload.stateRoot = h256(1);
+
+    auto legacyStatus = task::syncWait(pair.legacy.newPayload(legacyAltered, 3));
+    auto newStatus = task::syncWait(pair.fresh.newPayload(newAltered, 3));
+    checkStatusParity(legacyStatus, newStatus);
+    BOOST_CHECK_EQUAL(static_cast<int>(newStatus.status),
+        static_cast<int>(PayloadValidationStatus::InvalidBlockHash));
+    BOOST_REQUIRE(newStatus.validationError.has_value());
+    BOOST_CHECK_NE(newStatus.validationError->find("stateRoot"), std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(mirror_new_payload_rejects_malformed_extra_data)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    auto legacyBuild =
+        task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto newBuild =
+        task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 3));
+    BOOST_REQUIRE(legacyPayload);
+    BOOST_REQUIRE(newPayload);
+
+    auto legacyMalformed = makeNewPayloadRequestV3(legacyPayload->executionPayload);
+    // 17 bytes with Holocene version byte: neither shape accepts it.
+    legacyMalformed.executionPayload.extraData =
+        fromHexWithPrefix("0x00000000fa000000060000000000000000");
+    auto newMalformed = makeNewPayloadRequestV3(newPayload->executionPayload);
+    newMalformed.executionPayload.extraData =
+        fromHexWithPrefix("0x00000000fa000000060000000000000000");
+
+    auto legacyStatus = task::syncWait(pair.legacy.newPayload(legacyMalformed, 3));
+    auto newStatus = task::syncWait(pair.fresh.newPayload(newMalformed, 3));
+    checkStatusParity(legacyStatus, newStatus);
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(newStatus.status), static_cast<int>(PayloadValidationStatus::Invalid));
+}
+
+// Matrix: S4 — version × fork matrix for FCU / getPayload / newPayload gates.
+
+BOOST_AUTO_TEST_CASE(matrix_version_fork_fcu_and_get_payload)
+{
+    struct Row
+    {
+        evmc_revision rev;
+        std::uint32_t fcuVersion;
+        bool useV3Attrs;
+        bool expectUnsupportedFork;
+        char const* messageNeedle;  // substring of UnsupportedFork what(), or nullptr
+    };
+
+    // CANCUN + V2 attrs → needs V3 attributes; SHANGHAI + V3 → needs CANCUN chain.
+    constexpr Row rows[] = {
+        {EVMC_CANCUN, 2, false, true, "requires the V3 payload attributes"},
+        {EVMC_CANCUN, 3, true, false, nullptr},
+        {EVMC_SHANGHAI, 2, false, false, nullptr},
+        {EVMC_SHANGHAI, 3, true, true, "requires a CANCUN-or-later chain fork"},
+    };
+
+    for (auto const& row : rows)
+    {
+        ServicePair pair(row.rev);
+        auto forkchoiceState = makeForkchoiceState();
+        setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+            c_initialBlockNumber, c_initialBlockNumber);
+        setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+            c_initialBlockNumber, c_initialBlockNumber);
+        auto attrs = row.useV3Attrs ? makePayloadAttributesV3() : makePayloadAttributesV2();
+
+        if (row.expectUnsupportedFork)
+        {
+            auto expect = [needle = row.messageNeedle](UnsupportedFork const& e) {
+                return std::string(e.what()).find(needle) != std::string::npos;
+            };
+            BOOST_CHECK_EXCEPTION(task::syncWait(pair.legacy.updateForkchoice(
+                                      forkchoiceState, &attrs, row.fcuVersion)),
+                UnsupportedFork, expect);
+            BOOST_CHECK_EXCEPTION(task::syncWait(pair.fresh.updateForkchoice(
+                                      forkchoiceState, &attrs, row.fcuVersion)),
+                UnsupportedFork, expect);
+            continue;
+        }
+
+        auto legacyResult =
+            task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, row.fcuVersion));
+        auto newResult =
+            task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, row.fcuVersion));
+        checkForkchoiceParity(legacyResult, newResult);
+        BOOST_REQUIRE(legacyResult.payloadId.has_value());
+        BOOST_REQUIRE(newResult.payloadId.has_value());
+
+        // getPayload version window: V2 build answers V1–V2; V3 build answers V1–V5 per
+        // engine_common / detail compatibility matrix (already unit-tested in S3).
+        auto const getVersion = row.fcuVersion;
+        auto legacyPayload =
+            task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, getVersion));
+        auto newPayload = task::syncWait(pair.fresh.getPayload(*newResult.payloadId, getVersion));
+        checkGetPayloadParity(*legacyPayload, *newPayload);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(matrix_new_payload_v4_empty_lists_match)
+{
+    ServicePair pair;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(pair.legacyStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(pair.newStorage, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto attrs = makeKarstPayloadAttributes();
+    auto legacyBuild = task::syncWait(pair.legacy.updateForkchoice(forkchoiceState, &attrs, 3));
+    auto newBuild = task::syncWait(pair.fresh.updateForkchoice(forkchoiceState, &attrs, 3));
+    checkForkchoiceParity(legacyBuild, newBuild);
+
+    auto legacyPayload = task::syncWait(pair.legacy.getPayload(*legacyBuild.payloadId, 5));
+    auto newPayload = task::syncWait(pair.fresh.getPayload(*newBuild.payloadId, 5));
+    checkGetPayloadParity(*legacyPayload, *newPayload);
+
+    NewPayloadRequest legacyRequest;
+    legacyRequest.executionPayload = legacyPayload->executionPayload;
+    legacyRequest.parentBeaconBlockRoot = legacyPayload->parentBeaconBlockRoot;
+    legacyRequest.executionRequests = std::vector<bytes>{};
+    NewPayloadRequest newRequest;
+    newRequest.executionPayload = newPayload->executionPayload;
+    newRequest.parentBeaconBlockRoot = newPayload->parentBeaconBlockRoot;
+    newRequest.executionRequests = std::vector<bytes>{};
+
+    checkStatusParity(task::syncWait(pair.legacy.newPayload(legacyRequest, 4)),
+        task::syncWait(pair.fresh.newPayload(newRequest, 4)));
+}
+
+// Matrix: S7 — Eth publish under shared guard blocks exclusive writer (same handshake as OP).
+
+BOOST_AUTO_TEST_CASE(eth_publish_blocks_behind_shared_guard)
+{
+    EngineTracker tracker;
+    std::unordered_map<PayloadID, EthPayloadArtifacts<RealGlobalStateStorage::ViewType>> artifacts;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+
+    h256 const targetHash(0x42);
+    PayloadID const targetPayloadId = "0xdeadbeef";
+    constexpr protocol::BlockNumber kTargetNumber = 7;
+
+    {
+        auto guard = tracker.lockExclusive();
+        auto entry = std::make_shared<BuiltPayload>();
+        entry->executionPayload.blockHash = targetHash;
+        auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+        header->setNumber(kTargetNumber);
+        EthPayloadArtifacts<RealGlobalStateStorage::ViewType> node{
+            .view = nullptr, .header = header, .receipts = {}};
+        (void)publishBuiltPayload(
+            guard, artifacts, targetPayloadId, targetHash, entry, std::move(node));
+    }
+
+    protocol::BlockHeader::Ptr initialHeader;
+    std::atomic<bool> writerFinished{false};
+    std::exception_ptr writerError;
+    std::latch writerReady{1};
+    std::latch permission{1};
+    std::latch committed{1};
+
+    std::optional<std::thread> writer;
+    {
+        auto shared = tracker.lockShared();
+        auto id = shared.payloadIdForHash(targetHash);
+        BOOST_REQUIRE(id.has_value());
+        auto it = artifacts.find(*id);
+        BOOST_REQUIRE(it != artifacts.end());
+        initialHeader = it->second.header;
+        BOOST_REQUIRE(initialHeader);
+        BOOST_CHECK_EQUAL(initialHeader->number(), kTargetNumber);
+
+        writer.emplace([&] {
+            try
+            {
+                writerReady.count_down();
+                permission.wait();
+                committed.count_down();
+                auto guard = tracker.lockExclusive();
+                h256 writerHash(0x99);
+                PayloadID writerPayloadId = "0xcafebabe";
+                auto entry = std::make_shared<BuiltPayload>();
+                entry->executionPayload.blockHash = writerHash;
+                auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+                header->setNumber(99);
+                EthPayloadArtifacts<RealGlobalStateStorage::ViewType> node{
+                    .view = nullptr, .header = header, .receipts = {}};
+                (void)publishBuiltPayload(
+                    guard, artifacts, writerPayloadId, writerHash, entry, std::move(node));
+                writerFinished.store(true, std::memory_order_release);
+            }
+            catch (...)
+            {
+                writerError = std::current_exception();
+            }
+        });
+
+        writerReady.wait();
+        permission.count_down();
+        committed.wait();
+        BOOST_CHECK(!writerFinished.load(std::memory_order_acquire));
+    }
+
+    writer->join();
+    if (writerError)
+    {
+        std::rethrow_exception(writerError);
+    }
+    BOOST_CHECK(writerFinished.load(std::memory_order_acquire));
+
+    {
+        auto shared = tracker.lockShared();
+        auto id = shared.payloadIdForHash(targetHash);
+        BOOST_REQUIRE(id.has_value());
+        auto it = artifacts.find(*id);
+        BOOST_REQUIRE(it != artifacts.end());
+        BOOST_CHECK_EQUAL(it->second.header->number(), kTargetNumber);
+        BOOST_CHECK_EQUAL(it->second.header.get(), initialHeader.get());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
@@ -1,10 +1,25 @@
 /**
  *  Copyright (C) 2026 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthEngineServiceParityTest.cpp
+ * @brief Ethereum Engine API parity tests for EthEngineService
  */
 
 #include "engine/bcos-engine/EngineServiceImpl.h"
 #include "engine/bcos-engine/EthEngineService.h"
+#include "engine/test/unittests/engine/EthServiceStubs.h"
 
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPEncode.h>
@@ -47,8 +62,12 @@ using namespace bcos::txpool;
 using namespace bcos::protocol;
 using namespace bcos::crypto;
 
+constexpr bcos::protocol::BlockNumber c_rebuildBaseBlockNumber = 60;
+
 namespace eth_parity_test
 {
+
+using namespace bcos::engine::eth_test;
 // Whole-second milliseconds: finalizeEthBlockHeader / validateHeader require a whole
 // number of seconds at the Eth RLP boundary.
 constexpr std::uint64_t c_timestamp = 1700000000ULL * 1000ULL;
@@ -62,72 +81,6 @@ constexpr bcos::protocol::BlockNumber c_staleInitialBlockNumber = 50;
 constexpr bcos::protocol::BlockNumber c_staleNextBlockNumber = 51;
 constexpr bcos::protocol::BlockNumber c_staleThirdBlockNumber = 52;
 constexpr bcos::protocol::BlockNumber c_rebuildBaseBlockNumber = 60;
-
-using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
-    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
-    bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
-                                              bcos::storage2::memory_storage::LOGICAL_DELETION)>;
-using RealGlobalStateBackendStorage =
-    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
-        bcos::executor_v1::StateValue,
-        bcos::storage2::memory_storage::Attribute(
-            bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::CONCURRENT),
-        std::hash<bcos::executor_v1::StateKey>>;
-
-template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
-struct TrivialCheckpointStorage
-{
-    using CheckpointName = bcos::h256;
-    Storage& m_storage;
-    explicit TrivialCheckpointStorage(Storage& s) : m_storage(s) {}
-    Storage& open() { return m_storage; }
-    [[noreturn]] Storage& open(CheckpointName const&) { std::abort(); }
-    void createCheckpoint(Storage&, CheckpointName const&) {}
-    void deleteCheckpoint(CheckpointName const&) {}
-    std::optional<CheckpointName> latestCheckpointName() const { return std::nullopt; }
-    std::optional<CheckpointName> oldestCheckpointName() const { return std::nullopt; }
-};
-
-using RealGlobalCheckpointBackend = TrivialCheckpointStorage<bcos::executor_v1::StateKey,
-    bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
-using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
-    void, RealGlobalCheckpointBackend>;
-
-struct StubExecutor
-{
-    template <class Storage>
-    struct ExecuteContext
-    {
-        task::Task<void> prepare() { co_return; }
-        task::Task<void> execute() { co_return; }
-        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
-    };
-
-    template <class Storage>
-    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
-        const protocol::BlockHeader&, const protocol::Transaction&, int,
-        const ledger::LedgerConfig&, bool)
-    {
-        co_return nullptr;
-    }
-
-    template <class Storage>
-    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&, const protocol::BlockHeader&,
-        const protocol::Transaction&, int, const ledger::LedgerConfig&, bool)
-    {
-        co_return ExecuteContext<Storage>{};
-    }
-};
-
-struct StubScheduler
-{
-    template <class Storage, class Executor>
-    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
-        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
-    {
-        co_return {};
-    }
-};
 
 using LegacyService =
     EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
@@ -1061,7 +1014,7 @@ BOOST_AUTO_TEST_CASE(generic_validation_error_table_matches)
             },
             4, "executionRequests must be a present-but-empty list on this chain"},
         // Matrix: E6 — wide/bad in-process payloads. JSON-null blob fields are a parse
-        // concern (OpEngineReviewFixTest); these rows hit validateExecutionPayload.
+        // concern below this layer (the RPC dialect tests); these rows hit validateExecutionPayload.
         {"v2_with_blob_gas",
             [&] {
                 NewPayloadRequest r;
@@ -1565,7 +1518,7 @@ BOOST_AUTO_TEST_CASE(matrix_version_fork_fcu_and_get_payload)
         BOOST_REQUIRE(newResult.payloadId.has_value());
 
         // getPayload version window: V2 build answers V1–V2; V3 build answers V1–V5 per
-        // engine_common / detail compatibility matrix (already unit-tested in S3).
+        // the engine_common compatibility matrix exercised by the rows below.
         auto const getVersion = row.fcuVersion;
         auto legacyPayload =
             task::syncWait(pair.legacy.getPayload(*legacyResult.payloadId, getVersion));
@@ -1614,14 +1567,14 @@ BOOST_AUTO_TEST_CASE(eth_publish_blocks_behind_shared_guard)
 
     h256 const targetHash(0x42);
     PayloadID const targetPayloadId = "0xdeadbeef";
-    constexpr protocol::BlockNumber kTargetNumber = 7;
+    constexpr protocol::BlockNumber c_targetNumber = 7;
 
     {
         auto guard = tracker.lockExclusive();
         auto entry = std::make_shared<BuiltPayload>();
         entry->executionPayload.blockHash = targetHash;
         auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
-        header->setNumber(kTargetNumber);
+        header->setNumber(c_targetNumber);
         EthPayloadArtifacts<RealGlobalStateStorage::ViewType> node{
             .view = nullptr, .header = header, .receipts = {}};
         (void)publishBuiltPayload(
@@ -1644,7 +1597,7 @@ BOOST_AUTO_TEST_CASE(eth_publish_blocks_behind_shared_guard)
         BOOST_REQUIRE(it != artifacts.end());
         initialHeader = it->second.header;
         BOOST_REQUIRE(initialHeader);
-        BOOST_CHECK_EQUAL(initialHeader->number(), kTargetNumber);
+        BOOST_CHECK_EQUAL(initialHeader->number(), c_targetNumber);
 
         writer.emplace([&] {
             try
@@ -1690,7 +1643,7 @@ BOOST_AUTO_TEST_CASE(eth_publish_blocks_behind_shared_guard)
         BOOST_REQUIRE(id.has_value());
         auto it = artifacts.find(*id);
         BOOST_REQUIRE(it != artifacts.end());
-        BOOST_CHECK_EQUAL(it->second.header->number(), kTargetNumber);
+        BOOST_CHECK_EQUAL(it->second.header->number(), c_targetNumber);
         BOOST_CHECK_EQUAL(it->second.header.get(), initialHeader.get());
     }
 }

--- a/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
@@ -63,8 +63,6 @@ using namespace bcos::txpool;
 using namespace bcos::protocol;
 using namespace bcos::crypto;
 
-constexpr bcos::protocol::BlockNumber c_rebuildBaseBlockNumber = 60;
-
 namespace eth_parity_test
 {
 
@@ -1597,14 +1595,14 @@ BOOST_AUTO_TEST_CASE(eth_nonempty_withdrawals_rejected_with_pinned_message)
     NewPayloadRequest legacyV2;
     legacyV2.executionPayload = legacyPayload->executionPayload;
     legacyV2.executionPayload.withdrawals =
-        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .validatorIndex = 0, .amount = 1, .address = {}}};
     auto legacyV2Status = task::syncWait(pair.legacy.newPayload(legacyV2, 2));
     checkNonEmptyWithdrawalsInvalid(legacyV2Status, "legacy V2");
 
     NewPayloadRequest newV2;
     newV2.executionPayload = newPayload->executionPayload;
     newV2.executionPayload.withdrawals =
-        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .validatorIndex = 0, .amount = 1, .address = {}}};
     auto newV2Status = task::syncWait(pair.fresh.newPayload(newV2, 2));
     checkNonEmptyWithdrawalsInvalid(newV2Status, "fresh V2");
 
@@ -1612,14 +1610,14 @@ BOOST_AUTO_TEST_CASE(eth_nonempty_withdrawals_rejected_with_pinned_message)
     NewPayloadRequest legacyV4 = makeNewPayloadRequestV3(legacyPayload->executionPayload);
     legacyV4.executionRequests = std::vector<bytes>{};
     legacyV4.executionPayload.withdrawals =
-        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .validatorIndex = 0, .amount = 1, .address = {}}};
     auto legacyV4Status = task::syncWait(pair.legacy.newPayload(legacyV4, 4));
     checkNonEmptyWithdrawalsInvalid(legacyV4Status, "legacy V4");
 
     NewPayloadRequest newV4 = makeNewPayloadRequestV3(newPayload->executionPayload);
     newV4.executionRequests = std::vector<bytes>{};
     newV4.executionPayload.withdrawals =
-        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .amount = 1}};
+        std::vector<WithdrawalV1>{WithdrawalV1{.index = 1, .validatorIndex = 0, .amount = 1, .address = {}}};
     auto newV4Status = task::syncWait(pair.fresh.newPayload(newV4, 4));
     checkNonEmptyWithdrawalsInvalid(newV4Status, "fresh V4");
 }
@@ -1752,7 +1750,8 @@ BOOST_AUTO_TEST_CASE(wire_round_trip_through_engine_helper)
         BOOST_CHECK_EQUAL(parsed.parentBeaconBlockRoot->hexPrefixed(),
             built->parentBeaconBlockRoot->hexPrefixed());
         auto mismatch =
-            detail::compareWithBuiltPayload(parsed.executionPayload, built->executionPayload);
+            bcos::engine::detail::compareWithBuiltPayload(
+                parsed.executionPayload, built->executionPayload);
         BOOST_CHECK_MESSAGE(!mismatch, label << " wire round-trip diverged: " << *mismatch);
     }
 

--- a/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceParityTest.cpp
@@ -1733,7 +1733,7 @@ BOOST_AUTO_TEST_CASE(wire_round_trip_through_engine_helper)
     BOOST_REQUIRE(built);
     BOOST_REQUIRE(built->parentBeaconBlockRoot.has_value());
 
-    for (auto const [version, label] :
+    for (auto const& [version, label] :
         {std::pair{ApiVersion::V3, "V3"}, std::pair{ApiVersion::V5, "V5"}})
     {
         auto ep = bcos::rpc::serializeExecutionPayload(built->executionPayload, version);

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -255,8 +255,10 @@ public:
         (void)features;
         (void)blockHashOverride;
         (void)writeNonces;
-        if (block && block->blockHeader())
+        if (block)
         {
+            // AnyBlockHeader is returned by value and cannot be null; use it directly,
+            // the way Ledger::asyncPrewriteBlock does.
             auto const header = block->blockHeader();
             bcos::storage::Entry hash2NumberEntry;
             hash2NumberEntry.set(std::to_string(header->number()));
@@ -524,7 +526,7 @@ BOOST_AUTO_TEST_CASE(commit_retained_payload_rolls_back_on_artifacts_clear_throw
                   });
 
     artifacts.throwOnClear = true;
-    BOOST_CHECK_THROW(detail::commitRetainedPayload(
+    BOOST_CHECK_THROW(bcos::engine::detail::commitRetainedPayload(
                           guard, artifacts, "0xcommit", h256(2), makeEntry("0xcommit")),
         std::runtime_error);
 
@@ -565,9 +567,15 @@ BOOST_AUTO_TEST_CASE(commit_merge_failure_leaves_cache_and_artifacts)
     BOOST_CHECK_NO_THROW(task::syncWait(service.getPayload(*build.payloadId, 3)));
 
     storage.throwOnMerge->store(false);
+    // The retryable-commit contract: the retained artifact means the durable write
+    // never succeeded, so the retry lands the prewritten rows and answers the
+    // idempotent VALID — a terminal-Syncing retry would strand a fully built block
+    // forever (the bug the retryable-commit fix removed). Terminal SYNCING stays
+    // reserved for the mid-persist-death guard (no artifact, no ledger row), which
+    // 81f6576fb made visible via warnSyncingRateLimited.
     auto retryStatus = task::syncWait(service.newPayload(request, 3));
     BOOST_CHECK_EQUAL(
-        static_cast<int>(retryStatus.status), static_cast<int>(PayloadValidationStatus::Syncing));
+        static_cast<int>(retryStatus.status), static_cast<int>(PayloadValidationStatus::Valid));
 }
 
 BOOST_AUTO_TEST_CASE(commit_retry_valid_when_ledger_row_exists)

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -117,6 +117,20 @@ struct GateMergeStorage
         }
         co_return co_await inner.mergeBackStorage(extra);
     }
+
+    task::Task<void> mergeToBackends(MutableStorage& extra)
+    {
+        mergeStarted->store(true, std::memory_order_release);
+        while (!mergeGate->load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+        if (throwOnMerge->load())
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
+        }
+        co_await inner.mergeToBackends(extra);
+    }
 };
 
 struct StubExecutor

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -67,6 +67,11 @@ struct GateMergeStorage
     std::shared_ptr<std::atomic<bool>> throwOnMerge = std::make_shared<std::atomic<bool>>(false);
     // Landed merges only: incremented after the gate and the throw check.
     std::atomic<unsigned> mergeCount{0};
+    // Mirror of the inner MultiLayerStorage deque depth: +1 per pushView, -1 per
+    // landed deque-consuming merge (bare and extra overloads), unchanged on the
+    // NotExistsImmutableStorageError empty-deque throw. The drain contract of
+    // commit_drains_every_queued_layer asserts this reaches zero.
+    std::atomic<int> queuedDepth{0};
 
     ViewType fork() { return inner.fork(); }
     void pushView(ViewType view)
@@ -77,6 +82,7 @@ struct GateMergeStorage
             std::this_thread::yield();
         }
         inner.pushView(std::move(view));
+        ++queuedDepth;
     }
 
     task::Task<std::shared_ptr<MutableStorage>> mergeBackStorage()
@@ -90,8 +96,19 @@ struct GateMergeStorage
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
-        ++mergeCount;
-        co_return co_await inner.mergeBackStorage();
+        try
+        {
+            auto landed = co_await inner.mergeBackStorage();
+            ++mergeCount;
+            --queuedDepth;
+            co_return landed;
+        }
+        catch (bcos::storage2::NotExistsImmutableStorageError const&)
+        {
+            // Empty deque: nothing was consumed, depth unchanged; rethrow so a
+            // drain loop can tell the difference between landed and empty.
+            throw;
+        }
     }
 
     task::Task<std::shared_ptr<MutableStorage>> mergeBackStorage(MutableStorage& extra)
@@ -105,8 +122,17 @@ struct GateMergeStorage
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
-        ++mergeCount;
-        co_return co_await inner.mergeBackStorage(extra);
+        try
+        {
+            auto landed = co_await inner.mergeBackStorage(extra);
+            ++mergeCount;
+            --queuedDepth;
+            co_return landed;
+        }
+        catch (bcos::storage2::NotExistsImmutableStorageError const&)
+        {
+            throw;
+        }
     }
 
     task::Task<void> mergeToBackends(MutableStorage& extra)
@@ -120,8 +146,8 @@ struct GateMergeStorage
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
-        ++mergeCount;
         co_await inner.mergeToBackends(extra);
+        ++mergeCount;
     }
 };
 
@@ -576,6 +602,66 @@ BOOST_AUTO_TEST_CASE(commit_merge_failure_leaves_cache_and_artifacts)
     auto retryStatus = task::syncWait(service.newPayload(request, 3));
     BOOST_CHECK_EQUAL(
         static_cast<int>(retryStatus.status), static_cast<int>(PayloadValidationStatus::Valid));
+}
+
+BOOST_AUTO_TEST_CASE(commit_drains_every_queued_layer)
+{
+    // A residual layer from an abandoned payload must not survive a later commit:
+    // MultiLayerStorage pushes to the front and merges the back, so one merge per
+    // push makes any residual queued layer permanent — the newest block's state
+    // would stay in memory while the service answers VALID, and would be lost on
+    // restart. newPayload must drain the deque in both landing branches; this
+    // test pins the invariant that the queue is EMPTY once a commit returns.
+    GateMergeStorage storage;
+    MemPoolImpl memPool;
+    StubExecutor executor;
+    StubScheduler scheduler;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto ledger = std::make_shared<PersistingFakeLedger>(blockFactory, 20, 10, 10);
+
+    using Service = EthEngineService<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
+    Service service(memPool, storage, executor, scheduler, blockFactory, ledger);
+
+    auto forkchoice = makeForkchoiceState();
+    seedForkchoiceStorage(storage, forkchoice);
+
+    // Payload N: build, then let the commit fail mid-merge (throwOnMerge), then
+    // abandon it — the CL never retries. Its view layer stays queued.
+    PayloadAttributes attrsN = makeAttrs(1'700'000'000'000ULL);
+    auto buildN = task::syncWait(service.updateForkchoice(forkchoice, &attrsN, 3));
+    BOOST_REQUIRE(buildN.payloadId.has_value());
+    auto payloadN = task::syncWait(service.getPayload(*buildN.payloadId, 3));
+
+    storage.throwOnMerge->store(true);
+    storage.mergeGate->store(true);
+
+    NewPayloadRequest requestN;
+    requestN.executionPayload = payloadN->executionPayload;
+    requestN.parentBeaconBlockRoot = attrsN.parentBeaconBlockRoot;
+    BOOST_CHECK_THROW(task::syncWait(service.newPayload(requestN, 3)), std::runtime_error);
+    BOOST_CHECK_EQUAL(storage.queuedDepth.load(), 1);
+
+    // Payload N+1: a fresh FCU at the same head with different attributes. The
+    // commit lands N+1's prewritten rows (together with the residual layer, FIFO)
+    // and then DRAINS the deque — N+1's own state layer must reach the backend,
+    // not linger in memory behind a VALID answer.
+    storage.throwOnMerge->store(false);
+    PayloadAttributes attrsN1 = makeAttrs(1'700'000'001'000ULL);
+    auto buildN1 = task::syncWait(service.updateForkchoice(forkchoice, &attrsN1, 3));
+    BOOST_REQUIRE(buildN1.payloadId.has_value());
+    BOOST_REQUIRE(*buildN1.payloadId != *buildN.payloadId);
+    auto payloadN1 = task::syncWait(service.getPayload(*buildN1.payloadId, 3));
+
+    NewPayloadRequest requestN1;
+    requestN1.executionPayload = payloadN1->executionPayload;
+    requestN1.parentBeaconBlockRoot = attrsN1.parentBeaconBlockRoot;
+    auto statusN1 = task::syncWait(service.newPayload(requestN1, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(statusN1.status), static_cast<int>(PayloadValidationStatus::Valid));
+    BOOST_CHECK_MESSAGE(storage.queuedDepth.load() == 0,
+        "a residual queued layer survived the commit — the newest payload's state is "
+        "in-memory only and would be lost on restart (depth " +
+            std::to_string(storage.queuedDepth.load()) + ")");
 }
 
 BOOST_AUTO_TEST_CASE(commit_retry_valid_when_ledger_row_exists)

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -1,0 +1,806 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "engine/bcos-engine/EngineServiceImpl.h"
+#include "engine/bcos-engine/EngineTracker.h"
+#include "engine/bcos-engine/EthEngineService.h"
+#include "engine/bcos-engine/PayloadCache.h"
+
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage/Serialize.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/testutils/faker/FakeBlock.h>
+#include <bcos-framework/testutils/faker/FakeLedger.h>
+#include <bcos-mempool/MemPoolImpl.h>
+#include <bcos-task/Wait.h>
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <magic_enum/magic_enum.hpp>
+
+#include <atomic>
+#include <functional>
+#include <thread>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::engine;
+using namespace bcos::txpool;
+
+namespace eth_tx_test
+{
+
+using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
+    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
+    bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
+                                              bcos::storage2::memory_storage::LOGICAL_DELETION)>;
+using RealGlobalStateBackendStorage =
+    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+        bcos::executor_v1::StateValue,
+        bcos::storage2::memory_storage::Attribute(
+            bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::CONCURRENT),
+        std::hash<bcos::executor_v1::StateKey>>;
+
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& s) : m_storage(s) {}
+    Storage& open() { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const&) { std::abort(); }
+    void createCheckpoint(Storage&, CheckpointName const&) {}
+    void deleteCheckpoint(CheckpointName const&) {}
+    std::optional<CheckpointName> latestCheckpointName() const { return std::nullopt; }
+    std::optional<CheckpointName> oldestCheckpointName() const { return std::nullopt; }
+};
+
+using RealGlobalCheckpointBackend = TrivialCheckpointStorage<bcos::executor_v1::StateKey,
+    bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
+using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
+    void, RealGlobalCheckpointBackend>;
+
+struct GateMergeStorage
+{
+    using ViewType = RealGlobalStateStorage::ViewType;
+    using MutableStorage = RealGlobalStateStorage::MutableStorage;
+
+    RealGlobalStateBackendStorage backendStorage;
+    RealGlobalCheckpointBackend checkpointBackend{backendStorage};
+    RealGlobalStateStorage inner{checkpointBackend};
+    std::shared_ptr<std::atomic<bool>> mergeGate = std::make_shared<std::atomic<bool>>(false);
+    std::shared_ptr<std::atomic<bool>> mergeStarted = std::make_shared<std::atomic<bool>>(false);
+    std::shared_ptr<std::atomic<bool>> pushViewGate = std::make_shared<std::atomic<bool>>(true);
+    std::shared_ptr<std::atomic<bool>> pushViewStarted = std::make_shared<std::atomic<bool>>(false);
+    std::shared_ptr<std::atomic<bool>> throwOnMerge = std::make_shared<std::atomic<bool>>(false);
+
+    ViewType fork() { return inner.fork(); }
+    void pushView(ViewType view)
+    {
+        pushViewStarted->store(true, std::memory_order_release);
+        while (!pushViewGate->load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+        inner.pushView(std::move(view));
+    }
+
+    task::Task<std::shared_ptr<MutableStorage>> mergeBackStorage()
+    {
+        mergeStarted->store(true, std::memory_order_release);
+        while (!mergeGate->load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+        if (throwOnMerge->load())
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
+        }
+        co_return co_await inner.mergeBackStorage();
+    }
+
+    task::Task<std::shared_ptr<MutableStorage>> mergeBackStorage(MutableStorage& extra)
+    {
+        mergeStarted->store(true, std::memory_order_release);
+        while (!mergeGate->load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+        if (throwOnMerge->load())
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
+        }
+        co_return co_await inner.mergeBackStorage(extra);
+    }
+};
+
+struct StubExecutor
+{
+    template <class Storage>
+    struct ExecuteContext
+    {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
+    };
+
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
+        const protocol::BlockHeader&, const protocol::Transaction&, int,
+        const ledger::LedgerConfig&, bool)
+    {
+        co_return nullptr;
+    }
+
+    template <class Storage>
+    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&, const protocol::BlockHeader&,
+        const protocol::Transaction&, int, const ledger::LedgerConfig&, bool)
+    {
+        co_return ExecuteContext<Storage>{};
+    }
+};
+
+struct StubScheduler
+{
+    template <class Storage, class Executor>
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
+    {
+        co_return {};
+    }
+};
+
+struct ArtifactNode
+{
+    int value = 0;
+};
+
+struct ThrowingArtifactsMap
+{
+    std::unordered_map<PayloadID, ArtifactNode> inner;
+    bool throwOnAssign = false;
+
+    struct AssignProxy
+    {
+        ArtifactNode& slot;
+        bool& throwFlag;
+        AssignProxy(ArtifactNode& s, bool& f) : slot(s), throwFlag(f) {}
+        AssignProxy& operator=(ArtifactNode&&)
+        {
+            if (throwFlag)
+            {
+                throw std::runtime_error{"artifact assign failed"};
+            }
+            slot.value = 1;
+            return *this;
+        }
+    };
+
+    AssignProxy operator[](PayloadID const& id) { return AssignProxy(inner[id], throwOnAssign); }
+
+    void erase(PayloadID const& id) { inner.erase(id); }
+};
+
+BuiltPayloadPtr makeEntry(PayloadID const& id)
+{
+    auto entry = std::make_shared<BuiltPayload>();
+    entry->version = 3;
+    entry->executionPayload.blockNumber = static_cast<bcos::protocol::BlockNumber>(id.size());
+    return entry;
+}
+
+struct CommitCleanup
+{
+    std::vector<std::thread*> threads;
+    std::vector<std::shared_ptr<std::atomic<bool>>> gates;
+
+    ~CommitCleanup()
+    {
+        for (auto const& gate : gates)
+        {
+            if (gate)
+            {
+                gate->store(true, std::memory_order_release);
+            }
+        }
+        for (auto* thread : threads)
+        {
+            if (thread != nullptr && thread->joinable())
+            {
+                thread->join();
+            }
+        }
+    }
+};
+
+bool waitUntil(std::chrono::steady_clock::duration timeout, auto&& predicate)
+{
+    auto const deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (predicate())
+        {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    return predicate();
+}
+
+class GatedFakeLedger : public bcos::test::FakeLedger
+{
+public:
+    using FakeLedger::FakeLedger;
+
+    std::atomic<bool> prewriteStarted{false};
+    std::shared_ptr<std::atomic<bool>> prewriteGate = std::make_shared<std::atomic<bool>>(false);
+
+    void asyncPrewriteBlock(bcos::storage::StorageInterface::Ptr storage,
+        bcos::protocol::ConstTransactionsPtr blockTxs, bcos::protocol::Block::ConstPtr block,
+        std::function<void(std::string, Error::Ptr&&)> callback, bool writeTxsAndReceipts,
+        std::optional<bcos::ledger::Features> features,
+        std::optional<bcos::crypto::HashType> blockHashOverride, bool writeNonces) override
+    {
+        (void)storage;
+        (void)blockTxs;
+        (void)block;
+        (void)writeTxsAndReceipts;
+        (void)features;
+        (void)blockHashOverride;
+        (void)writeNonces;
+        prewriteStarted.store(true, std::memory_order_release);
+        // prewriteBlockToBuffer suspends until this callback runs; keep it on the
+        // commit thread (spin/yield) so task::syncWait can resume without a
+        // cross-thread handle.resume() deadlock.
+        while (!prewriteGate->load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+        callback("", nullptr);
+    }
+};
+
+template <class ViewType>
+struct ThrowingPayloadArtifactsMap
+{
+    std::unordered_map<PayloadID, EthPayloadArtifacts<ViewType>> inner;
+    bool throwOnAssign = false;
+
+    struct AssignProxy
+    {
+        EthPayloadArtifacts<ViewType>& slot;
+        bool& throwFlag;
+        AssignProxy(EthPayloadArtifacts<ViewType>& s, bool& f) : slot(s), throwFlag(f) {}
+        AssignProxy& operator=(EthPayloadArtifacts<ViewType>&& other)
+        {
+            if (throwFlag)
+            {
+                throw std::runtime_error{"artifact assign failed"};
+            }
+            slot = std::move(other);
+            return *this;
+        }
+    };
+
+    AssignProxy operator[](PayloadID const& id) { return AssignProxy(inner[id], throwOnAssign); }
+
+    void erase(PayloadID const& id) { inner.erase(id); }
+
+    ThrowingPayloadArtifactsMap duplicate() const { return *this; }
+};
+
+template <class ViewType>
+struct ThrowingClearArtifactStore
+{
+    std::unordered_map<PayloadID, EthPayloadArtifacts<ViewType>> inner;
+    bool throwOnClear = false;
+
+    void clear()
+    {
+        if (throwOnClear)
+        {
+            throw std::runtime_error{"artifacts clear failed"};
+        }
+        inner.clear();
+    }
+};
+
+ForkchoiceState makeForkchoiceState()
+{
+    return {h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        h256("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        h256("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")};
+}
+
+void seedForkchoiceStorage(GateMergeStorage& storageFixture, ForkchoiceState const& forkchoice)
+{
+    auto writeSysConfig = [&](std::string_view key, std::string value) {
+        storage::Entry entry;
+        entry.set(bcos::storage::serialize::encode(ledger::SystemConfigEntry{std::move(value), 0}));
+        task::syncWait(bcos::storage2::writeOne(storageFixture.backendStorage,
+            bcos::executor_v1::StateKey{ledger::SYS_CONFIG, key}, std::move(entry)));
+    };
+    writeSysConfig(magic_enum::enum_name(ledger::SystemConfig::executor_version),
+        std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION));
+    writeSysConfig(
+        ledger::SYSTEM_KEY_EVMC_REVISION, ledger::encodeEVMCRevisionConfig(EVMC_CANCUN, {}));
+
+    auto writeBlock = [&](h256 const& hash, char const* number) {
+        storage::Entry entry;
+        entry.set(number);
+        task::syncWait(bcos::storage2::writeOne(storageFixture.backendStorage,
+            bcos::executor_v1::StateKey{
+                ledger::SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(hash)},
+            std::move(entry)));
+        storage::Entry hashEntry;
+        hashEntry.set(hash.asBytes());
+        task::syncWait(bcos::storage2::writeOne(storageFixture.backendStorage,
+            bcos::executor_v1::StateKey{ledger::SYS_NUMBER_2_HASH, number}, std::move(hashEntry)));
+    };
+    writeBlock(forkchoice.finalizedBlockHash, "3");
+    writeBlock(forkchoice.safeBlockHash, "4");
+    writeBlock(forkchoice.headBlockHash, "5");
+}
+
+PayloadAttributes makeAttrs(std::uint64_t timestamp)
+{
+    PayloadAttributes attrs;
+    attrs.timestamp = timestamp;
+    attrs.prevRandao = h256(std::string(64, '1'));
+    attrs.suggestedFeeRecipient = Address(std::string(40, '2'));
+    attrs.withdrawals = std::vector<WithdrawalV1>{};
+    attrs.parentBeaconBlockRoot = h256(std::string(64, '3'));
+    return attrs;
+}
+
+}  // namespace eth_tx_test
+
+namespace eth_tx_test
+{
+
+BOOST_AUTO_TEST_SUITE(EthEngineServiceTransactionalTest)
+
+using namespace eth_tx_test;
+
+BOOST_AUTO_TEST_CASE(payload_cache_put_and_retain_only_is_atomic)
+{
+    PayloadCache cache;
+    for (std::uint64_t i = 0; i < 3; ++i)
+    {
+        auto entry = makeEntry("0x0" + std::to_string(i));
+        cache.put("0x0" + std::to_string(i), h256(i + 1), entry);
+    }
+    BOOST_REQUIRE(cache.find("0x00"));
+    BOOST_REQUIRE(cache.find("0x01"));
+
+    auto retained = makeEntry("0xretained");
+    cache.putAndRetainOnly("0xretained", h256(99), retained);
+
+    BOOST_CHECK(!cache.find("0x00"));
+    BOOST_CHECK(!cache.find("0x01"));
+    BOOST_REQUIRE(cache.find("0xretained"));
+    BOOST_CHECK_EQUAL(*cache.payloadIdForHash(h256(99)), "0xretained");
+}
+
+BOOST_AUTO_TEST_CASE(payload_cache_publish_from_restores_snapshot)
+{
+    PayloadCache cache;
+    cache.put("0x01", h256(1), makeEntry("0x01"));
+    auto snapshot = cache.duplicate();
+    cache.put("0x02", h256(2), makeEntry("0x02"));
+    BOOST_REQUIRE(cache.find("0x02"));
+
+    cache.publishFrom(std::move(snapshot));
+    BOOST_REQUIRE(cache.find("0x01"));
+    BOOST_CHECK(!cache.find("0x02"));
+}
+
+BOOST_AUTO_TEST_CASE(publish_built_payload_rolls_back_cache_and_artifacts_on_throw)
+{
+    EngineTracker tracker;
+    auto guard = tracker.lockExclusive();
+    guard.putPayload("0xexisting", h256(1), makeEntry("0xexisting"));
+
+    ThrowingArtifactsMap artifacts;
+    artifacts.inner.emplace("0xexisting", ArtifactNode{.value = 42});
+    artifacts.throwOnAssign = true;
+
+    PayloadID newId = "0xnew";
+    BOOST_CHECK_THROW(publishBuiltPayload(guard, artifacts, newId, h256(2), makeEntry(newId),
+                          ArtifactNode{.value = 7}),
+        std::runtime_error);
+
+    BOOST_REQUIRE(guard.findPayload("0xexisting"));
+    BOOST_CHECK(!guard.findPayload(newId));
+    BOOST_CHECK_EQUAL(artifacts.inner.at("0xexisting").value, 42);
+    BOOST_CHECK(!artifacts.inner.contains(newId));
+}
+
+BOOST_AUTO_TEST_CASE(publish_built_payload_does_not_restore_fifo_evicted_on_artifacts_throw)
+{
+    EngineTracker tracker;
+    auto guard = tracker.lockExclusive();
+
+    // PayloadCache::put FIFO cap is 64. Fill it, then a 65th put evicts the oldest.
+    constexpr std::size_t kMaxEntries = 64;
+    for (std::size_t i = 0; i < kMaxEntries; ++i)
+    {
+        auto id = "0x" + std::to_string(i);
+        guard.putPayload(id, h256(i + 1), makeEntry(id));
+    }
+    BOOST_REQUIRE(guard.findPayload("0x0"));
+
+    ThrowingArtifactsMap artifacts;
+    artifacts.throwOnAssign = true;
+    PayloadID newId = "0xnew";
+    BOOST_CHECK_THROW(publishBuiltPayload(guard, artifacts, newId, h256(100), makeEntry(newId),
+                          ArtifactNode{.value = 7}),
+        std::runtime_error);
+
+    BOOST_CHECK(!guard.findPayload(newId));
+    BOOST_CHECK(!artifacts.inner.contains(newId));
+    // Finding T: FIFO-evicted entries stay evicted when artifacts assign throws.
+    BOOST_CHECK(!guard.findPayload("0x0"));
+    BOOST_REQUIRE(guard.findPayload("0x1"));
+}
+
+BOOST_AUTO_TEST_CASE(payload_cache_erase_removes_id_hash_and_order)
+{
+    PayloadCache cache;
+    cache.put("0xkeep", h256(1), makeEntry("0xkeep"));
+    cache.put("0xdrop", h256(2), makeEntry("0xdrop"));
+    cache.erase("0xdrop");
+
+    BOOST_REQUIRE(cache.find("0xkeep"));
+    BOOST_CHECK(!cache.find("0xdrop"));
+    BOOST_CHECK(!cache.payloadIdForHash(h256(2)).has_value());
+    BOOST_CHECK_EQUAL(*cache.payloadIdForHash(h256(1)), "0xkeep");
+
+    // A later put must not evict `keep` as if `drop` were still in FIFO order.
+    for (std::size_t i = 0; i < 63; ++i)
+    {
+        auto id = "0xf" + std::to_string(i);
+        cache.put(id, h256(10 + i), makeEntry(id));
+    }
+    BOOST_REQUIRE(cache.find("0xkeep"));
+}
+
+BOOST_AUTO_TEST_CASE(publish_built_payload_preserves_prior_generic_artifact)
+{
+    EngineTracker tracker;
+    ThrowingPayloadArtifactsMap<RealGlobalStateStorage::ViewType> artifacts;
+    GateMergeStorage storage;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto guard = tracker.lockExclusive();
+
+    PayloadID keepId = "0xkeep";
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setTimestamp(424242);
+    EthPayloadArtifacts<RealGlobalStateStorage::ViewType> staged{
+        .view = std::make_shared<RealGlobalStateStorage::ViewType>(storage.fork()),
+        .header = std::move(header),
+        .receipts = {},
+    };
+    publishBuiltPayload(guard, artifacts, keepId, h256(1), makeEntry(keepId), std::move(staged));
+
+    artifacts.throwOnAssign = true;
+    PayloadID failingId = "0xfailing";
+    BOOST_CHECK_THROW(
+        publishBuiltPayload(guard, artifacts, failingId, h256(99), makeEntry(failingId),
+            EthPayloadArtifacts<RealGlobalStateStorage::ViewType>{}),
+        std::runtime_error);
+
+    BOOST_REQUIRE(guard.findPayload(keepId));
+    BOOST_CHECK(!guard.findPayload(failingId));
+    BOOST_REQUIRE(artifacts.inner.contains(keepId));
+    BOOST_CHECK_EQUAL(artifacts.inner.at(keepId).header->timestamp(), 424242);
+}
+
+BOOST_AUTO_TEST_CASE(commit_retained_payload_rolls_back_on_artifacts_clear_throw)
+{
+    EngineTracker tracker;
+    ThrowingClearArtifactStore<RealGlobalStateStorage::ViewType> artifacts;
+    auto guard = tracker.lockExclusive();
+    guard.putPayload("0xkeep", h256(1), makeEntry("0xkeep"));
+    GateMergeStorage storage;
+    auto header = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite())
+                      ->blockHeaderFactory()
+                      ->createBlockHeader();
+    header->setTimestamp(515151);
+    artifacts.inner.emplace(
+        "0xkeep", EthPayloadArtifacts<RealGlobalStateStorage::ViewType>{
+                      .view = std::make_shared<RealGlobalStateStorage::ViewType>(storage.fork()),
+                      .header = std::move(header),
+                      .receipts = {},
+                  });
+
+    artifacts.throwOnClear = true;
+    BOOST_CHECK_THROW(eth_detail::commitRetainedPayload(
+                          guard, artifacts, "0xcommit", h256(2), makeEntry("0xcommit")),
+        std::runtime_error);
+
+    BOOST_REQUIRE(guard.findPayload("0xkeep"));
+    BOOST_CHECK(!guard.findPayload("0xcommit"));
+    BOOST_REQUIRE(artifacts.inner.contains("0xkeep"));
+    BOOST_CHECK_EQUAL(artifacts.inner.at("0xkeep").header->timestamp(), 515151);
+}
+
+BOOST_AUTO_TEST_CASE(commit_merge_failure_leaves_cache_and_artifacts)
+{
+    GateMergeStorage storage;
+    MemPoolImpl memPool;
+    StubExecutor executor;
+    StubScheduler scheduler;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto ledger = std::make_shared<bcos::test::FakeLedger>(blockFactory, 20, 10, 10);
+
+    using Service = EthEngineService<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
+    Service service(memPool, storage, executor, scheduler, blockFactory, ledger);
+
+    auto forkchoice = makeForkchoiceState();
+    seedForkchoiceStorage(storage, forkchoice);
+
+    PayloadAttributes attrs = makeAttrs(1'700'000'000'000ULL);
+    auto build = task::syncWait(service.updateForkchoice(forkchoice, &attrs, 3));
+    BOOST_REQUIRE(build.payloadId.has_value());
+    auto payload = task::syncWait(service.getPayload(*build.payloadId, 3));
+
+    storage.throwOnMerge->store(true);
+    storage.mergeGate->store(true);
+
+    NewPayloadRequest request;
+    request.executionPayload = payload->executionPayload;
+    request.parentBeaconBlockRoot = attrs.parentBeaconBlockRoot;
+
+    BOOST_CHECK_THROW(task::syncWait(service.newPayload(request, 3)), std::runtime_error);
+    BOOST_CHECK_NO_THROW(task::syncWait(service.getPayload(*build.payloadId, 3)));
+
+    storage.throwOnMerge->store(false);
+    auto retryStatus = task::syncWait(service.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(retryStatus.status), static_cast<int>(PayloadValidationStatus::Syncing));
+}
+
+BOOST_AUTO_TEST_CASE(commit_retry_valid_when_ledger_row_exists)
+{
+    GateMergeStorage storage;
+    MemPoolImpl memPool;
+    StubExecutor executor;
+    StubScheduler scheduler;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto ledger = std::make_shared<bcos::test::FakeLedger>(blockFactory, 20, 10, 10);
+
+    using Service = EthEngineService<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
+    Service service(memPool, storage, executor, scheduler, blockFactory, ledger);
+
+    auto forkchoice = makeForkchoiceState();
+    seedForkchoiceStorage(storage, forkchoice);
+
+    PayloadAttributes attrs = makeAttrs(1'700'000'001'000ULL);
+    auto build = task::syncWait(service.updateForkchoice(forkchoice, &attrs, 3));
+    BOOST_REQUIRE(build.payloadId.has_value());
+    auto payload = task::syncWait(service.getPayload(*build.payloadId, 3));
+
+    storage.mergeGate->store(true);
+
+    NewPayloadRequest request;
+    request.executionPayload = payload->executionPayload;
+    request.parentBeaconBlockRoot = attrs.parentBeaconBlockRoot;
+
+    auto firstStatus = task::syncWait(service.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(firstStatus.status), static_cast<int>(PayloadValidationStatus::Valid));
+
+    storage::Entry persisted;
+    persisted.set(std::to_string(static_cast<int64_t>(request.executionPayload.blockNumber)));
+    task::syncWait(bcos::storage2::writeOne(storage.backendStorage,
+        bcos::executor_v1::StateKey{ledger::SYS_HASH_2_NUMBER,
+            bcos::concepts::bytebuffer::toView(request.executionPayload.blockHash)},
+        std::move(persisted)));
+
+    auto retryStatus = task::syncWait(service.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(retryStatus.status), static_cast<int>(PayloadValidationStatus::Valid));
+}
+
+BOOST_AUTO_TEST_CASE(commit_releases_exclusive_guard_during_merge)
+{
+    GateMergeStorage legacyStorage;
+    GateMergeStorage newStorage;
+    MemPoolImpl legacyMemPool;
+    MemPoolImpl newMemPool;
+    StubExecutor legacyExecutor;
+    StubExecutor newExecutor;
+    StubScheduler legacyScheduler;
+    StubScheduler newScheduler;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+
+    using LegacyService =
+        EngineServiceImpl<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
+    using NewService = EthEngineService<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
+
+    LegacyService legacy(
+        legacyMemPool, legacyStorage, legacyExecutor, legacyScheduler, blockFactory);
+    NewService fresh(newMemPool, newStorage, newExecutor, newScheduler, blockFactory);
+
+    auto forkchoice = makeForkchoiceState();
+    seedForkchoiceStorage(legacyStorage, forkchoice);
+    seedForkchoiceStorage(newStorage, forkchoice);
+
+    PayloadAttributes attrs = makeAttrs(1'700'000'001'000ULL);
+    auto legacyBuild = task::syncWait(legacy.updateForkchoice(forkchoice, &attrs, 3));
+    auto newBuild = task::syncWait(fresh.updateForkchoice(forkchoice, &attrs, 3));
+    BOOST_REQUIRE(legacyBuild.payloadId.has_value());
+    BOOST_REQUIRE(newBuild.payloadId.has_value());
+
+    auto legacyPayload = task::syncWait(legacy.getPayload(*legacyBuild.payloadId, 3));
+    auto newPayload = task::syncWait(fresh.getPayload(*newBuild.payloadId, 3));
+
+    NewPayloadRequest legacyRequest;
+    legacyRequest.executionPayload = legacyPayload->executionPayload;
+    legacyRequest.parentBeaconBlockRoot = attrs.parentBeaconBlockRoot;
+    NewPayloadRequest newRequest;
+    newRequest.executionPayload = newPayload->executionPayload;
+    newRequest.parentBeaconBlockRoot = attrs.parentBeaconBlockRoot;
+
+    legacyStorage.mergeGate->store(false, std::memory_order_release);
+    newStorage.mergeGate->store(false, std::memory_order_release);
+
+    std::atomic<bool> legacyProbeFinished{false};
+    std::atomic<bool> newProbeFinished{false};
+    bool mergeStarted = false;
+    bool probesFinishedDuringMerge = false;
+
+    std::thread legacyThread([&] {
+        try
+        {
+            task::syncWait(legacy.newPayload(legacyRequest, 3));
+        }
+        catch (...)
+        {}
+    });
+    std::thread newThread([&] {
+        try
+        {
+            task::syncWait(fresh.newPayload(newRequest, 3));
+        }
+        catch (...)
+        {}
+    });
+
+    mergeStarted = waitUntil(std::chrono::seconds(3), [&] {
+        return legacyStorage.mergeStarted->load(std::memory_order_acquire) &&
+               newStorage.mergeStarted->load(std::memory_order_acquire);
+    });
+
+    std::thread legacyProbe;
+    std::thread newProbe;
+    if (mergeStarted)
+    {
+        legacyProbe = std::thread([&] {
+            task::syncWait(legacy.getPayload(*legacyBuild.payloadId, 3));
+            legacyProbeFinished.store(true, std::memory_order_release);
+        });
+        newProbe = std::thread([&] {
+            task::syncWait(fresh.getPayload(*newBuild.payloadId, 3));
+            newProbeFinished.store(true, std::memory_order_release);
+        });
+
+        CommitCleanup cleanup{
+            .threads = {&legacyThread, &newThread, &legacyProbe, &newProbe},
+            .gates = {legacyStorage.mergeGate, newStorage.mergeGate},
+        };
+
+        // Both paths release the tracker lock before gated merge, so getPayload proceeds.
+        probesFinishedDuringMerge = waitUntil(std::chrono::seconds(3), [&] {
+            return legacyProbeFinished.load(std::memory_order_acquire) &&
+                   newProbeFinished.load(std::memory_order_acquire);
+        });
+    }
+    else
+    {
+        CommitCleanup cleanup{
+            .threads = {&legacyThread, &newThread},
+            .gates = {legacyStorage.mergeGate, newStorage.mergeGate},
+        };
+    }
+
+    BOOST_CHECK(mergeStarted);
+    BOOST_CHECK(probesFinishedDuringMerge);
+}
+
+BOOST_AUTO_TEST_CASE(commit_releases_exclusive_guard_during_prewrite)
+{
+    GateMergeStorage storage;
+    MemPoolImpl memPool;
+    StubExecutor executor;
+    StubScheduler scheduler;
+    auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto ledger = std::make_shared<GatedFakeLedger>(blockFactory, 20, 10, 10);
+
+    using Service = EthEngineService<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
+    Service service(memPool, storage, executor, scheduler, blockFactory, ledger);
+
+    auto forkchoice = makeForkchoiceState();
+    seedForkchoiceStorage(storage, forkchoice);
+
+    PayloadAttributes attrs = makeAttrs(1'700'000'002'000ULL);
+    auto build = task::syncWait(service.updateForkchoice(forkchoice, &attrs, 3));
+    BOOST_REQUIRE(build.payloadId.has_value());
+    auto payload = task::syncWait(service.getPayload(*build.payloadId, 3));
+
+    NewPayloadRequest request;
+    request.executionPayload = payload->executionPayload;
+    request.parentBeaconBlockRoot = attrs.parentBeaconBlockRoot;
+
+    storage.mergeGate->store(false, std::memory_order_release);
+
+    std::atomic<bool> probeFinished{false};
+    bool prewriteStarted = false;
+    bool probeFinishedDuringPrewrite = false;
+
+    std::thread commitThread([&] {
+        try
+        {
+            task::syncWait(service.newPayload(request, 3));
+        }
+        catch (...)
+        {}
+    });
+
+    prewriteStarted = waitUntil(std::chrono::seconds(3),
+        [&] { return ledger->prewriteStarted.load(std::memory_order_acquire); });
+
+    std::thread probeThread;
+    if (prewriteStarted)
+    {
+        probeThread = std::thread([&] {
+            task::syncWait(service.getPayload(*build.payloadId, 3));
+            probeFinished.store(true, std::memory_order_release);
+        });
+
+        CommitCleanup cleanup{
+            .threads = {&commitThread, &probeThread},
+            .gates = {ledger->prewriteGate, storage.mergeGate},
+        };
+
+        // newPayload no longer holds exclusive across prewrite; getPayload must proceed.
+        probeFinishedDuringPrewrite = waitUntil(
+            std::chrono::seconds(3), [&] { return probeFinished.load(std::memory_order_acquire); });
+    }
+    else
+    {
+        CommitCleanup cleanup{
+            .threads = {&commitThread},
+            .gates = {ledger->prewriteGate, storage.mergeGate},
+        };
+    }
+
+    BOOST_CHECK(prewriteStarted);
+    BOOST_CHECK(probeFinishedDuringPrewrite);
+}
+
+BOOST_AUTO_TEST_CASE(engine_tracker_bounded_put_fifo_evicts_oldest)
+{
+    EngineTracker tracker;
+    auto guard = tracker.lockExclusive();
+    std::vector<PayloadID> ids;
+    for (std::uint64_t i = 0; i < 65; ++i)
+    {
+        PayloadID id = "0xbounded" + std::to_string(i);
+        ids.push_back(id);
+        guard.putPayload(id, h256(i + 1), makeEntry(id));
+    }
+    BOOST_CHECK(!guard.findPayload(ids.front()));
+    BOOST_REQUIRE(guard.findPayload(ids[1]));
+    BOOST_REQUIRE(guard.findPayload(ids.back()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace eth_tx_test

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -65,6 +65,8 @@ struct GateMergeStorage
     std::shared_ptr<std::atomic<bool>> pushViewGate = std::make_shared<std::atomic<bool>>(true);
     std::shared_ptr<std::atomic<bool>> pushViewStarted = std::make_shared<std::atomic<bool>>(false);
     std::shared_ptr<std::atomic<bool>> throwOnMerge = std::make_shared<std::atomic<bool>>(false);
+    // Landed merges only: incremented after the gate and the throw check.
+    std::atomic<unsigned> mergeCount{0};
 
     ViewType fork() { return inner.fork(); }
     void pushView(ViewType view)
@@ -88,6 +90,7 @@ struct GateMergeStorage
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
+        ++mergeCount;
         co_return co_await inner.mergeBackStorage();
     }
 
@@ -102,6 +105,7 @@ struct GateMergeStorage
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
+        ++mergeCount;
         co_return co_await inner.mergeBackStorage(extra);
     }
 
@@ -116,6 +120,7 @@ struct GateMergeStorage
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
+        ++mergeCount;
         co_await inner.mergeToBackends(extra);
     }
 };
@@ -226,6 +231,40 @@ public:
         {
             std::this_thread::yield();
         }
+        callback("", nullptr);
+    }
+};
+
+// A ledger stub whose prewrite actually persists the row the fail-closed guard
+// reads (SYS_HASH_2_NUMBER), the way the real Ledger::asyncPrewriteBlock does.
+// The commit path's own persist — not a hand-written row — must feed the guard.
+class PersistingFakeLedger : public bcos::test::FakeLedger
+{
+public:
+    using FakeLedger::FakeLedger;
+
+    std::atomic<unsigned> prewriteCount{0};
+
+    void asyncPrewriteBlock(bcos::storage::StorageInterface::Ptr storage,
+        bcos::protocol::ConstTransactionsPtr, bcos::protocol::Block::ConstPtr block,
+        std::function<void(std::string, Error::Ptr&&)> callback, bool writeTxsAndReceipts,
+        std::optional<bcos::ledger::Features> features,
+        std::optional<bcos::crypto::HashType> blockHashOverride, bool writeNonces) override
+    {
+        (void)writeTxsAndReceipts;
+        (void)features;
+        (void)blockHashOverride;
+        (void)writeNonces;
+        if (block && block->blockHeader())
+        {
+            auto const header = block->blockHeader();
+            bcos::storage::Entry hash2NumberEntry;
+            hash2NumberEntry.set(std::to_string(header->number()));
+            storage->asyncSetRow(ledger::SYS_HASH_2_NUMBER,
+                bcos::concepts::bytebuffer::toView(header->hash()),
+                std::move(hash2NumberEntry), [](auto&&) {});
+        }
+        ++prewriteCount;
         callback("", nullptr);
     }
 };
@@ -538,7 +577,7 @@ BOOST_AUTO_TEST_CASE(commit_retry_valid_when_ledger_row_exists)
     StubExecutor executor;
     StubScheduler scheduler;
     auto blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
-    auto ledger = std::make_shared<bcos::test::FakeLedger>(blockFactory, 20, 10, 10);
+    auto ledger = std::make_shared<PersistingFakeLedger>(blockFactory, 20, 10, 10);
 
     using Service = EthEngineService<MemPoolImpl, GateMergeStorage, StubExecutor, StubScheduler>;
     Service service(memPool, storage, executor, scheduler, blockFactory, ledger);
@@ -561,16 +600,25 @@ BOOST_AUTO_TEST_CASE(commit_retry_valid_when_ledger_row_exists)
     BOOST_CHECK_EQUAL(
         static_cast<int>(firstStatus.status), static_cast<int>(PayloadValidationStatus::Valid));
 
-    storage::Entry persisted;
-    persisted.set(std::to_string(static_cast<int64_t>(request.executionPayload.blockNumber)));
-    task::syncWait(bcos::storage2::writeOne(storage.backendStorage,
-        bcos::executor_v1::StateKey{ledger::SYS_HASH_2_NUMBER,
-            bcos::concepts::bytebuffer::toView(request.executionPayload.blockHash)},
-        std::move(persisted)));
+    // The commit path's own persist — the prewrite the ledger stub lands through the
+    // merge — must have written the row the fail-closed guard reads. A hand-written
+    // row proves nothing about the service.
+    BOOST_CHECK_EQUAL(ledger->prewriteCount.load(), 1u);
+    BOOST_CHECK_EQUAL(storage.mergeCount.load(), 1u);
+    auto checkView = storage.fork();
+    auto persistedNumber = task::syncWait(bcos::ledger::getBlockNumber(
+        checkView, request.executionPayload.blockHash, bcos::ledger::fromStorage));
+    BOOST_REQUIRE_MESSAGE(persistedNumber.has_value(),
+        "the commit path's own persist must write the SYS_HASH_2_NUMBER row");
+    BOOST_CHECK_EQUAL(*persistedNumber, request.executionPayload.blockNumber);
 
+    // The retry is a pure no-op VALID: artifacts consumed on success, the ledger row
+    // proves the persist — no second prewrite and no second merge (no double commit).
     auto retryStatus = task::syncWait(service.newPayload(request, 3));
     BOOST_CHECK_EQUAL(
         static_cast<int>(retryStatus.status), static_cast<int>(PayloadValidationStatus::Valid));
+    BOOST_CHECK_EQUAL(ledger->prewriteCount.load(), 1u);
+    BOOST_CHECK_EQUAL(storage.mergeCount.load(), 1u);
 }
 
 BOOST_AUTO_TEST_CASE(commit_releases_exclusive_guard_during_merge)

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(publish_built_payload_rolls_back_cache_and_artifacts_on_thr
     BOOST_CHECK(!artifacts.inner.contains(newId));
 }
 
-BOOST_AUTO_TEST_CASE(publish_built_payload_does_not_restore_fifo_evicted_on_artifacts_throw)
+BOOST_AUTO_TEST_CASE(publish_built_payload_restores_fifo_evicted_on_artifacts_throw)
 {
     EngineTracker tracker;
     auto guard = tracker.lockExclusive();
@@ -444,8 +444,8 @@ BOOST_AUTO_TEST_CASE(publish_built_payload_does_not_restore_fifo_evicted_on_arti
 
     BOOST_CHECK(!guard.findPayload(newId));
     BOOST_CHECK(!artifacts.inner.contains(newId));
-    // Finding T: FIFO-evicted entries stay evicted when artifacts assign throws.
-    BOOST_CHECK(!guard.findPayload("0x0"));
+    // Failed publish restores the pre-put snapshot, including the FIFO victim.
+    BOOST_REQUIRE(guard.findPayload("0x0"));
     BOOST_REQUIRE(guard.findPayload("0x1"));
 }
 

--- a/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
+++ b/engine/test/unittests/engine/EthEngineServiceTransactionalTest.cpp
@@ -1,12 +1,27 @@
 /**
  *  Copyright (C) 2026 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthEngineServiceTransactionalTest.cpp
+ * @brief Transactional (retry/commit) tests for EthEngineService
  */
 
 #include "engine/bcos-engine/EngineServiceImpl.h"
 #include "engine/bcos-engine/EngineTracker.h"
 #include "engine/bcos-engine/EthEngineService.h"
 #include "engine/bcos-engine/PayloadCache.h"
+#include "engine/test/unittests/engine/EthServiceStubs.h"
 
 #include <bcos-concepts/ByteBuffer.h>
 #include <bcos-framework/ledger/LedgerConfig.h>
@@ -35,35 +50,7 @@ using namespace bcos::txpool;
 namespace eth_tx_test
 {
 
-using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
-    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
-    bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
-                                              bcos::storage2::memory_storage::LOGICAL_DELETION)>;
-using RealGlobalStateBackendStorage =
-    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
-        bcos::executor_v1::StateValue,
-        bcos::storage2::memory_storage::Attribute(
-            bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::CONCURRENT),
-        std::hash<bcos::executor_v1::StateKey>>;
-
-template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
-struct TrivialCheckpointStorage
-{
-    using CheckpointName = bcos::h256;
-    Storage& m_storage;
-    explicit TrivialCheckpointStorage(Storage& s) : m_storage(s) {}
-    Storage& open() { return m_storage; }
-    [[noreturn]] Storage& open(CheckpointName const&) { std::abort(); }
-    void createCheckpoint(Storage&, CheckpointName const&) {}
-    void deleteCheckpoint(CheckpointName const&) {}
-    std::optional<CheckpointName> latestCheckpointName() const { return std::nullopt; }
-    std::optional<CheckpointName> oldestCheckpointName() const { return std::nullopt; }
-};
-
-using RealGlobalCheckpointBackend = TrivialCheckpointStorage<bcos::executor_v1::StateKey,
-    bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
-using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
-    void, RealGlobalCheckpointBackend>;
+using namespace bcos::engine::eth_test;
 
 struct GateMergeStorage
 {
@@ -130,42 +117,6 @@ struct GateMergeStorage
             BOOST_THROW_EXCEPTION(std::runtime_error{"merge failed"});
         }
         co_await inner.mergeToBackends(extra);
-    }
-};
-
-struct StubExecutor
-{
-    template <class Storage>
-    struct ExecuteContext
-    {
-        task::Task<void> prepare() { co_return; }
-        task::Task<void> execute() { co_return; }
-        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
-    };
-
-    template <class Storage>
-    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
-        const protocol::BlockHeader&, const protocol::Transaction&, int,
-        const ledger::LedgerConfig&, bool)
-    {
-        co_return nullptr;
-    }
-
-    template <class Storage>
-    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&, const protocol::BlockHeader&,
-        const protocol::Transaction&, int, const ledger::LedgerConfig&, bool)
-    {
-        co_return ExecuteContext<Storage>{};
-    }
-};
-
-struct StubScheduler
-{
-    template <class Storage, class Executor>
-    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
-        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
-    {
-        co_return {};
     }
 };
 
@@ -441,8 +392,8 @@ BOOST_AUTO_TEST_CASE(publish_built_payload_restores_fifo_evicted_on_artifacts_th
     auto guard = tracker.lockExclusive();
 
     // PayloadCache::put FIFO cap is 64. Fill it, then a 65th put evicts the oldest.
-    constexpr std::size_t kMaxEntries = 64;
-    for (std::size_t i = 0; i < kMaxEntries; ++i)
+    constexpr std::size_t c_maxEntries = 64;
+    for (std::size_t i = 0; i < c_maxEntries; ++i)
     {
         auto id = "0x" + std::to_string(i);
         guard.putPayload(id, h256(i + 1), makeEntry(id));
@@ -534,7 +485,7 @@ BOOST_AUTO_TEST_CASE(commit_retained_payload_rolls_back_on_artifacts_clear_throw
                   });
 
     artifacts.throwOnClear = true;
-    BOOST_CHECK_THROW(eth_detail::commitRetainedPayload(
+    BOOST_CHECK_THROW(detail::commitRetainedPayload(
                           guard, artifacts, "0xcommit", h256(2), makeEntry("0xcommit")),
         std::runtime_error);
 

--- a/engine/test/unittests/engine/EthServiceStubs.h
+++ b/engine/test/unittests/engine/EthServiceStubs.h
@@ -1,0 +1,109 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthServiceStubs.h
+ * @brief Shared test stubs for the EthEngineService suites (storage stack,
+ *        checkpoint backend, no-op executor/scheduler). One definition so the
+ *        suites cannot drift apart.
+ */
+
+#pragma once
+
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/protocol/BlockHeader.h>
+#include <bcos-framework/protocol/Transaction.h>
+#include <bcos-framework/protocol/TransactionReceipt.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.h>
+#include <range/v3/range/concepts.hpp>
+
+#include <cstdlib>
+#include <functional>
+#include <optional>
+
+namespace bcos::engine::eth_test
+{
+
+using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
+    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
+    bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
+                                              bcos::storage2::memory_storage::LOGICAL_DELETION)>;
+using RealGlobalStateBackendStorage =
+    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+        bcos::executor_v1::StateValue,
+        bcos::storage2::memory_storage::Attribute(
+            bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::CONCURRENT),
+        std::hash<bcos::executor_v1::StateKey>>;
+
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& s) : m_storage(s) {}
+    Storage& open() { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const&) { std::abort(); }
+    void createCheckpoint(Storage&, CheckpointName const&) {}
+    void deleteCheckpoint(CheckpointName const&) {}
+    std::optional<CheckpointName> latestCheckpointName() const { return std::nullopt; }
+    std::optional<CheckpointName> oldestCheckpointName() const { return std::nullopt; }
+};
+
+using RealGlobalCheckpointBackend = TrivialCheckpointStorage<bcos::executor_v1::StateKey,
+    bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
+using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
+    void, RealGlobalCheckpointBackend>;
+
+struct StubExecutor
+{
+    template <class Storage>
+    struct ExecuteContext
+    {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
+    };
+
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
+        const protocol::BlockHeader&, const protocol::Transaction&, int,
+        const ledger::LedgerConfig&, bool)
+    {
+        co_return nullptr;
+    }
+
+    template <class Storage>
+    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&, const protocol::BlockHeader&,
+        const protocol::Transaction&, int, const ledger::LedgerConfig&, bool)
+    {
+        co_return ExecuteContext<Storage>{};
+    }
+};
+
+struct StubScheduler
+{
+    template <class Storage, class Executor>
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
+    {
+        co_return {};
+    }
+};
+
+}  // namespace bcos::engine::eth_test


### PR DESCRIPTION
## Summary
- Second of four PRs split from #5544 by file.
- Add `EthEngineService` plus Eth parity / transactional tests. Production Initializer is unchanged.
- Depends on [#5547](https://github.com/FISCO-BCOS/FISCO-BCOS/pull/5547). Review in parallel with [#5549](https://github.com/FISCO-BCOS/FISCO-BCOS/pull/5549).

**Source:** #5544 @ `989b3d34c` (original branch not rewritten).

## Test plan
- [ ] `EthEngineServiceParityTest`, `EthEngineServiceTransactionalTest`
- [ ] Production still uses `EngineServiceImpl` until [#5550](https://github.com/FISCO-BCOS/FISCO-BCOS/pull/5550)