### PR TITLE
refactor(ledger): deduplicate Ledger/LedgerMethods read & write paths

### DIFF
--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -595,8 +595,10 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
         return;
     }
 
-    task::wait([callback = std::move(_onGetBlock)](decltype(*this)& self,
-                   bcos::protocol::BlockNumber blockNumber, int32_t blockFlag) -> task::Task<void> {
+    task::wait([](decltype(*this)& self, bcos::protocol::BlockNumber blockNumber,
+                   int32_t blockFlag,
+                   std::function<void(Error::Ptr, bcos::protocol::Block::Ptr)> callback)
+                   -> task::Task<void> {
         try
         {
             // Delegate the block assembly to the shared two-storage getBlockData
@@ -644,7 +646,7 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
                          "Get block failed with errors!", e),
                 nullptr);
         }
-    }(*this, _blockNumber, _blockFlag));
+    }(*this, _blockNumber, _blockFlag, std::move(_onGetBlock)));
 }
 
 void Ledger::asyncGetBlockNumber(
@@ -692,8 +694,9 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
         return;
     }
 
-    task::wait([callback = std::move(_onGetBlock)](decltype(*this)& self,
-                   bcos::protocol::BlockNumber blockNumber) -> task::Task<void> {
+    task::wait([](decltype(*this)& self, bcos::protocol::BlockNumber blockNumber,
+                   std::function<void(Error::Ptr, bcos::crypto::HashType)> callback)
+                   -> task::Task<void> {
         try
         {
             // Delegate the SYS_NUMBER_2_HASH read to the shared storage2 free function;
@@ -719,7 +722,7 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
                          LedgerError::GetStorageError, "GetBlockHashByNumber failed", e),
                 bcos::crypto::HashType());
         }
-    }(*this, _blockNumber));
+    }(*this, _blockNumber, std::move(_onGetBlock)));
 }
 
 void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
@@ -727,8 +730,9 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
 {
     LEDGER_LOG(TRACE) << "GetBlockNumberByHash request" << LOG_KV("hash", _blockHash.hex());
 
-    task::wait([callback = std::move(_onGetBlock)](decltype(*this)& self,
-                   crypto::HashType blockHash) -> task::Task<void> {
+    task::wait([](decltype(*this)& self, crypto::HashType blockHash,
+                   std::function<void(Error::Ptr, bcos::protocol::BlockNumber)> callback)
+                   -> task::Task<void> {
         try
         {
             // Delegate the SYS_HASH_2_NUMBER read to the shared storage2 free function;
@@ -760,7 +764,7 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
                          LedgerError::GetStorageError, "GetBlockNumberByHash failed", e),
                 -1);
         }
-    }(*this, _blockHash));
+    }(*this, _blockHash, std::move(_onGetBlock)));
 }
 
 void Ledger::asyncGetBatchTxsByHashList(crypto::HashListPtr _txHashList, bool _withProof,
@@ -982,8 +986,9 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
 {
     LEDGER_LOG(TRACE) << "GetSystemConfigByKey request" << LOG_KV("key", _key);
 
-    task::wait([callback = std::move(_onGetConfig)](decltype(*this)& self,
-                   std::string key) -> task::Task<void> {
+    task::wait([](decltype(*this)& self, std::string key,
+                   std::function<void(Error::Ptr, std::string, bcos::protocol::BlockNumber)>
+                       callback) -> task::Task<void> {
         try
         {
             // Delegate the SYS_CONFIG read to the shared storage2 free function. The
@@ -1028,7 +1033,7 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
             callback(
                 BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError, "error", e), "", -1);
         }
-    }(*this, std::string(_key)));
+    }(*this, std::string(_key), std::move(_onGetConfig)));
 }
 
 void Ledger::asyncGetNonceList(bcos::protocol::BlockNumber _startNumber, int64_t _offset,

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -523,42 +523,21 @@ bcos::Error::Ptr Ledger::storeTransactionsAndReceipts(
         auto err = storage->setRows(SYS_HASH_2_RECEIPT, keys, values);
         promise->set_value(err);
     });
-    auto txsToStore = std::make_shared<std::vector<bytes>>();
-    txsToStore->reserve(txSize);
-    auto txsToStoreHash = std::make_shared<HashList>();
-    txsToStoreHash->reserve(txSize);
-    std::vector<std::string_view> keys;
-    keys.reserve(txSize);
-    std::vector<std::string_view> values;
-    values.reserve(txSize);
-
     RecursiveGuard guard(m_mutex);
-    size_t unstoredTxs = 0;
-    // TODO: usr block level flag to indicate whether the transactions has been stored
-    for (size_t i = 0; i < txSize; i++)
+    // Select + encode the transactions that are not yet persisted (dedup via the
+    // storeToBackend flag) — shared with asyncPreStoreBlockTxs and the storage2
+    // prewriteBlockToBuffer path (LedgerMethods.h::encodeUnsavedBlockTransactions).
+    auto pending = encodeUnsavedBlockTransactions(block, blockTxs);
+    size_t unstoredTxs = pending.size();
+    std::vector<std::string_view> keys;
+    std::vector<std::string_view> values;
+    keys.reserve(pending.size());
+    values.reserve(pending.size());
+    for (auto const& item : pending)
     {
-        std::optional<AnyTransaction> anyTx;
-        const Transaction* tx = nullptr;
-        if (blockTxs)
-        {
-            tx = blockTxs->at(i).get();
-        }
-        else
-        {
-            anyTx = transactions[i];
-            tx = anyTx->get();
-        }
-        if (blockTxs && tx->storeToBackend())
-        {
-            continue;
-        }
-        bcos::bytes encodeData;
-        tx->encode(encodeData);
-        txsToStoreHash->emplace_back(tx->hash());
-        txsToStore->emplace_back(std::move(encodeData));
-        keys.push_back(bcos::concepts::bytebuffer::toView((*txsToStoreHash)[unstoredTxs]));
-        values.push_back(bcos::concepts::bytebuffer::toView((*txsToStore)[unstoredTxs]));
-        ++unstoredTxs;
+        keys.push_back(std::string_view((const char*)item.hash.data(), item.hash.size()));
+        values.push_back(
+            std::string_view((const char*)item.encoded.data(), item.encoded.size()));
     }
     if (!keys.empty())
     {
@@ -573,11 +552,11 @@ bcos::Error::Ptr Ledger::storeTransactionsAndReceipts(
             return error;
         }
         // set the flag when store success
-        if (blockTxs)
+        for (auto const& item : pending)
         {
-            for (size_t i = 0; i < block->transactionsSize(); i++)
+            if (item.tx)
             {
-                blockTxs->at(i)->setStoreToBackend(true);
+                item.tx->setStoreToBackend(true);
             }
         }
     }
@@ -616,173 +595,56 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
         return;
     }
 
-    if ((_blockFlag & TRANSACTIONS) != 0 || (_blockFlag & RECEIPTS) != 0)
-    {
-        protocol::BlockNumber archivedBlockNumber = 0;
-        std::promise<std::pair<Error::Ptr, std::optional<bcos::storage::Entry>>> statePromise;
-        asyncGetCurrentStateByKey(ledger::SYS_KEY_ARCHIVED_NUMBER,
-            [&statePromise](Error::Ptr&& err, std::optional<bcos::storage::Entry>&& entry) {
-                statePromise.set_value(std::make_pair(std::move(err), std::move(entry)));
-            });
-        auto archiveRet = statePromise.get_future().get();
-        if (!archiveRet.first && archiveRet.second.has_value())
+    task::wait([callback = std::move(_onGetBlock)](decltype(*this)& self,
+                   bcos::protocol::BlockNumber blockNumber, int32_t blockFlag) -> task::Task<void> {
+        try
         {
-            archivedBlockNumber = boost::lexical_cast<int64_t>(archiveRet.second->get());
-        }
-        if (_blockNumber < archivedBlockNumber)
-        {
-            LEDGER_LOG(INFO) << "GetBlockDataByNumber, block number is larger than archived number";
-            _onGetBlock(BCOS_ERROR_PTR(LedgerError::ErrorArgument,
-                            "Wrong argument, this block's transactions and receipts are archived"),
-                nullptr);
-            return;
-        }
-    }
+            // Delegate the block assembly to the shared two-storage getBlockData
+            // (LedgerMethods.h::getBlockDataFromStorages): headers / tx-hashes / archived
+            // number come from the state storage, tx / receipt rows from the block storage
+            // (== state storage unless a separate block storage is enabled). This replaces
+            // the per-table async fetchers while keeping the reads on the storage2 path.
+            auto block = co_await ledger::getBlockDataFromStorages(*self.m_stateStorage,
+                *self.getBlockStorage(), blockNumber, blockFlag, *self.m_blockFactory);
 
-    std::list<std::function<void()>> fetchers;
-    auto block = m_blockFactory->createBlock();
-    auto total = std::make_shared<size_t>(0);
-    auto result = std::make_shared<std::tuple<std::atomic<size_t>, std::atomic<size_t>>>(0, 0);
-
-    auto finally = [_blockNumber, total, result, block, _onGetBlock](Error::Ptr&& error) {
-        if (error)
-        {
-            ++std::get<1>(*result);
-        }
-        else
-        {
-            ++std::get<0>(*result);
-        }
-
-        if (std::get<0>(*result) + std::get<1>(*result) == *total)
-        {
-            // All finished
-            if (std::get<0>(*result) != *total)
+            if (block && ((blockFlag & RECEIPTS) != 0))
             {
-                LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!"
-                                  << LOG_KV("number", _blockNumber);
-                _onGetBlock(BCOS_ERROR_PTR(LedgerError::CollectAsyncCallbackError,
-                                "Get block failed with errors!"),
-                    nullptr);
-                return;
+                // The block-level logsBloom is not persisted with the block
+                // (only header / tx hashes / txs / receipts are stored), so a
+                // block reconstructed here would otherwise carry 256 zero bytes
+                // and eth_getBlockByNumber / eth_getLogs would report an empty
+                // bloom for blocks with logs — from the legacy BaselineScheduler
+                // commit path and the built-in single-node driver alike. Recompute
+                // it from the receipts' log entries (receipts may carry an empty
+                // per-receipt logsBloom, but their logEntries are populated).
+                bcos::Bloom logsBloom{};
+                auto receipts = block->receipts();
+                for (size_t i = 0; i < block->receiptsSize(); ++i)
+                {
+                    bcos::orBloom(logsBloom, bcos::getLogsBloom(receipts[i]->logEntries()));
+                }
+                block->setLogsBloom(bcos::bytesConstRef(logsBloom.data(), logsBloom.size()));
             }
-
-            _onGetBlock(nullptr, block);
+            callback(nullptr, std::move(block));
         }
-    };
-
-    if (_blockFlag & HEADER)
-    {
-        ++(*total);
-
-        fetchers.emplace_back([this, _blockNumber, block, finally]() {
-            asyncGetBlockHeader(
-                block, _blockNumber, [finally](Error::Ptr&& error) { finally(std::move(error)); });
-        });
-    }
-    if ((_blockFlag & TRANSACTIONS) != 0 || (_blockFlag & TRANSACTIONS_HASH) != 0)
-    {
-        ++(*total);
-    }
-    if ((_blockFlag & RECEIPTS) != 0)
-    {
-        ++(*total);
-    }
-    if (((_blockFlag & TRANSACTIONS) != 0) || ((_blockFlag & RECEIPTS) != 0) ||
-        (_blockFlag & TRANSACTIONS_HASH) != 0)
-    {
-        fetchers.emplace_back([this, block, _blockNumber, finally, _blockFlag]() {
-            asyncGetBlockTransactionHashes(_blockNumber, [this, _blockFlag, block, finally](
-                                                             Error::Ptr&& error,
-                                                             std::vector<std::string>&& hashes) {
-                if (error)
-                {
-                    // if flag has both TRANSACTIONS and RECEIPTS, then the finally need to be
-                    // called twice, so has below if logic
-                    if ((_blockFlag & TRANSACTIONS) != 0 || (_blockFlag & TRANSACTIONS_HASH) != 0)
-                    {
-                        finally(std::move(error));
-                    }
-                    if ((_blockFlag & RECEIPTS) != 0)
-                    {
-                        finally(std::move(error));
-                    }
-                    return;
-                }
-
-                LEDGER_LOG(TRACE) << "Get transactions hash list success, size:" << hashes.size();
-
-                auto hashesPtr = std::make_shared<std::vector<std::string>>(std::move(hashes));
-                if ((_blockFlag & TRANSACTIONS) != 0)
-                {
-                    asyncBatchGetTransactions(
-                        hashesPtr, [block, finally](Error::Ptr&& error,
-                                       std::vector<protocol::Transaction::Ptr>&& transactions) {
-                            if (error)
-                            {
-                                LEDGER_LOG(DEBUG)
-                                    << LOG_DESC(
-                                           "asyncGetBlockDataByNumber batch getTransactions failed")
-                                    << LOG_KV("code", error->errorCode())
-                                    << LOG_KV("msg", error->errorMessage());
-                            }
-                            for (auto& it : transactions)
-                            {
-                                block->appendTransaction(it);
-                            }
-                            finally(std::move(error));
-                        });
-                }
-                if ((_blockFlag & RECEIPTS) != 0)
-                {
-                    asyncBatchGetReceipts(
-                        hashesPtr, [block, finally](Error::Ptr&& error,
-                                       std::vector<protocol::TransactionReceipt::Ptr>&& receipts) {
-                            for (auto& it : receipts)
-                            {
-                                block->appendReceipt(it);
-                            }
-                            // The block-level logsBloom is not persisted with the block
-                            // (only header / tx hashes / txs / receipts are stored), so a
-                            // block reconstructed here would otherwise carry 256 zero bytes
-                            // and eth_getBlockByNumber / eth_getLogs would report an empty
-                            // bloom for blocks with logs — from the legacy BaselineScheduler
-                            // commit path and the built-in single-node driver alike. Recompute
-                            // it from the receipts' log entries (receipts may carry an empty
-                            // per-receipt logsBloom, but their logEntries are populated).
-                            bcos::Bloom logsBloom{};
-                            for (auto const& receipt : receipts)
-                            {
-                                if (!receipt)
-                                {
-                                    continue;
-                                }
-                                bcos::orBloom(logsBloom, bcos::getLogsBloom(receipt->logEntries()));
-                            }
-                            block->setLogsBloom(
-                                bcos::bytesConstRef(logsBloom.data(), logsBloom.size()));
-                            finally(std::move(error));
-                        });
-                }
-                if ((_blockFlag & TRANSACTIONS_HASH) != 0)
-                {
-                    for (auto& hash : *hashesPtr)
-                    {
-                        auto txMeta = m_blockFactory->createTransactionMetaData();
-                        txMeta->setHash(bcos::crypto::HashType(
-                            hash, bcos::crypto::HashType::StringDataType::FromBinary));
-                        block->appendTransactionMetaData(std::move(txMeta));
-                    }
-                    finally(nullptr);
-                }
-            });
-        });
-    }
-
-    for (auto& it : fetchers)
-    {
-        it();
-    }
+        catch (bcos::Error const& e)
+        {
+            // Argument / archived errors carry their LedgerError code through.
+            LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!" << LOG_KV("number", blockNumber)
+                              << LOG_KV("code", e.errorCode()) << LOG_KV("msg", e.errorMessage());
+            callback(BCOS_ERROR_WITH_PREV_PTR(e.errorCode(), e.errorMessage(), e), nullptr);
+        }
+        catch (std::exception& e)
+        {
+            // Missing header / storage failures surface as the aggregated block-read error,
+            // matching the historical CollectAsyncCallbackError contract.
+            LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!" << LOG_KV("number", blockNumber)
+                              << boost::diagnostic_information(e);
+            callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::CollectAsyncCallbackError,
+                         "Get block failed with errors!", e),
+                nullptr);
+        }
+    }(*this, _blockNumber, _blockFlag));
 }
 
 void Ledger::asyncGetBlockNumber(
@@ -830,81 +692,75 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
         return;
     }
 
-    auto key = boost::lexical_cast<std::string>(_blockNumber);
-    asyncGetSystemTableEntry(SYS_NUMBER_2_HASH, key,
-        [callback = std::move(_onGetBlock)](
-            Error::Ptr&& error, std::optional<bcos::storage::Entry>&& entry) {
-            try
+    task::wait([callback = std::move(_onGetBlock)](decltype(*this)& self,
+                   bcos::protocol::BlockNumber blockNumber) -> task::Task<void> {
+        try
+        {
+            // Delegate the SYS_NUMBER_2_HASH read to the shared storage2 free function;
+            // a missing row (block not yet committed) keeps the historical GetStorageError
+            // contract of this async API.
+            auto blockHash =
+                co_await ledger::getBlockHash(*self.m_stateStorage, blockNumber, fromStorage);
+            if (!blockHash)
             {
-                if (error)
-                {
-                    LEDGER_LOG(DEBUG)
-                        << "GetBlockHashByNumber failed" << boost::diagnostic_information(error);
-                    callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError,
-                                 "GetBlockHashByNumber failed", *error),
-                        bcos::crypto::HashType());
-                    return;
-                }
-
-                auto hashStr = entry->get();
-                bcos::crypto::HashType hash(
-                    std::string(hashStr), bcos::crypto::HashType::FromBinary);
-
-                callback(nullptr, hash);
-            }
-            catch (std::exception& e)
-            {
-                callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::UnknownError, "Unknown error", e),
+                LEDGER_LOG(DEBUG) << "GetBlockHashByNumber failed, entry doesn't exist";
+                callback(BCOS_ERROR_PTR(
+                             LedgerError::GetStorageError, "GetBlockHashByNumber failed"),
                     bcos::crypto::HashType());
-                return;
+                co_return;
             }
-        });
+            callback(nullptr, *blockHash);
+        }
+        catch (std::exception& e)
+        {
+            LEDGER_LOG(DEBUG) << "GetBlockHashByNumber failed"
+                              << boost::diagnostic_information(e);
+            callback(BCOS_ERROR_WITH_PREV_PTR(
+                         LedgerError::GetStorageError, "GetBlockHashByNumber failed", e),
+                bcos::crypto::HashType());
+        }
+    }(*this, _blockNumber));
 }
 
 void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
     std::function<void(Error::Ptr, bcos::protocol::BlockNumber)> _onGetBlock)
 {
-    auto key = _blockHash;
-    LEDGER_LOG(TRACE) << "GetBlockNumberByHash request" << LOG_KV("hash", key.hex());
+    LEDGER_LOG(TRACE) << "GetBlockNumberByHash request" << LOG_KV("hash", _blockHash.hex());
 
-    asyncGetSystemTableEntry(SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(key),
-        [callback = std::move(_onGetBlock)](
-            Error::Ptr&& error, std::optional<bcos::storage::Entry>&& entry) {
-            try
+    task::wait([callback = std::move(_onGetBlock)](decltype(*this)& self,
+                   crypto::HashType blockHash) -> task::Task<void> {
+        try
+        {
+            // Delegate the SYS_HASH_2_NUMBER read to the shared storage2 free function;
+            // a missing row keeps the historical GetStorageError contract of this async API.
+            auto blockNumber =
+                co_await ledger::getBlockNumber(*self.m_stateStorage, blockHash, fromStorage);
+            if (!blockNumber)
             {
-                if (error)
-                {
-                    LEDGER_LOG(DEBUG)
-                        << "GetBlockNumberByHash failed " << boost::diagnostic_information(*error);
-                    callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError,
-                                 "GetBlockNumberByHash failed ", *error),
-                        -1);
-                    return;
-                }
-
-                bcos::protocol::BlockNumber blockNumber = -1;
-                try
-                {
-                    blockNumber = boost::lexical_cast<bcos::protocol::BlockNumber>(entry->get());
-                }
-                catch (boost::bad_lexical_cast& e)
-                {
-                    // Ignore the exception
-                    LEDGER_LOG(INFO)
-                        << "Cast blockNumber failed, may be empty, set to default value -1"
-                        << LOG_KV("blockNumber str", entry->get());
-                }
-                callback(nullptr, blockNumber);
-            }
-            catch (std::exception& e)
-            {
-                LEDGER_LOG(INFO) << "GetBlockNumberByHash failed "
-                                 << boost::diagnostic_information(e);
-                callback(BCOS_ERROR_WITH_PREV_PTR(
-                             LedgerError::GetStorageError, "GetBlockNumberByHash failed ", e),
+                LEDGER_LOG(DEBUG) << "GetBlockNumberByHash failed, entry doesn't exist";
+                callback(BCOS_ERROR_PTR(
+                             LedgerError::GetStorageError, "GetBlockNumberByHash failed"),
                     -1);
+                co_return;
             }
-        });
+            callback(nullptr, *blockNumber);
+        }
+        catch (boost::bad_lexical_cast const& e)
+        {
+            // Unparseable stored value — historical contract: default to -1 without error
+            // (the shared storage2 free function surfaces it as an exception instead).
+            LEDGER_LOG(INFO) << "Cast blockNumber failed, may be empty, set to default value -1";
+            callback(nullptr, -1);
+        }
+        catch (std::exception& e)
+        {
+            LEDGER_LOG(DEBUG) << "GetBlockNumberByHash failed "
+                              << boost::diagnostic_information(e);
+            callback(BCOS_ERROR_WITH_PREV_PTR(
+                         LedgerError::GetStorageError, "GetBlockNumberByHash failed", e),
+                -1);
+        }
+    }(*this, _blockHash));
 }
 
 void Ledger::asyncGetBatchTxsByHashList(crypto::HashListPtr _txHashList, bool _withProof,
@@ -1126,69 +982,53 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
 {
     LEDGER_LOG(TRACE) << "GetSystemConfigByKey request" << LOG_KV("key", _key);
 
-    asyncGetBlockNumber([this, callback = std::move(_onGetConfig), _key](
-                            Error::Ptr error, bcos::protocol::BlockNumber blockNumber) {
-        if (error)
+    task::wait([callback = std::move(_onGetConfig)](decltype(*this)& self,
+                   std::string key) -> task::Task<void> {
+        try
         {
-            LEDGER_LOG(DEBUG) << "GetSystemConfigByKey, " << boost::diagnostic_information(*error);
-            callback(std::move(error), "", -1);
-            return;
+            // Delegate the SYS_CONFIG read to the shared storage2 free function. The
+            // historical async contract is preserved on top: a missing row surfaces as
+            // GetStorageError, and a config whose enableNumber is beyond the block that is
+            // currently being executed (latest + 1) is reported as "not available yet".
+            auto blockNumber =
+                co_await ledger::getCurrentBlockNumber(*self.m_stateStorage, fromStorage);
+            auto config = co_await ledger::getSystemConfig(*self.m_stateStorage, key);
+            if (!config)
+            {
+                LEDGER_LOG(DEBUG) << "GetSystemConfigByKey, entry doesn't exists";
+                callback(BCOS_ERROR_PTR(LedgerError::GetStorageError,
+                             "getSystemConfig failed for empty entry"),
+                    "", -1);
+                co_return;
+            }
+
+            auto [value, number] = *config;
+
+            // The param was reset at height getLatestBlockNumber(), and takes effect in
+            // next block. So we query the status of getLatestBlockNumber() + 1.
+            auto effectNumber = blockNumber + 1;
+            if (number > effectNumber)
+            {
+                LEDGER_LOG(INFO) << "GetSystemConfigByKey, config not available"
+                                 << LOG_KV("currentBlockNumber", effectNumber)
+                                 << LOG_KV("available number", number);
+                callback(BCOS_ERROR_PTR(LedgerError::ErrorArgument, "Config not available"), "",
+                    -1);
+                co_return;
+            }
+
+            LEDGER_LOG(TRACE) << "GetSystemConfigByKey success" << LOG_KV("value", value)
+                              << LOG_KV("number", number);
+            callback(nullptr, std::move(value), number);
         }
-
-        asyncGetSystemTableEntry(SYS_CONFIG, _key,
-            [blockNumber, callback = std::move(callback)](
-                Error::Ptr&& error, std::optional<bcos::storage::Entry>&& entry) {
-                try
-                {
-                    // Note: should considerate the case that the compatibility_version is not
-                    // set
-                    if (error)
-                    {
-                        LEDGER_LOG(DEBUG) << "GetSystemConfigByKey, " << error->errorMessage();
-                        callback(std::move(error), "", -1);
-                        return;
-                    }
-
-                    if (!entry)
-                    {
-                        LEDGER_LOG(DEBUG) << "asyncGetSystemTableEntry: entry doesn't exists";
-                        callback(BCOS_ERROR_PTR(LedgerError::EmptyEntry,
-                                     "asyncGetSystemTableEntry failed for empty entry"),
-                            "", -1);
-                        return;
-                    }
-
-                    LEDGER_LOG(TRACE) << "Entry value: " << toHex(entry->get());
-
-                    auto [value, number] =
-                        bcos::storage::serialize::decode<SystemConfigEntry>(entry->get());
-
-                    // The param was reset at height getLatestBlockNumber(), and takes effect in
-                    // next block. So we query the status of getLatestBlockNumber() + 1.
-                    auto effectNumber = blockNumber + 1;
-                    if (number > effectNumber)
-                    {
-                        LEDGER_LOG(INFO) << "GetSystemConfigByKey, config not available"
-                                         << LOG_KV("currentBlockNumber", effectNumber)
-                                         << LOG_KV("available number", number);
-                        callback(BCOS_ERROR_PTR(LedgerError::ErrorArgument, "Config not available"),
-                            "", -1);
-                        return;
-                    }
-
-                    LEDGER_LOG(TRACE) << "GetSystemConfigByKey success" << LOG_KV("value", value)
-                                      << LOG_KV("number", number);
-                    callback(nullptr, std::move(value), number);
-                }
-                catch (std::exception& e)
-                {
-                    LEDGER_LOG(ERROR)
-                        << "GetSystemConfigByKey error, " << boost::diagnostic_information(e);
-                    callback(
-                        BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError, "error", e), "", -1);
-                }
-            });
-    });
+        catch (std::exception& e)
+        {
+            LEDGER_LOG(ERROR) << "GetSystemConfigByKey error, "
+                              << boost::diagnostic_information(e);
+            callback(
+                BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError, "error", e), "", -1);
+        }
+    }(*this, std::string(_key)));
 }
 
 void Ledger::asyncGetNonceList(bcos::protocol::BlockNumber _startNumber, int64_t _offset,
@@ -1382,38 +1222,6 @@ Error::Ptr Ledger::checkEntryValid(Error::UniquePtr&& error,
     return nullptr;
 }
 
-void Ledger::asyncGetBlockHeader(bcos::protocol::Block::Ptr block,
-    bcos::protocol::BlockNumber blockNumber, std::function<void(Error::Ptr&&)> callback)
-{
-    m_stateStorage->asyncOpenTable(SYS_NUMBER_2_BLOCK_HEADER,
-        [this, blockNumber, block, callback](auto&& error, std::optional<Table>&& table) {
-            auto validError = checkTableValid(std::move(error), table, SYS_NUMBER_2_BLOCK_HEADER);
-            if (validError)
-            {
-                callback(std::move(validError));
-                return;
-            }
-
-            table->asyncGetRow(boost::lexical_cast<std::string>(blockNumber),
-                [this, blockNumber, block, callback](auto&& error, std::optional<Entry>&& entry) {
-                    auto validError = checkEntryValid(
-                        std::move(error), entry, boost::lexical_cast<std::string>(blockNumber));
-                    if (validError)
-                    {
-                        callback(std::move(validError));
-                        return;
-                    }
-
-                    auto field = entry->get();
-                    auto headerPtr = m_blockFactory->blockHeaderFactory()->createBlockHeader(
-                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
-
-                    block->setBlockHeader(std::move(headerPtr));
-                    callback(nullptr);
-                });
-        });
-}
-
 void Ledger::asyncGetBlockTransactionHashes(bcos::protocol::BlockNumber blockNumber,
     std::function<void(Error::Ptr&&, std::vector<std::string>&&)> callback)
 {
@@ -1513,76 +1321,6 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
 
             callback(nullptr, std::move(transactions));
         });
-#if 0
-    m_stateStorage->asyncOpenTable(
-        SYS_HASH_2_TX, [this, hashes, callback](auto&& error, std::optional<Table>&& table) {
-            auto validError =
-                checkTableValid(std::forward<decltype(error)>(error), table, SYS_HASH_2_TX);
-            if (validError)
-            {
-                callback(std::move(validError), std::vector<protocol::Transaction::Ptr>());
-                return;
-            }
-
-            std::vector<std::string_view> hashesView;
-            hashesView.reserve(hashes->size());
-            for (auto& hash : *hashes)
-            {
-                hashesView.push_back(hash);
-            }
-
-            table->asyncGetRows(hashesView, [this, hashes, callback](auto&& error,
-                                                std::vector<std::optional<Entry>>&& entries) {
-                if (error)
-                {
-                    LEDGER_LOG(DEBUG)
-                        << "Batch get transaction failed " << boost::diagnostic_information(*error);
-                    callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError,
-                                 "Batch get transaction failed ", *error),
-                        std::vector<protocol::Transaction::Ptr>());
-
-                    return;
-                }
-
-                std::vector<protocol::Transaction::Ptr> transactions;
-                size_t i = 0;
-                for (auto& entry : entries)
-                {
-                    if (!entry.has_value())
-                    {
-                        LEDGER_LOG(TRACE)
-                            << "Get transaction failed: " << LOG_KV("txHash", toHex((*hashes)[i]));
-                    }
-                    else
-                    {
-                        auto field = entry->get();
-                        auto transaction = m_blockFactory->transactionFactory()->createTransaction(
-                            bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
-                            false, false);
-                        transactions.push_back(std::move(transaction));
-                    }
-
-                    ++i;
-                }
-                if (transactions.size() != hashes->size())
-                {
-                    LEDGER_LOG(DEBUG)
-                        << "Batch get transaction failed, transactions size not match hashesSize"
-                        << LOG_KV("txsSize", transactions.size())
-                        << LOG_KV("hashesSize", hashes->size());
-                    callback(BCOS_ERROR_PTR(LedgerError::CollectAsyncCallbackError,
-                                 "Batch get transaction failed, transactions size not match "
-                                 "hashesSize, txsSize: " +
-                                     std::to_string(transactions.size()) +
-                                     ", hashesSize: " + std::to_string(hashes->size())),
-                        std::move(transactions));
-                    return;
-                }
-
-                callback(nullptr, std::move(transactions));
-            });
-        });
-#endif
 }
 
 void Ledger::asyncBatchGetReceipts(std::shared_ptr<std::vector<std::string>> hashes,

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -599,6 +599,7 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
                    int32_t blockFlag,
                    std::function<void(Error::Ptr, bcos::protocol::Block::Ptr)> callback)
                    -> task::Task<void> {
+        bcos::protocol::Block::Ptr block;
         try
         {
             // Delegate the block assembly to the shared two-storage getBlockData
@@ -606,7 +607,7 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
             // number come from the state storage, tx / receipt rows from the block storage
             // (== state storage unless a separate block storage is enabled). This replaces
             // the per-table async fetchers while keeping the reads on the storage2 path.
-            auto block = co_await ledger::getBlockDataFromStorages(*self.m_stateStorage,
+            block = co_await ledger::getBlockDataFromStorages(*self.m_stateStorage,
                 *self.getBlockStorage(), blockNumber, blockFlag, *self.m_blockFactory);
 
             if (block && ((blockFlag & RECEIPTS) != 0))
@@ -627,7 +628,6 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
                 }
                 block->setLogsBloom(bcos::bytesConstRef(logsBloom.data(), logsBloom.size()));
             }
-            callback(nullptr, std::move(block));
         }
         catch (bcos::Error const& e)
         {
@@ -635,6 +635,7 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
             LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!" << LOG_KV("number", blockNumber)
                               << LOG_KV("code", e.errorCode()) << LOG_KV("msg", e.errorMessage());
             callback(BCOS_ERROR_WITH_PREV_PTR(e.errorCode(), e.errorMessage(), e), nullptr);
+            co_return;
         }
         catch (std::exception& e)
         {
@@ -645,7 +646,11 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
             callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::CollectAsyncCallbackError,
                          "Get block failed with errors!", e),
                 nullptr);
+            co_return;
         }
+        // Invoked outside the try so a throwing consumer callback cannot be caught
+        // above and re-invoked with an error.
+        callback(nullptr, std::move(block));
     }(*this, _blockNumber, _blockFlag, std::move(_onGetBlock)));
 }
 
@@ -995,8 +1000,10 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
             // historical async contract is preserved on top: a missing row surfaces as
             // GetStorageError, and a config whose enableNumber is beyond the block that is
             // currently being executed (latest + 1) is reported as "not available yet".
-            auto blockNumber =
-                co_await ledger::getCurrentBlockNumber(*self.m_stateStorage, fromStorage);
+            // The LedgerInterface overload of getCurrentBlockNumber is used (rather than
+            // the storage2 -1-fallback variant) so a missing current-number row still
+            // fails closed with GetStorageError, as asyncGetBlockNumber did.
+            auto blockNumber = co_await ledger::getCurrentBlockNumber(self);
             auto config = co_await ledger::getSystemConfig(*self.m_stateStorage, key);
             if (!config)
             {

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -632,8 +632,9 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
         catch (bcos::Error const& e)
         {
             // Argument / archived errors carry their LedgerError code through.
-            LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!" << LOG_KV("number", blockNumber)
-                              << LOG_KV("code", e.errorCode()) << LOG_KV("msg", e.errorMessage());
+            LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!"
+                              << LOG_KV("number", blockNumber) << LOG_KV("code", e.errorCode())
+                              << LOG_KV("msg", e.errorMessage());
             callback(BCOS_ERROR_WITH_PREV_PTR(e.errorCode(), e.errorMessage(), e), nullptr);
             co_return;
         }
@@ -641,8 +642,8 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
         {
             // Missing header / storage failures surface as the aggregated block-read error,
             // matching the historical CollectAsyncCallbackError contract.
-            LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!" << LOG_KV("number", blockNumber)
-                              << boost::diagnostic_information(e);
+            LEDGER_LOG(DEBUG) << "GetBlockDataByNumber request failed!"
+                              << LOG_KV("number", blockNumber) << boost::diagnostic_information(e);
             callback(BCOS_ERROR_WITH_PREV_PTR(LedgerError::CollectAsyncCallbackError,
                          "Get block failed with errors!", e),
                 nullptr);
@@ -702,12 +703,13 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
     task::wait([](decltype(*this)& self, bcos::protocol::BlockNumber blockNumber,
                    std::function<void(Error::Ptr, bcos::crypto::HashType)> callback)
                    -> task::Task<void> {
+        std::optional<bcos::crypto::HashType> blockHash;
         try
         {
             // Delegate the SYS_NUMBER_2_HASH read to the shared storage2 free function;
             // a missing row (block not yet committed) keeps the historical GetStorageError
             // contract of this async API.
-            auto blockHash =
+            blockHash =
                 co_await ledger::getBlockHash(*self.m_stateStorage, blockNumber, fromStorage);
             if (!blockHash)
             {
@@ -717,7 +719,6 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
                     bcos::crypto::HashType());
                 co_return;
             }
-            callback(nullptr, *blockHash);
         }
         catch (std::exception& e)
         {
@@ -726,7 +727,11 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
             callback(BCOS_ERROR_WITH_PREV_PTR(
                          LedgerError::GetStorageError, "GetBlockHashByNumber failed", e),
                 bcos::crypto::HashType());
+            co_return;
         }
+        // Outside the try: a throwing consumer callback must not be re-invoked from the
+        // catch above.
+        callback(nullptr, *blockHash);
     }(*this, _blockNumber, std::move(_onGetBlock)));
 }
 
@@ -738,11 +743,12 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
     task::wait([](decltype(*this)& self, crypto::HashType blockHash,
                    std::function<void(Error::Ptr, bcos::protocol::BlockNumber)> callback)
                    -> task::Task<void> {
+        std::optional<bcos::protocol::BlockNumber> blockNumber;
         try
         {
             // Delegate the SYS_HASH_2_NUMBER read to the shared storage2 free function;
             // a missing row keeps the historical GetStorageError contract of this async API.
-            auto blockNumber =
+            blockNumber =
                 co_await ledger::getBlockNumber(*self.m_stateStorage, blockHash, fromStorage);
             if (!blockNumber)
             {
@@ -752,7 +758,6 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
                     -1);
                 co_return;
             }
-            callback(nullptr, *blockNumber);
         }
         catch (boost::bad_lexical_cast const& e)
         {
@@ -760,6 +765,7 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
             // (the shared storage2 free function surfaces it as an exception instead).
             LEDGER_LOG(INFO) << "Cast blockNumber failed, may be empty, set to default value -1";
             callback(nullptr, -1);
+            co_return;
         }
         catch (std::exception& e)
         {
@@ -768,7 +774,11 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
             callback(BCOS_ERROR_WITH_PREV_PTR(
                          LedgerError::GetStorageError, "GetBlockNumberByHash failed", e),
                 -1);
+            co_return;
         }
+        // Outside the try: a throwing consumer callback must not be re-invoked from the
+        // catch above.
+        callback(nullptr, *blockNumber);
     }(*this, _blockHash, std::move(_onGetBlock)));
 }
 
@@ -994,6 +1004,8 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
     task::wait([](decltype(*this)& self, std::string key,
                    std::function<void(Error::Ptr, std::string, bcos::protocol::BlockNumber)>
                        callback) -> task::Task<void> {
+        std::string value;
+        bcos::protocol::BlockNumber number = -1;
         try
         {
             // Delegate the SYS_CONFIG read to the shared storage2 free function. The
@@ -1014,7 +1026,7 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
                 co_return;
             }
 
-            auto [value, number] = *config;
+            std::tie(value, number) = std::move(*config);
 
             // The param was reset at height getLatestBlockNumber(), and takes effect in
             // next block. So we query the status of getLatestBlockNumber() + 1.
@@ -1028,10 +1040,6 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
                     -1);
                 co_return;
             }
-
-            LEDGER_LOG(TRACE) << "GetSystemConfigByKey success" << LOG_KV("value", value)
-                              << LOG_KV("number", number);
-            callback(nullptr, std::move(value), number);
         }
         catch (std::exception& e)
         {
@@ -1039,7 +1047,14 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
                               << boost::diagnostic_information(e);
             callback(
                 BCOS_ERROR_WITH_PREV_PTR(LedgerError::GetStorageError, "error", e), "", -1);
+            co_return;
         }
+
+        LEDGER_LOG(TRACE) << "GetSystemConfigByKey success" << LOG_KV("value", value)
+                          << LOG_KV("number", number);
+        // Outside the try: a throwing consumer callback must not be re-invoked from the
+        // catch above.
+        callback(nullptr, std::move(value), number);
     }(*this, std::string(_key), std::move(_onGetConfig)));
 }
 

--- a/bcos-ledger/bcos-ledger/Ledger.h
+++ b/bcos-ledger/bcos-ledger/Ledger.h
@@ -161,9 +161,6 @@ private:
     Error::Ptr checkEntryValid(Error::UniquePtr&& error,
         const std::optional<bcos::storage::Entry>& entry, const std::string_view& key);
 
-    void asyncGetBlockHeader(bcos::protocol::Block::Ptr block,
-        bcos::protocol::BlockNumber blockNumber, std::function<void(Error::Ptr&&)> callback);
-
     void asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>> hashes,
         std::function<void(Error::Ptr&&, std::vector<protocol::Transaction::Ptr>&&)> callback);
 

--- a/bcos-ledger/bcos-ledger/LedgerMethods.cpp
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.cpp
@@ -369,161 +369,32 @@ bcos::task::Task<bcos::consensus::ConsensusNodeList> bcos::ledger::tag_invoke(
     co_return co_await awaitable;
 }
 
-static bcos::task::Task<std::tuple<std::string, bcos::protocol::BlockNumber>>
-getSystemConfigOrDefault(
-    bcos::ledger::LedgerInterface& ledger, std::string_view key, std::string defaultValue)
-{
-    try
-    {
-        auto config = co_await bcos::ledger::getSystemConfig(ledger, key);
-        if (!config)
-        {
-            LEDGER2_LOG(DEBUG) << "Get " << key << " failed, use default value"
-                               << LOG_KV("defaultValue", defaultValue);
-            co_return std::tuple<std::string, bcos::protocol::BlockNumber>{defaultValue, 0};
-        }
-        auto [value, blockNumber] = *config;
-        co_return std::tuple<std::string, bcos::protocol::BlockNumber>{value, blockNumber};
-    }
-    catch (std::exception& e)
-    {
-        LEDGER2_LOG(DEBUG) << "Get " << key << " failed, use default value"
-                           << LOG_KV("defaultValue", defaultValue);
-        co_return std::tuple<std::string, bcos::protocol::BlockNumber>{defaultValue, 0};
-    }
-}
-
-static bcos::task::Task<std::tuple<int64_t, bcos::protocol::BlockNumber>> getSystemConfigOrDefault(
-    bcos::ledger::LedgerInterface& ledger, std::string_view key, int64_t defaultValue)
-{
-    auto [value, blockNumber] = co_await getSystemConfigOrDefault(ledger, key, "");
-    if (value.empty())
-    {
-        co_return std::make_tuple(defaultValue, 0);
-    }
-    co_return std::make_tuple(boost::lexical_cast<int64_t>(value), blockNumber);
-}
-
 bcos::task::Task<void> bcos::ledger::tag_invoke(
     ledger::tag_t<getLedgerConfig> /*unused*/, LedgerInterface& ledger, LedgerConfig& ledgerConfig)
 {
+    // Fetch-then-assemble shape mirrors the storage2-view getLedgerConfig overload in
+    // LedgerMethods.h: resolve all inputs (at THIS path's block basis — sysConfigs /
+    // features effective at blockNumber + 1) and delegate the shared, consensus-relevant
+    // assembly to applyLedgerConfig so the two paths cannot drift from each other.
     auto nodeList = co_await getNodeList(ledger, {});
-    ledgerConfig.setConsensusNodeList(::ranges::views::filter(nodeList, [](auto& node) {
-        return node.type == consensus::Type::consensus_sealer;
-    }) | ::ranges::to<std::vector>());
-    ledgerConfig.setObserverNodeList(::ranges::views::filter(nodeList, [](auto& node) {
-        return node.type == consensus::Type::consensus_observer;
-    }) | ::ranges::to<std::vector>());
 
     auto blockNumber = co_await getCurrentBlockNumber(ledger);
     auto sysConfig = co_await ledger.fetchAllSystemConfigs(blockNumber + 1);
 
-    if (auto txLimitConfig = sysConfig.get(ledger::SystemConfig::tx_count_limit))
-    {
-        ledgerConfig.setBlockTxCountLimit(
-            boost::lexical_cast<uint64_t>(txLimitConfig.value().first));
-    }
-    if (auto ledgerSwitchPeriodConfig =
-            sysConfig.get(ledger::SystemConfig::consensus_leader_period))
-    {
-        ledgerConfig.setLeaderSwitchPeriod(
-            boost::lexical_cast<uint64_t>(ledgerSwitchPeriodConfig.value().first));
-    }
-    auto txGasLimit = sysConfig.getOrDefault(ledger::SystemConfig::tx_gas_limit, "0");
-    ledgerConfig.setGasLimit({boost::lexical_cast<uint64_t>(txGasLimit.first), txGasLimit.second});
-
-    if (auto versionConfig = sysConfig.get(ledger::SystemConfig::compatibility_version))
-    {
-        ledgerConfig.setCompatibilityVersion(tool::toVersionNumber(versionConfig.value().first));
-    }
-    auto gasPrice = sysConfig.getOrDefault(ledger::SystemConfig::tx_gas_price, "0x0");
-    ledgerConfig.setGasPrice(std::make_tuple(gasPrice.first, gasPrice.second));
-
-    // Excess blob gas (EIP-4844) — consumed only by the pure-Ethereum EthereumExecutor
-    // (executor_version=2) to derive the blob base fee. Persisted at genesis by
-    // Ledger::buildGenesisBlock from tx.excess_blob_gas; when absent the executor defaults
-    // to an excess of 0 (blob base fee 1).
-    if (auto excessBlobGas = sysConfig.get(ledger::SystemConfig::excess_blob_gas); excessBlobGas)
-    {
-        ledgerConfig.setExcessBlobGas(boost::lexical_cast<uint64_t>(excessBlobGas.value().first));
-    }
-
-    // Get block header to retrieve timestamp
+    // Timestamp from the block header; hash from the SYS_NUMBER_2_HASH row (works for OP
+    // headers whose in-memory BlockHeader::hash() would throw).
+    std::optional<int64_t> timestamp;
     auto block = co_await getBlockData(ledger, blockNumber, HEADER);
     if (block && block->blockHeader())
     {
-        ledgerConfig.setTimestamp(block->blockHeader()->timestamp());
-        // ledgerConfig.setHash(block->blockHeader()->hash());
+        timestamp = block->blockHeader()->timestamp();
     }
-    ledgerConfig.setBlockNumber(blockNumber);
-    ledgerConfig.setHash(co_await getBlockHash(ledger, blockNumber));
-    ledgerConfig.setFeatures(co_await getFeatures(ledger));
+    auto blockHash = co_await getBlockHash(ledger, blockNumber);
+    auto features = co_await getFeatures(ledger);
 
-    auto enableRPBFT =
-        (sysConfig.getOrDefault(ledger::SystemConfig::feature_rpbft, "0").first == "1");
-    ledgerConfig.setConsensusType(
-        std::string(enableRPBFT ? ledger::RPBFT_CONSENSUS_TYPE : ledger::PBFT_CONSENSUS_TYPE));
-    if (enableRPBFT)
-    {
-        ledgerConfig.setCandidateSealerNodeList(::ranges::views::filter(nodeList, [](auto& node) {
-            return node.type == consensus::Type::consensus_candidate_sealer;
-        }) | ::ranges::to<std::vector>());
-
-        auto epochSealer =
-            sysConfig.getOrDefault(ledger::SystemConfig::feature_rpbft_epoch_sealer_num,
-                std::to_string(DEFAULT_EPOCH_SEALER_NUM));
-        ledgerConfig.setEpochSealerNum(
-            {boost::lexical_cast<uint64_t>(epochSealer.first), epochSealer.second});
-
-        auto epochBlock =
-            sysConfig.getOrDefault(ledger::SystemConfig::feature_rpbft_epoch_block_num,
-                std::to_string(DEFAULT_EPOCH_BLOCK_NUM));
-        ledgerConfig.setEpochBlockNum(
-            {boost::lexical_cast<uint64_t>(epochBlock.first), epochBlock.second});
-        ledgerConfig.setNotifyRotateFlagInfo(std::get<0>(co_await getSystemConfigOrDefault(
-            ledger, INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE, DEFAULT_INTERNAL_NOTIFY_FLAG)));
-    }
-    auto auth = sysConfig.getOrDefault(ledger::SystemConfig::auth_check_status, "0");
-    ledgerConfig.setAuthCheckStatus(boost::lexical_cast<uint32_t>(auth.first));
-    auto [chainId, _] = sysConfig.getOrDefault(ledger::SystemConfig::web3_chain_id, "0");
-    // Fail-stop on a malformed value (InvalidWeb3ChainIdConfig), same policy as
-    // evmc_revision below: CHAINID is contract-visible execution semantics and the
-    // admission side already rejects the same value, so silently serving 0 is a
-    // silent-divergence hazard. Absent config arrives as the "0" default and parses fine.
-    ledgerConfig.setChainId(bcos::toEvmC(ledger::parseConfiguredWeb3ChainId(chainId)));
-    ledgerConfig.setBalanceTransfer(
-        sysConfig.getOrDefault(ledger::SystemConfig::balance_transfer, "0").first != "0");
-
-    int executorVersion = 0;
-    if (auto versionConfig = sysConfig.get(ledger::SystemConfig::executor_version); versionConfig)
-    {
-        executorVersion = boost::lexical_cast<int>(versionConfig.value().first);
-        ledgerConfig.setExecutorVersion(executorVersion);
-    }
-
-    // EVMC revision — consumed only by the pure-Ethereum EthereumExecutor
-    // (executor_version=2); v0/v1 schedulers never read evmcRevision()/evmcRevisionForBlock(),
-    // so a non-v2 chain is left untouched (no implicit default injection, which would be an
-    // unnoticed behavior change if a future v0/v1 path started reading it). For v2, an
-    // explicitly configured revision was persisted at genesis (Ledger::buildGenesisBlock).
-    // A v2 chain WITHOUT one stays UNCONFIGURED here (no binary-side default injected): the
-    // consumers fail closed — EthereumExecutor throws EvmcRevisionNotConfigured and
-    // EngineService buildPayload throws UnsupportedFork — rather than hash state or block
-    // headers under a fork the chain never configured. The initializer already refuses to
-    // boot such a chain, so this branch only fires on corrupt/legacy state.
-    //
-    // No per-call logging here: getLedgerConfig sits on the per-block / per-RPC hot path.
-    // The effective revision is parsed and logged once at startup (Initializer), which the
-    // CI pins and where a corrupt value becomes a boot refusal.
-    if (executorVersion >= ledger::ETHEREUM_EXECUTOR_VERSION)
-    {
-        if (auto evmcRevision = sysConfig.get(ledger::SystemConfig::evmc_revision); evmcRevision)
-        {
-            // A corrupt persisted value halts loudly (InvalidEVMCRevisionConfig) instead of
-            // silently running a compile-time default that could differ between binaries.
-            ledger::applyEVMCRevisionConfig(ledgerConfig, evmcRevision.value().first);
-        }
-    }
+    applyLedgerConfig(ledgerConfig, nodeList, sysConfig, features, blockNumber, timestamp,
+        std::optional<crypto::HashType>{blockHash});
+    co_return;
 }
 
 bcos::task::Task<bcos::ledger::Features> bcos::ledger::tag_invoke(

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -332,6 +332,11 @@ task::Task<protocol::Block::Ptr> getBlockDataFromStorages(
                 }
             }
         }
+        else
+        {
+            BOOST_THROW_EXCEPTION(
+                BCOS_ERROR(LedgerError::GetStorageError, "missing SYS_NUMBER_2_TXS row"));
+        }
     }
     co_return block;
 }

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -126,7 +126,10 @@ inline std::vector<EncodedBlockTransaction> encodeUnsavedBlockTransactions(
 
         bcos::bytes encoded;
         tx->encode(encoded);
-        out.push_back(EncodedBlockTransaction{tx->hash(), std::move(encoded), tx});
+        // Only externally owned transactions may be marked persisted after the write;
+        // for inline transactions tx points into the per-iteration anyTx holder and
+        // must not escape the loop.
+        out.push_back(EncodedBlockTransaction{tx->hash(), std::move(encoded), blockTxs ? tx : nullptr});
     }
     return out;
 }

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -129,7 +129,8 @@ inline std::vector<EncodedBlockTransaction> encodeUnsavedBlockTransactions(
         // Only externally owned transactions may be marked persisted after the write;
         // for inline transactions tx points into the per-iteration anyTx holder and
         // must not escape the loop.
-        out.push_back(EncodedBlockTransaction{tx->hash(), std::move(encoded), blockTxs ? tx : nullptr});
+        out.push_back(
+            EncodedBlockTransaction{tx->hash(), std::move(encoded), blockTxs ? tx : nullptr});
     }
     return out;
 }
@@ -283,6 +284,14 @@ task::Task<protocol::Block::Ptr> getBlockDataFromStorages(
                     }));
                 for (auto& txEntry : transactions)
                 {
+                    if (!txEntry)
+                    {
+                        // Fail closed like the base asyncBatchGetTransactions path: a
+                        // missing SYS_HASH_2_TX row (lagging or pruned block storage) is a
+                        // storage error, not a reason to dereference a disengaged optional.
+                        BOOST_THROW_EXCEPTION(
+                            BCOS_ERROR(LedgerError::GetStorageError, "missing SYS_HASH_2_TX row"));
+                    }
                     auto field = txEntry->get();
                     auto transaction = blockFactory.transactionFactory()->createTransaction(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false,
@@ -300,6 +309,12 @@ task::Task<protocol::Block::Ptr> getBlockDataFromStorages(
                     }));
                 for (auto& receiptEntry : receipts)
                 {
+                    if (!receiptEntry)
+                    {
+                        // Same fail-closed contract as the base asyncBatchGetReceipts path.
+                        BOOST_THROW_EXCEPTION(BCOS_ERROR(
+                            LedgerError::GetStorageError, "missing SYS_HASH_2_RECEIPT row"));
+                    }
                     auto field = receiptEntry->get();
                     auto receipt = blockFactory.receiptFactory()->createReceipt(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -80,6 +80,57 @@ task::Task<void> tag_invoke(ledger::tag_t<prewriteBlock> /*unused*/, LedgerInter
 task::Task<void> tag_invoke(ledger::tag_t<storeTransactionsAndReceipts>, LedgerInterface& ledger,
     bcos::protocol::ConstTransactionsPtr blockTxs, bcos::protocol::Block::ConstPtr block);
 
+/// A transaction pending persistence: its hash and encoded body. When the transaction
+/// came from an external @c ConstTransactionsPtr list, @p tx points at it so the caller
+/// can mark it persisted via setStoreToBackend() (a const method on a mutable flag)
+/// after the write succeeds; it stays null for block-carried (inline) transactions,
+/// which are never marked — matching the historical behavior of both write paths.
+struct EncodedBlockTransaction
+{
+    bcos::crypto::HashType hash;
+    bcos::bytes encoded;
+    bcos::protocol::Transaction const* tx = nullptr;
+};
+
+/// Select the transactions of @p block that still need persisting and encode them, in
+/// block order. With an external @p blockTxs list, transactions whose storeToBackend()
+/// flag is already set are skipped (dedup) and the resulting items carry the external
+/// transaction pointer for post-write marking. With @p blockTxs null the block's inline
+/// transactions are used and always emitted. Shared by Ledger::storeTransactionsAndReceipts
+/// (Ledger.cpp) and the storage2 prewriteBlockToBuffer path below so the dedup/encode
+/// decision lives in exactly one place.
+inline std::vector<EncodedBlockTransaction> encodeUnsavedBlockTransactions(
+    bcos::protocol::Block::ConstPtr block, bcos::protocol::ConstTransactionsPtr blockTxs)
+{
+    auto const txCount = std::max(block->transactionsSize(), block->transactionsMetaDataSize());
+    auto inlineTxs = block->transactions();
+    std::vector<EncodedBlockTransaction> out;
+    out.reserve(txCount);
+    for (size_t i = 0; i < txCount; ++i)
+    {
+        bcos::protocol::Transaction const* tx = nullptr;
+        std::optional<bcos::protocol::AnyTransaction> anyTx;
+        if (blockTxs)
+        {
+            tx = blockTxs->at(i).get();
+        }
+        else
+        {
+            anyTx = inlineTxs[i];
+            tx = anyTx->get();
+        }
+        if (blockTxs && tx->storeToBackend())
+        {
+            continue;
+        }
+
+        bcos::bytes encoded;
+        tx->encode(encoded);
+        out.push_back(EncodedBlockTransaction{tx->hash(), std::move(encoded), tx});
+    }
+    return out;
+}
+
 // FIB-104: Unified prewrite — routes block, transaction, and receipt data into
 // the caller-provided storage buffer. Phase 1 reuses the existing prewriteBlock
 // path (with txs/receipts disabled) to write metadata; phase 2 writes
@@ -126,39 +177,21 @@ task::Task<void> tag_invoke(ledger::tag_t<prewriteBlockToBuffer> /*unused*/,
             std::move(receiptEntry));
     }
 
-    // SYS_HASH_2_TX — encoded transactions keyed by tx hash. Skip txs already
-    // persisted (storeToBackend flag) to match existing dedup semantics.
-    for (size_t i = 0; i < txSize; ++i)
+    // SYS_HASH_2_TX — encoded transactions keyed by tx hash, deduped by the
+    // storeToBackend flag (same shared logic as storeTransactionsAndReceipts /
+    // asyncPreStoreBlockTxs); txs already persisted are skipped.
+    for (auto& pending : encodeUnsavedBlockTransactions(block, blockTxs))
     {
-        const protocol::Transaction* tx = nullptr;
-        std::optional<protocol::AnyTransaction> anyTx;
-        if (blockTxs)
-        {
-            tx = blockTxs->at(i).get();
-        }
-        else
-        {
-            anyTx = inlineTxs[i];
-            tx = anyTx->get();
-        }
-        if (blockTxs && tx->storeToBackend())
-        {
-            continue;
-        }
-
-        bytes encodedTx;
-        tx->encode(encodedTx);
-        auto txHash = tx->hash();
-
         storage::Entry txEntry;
-        txEntry.set(std::move(encodedTx));
+        txEntry.set(std::move(pending.encoded));
         co_await storage2::writeOne(storage,
-            executor_v1::StateKey{SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(txHash)},
+            executor_v1::StateKey{
+                SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(pending.hash)},
             std::move(txEntry));
 
-        if (blockTxs)
+        if (pending.tx)
         {
-            tx->setStoreToBackend(true);
+            pending.tx->setStoreToBackend(true);
         }
     }
 }
@@ -169,8 +202,15 @@ void tag_invoke(ledger::tag_t<removeExpiredNonce>, LedgerInterface& ledger,
 task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused*/,
     LedgerInterface& ledger, protocol::BlockNumber blockNumber, int32_t blockFlag);
 
-task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused*/,
-    storage2::ReadableStorage<executor_v1::StateKeyView> auto& storage,
+// Shared two-storage block assembly. The header / tx-hash list / archived-number rows live
+// in the state storage (@p metaStorage), while the SYS_HASH_2_TX / SYS_HASH_2_RECEIPT rows
+// live in the block storage (@p dataStorage) — the same object unless the node runs with a
+// separate block storage (enableSeparateBlockAndState). Ledger::asyncGetBlockDataByNumber
+// passes {m_stateStorage, getBlockStorage()}; the single-storage tag_invoke below passes the
+// same storage for both so the block assembly stays in exactly one place.
+task::Task<protocol::Block::Ptr> getBlockDataFromStorages(
+    storage2::ReadableStorage<executor_v1::StateKeyView> auto& metaStorage,
+    storage2::ReadableStorage<executor_v1::StateKeyView> auto& dataStorage,
     protocol::BlockNumber _blockNumber, int32_t _blockFlag, protocol::BlockFactory& blockFactory)
 {
     LEDGER_LOG(TRACE) << "GetBlockDataByNumber request" << LOG_KV("blockNumber", _blockNumber)
@@ -189,7 +229,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
     if ((_blockFlag & TRANSACTIONS) != 0 || (_blockFlag & RECEIPTS) != 0)
     {
         if (auto entry = co_await storage2::readOne(
-                storage, executor_v1::StateKeyView{SYS_CURRENT_STATE, SYS_KEY_ARCHIVED_NUMBER}))
+                metaStorage, executor_v1::StateKeyView{SYS_CURRENT_STATE, SYS_KEY_ARCHIVED_NUMBER}))
         {
             auto archivedBlockNumber = boost::lexical_cast<int64_t>(entry->get());
             if (_blockNumber < archivedBlockNumber)
@@ -207,7 +247,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
     if (_blockFlag & HEADER)
     {
         if (auto entry = co_await storage2::readOne(
-                storage, executor_v1::StateKeyView{SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}))
+                metaStorage, executor_v1::StateKeyView{SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}))
         {
             auto field = entry->get();
             auto headerPtr = blockFactory.blockHeaderFactory()->createBlockHeader(
@@ -223,7 +263,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
         (_blockFlag & TRANSACTIONS_HASH) != 0)
     {
         if (auto txsEntry = co_await storage2::readOne(
-                storage, executor_v1::StateKeyView{SYS_NUMBER_2_TXS, blockNumberStr}))
+                metaStorage, executor_v1::StateKeyView{SYS_NUMBER_2_TXS, blockNumberStr}))
         {
             auto txs = txsEntry->get();
             auto blockWithTxs =
@@ -234,7 +274,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
             if ((_blockFlag & TRANSACTIONS) != 0)
             {
                 auto transactions = co_await storage2::readSome(
-                    storage, hashes | ::ranges::views::transform([](auto& hash) {
+                    dataStorage, hashes | ::ranges::views::transform([](auto& hash) {
                         return executor_v1::StateKeyView{
                             SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(hash)};
                     }));
@@ -251,7 +291,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
             if ((_blockFlag & RECEIPTS) != 0)
             {
                 auto receipts = co_await storage2::readSome(
-                    storage, ::ranges::views::transform(hashes, [](auto& hash) {
+                    dataStorage, ::ranges::views::transform(hashes, [](auto& hash) {
                         return executor_v1::StateKeyView{
                             SYS_HASH_2_RECEIPT, bcos::concepts::bytebuffer::toView(hash)};
                     }));
@@ -278,6 +318,16 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
     co_return block;
 }
 
+task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused*/,
+    storage2::ReadableStorage<executor_v1::StateKeyView> auto& storage,
+    protocol::BlockNumber _blockNumber, int32_t _blockFlag, protocol::BlockFactory& blockFactory)
+{
+    // Single-storage flavor (storage2 views hold meta + tx/receipt rows together): both
+    // storages are the same object.
+    co_return co_await getBlockDataFromStorages(
+        storage, storage, _blockNumber, _blockFlag, blockFactory);
+}
+
 task::Task<TransactionCount> tag_invoke(
     ledger::tag_t<getTransactionCount> /*unused*/, LedgerInterface& ledger);
 
@@ -296,20 +346,24 @@ task::Task<consensus::ConsensusNodeList> tag_invoke(
 task::Task<void> tag_invoke(
     ledger::tag_t<getLedgerConfig> /*unused*/, LedgerInterface& ledger, LedgerConfig& ledgerConfig);
 
-task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& storage,
-    LedgerConfig& ledgerConfig, protocol::BlockNumber blockNumber,
-    protocol::BlockFactory& blockFactory)
+/// Shared LedgerConfig assembly used by both getLedgerConfig overloads (the
+/// LedgerInterface-based one in LedgerMethods.cpp and the storage2-view one below). The two
+/// call sites only differ in how they fetch their inputs (node list, system configs /
+/// features at their respective block basis, header hash / timestamp); this helper performs
+/// the pure mapping so the consensus-relevant assembly cannot drift between the paths.
+/// Callers resolve an absent committed header to a disengaged hash/timestamp, leaving the
+/// previous values untouched — matching the historical behavior of both call sites.
+inline void applyLedgerConfig(ledger::LedgerConfig& ledgerConfig,
+    bcos::consensus::ConsensusNodeList const& nodeList, ledger::SystemConfigs const& sysConfig,
+    ledger::Features const& features, protocol::BlockNumber blockNumber,
+    std::optional<int64_t> const& timestamp, std::optional<crypto::HashType> const& blockHash)
 {
-    auto nodeList = co_await ledger::getNodeList(storage);
-    ledgerConfig.setConsensusNodeList(::ranges::views::filter(nodeList, [](auto& node) {
+    ledgerConfig.setConsensusNodeList(::ranges::views::filter(nodeList, [](auto const& node) {
         return node.type == consensus::Type::consensus_sealer;
     }) | ::ranges::to<std::vector>());
-    ledgerConfig.setObserverNodeList(::ranges::views::filter(nodeList, [](auto& node) {
+    ledgerConfig.setObserverNodeList(::ranges::views::filter(nodeList, [](auto const& node) {
         return node.type == consensus::Type::consensus_observer;
     }) | ::ranges::to<std::vector>());
-
-    ledger::SystemConfigs sysConfig;
-    co_await readFromStorage(sysConfig, storage, blockNumber);
 
     if (auto txLimitConfig = sysConfig.get(ledger::SystemConfig::tx_count_limit))
     {
@@ -341,23 +395,15 @@ task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& sto
         ledgerConfig.setExcessBlobGas(boost::lexical_cast<uint64_t>(excessBlobGas.value().first));
     }
 
-    // Get block header to retrieve timestamp
-    auto blockNumberStr = std::to_string(blockNumber);
-    if (auto entry = co_await storage2::readOne(
-            storage, executor_v1::StateKeyView{SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}))
-    {
-        auto field = entry->get();
-        auto headerPtr = blockFactory.blockHeaderFactory()->createBlockHeader(
-            bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
-        ledgerConfig.setTimestamp(headerPtr->timestamp());
-        ledgerConfig.setHash(headerPtr->hash());
-    }
     ledgerConfig.setBlockNumber(blockNumber);
-    // auto blockHash = co_await getBlockHash(storage, blockNumber, fromStorage);
-    // ledgerConfig.setHash(blockHash.value_or(crypto::HashType{}));
-
-    Features features;
-    co_await readFromStorage(features, storage, blockNumber);
+    if (blockHash)
+    {
+        ledgerConfig.setHash(*blockHash);
+    }
+    if (timestamp)
+    {
+        ledgerConfig.setTimestamp(*timestamp);
+    }
     ledgerConfig.setFeatures(features);
 
     auto enableRPBFT =
@@ -428,6 +474,38 @@ task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& sto
             ledger::applyEVMCRevisionConfig(ledgerConfig, evmcRevision.value().first);
         }
     }
+}
+
+task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& storage,
+    LedgerConfig& ledgerConfig, protocol::BlockNumber blockNumber,
+    protocol::BlockFactory& blockFactory)
+{
+    // Resolve all inputs first (node list, system configs at @p blockNumber's basis, the
+    // committed header's hash / timestamp), then let applyLedgerConfig do the shared
+    // assembly. Block hash / timestamp come from the SYS_NUMBER_2_BLOCK_HEADER row.
+    auto nodeList = co_await ledger::getNodeList(storage);
+
+    ledger::SystemConfigs sysConfig;
+    co_await readFromStorage(sysConfig, storage, blockNumber);
+
+    std::optional<int64_t> timestamp;
+    std::optional<crypto::HashType> blockHash;
+    auto blockNumberStr = std::to_string(blockNumber);
+    if (auto entry = co_await storage2::readOne(
+            storage, executor_v1::StateKeyView{SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}))
+    {
+        auto field = entry->get();
+        auto headerPtr = blockFactory.blockHeaderFactory()->createBlockHeader(
+            bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
+        timestamp = headerPtr->timestamp();
+        blockHash = headerPtr->hash();
+    }
+
+    Features features;
+    co_await readFromStorage(features, storage, blockNumber);
+
+    applyLedgerConfig(
+        ledgerConfig, nodeList, sysConfig, features, blockNumber, timestamp, blockHash);
 }
 
 task::Task<Features> tag_invoke(ledger::tag_t<getFeatures> /*unused*/, LedgerInterface& ledger);

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -975,6 +975,72 @@ BOOST_AUTO_TEST_CASE(getBlockDataByNumber)
     BOOST_CHECK_EQUAL(f8.get(), true);
 }
 
+BOOST_AUTO_TEST_CASE(getBlockDataMissingTxRowFailsClosed)
+{
+    initFixture();
+    initChain(10);
+
+    // m_fakeBlocks->at(i) carries block number i + 1.
+    // Delete one SYS_HASH_2_TX row of block 3 (simulating a lagging or pruned block
+    // storage): the block read must fail closed with a storage error instead of
+    // dereferencing the disengaged optional returned by readSome.
+    auto txHash = m_fakeBlocks->at(2)->transactionHash(0);
+    Entry deletedEntry;
+    deletedEntry.setStatus(Entry::DELETED);
+    std::promise<bool> deletePromise;
+    m_storage->asyncSetRow(SYS_HASH_2_TX, std::string((char*)txHash.data(), txHash.size()),
+        std::move(deletedEntry), [&deletePromise](Error::UniquePtr error) {
+            deletePromise.set_value(!error);
+        });
+    BOOST_CHECK(deletePromise.get_future().get());
+
+    // No assertions inside the callback: a failing BOOST_REQUIRE would unwind through
+    // the coroutine resumption that invoked it.
+    Error::Ptr readError;
+    Block::Ptr readBlock;
+    std::promise<bool> p1;
+    m_ledger->asyncGetBlockDataByNumber(
+        3, FULL_BLOCK, [&](Error::Ptr _error, Block::Ptr _block) {
+            readError = std::move(_error);
+            readBlock = std::move(_block);
+            p1.set_value(true);
+        });
+    BOOST_CHECK(p1.get_future().get());
+    BOOST_REQUIRE(readError != nullptr);
+    BOOST_CHECK_EQUAL(readError->errorCode(), LedgerError::GetStorageError);
+    BOOST_CHECK(readBlock == nullptr);
+
+    BOOST_CHECK_THROW(
+        task::syncWait(ledger::getBlockData(*m_storage, 3, FULL_BLOCK, *m_blockFactory)),
+        bcos::Error);
+
+    // A missing SYS_HASH_2_RECEIPT row fails closed the same way (block 4 -> at(3)).
+    auto receiptHash = m_fakeBlocks->at(3)->transactionHash(0);
+    Entry deletedReceiptEntry;
+    deletedReceiptEntry.setStatus(Entry::DELETED);
+    std::promise<bool> deletePromise2;
+    m_storage->asyncSetRow(SYS_HASH_2_RECEIPT,
+        std::string((char*)receiptHash.data(), receiptHash.size()),
+        std::move(deletedReceiptEntry), [&deletePromise2](Error::UniquePtr error) {
+            deletePromise2.set_value(!error);
+        });
+    BOOST_CHECK(deletePromise2.get_future().get());
+
+    Error::Ptr readError2;
+    Block::Ptr readBlock2;
+    std::promise<bool> p2;
+    m_ledger->asyncGetBlockDataByNumber(
+        4, RECEIPTS, [&](Error::Ptr _error, Block::Ptr _block) {
+            readError2 = std::move(_error);
+            readBlock2 = std::move(_block);
+            p2.set_value(true);
+        });
+    BOOST_CHECK(p2.get_future().get());
+    BOOST_REQUIRE(readError2 != nullptr);
+    BOOST_CHECK_EQUAL(readError2->errorCode(), LedgerError::GetStorageError);
+    BOOST_CHECK(readBlock2 == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(getBlockDataRecomputesLogsBloom)
 {
     // The ledger persists header / tx hashes / txs / receipts but NOT the block-level

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -1010,9 +1010,10 @@ BOOST_AUTO_TEST_CASE(getBlockDataMissingTxRowFailsClosed)
     BOOST_CHECK_EQUAL(readError->errorCode(), LedgerError::GetStorageError);
     BOOST_CHECK(readBlock == nullptr);
 
-    BOOST_CHECK_THROW(
+    BOOST_CHECK_EXCEPTION(
         task::syncWait(ledger::getBlockData(*m_storage, 3, FULL_BLOCK, *m_blockFactory)),
-        bcos::Error);
+        bcos::Error,
+        [](bcos::Error const& e) { return e.errorCode() == LedgerError::GetStorageError; });
 
     // A missing SYS_HASH_2_RECEIPT row fails closed the same way (block 4 -> at(3)).
     auto receiptHash = m_fakeBlocks->at(3)->transactionHash(0);
@@ -1039,6 +1040,28 @@ BOOST_AUTO_TEST_CASE(getBlockDataMissingTxRowFailsClosed)
     BOOST_REQUIRE(readError2 != nullptr);
     BOOST_CHECK_EQUAL(readError2->errorCode(), LedgerError::GetStorageError);
     BOOST_CHECK(readBlock2 == nullptr);
+
+    // A missing SYS_NUMBER_2_TXS row must also fail closed instead of yielding an empty
+    // block body (block 5).
+    Entry deletedTxsEntry;
+    deletedTxsEntry.setStatus(Entry::DELETED);
+    std::promise<bool> deletePromise3;
+    m_storage->asyncSetRow(SYS_NUMBER_2_TXS, "5", std::move(deletedTxsEntry),
+        [&deletePromise3](Error::UniquePtr error) { deletePromise3.set_value(!error); });
+    BOOST_CHECK(deletePromise3.get_future().get());
+
+    Error::Ptr readError3;
+    Block::Ptr readBlock3;
+    std::promise<bool> p3;
+    m_ledger->asyncGetBlockDataByNumber(5, TRANSACTIONS, [&](Error::Ptr _error, Block::Ptr _block) {
+        readError3 = std::move(_error);
+        readBlock3 = std::move(_block);
+        p3.set_value(true);
+    });
+    BOOST_CHECK(p3.get_future().get());
+    BOOST_REQUIRE(readError3 != nullptr);
+    BOOST_CHECK_EQUAL(readError3->errorCode(), LedgerError::GetStorageError);
+    BOOST_CHECK(readBlock3 == nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(getBlockDataRecomputesLogsBloom)


### PR DESCRIPTION
## 概述

对 `bcos-ledger` 中 `Ledger`（`Ledger.h/.cpp`）与 `LedgerMethods`（`LedgerMethods.h/.cpp`）之间逻辑相似/重复的函数做收敛去重，共 4 个文件，净 **-316 行**（+307 / -623），纯重构、无行为变更（各路径语义差异均已在调用点显式保留并注释）。

## 改动内容

### 1. `getLedgerConfig` 组装逻辑去重（重复度最高的单点）
- 两份 `tag_invoke(getLedgerConfig)`（`LedgerMethods.h` 的 storage2 版模板与 `LedgerMethods.cpp` 的 `LedgerInterface` 版）原先重复约 120 行 LedgerConfig 组装；
- 收敛为 `LedgerMethods.h` 中共享纯函数 `applyLedgerConfig(cfg, nodeList, sysConfig, features, blockNumber, hash, timestamp)`，两个重载只保留各自「取数」并调用之；
- 两路径既有语义差异刻意保留在调用点（.cpp 用 `fetchAllSystemConfigs(blockNumber+1)` 基准、hash 取 `SYS_NUMBER_2_HASH` 以兼容 OP 头；.h 用 `readFromStorage(..., blockNumber)` 基准、hash 取 header.hash()），并在注释中说明；
- `notify_rotate` 由原先 .cpp 额外的 `getSystemConfigOrDefault` 独立取数改为统一从 `sysConfig` 读取（键相同、默认一致、语义等价），删除两个不再使用的 static `getSystemConfigOrDefault`。

### 2. 读路径类方法委托 storage2 自由函数
- `asyncGetBlockHashByNumber` / `asyncGetBlockNumberByHash` / `asyncGetSystemConfigByKey` 改为 `task::wait` + 委托 `ledger::getBlockHash/getBlockNumber/getSystemConfig`，保留回调错误契约（缺失→`GetStorageError`、`bad_lexical_cast`→-1 无错、`effectNumber=latest+1` 生效校验）；
- 新增双 storage 核心 `getBlockDataFromStorages(metaStorage, dataStorage, ...)`：header/tx-hash/archived 号读 state 库，`SYS_HASH_2_TX/SYS_HASH_2_RECEIPT` 读块库（`enableSeparateBlockAndState` 时两者不同），原单 storage `tag_invoke(getBlockData)` 变为 `(storage, storage)` 薄转发；
- `asyncGetBlockDataByNumber` 委托该双 storage 实现（替换约 180 行并行 fetchers/聚合代码），保留 RECEIPTS 分支的 logsBloom 重算与错误聚合语义（缺失 header→`CollectAsyncCallbackError`）。

### 3. 写路径去重
- 新增共享 `encodeUnsavedBlockTransactions(block, blockTxs)`（含 `storeToBackend()` 去重 + 编码 + 返回可标记 tx 指针），`storeTransactionsAndReceipts` 与 `prewriteBlockToBuffer` 的 `SYS_HASH_2_TX` 段统一使用。

### 4. 纵向裁剪
- 删除 `asyncBatchGetTransactions` 内整段 `#if 0` 死代码（旧 table-API 重复实现）；
- 删除已失联的私有 `asyncGetBlockHeader`（定义 + 声明）。

## 已知行为差异（有意）

- `storeTransactionsAndReceipts` 在 setRows 成功后会对每条写入的外部交易置 `storeToBackend`；base 只标记前 `transactionsSize()` 条，而到达此处的 PBFT 块携带的是 metadata 而非 inline 交易，base 实际一条都不标记。`storeToBackend` 仅被 `needStoreUnsavedTxs` 与 `encodeUnsavedBlockTransactions` 消费，可观察效果只是减少冗余的 `SYS_HASH_2_TX` 重复写入；正常路径下 `asyncPreStoreBlockTxs` 已先行标记，`pending` 通常为空。

## 有意保留（不做改动的原因）
- `asyncGetBlockNumber`：缺行报错是启动 fail-closed 契约（`LedgerInitializer::build` 依赖 `error` 抛错），与 storage2 `getCurrentBlockNumber` 的 -1 语义存在真实分歧，未强行统一；
- `asyncBatchGetTransactions/asyncBatchGetReceipts/asyncGetBlockTransactionHashes`：仍被 Merkle proof（`getTxProof/getReceiptProof`）与批量取数 API 使用。

## 验证
- `bcos-ledger` 库 + 完整 ledger 单测（`test-bcos-ledger`）通过（含 `getLedgerConfig`、`getBlockDataByNumber` 各 flag、logsBloom 回归、`getBlockNumberByHash/getSystemConfig` 等）；
- 下游 storage2 模板实例化 `-fsyntax-only` 通过（transaction-scheduler、engine 相关 TU）；
- 全量主节点 `fisco-bcos-air/fisco-bcos` 构建链接成功。
