### PR TITLE
feat(mpt): ReverseHistoryStore — reverse-history index and manifest for pruning option 3 (PR-B)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryErrors.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryErrors.h
@@ -23,17 +23,27 @@
 namespace bcos::ledger::mpt::history
 {
 
-/// The requested block has fallen out of the retention window (block < tip - depth + 1), so the
-/// index rows that would answer the query have been expired away. Raised by the window guard
-/// that spec B.3 requires to run BEFORE the seek: past the window the seek cannot tell "this key
-/// was never changed after B" from "the record existed and was deleted", and would otherwise
-/// return the current value as if it were the historical one — the one silently-wrong answer the
-/// whole layout is built to avoid.
+/// The records that would answer the query are gone. Three places raise it, all saying the same
+/// thing from different evidence: the window guard spec B.3 requires to run BEFORE the lookup
+/// (block < tip - depth + 1), the on-disk retention boundary the index carries, and a located
+/// version whose shard row turns out to be deleted.
+///
+/// The guard has to run first because past the window a lookup cannot tell "this key was never
+/// changed after B" from "the record existed and was deleted", and would otherwise return the
+/// current value as if it were the historical one — the one silently-wrong answer the whole layout
+/// is built to avoid.
 DERIVE_BCOS_EXCEPTION(HistoryPruned);
 
 /// The requested block number is not a queryable point on this chain — negative, or ahead of the
 /// caller-supplied tip. Distinct from HistoryPruned: that one means "was retained, no longer is",
 /// this one means "never was".
 DERIVE_BCOS_EXCEPTION(InvalidHistoryBlock);
+
+/// The in-memory query index cannot answer: it has never been rebuilt (IndexState::Empty), or a
+/// rebuild or a publish failed and left it IndexState::Unavailable. G10 — a missing index is not
+/// evidence that a key went unmodified, so every history read refuses instead of falling through
+/// to the current value. Distinct from HistoryPruned, which is a statement about a block the
+/// store deliberately dropped; this one says the store does not know what it holds.
+DERIVE_BCOS_EXCEPTION(HistoryIndexUnavailable);
 
 }  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryErrors.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryErrors.h
@@ -18,10 +18,24 @@
  */
 #pragma once
 
+#include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <bcos-utilities/Exceptions.h>
+#include <boost/exception/info.hpp>
 
 namespace bcos::ledger::mpt::history
 {
+
+/// The block a layout violation was found at, carried on the exception itself.
+///
+/// `rebuild` walks the whole retained range and throws at the first row it cannot account for. The
+/// message names WHAT is wrong; without this the caller cannot say WHERE. That caller is PR-D's
+/// B.10 audit, which reports a failed rebuild as a finding against a block number — and a finding
+/// pointing at the wrong height sends an operator to the wrong rows.
+///
+/// Read it back with `boost::get_error_info<errinfo_historyBlock>(error)`; it is absent on
+/// exceptions raised below the walk (the row codec knows the bytes, not the block), so a reader
+/// must handle nullptr rather than assume it is there.
+using errinfo_historyBlock = boost::error_info<struct tag_historyBlock, protocol::BlockNumber>;
 
 /// The records that would answer the query are gone. Three places raise it, all saying the same
 /// thing from different evidence: the window guard spec B.3 requires to run BEFORE the lookup

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryErrors.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryErrors.h
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryErrors.h
+ * @brief Exception types raised by the reverse-history index (spec B.3)
+ */
+#pragma once
+
+#include <bcos-utilities/Exceptions.h>
+
+namespace bcos::ledger::mpt::history
+{
+
+/// The requested block has fallen out of the retention window (block < tip - depth + 1), so the
+/// index rows that would answer the query have been expired away. Raised by the window guard
+/// that spec B.3 requires to run BEFORE the seek: past the window the seek cannot tell "this key
+/// was never changed after B" from "the record existed and was deleted", and would otherwise
+/// return the current value as if it were the historical one — the one silently-wrong answer the
+/// whole layout is built to avoid.
+DERIVE_BCOS_EXCEPTION(HistoryPruned);
+
+/// The requested block number is not a queryable point on this chain — negative, or ahead of the
+/// caller-supplied tip. Distinct from HistoryPruned: that one means "was retained, no longer is",
+/// this one means "never was".
+DERIVE_BCOS_EXCEPTION(InvalidHistoryBlock);
+
+}  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
@@ -26,6 +26,8 @@
 #include <bcos-utilities/Common.h>
 #include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -95,6 +97,19 @@ enum class IndexState : uint8_t
     Unavailable,
 };
 
+/// How long a historical read waits for an open publish window before refusing.
+///
+/// The window is NOT short: it deliberately spans the block's `mergeBackStorage` (a RocksDB
+/// write), the commit observer, the pending-result pop and a `getLedgerConfig` round trip, because
+/// the publish has to be the last fallible step before the tip advances (HistoryCommit.h). So the
+/// wait has to be bounded in TIME rather than in retries — a spin budget sized for "a few
+/// microseconds" refuses healthy queries that merely overlapped an ordinary commit.
+///
+/// Two seconds is far longer than any commit on a healthy node and far shorter than an RPC
+/// client's patience, so the timeout means "this node has a stuck committer", not "you were
+/// unlucky". Tests override it (setPublishWindowWaitBudget) to keep the refusal path fast.
+inline constexpr std::chrono::milliseconds kPublishWindowWaitBudget{2000};
+
 /// Transparent hash so a query can look up by `std::string_view` without allocating a key.
 struct TransparentStringHash
 {
@@ -156,7 +171,10 @@ public:
         catch (...)
         {
             m_state = IndexState::Unavailable;
-            closePublishWindow();
+            // Advance, not merely close: applyRetire may already have removed a block's versions
+            // before the throw, so a reader straddling this publish has to see the counter move
+            // even if no window was open. closePublishWindow would be a no-op in that case.
+            bumpGenerationAfterPublish();
             throw;
         }
         bumpGenerationAfterPublish();
@@ -191,6 +209,7 @@ public:
     /// assumes.
     void openPublishWindow() noexcept
     {
+        std::lock_guard lock(m_generationMutex);
         auto const current = m_generation.load(std::memory_order_relaxed);
         if ((current % 2) == 0)
         {
@@ -198,23 +217,59 @@ public:
         }
     }
 
-    /// Close the window opened above. `publish` calls it at the end, so the ordinary path needs
-    /// no separate call; the RAII guard on the commit path calls it on every failure path, so a
-    /// commit that dies between merge and publish does not leave every later query retrying
-    /// forever.
+    /// Close the window opened above. `publish` calls bumpGenerationAfterPublish instead, which
+    /// subsumes this; the RAII guard on the commit path calls it on every failure path, so a
+    /// commit that dies between merge and publish does not leave every later query waiting out
+    /// the full budget.
     void closePublishWindow() noexcept
     {
-        auto const current = m_generation.load(std::memory_order_relaxed);
-        if ((current % 2) != 0)
         {
+            std::lock_guard lock(m_generationMutex);
+            auto const current = m_generation.load(std::memory_order_relaxed);
+            if ((current % 2) == 0)
+            {
+                return;
+            }
             m_generation.store(current + 1, std::memory_order_release);
         }
+        m_generationChanged.notify_all();
     }
 
     /// The publish counter. Even: no commit is between its merge and its publish. Odd: one is.
     [[nodiscard]] uint64_t generation() const noexcept
     {
         return m_generation.load(std::memory_order_acquire);
+    }
+
+    /// Block until no commit is inside its publish window, or until @p budget runs out.
+    ///
+    /// @return true if the generation is even on return, false on timeout.
+    ///
+    /// Waiting rather than spinning is the point: the window spans a RocksDB write, so a reader
+    /// that merely overlapped an ordinary commit must sleep through it and then answer, not burn
+    /// a retry budget and refuse. The accepted cost is that an RPC (or scheduler) thread BLOCKS
+    /// for the length of a commit — typically a few milliseconds — which is the same order as the
+    /// storage read the query is about to do anyway, and far cheaper than a wrong answer or a
+    /// spurious refusal.
+    [[nodiscard]] bool waitForEvenGeneration(std::chrono::milliseconds budget) const
+    {
+        std::unique_lock lock(m_generationMutex);
+        return m_generationChanged.wait_for(lock, budget,
+            [this]() { return (m_generation.load(std::memory_order_acquire) % 2) == 0; });
+    }
+
+    /// How long waitForEvenGeneration is allowed to wait. kPublishWindowWaitBudget unless a test
+    /// shortened it.
+    [[nodiscard]] std::chrono::milliseconds publishWindowWaitBudget() const noexcept
+    {
+        return m_publishWindowWaitBudget;
+    }
+
+    /// Shorten (or lengthen) the wait. For tests that exercise the TIMEOUT path and would
+    /// otherwise sit out the full production budget; production never calls it.
+    void setPublishWindowWaitBudget(std::chrono::milliseconds budget) noexcept
+    {
+        m_publishWindowWaitBudget = budget;
     }
 
     /// Install a freshly rebuilt index in place of this one.
@@ -438,8 +493,12 @@ private:
     /// it read across a commit. So a publish with no window open advances by two.
     void bumpGenerationAfterPublish() noexcept
     {
-        auto const current = m_generation.load(std::memory_order_relaxed);
-        m_generation.store(current + ((current % 2) != 0 ? 1 : 2), std::memory_order_release);
+        {
+            std::lock_guard lock(m_generationMutex);
+            auto const current = m_generation.load(std::memory_order_relaxed);
+            m_generation.store(current + ((current % 2) != 0 ? 1 : 2), std::memory_order_release);
+        }
+        m_generationChanged.notify_all();
     }
 
     /// The boundary only ever grows: expired data does not come back, and the block an expiry
@@ -466,6 +525,11 @@ private:
     /// purpose: readers sample it without taking the shared lock, and the commit path opens the
     /// window before it holds anything.
     std::atomic<uint64_t> m_generation{0};
+    /// Guards only the counter's transitions and the wait below — never the maps. Always taken
+    /// INSIDE m_mutex when both are held (publish), never the other way round.
+    mutable std::mutex m_generationMutex;
+    mutable std::condition_variable m_generationChanged;
+    std::chrono::milliseconds m_publishWindowWaitBudget{kPublishWindowWaitBudget};
 };
 
 }  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
@@ -108,6 +108,11 @@ enum class IndexState : uint8_t
 /// Two seconds is far longer than any commit on a healthy node and far shorter than an RPC
 /// client's patience, so the timeout means "this node has a stuck committer", not "you were
 /// unlucky". Tests override it (setPublishWindowWaitBudget) to keep the refusal path fast.
+///
+/// It is the budget for the WHOLE query, not per attempt: HistoryRead.h::readAtOrCurrent may call
+/// readAt more than once, and it passes down what is left of its own deadline rather than letting
+/// each call start a fresh one — so the worst case a caller can block for is this value, not a
+/// multiple of it.
 inline constexpr std::chrono::milliseconds kPublishWindowWaitBudget{2000};
 
 /// Transparent hash so a query can look up by `std::string_view` without allocating a key.
@@ -267,6 +272,12 @@ public:
 
     /// Shorten (or lengthen) the wait. For tests that exercise the TIMEOUT path and would
     /// otherwise sit out the full production budget; production never calls it.
+    ///
+    /// TEST-ONLY, and call it BEFORE any reader can run. The budget is a plain field that readers
+    /// load without synchronisation — deliberately, because it is read on every query and never
+    /// written on a live node — so writing it while a query is in flight is a data race. Making
+    /// it atomic would buy nothing: there is no correct behaviour to define for a budget that
+    /// changes mid-wait.
     void setPublishWindowWaitBudget(std::chrono::milliseconds budget) noexcept
     {
         m_publishWindowWaitBudget = budget;

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
@@ -25,6 +25,7 @@
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <bcos-utilities/Common.h>
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -43,7 +44,7 @@ namespace bcos::ledger::mpt::history
 {
 
 /// Where one key's pre-image for one block physically is: the block's shard row, and the byte
-/// offset of the record inside that row's payload. Twelve bytes of RAM buy a query that reads
+/// offset of the record inside that row's payload. Sixteen bytes of RAM buy a query that reads
 /// exactly one row and decodes exactly one record.
 struct HistoryVersion
 {
@@ -53,6 +54,11 @@ struct HistoryVersion
 
     friend bool operator==(HistoryVersion const&, HistoryVersion const&) noexcept = default;
 };
+
+/// 8 + 2 + (2 padding) + 4. Pinned because the number is quoted as the per-version RAM cost of
+/// retention (MPTHistory.h) and read off the field list gets it wrong — the padding after
+/// `shard` is invisible there.
+static_assert(sizeof(HistoryVersion) == 16, "HistoryVersion is the index's per-version cost");
 
 /// What one `put` computed but has NOT published: the rows are in the block's WriteBatch, and the
 /// index must not learn about them until that batch lands (G9). The commit path holds this
@@ -150,8 +156,65 @@ public:
         catch (...)
         {
             m_state = IndexState::Unavailable;
+            closePublishWindow();
             throw;
         }
+        bumpGenerationAfterPublish();
+    }
+
+    /// Announce that a commit has reached the point where DISK is ahead of this index.
+    ///
+    /// The window this opens is the one hole the two-phase commit leaves. A query resolves
+    /// "unchanged since B" in two steps that cannot be one: `locate` says no version was recorded
+    /// after B, and then the caller reads the CURRENT value from the committed plane. Between
+    /// those two steps — and, worse, for the whole stretch between a block's merge and its
+    /// publish — the disk already holds block N's new value while this index does not yet know N
+    /// exists. A query for any B < N - 1 would pass admission, miss in the index, read the
+    /// current value, and hand back block N's bytes labelled B. That is the fabricated answer G6
+    /// forbids, and no amount of locking inside the index can see it, because the wrong value
+    /// comes from a plane the index does not own.
+    ///
+    /// So the index publishes a COUNTER instead of trying to serialize the disk read. Even means
+    /// quiescent; odd means a commit is somewhere between its merge and its publish. A reader
+    /// samples it before `locate` and again after its current-value read: an odd sample, or two
+    /// samples that differ, means a commit moved underneath the query and the "unchanged" reading
+    /// is not established — so the query retries, and eventually refuses. It never silently
+    /// answers.
+    ///
+    /// Relaxed ordering is enough on the reader side because the counter is not guarding data:
+    /// every value the reader actually returns comes from the index under its own mutex or from
+    /// the storage layer's own synchronisation. The counter only has to change, and a reader that
+    /// sees a stale even value has by construction not yet been overtaken.
+    ///
+    /// Idempotent in the sense that matters: opening an already-open window is a programming
+    /// error the commit path cannot make (one committer, RAII guard), and this checks rather than
+    /// assumes.
+    void openPublishWindow() noexcept
+    {
+        auto const current = m_generation.load(std::memory_order_relaxed);
+        if ((current % 2) == 0)
+        {
+            m_generation.store(current + 1, std::memory_order_release);
+        }
+    }
+
+    /// Close the window opened above. `publish` calls it at the end, so the ordinary path needs
+    /// no separate call; the RAII guard on the commit path calls it on every failure path, so a
+    /// commit that dies between merge and publish does not leave every later query retrying
+    /// forever.
+    void closePublishWindow() noexcept
+    {
+        auto const current = m_generation.load(std::memory_order_relaxed);
+        if ((current % 2) != 0)
+        {
+            m_generation.store(current + 1, std::memory_order_release);
+        }
+    }
+
+    /// The publish counter. Even: no commit is between its merge and its publish. Odd: one is.
+    [[nodiscard]] uint64_t generation() const noexcept
+    {
+        return m_generation.load(std::memory_order_acquire);
     }
 
     /// Install a freshly rebuilt index in place of this one.
@@ -366,6 +429,19 @@ private:
         m_blocks.erase(retired.block);
     }
 
+    /// Leave the counter EVEN and STRICTLY GREATER than it was, whether or not a window was open.
+    ///
+    /// Closing an open window (+1) is the ordinary path. The other case matters just as much: a
+    /// reader that sampled the counter before a publish and re-samples after its own read of the
+    /// current value is relying on the two samples DIFFERING, and a publish that only closed a
+    /// window it never had would leave them equal — the reader would then accept a current value
+    /// it read across a commit. So a publish with no window open advances by two.
+    void bumpGenerationAfterPublish() noexcept
+    {
+        auto const current = m_generation.load(std::memory_order_relaxed);
+        m_generation.store(current + ((current % 2) != 0 ? 1 : 2), std::memory_order_release);
+    }
+
     /// The boundary only ever grows: expired data does not come back, and the block an expiry
     /// names is not monotonic across callers (raising the retention depth makes N - H jump
     /// backwards). Assigning would claim heights are intact whose shards an earlier, higher
@@ -386,6 +462,10 @@ private:
     std::optional<protocol::BlockNumber> m_boundary;
     std::size_t m_versionCount{};
     IndexState m_state{IndexState::Empty};
+    /// Even = quiescent, odd = a commit is between its merge and its publish. Outside m_mutex on
+    /// purpose: readers sample it without taking the shared lock, and the commit path opens the
+    /// window before it holds anything.
+    std::atomic<uint64_t> m_generation{0};
 };
 
 }  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryIndex.h
@@ -1,0 +1,391 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryIndex.h
+ * @brief The in-memory (key -> ordered versions) index that turns a history query into one shard
+ *        read (layout spec §1.3)
+ */
+#pragma once
+
+#include "../Errors.h"
+#include "HistoryErrors.h"
+#include "HistoryRowCodec.h"
+#include <bcos-framework/protocol/ProtocolTypeDef.h>
+#include <bcos-utilities/Common.h>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt::history
+{
+
+/// Where one key's pre-image for one block physically is: the block's shard row, and the byte
+/// offset of the record inside that row's payload. Twelve bytes of RAM buy a query that reads
+/// exactly one row and decodes exactly one record.
+struct HistoryVersion
+{
+    protocol::BlockNumber block{};
+    uint16_t shard{};
+    uint32_t offset{};
+
+    friend bool operator==(HistoryVersion const&, HistoryVersion const&) noexcept = default;
+};
+
+/// What one `put` computed but has NOT published: the rows are in the block's WriteBatch, and the
+/// index must not learn about them until that batch lands (G9). The commit path holds this
+/// between `stageBlockHistory` and `publishBlockHistory`, and drops it on a merge failure.
+///
+/// Declared here rather than in ReverseHistoryStore.h because HistoryIndex::publish takes it; the
+/// names and fields are the ones layout spec §1.4 pins.
+struct StagedBlock
+{
+    protocol::BlockNumber block{};
+    BlockMeta meta;
+    std::vector<std::pair<bcos::bytes, HistoryVersion>> versions;
+};
+
+/// What one `expire` deleted, so the index can drop the same block without re-reading the shards.
+struct RetiredBlock
+{
+    protocol::BlockNumber block{};
+    std::vector<bcos::bytes> keys;
+    std::size_t shardsDeleted{};
+};
+
+/// Whether the index is entitled to answer at all (G10).
+enum class IndexState : uint8_t
+{
+    /// Never rebuilt and never published to. NOT the same as "this chain has no history": an
+    /// index that has not been built cannot tell the two apart, so it refuses.
+    Empty,
+    /// A rebuild completed, or a block was published. Queries are served.
+    Ready,
+    /// A rebuild or a publish failed. Whatever is in the maps may be missing versions, and a
+    /// missing version reads as "the key never changed" — the silent wrong answer this component
+    /// exists to prevent. Every query refuses until a successful rebuild replaces it.
+    Unavailable,
+};
+
+/// Transparent hash so a query can look up by `std::string_view` without allocating a key.
+struct TransparentStringHash
+{
+    using is_transparent = void;
+    std::size_t operator()(std::string_view value) const noexcept
+    {
+        return std::hash<std::string_view>{}(value);
+    }
+};
+
+/// The query index: for every key with retained history, the blocks that changed it, in ascending
+/// order, each paired with where its pre-image sits on disk.
+///
+/// Pure memory — it performs no I/O and knows nothing about storage. It is DERIVED data: every
+/// entry can be recomputed by walking the shard rows (ReverseHistoryStore::rebuild), which is why
+/// it is safe to lose it on a crash and why it is never written to disk. That is the whole saving
+/// of the optimized layout: no index rows to write on commit, no point-deletes to issue on expiry.
+///
+/// It carries its own `std::shared_mutex`: the commit path publishes under a unique lock while
+/// RPC and the scheduler read under shared locks.
+class HistoryIndex
+{
+public:
+    HistoryIndex() = default;
+    // The shared_mutex makes the object neither copyable nor movable. `replace` is how a rebuilt
+    // index is installed, and it moves the CONTENTS rather than the object.
+    HistoryIndex(const HistoryIndex&) = delete;
+    HistoryIndex(HistoryIndex&&) = delete;
+    HistoryIndex& operator=(const HistoryIndex&) = delete;
+    HistoryIndex& operator=(HistoryIndex&&) = delete;
+    ~HistoryIndex() = default;
+
+    /// Add block @p recorded, drop block @p retired, and move the boundary to @p boundaryWritten.
+    ///
+    /// Called ONLY after the block's WriteBatch has landed (G9). Everything it does is under one
+    /// unique lock, so a reader never sees a block half-added or half-retired.
+    ///
+    /// @p recorded must name a block strictly above every block this index already holds — see
+    /// applyStaged for why the whole lookup depends on it.
+    ///
+    /// If anything here throws — an allocation failure, or that ordering check — the maps may be
+    /// partially mutated, and a partially mutated index answers "this key never changed" for the
+    /// versions it is missing. So the state goes to Unavailable and the exception is rethrown:
+    /// refusing is the only safe reading of a half-applied publish.
+    void publish(StagedBlock&& recorded, std::optional<RetiredBlock> retired,
+        std::optional<protocol::BlockNumber> boundaryWritten)
+    {
+        std::unique_lock lock(m_mutex);
+        try
+        {
+            if (retired)
+            {
+                applyRetire(*retired);
+            }
+            applyStaged(std::move(recorded));
+            applyBoundary(boundaryWritten);
+            m_state = IndexState::Ready;
+        }
+        catch (...)
+        {
+            m_state = IndexState::Unavailable;
+            throw;
+        }
+    }
+
+    /// Install a freshly rebuilt index in place of this one.
+    ///
+    /// The state becomes Ready unconditionally, and that is the point rather than an oversight: a
+    /// rebuild that hit any inconsistency threw instead of returning, so reaching `replace` IS the
+    /// proof that the shards were walked end to end. A rebuild that legitimately found nothing —
+    /// a chain that has recorded no history yet — therefore installs an empty Ready index, which
+    /// answers "no recorded change" rather than refusing, and that is correct: the walk saw the
+    /// whole retained range.
+    void replace(HistoryIndex&& rebuilt)
+    {
+        std::unique_lock lock(m_mutex);
+        std::unique_lock rebuiltLock(rebuilt.m_mutex);
+        m_versions = std::move(rebuilt.m_versions);
+        m_blocks = std::move(rebuilt.m_blocks);
+        m_boundary = rebuilt.m_boundary;
+        m_versionCount = rebuilt.m_versionCount;
+        m_state = IndexState::Ready;
+    }
+
+    /// Refuse every query from here on. The startup path calls it after a failed rebuild; publish
+    /// latches the same state itself, under the lock it already holds.
+    void markUnavailable()
+    {
+        std::unique_lock lock(m_mutex);
+        m_state = IndexState::Unavailable;
+    }
+
+    /// Seed the boundary a rebuild read off disk, before it walks the shards.
+    ///
+    /// Separate from `publish` because the boundary must survive a rebuild that finds ZERO blocks:
+    /// a store whose whole retained window has been expired still has to refuse queries below the
+    /// boundary, and there is no block to hang that fact on. Max, not assignment — the boundary
+    /// only ever grows.
+    void setBoundary(std::optional<protocol::BlockNumber> boundary)
+    {
+        std::unique_lock lock(m_mutex);
+        applyBoundary(boundary);
+    }
+
+    /// The first recorded change strictly AFTER @p block, which is the version whose pre-image IS
+    /// the value at @p block. Nullopt means no change was recorded after @p block, so the caller
+    /// may read the current value — and that reading is only sound because `locate` has already
+    /// established that this index is Ready and covers @p block (G10).
+    [[nodiscard]] std::optional<HistoryVersion> firstChangeAfter(
+        std::span<const bcos::byte> key, protocol::BlockNumber block) const
+    {
+        std::shared_lock lock(m_mutex);
+        return firstChangeAfterLocked(asStringView(key), block);
+    }
+
+    /// The query path's three steps under ONE shared lock: the state check, the boundary check and
+    /// the lookup (layout spec §1.4, readAt rule 2). Taking three separate shared locks would let
+    /// a publish or a rebuild land between them and answer from a mix of two index generations.
+    ///
+    /// @throws HistoryIndexUnavailable when the index is not Ready.
+    /// @throws HistoryPruned when @p block is below the retention boundary.
+    [[nodiscard]] std::optional<HistoryVersion> locate(
+        std::span<const bcos::byte> key, protocol::BlockNumber block) const
+    {
+        std::shared_lock lock(m_mutex);
+        if (m_state != IndexState::Ready)
+        {
+            BOOST_THROW_EXCEPTION(
+                HistoryIndexUnavailable() << bcos::errinfo_comment(
+                    "the reverse-history query index has not been rebuilt, or a rebuild or "
+                    "publish left it unusable"));
+        }
+        if (m_boundary && *m_boundary > block)
+        {
+            BOOST_THROW_EXCEPTION(HistoryPruned() << bcos::errinfo_comment(
+                                      "the requested block is below the retention boundary this "
+                                      "store recorded on disk"));
+        }
+        return firstChangeAfterLocked(asStringView(key), block);
+    }
+
+    /// Was block @p block's history recorded here? One map probe, no I/O.
+    [[nodiscard]] bool hasBlock(protocol::BlockNumber block) const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_blocks.contains(block);
+    }
+
+    /// The block meta the Meta row carried, for a block this index holds.
+    [[nodiscard]] std::optional<BlockMeta> blockMeta(protocol::BlockNumber block) const
+    {
+        std::shared_lock lock(m_mutex);
+        auto iterator = m_blocks.find(block);
+        if (iterator == m_blocks.end())
+        {
+            return std::nullopt;
+        }
+        return iterator->second;
+    }
+
+    /// The oldest block this store can still answer for, as the index knows it.
+    [[nodiscard]] std::optional<protocol::BlockNumber> boundary() const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_boundary;
+    }
+
+    [[nodiscard]] IndexState state() const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_state;
+    }
+
+    /// Keys with at least one retained version.
+    [[nodiscard]] std::size_t keyCount() const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_versions.size();
+    }
+
+    /// Versions across all keys — the sum of every retained block's recordCount, which is what a
+    /// rebuild test compares against the meta rows.
+    [[nodiscard]] std::size_t versionCount() const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_versionCount;
+    }
+
+    /// Blocks whose history this index holds.
+    [[nodiscard]] std::size_t blockCount() const
+    {
+        std::shared_lock lock(m_mutex);
+        return m_blocks.size();
+    }
+
+private:
+    /// The lookup itself. `upper_bound` on an ascending vector: the first version whose block is
+    /// strictly greater than @p block.
+    [[nodiscard]] std::optional<HistoryVersion> firstChangeAfterLocked(
+        std::string_view key, protocol::BlockNumber block) const
+    {
+        auto iterator = m_versions.find(key);
+        if (iterator == m_versions.end())
+        {
+            return std::nullopt;
+        }
+        auto const& versions = iterator->second;
+        auto position = std::upper_bound(versions.begin(), versions.end(), block,
+            [](protocol::BlockNumber bound, HistoryVersion const& version) {
+                return bound < version.block;
+            });
+        if (position == versions.end())
+        {
+            return std::nullopt;
+        }
+        return *position;
+    }
+
+    /// Append one published block.
+    ///
+    /// Blocks must arrive in STRICTLY ASCENDING order, and that is the precondition the whole
+    /// index rests on: versions are appended with push_back, so a key's vector is sorted only
+    /// because the block numbers were. Publish a block below the current maximum and the vector
+    /// stops being sorted, at which point `upper_bound` in firstChangeAfterLocked has undefined
+    /// behaviour and hands back a plausible wrong version — the one silently-wrong answer this
+    /// component exists to prevent, reached from inside. Re-publishing the SAME block is the
+    /// special case of that (it would also give one key two versions for one block, and retiring
+    /// the block would leave one behind), so one check covers both.
+    ///
+    /// The check comes FIRST, before any version vector has been touched, so a refused publish
+    /// leaves the index exactly as it was rather than half-applied.
+    void applyStaged(StagedBlock&& recorded)
+    {
+        if (!m_blocks.empty() && m_blocks.rbegin()->first >= recorded.block)
+        {
+            BOOST_THROW_EXCEPTION(
+                MPTInvariantViolation() << bcos::errinfo_comment(
+                    "history index blocks must be published in strictly ascending order"));
+        }
+        m_blocks.emplace(recorded.block, recorded.meta);
+        for (auto& [key, version] : recorded.versions)
+        {
+            auto const keyView = asStringView(key);
+            auto iterator = m_versions.find(keyView);
+            if (iterator == m_versions.end())
+            {
+                iterator =
+                    m_versions.emplace(std::string(keyView), std::vector<HistoryVersion>{}).first;
+            }
+            iterator->second.push_back(version);
+            ++m_versionCount;
+        }
+    }
+
+    /// Drop one expired block. Its versions sit at the FRONT of each key's vector — it is the
+    /// oldest block still retained — so this is a bounded erase, not a scan.
+    void applyRetire(RetiredBlock const& retired)
+    {
+        for (auto const& key : retired.keys)
+        {
+            auto iterator = m_versions.find(asStringView(key));
+            if (iterator == m_versions.end())
+            {
+                continue;
+            }
+            auto& versions = iterator->second;
+            auto const removed = std::erase_if(versions,
+                [&](HistoryVersion const& version) { return version.block == retired.block; });
+            m_versionCount -= removed;
+            if (versions.empty())
+            {
+                m_versions.erase(iterator);
+            }
+        }
+        m_blocks.erase(retired.block);
+    }
+
+    /// The boundary only ever grows: expired data does not come back, and the block an expiry
+    /// names is not monotonic across callers (raising the retention depth makes N - H jump
+    /// backwards). Assigning would claim heights are intact whose shards an earlier, higher
+    /// expiry already deleted.
+    void applyBoundary(std::optional<protocol::BlockNumber> boundary)
+    {
+        if (boundary && (!m_boundary || *m_boundary < *boundary))
+        {
+            m_boundary = *boundary;
+        }
+    }
+
+    mutable std::shared_mutex m_mutex;
+    std::unordered_map<std::string, std::vector<HistoryVersion>, TransparentStringHash,
+        std::equal_to<>>
+        m_versions;
+    std::map<protocol::BlockNumber, BlockMeta> m_blocks;
+    std::optional<protocol::BlockNumber> m_boundary;
+    std::size_t m_versionCount{};
+    IndexState m_state{IndexState::Empty};
+};
+
+}  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryRowCodec.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryRowCodec.h
@@ -14,15 +14,24 @@
  *  limitations under the License.
  *
  * @file HistoryRowCodec.h
- * @brief Byte-exact layout of the four reverse-history row kinds (spec B.2)
+ * @brief Byte-exact layout of the three reverse-history row kinds (layout spec §1.2)
  *
  * ```text
- *   index    <table>: <logical key bytes> <block 8B big endian>  ->  <1B tag> <old value>
- *   manifest <table>: <block 8B big endian> <shard 2B big endian> ->  [<len 4B BE> <key>, ...]
+ *   meta      <shard table>: <BE64 block>                 -> <u8 version=1> <BE32 shardCount>
+ *                                                            <BE32 recordCount> <32B blockHash>
+ *   shard     <shard table>: <BE64 block> <BE16 shard>    -> record*
+ *   boundary  <boundary table>: "boundary"                -> <BE64 block>
  *
- *   tag 0x00 = the key did not exist before this block (ABSENT), no bytes follow
- *   tag 0x01 = the old value bytes follow
+ *   record = <BE32 keyLen> <key> <u8 tag> [<BE32 valueLen> <value>]
+ *   tag 0x00 = the key did not exist before this block (ABSENT), nothing follows
+ *   tag 0x01 = a length-prefixed old value follows
  * ```
+ *
+ * The old value now lives in the shard record, not in a separate index row: that is what lets one
+ * block's whole diff be deleted with `shardCount + 1` removes instead of one per key, and what
+ * lets the in-memory query index be REBUILT from the shards at startup (HistoryIndex.h). A
+ * record's `offset` — its byte position inside the shard payload, pointing at the `BE32 keyLen` —
+ * is the third component of the index's locator.
  */
 #pragma once
 
@@ -31,6 +40,8 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/Exceptions.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <limits>
@@ -45,22 +56,44 @@ namespace bcos::ledger::mpt::history
 
 /// Block numbers are 8 bytes big endian so that byte order equals numeric order — the property
 /// every seek in this component stands on. Little endian would make 255 sort after 256 and break
-/// the query outright (spec B.2(b)).
+/// both the query and the rebuild walk (spec B.2(b)).
 inline constexpr std::size_t kBlockNumberBytes = 8;
-/// Shard ordinal inside one block's manifest, 2 bytes big endian.
+/// Shard ordinal inside one block, 2 bytes big endian.
 inline constexpr std::size_t kShardIndexBytes = 2;
-/// Manifest row key = BE64(block) ‖ BE16(shard).
-inline constexpr std::size_t kManifestRowKeyBytes = kBlockNumberBytes + kShardIndexBytes;
-/// Length prefix of one manifest record, 4 bytes big endian.
+/// Meta row key = BE64(block). Eight bytes, and the length IS the discriminator.
+inline constexpr std::size_t kMetaRowKeyBytes = kBlockNumberBytes;
+/// Shard row key = BE64(block) ‖ BE16(shard).
+inline constexpr std::size_t kShardRowKeyBytes = kBlockNumberBytes + kShardIndexBytes;
+/// Length prefix of a record's key and of its value, 4 bytes big endian each.
 inline constexpr std::size_t kRecordLengthBytes = 4;
-/// The tag byte that opens every index row value.
+/// The tag byte that follows a record's key.
 inline constexpr std::size_t kTagBytes = 1;
-/// tag 0x00: the key did not exist before the indexed block.
+/// tag 0x00: the key did not exist before the recorded block.
 inline constexpr char kTagAbsent = '\x00';
-/// tag 0x01: the bytes after the tag are the key's value before the indexed block.
+/// tag 0x01: a length-prefixed old value follows.
 inline constexpr char kTagValue = '\x01';
 /// The largest shard ordinal a 2-byte field can name.
 inline constexpr std::size_t kMaxShardIndex = 0xFFFF;
+/// The only meta-row format this build understands. A row carrying anything else is refused
+/// rather than guessed at — this byte is the gate a future layout change goes through.
+inline constexpr char kMetaFormatVersion = '\x01';
+/// Meta row value: version ‖ BE32 shardCount ‖ BE32 recordCount ‖ 32-byte block hash. Fixed
+/// width, so a short or long row is a corruption the decoder can name.
+inline constexpr std::size_t kMetaRowValueBytes =
+    1 + kRecordLengthBytes + kRecordLengthBytes + bcos::h256::SIZE;
+static_assert(kMetaRowValueBytes == 41, "layout spec §1.2 pins the meta row at 41 bytes");
+
+/// One block's meta row, decoded. `shardCount` and `recordCount` are what make a truncated or
+/// partially-expired block detectable during the rebuild walk: the walk counts what it actually
+/// reads and compares.
+struct BlockMeta
+{
+    uint32_t shardCount{};
+    uint32_t recordCount{};
+    bcos::h256 blockHash;
+
+    friend bool operator==(BlockMeta const&, BlockMeta const&) noexcept = default;
+};
 
 /// Reinterpret a byte span as the character view every storage key/value API in this repo takes.
 /// A view, not a copy — the caller keeps ownership.
@@ -91,8 +124,8 @@ inline uint64_t readBigEndian(std::string_view bytes)
     return bcos::fromBigEndian<uint64_t>(bytes.substr(0, Width));
 }
 
-/// A block number as it is written into a row key. Rejects negatives rather than letting them
-/// wrap into the top of the unsigned range, where they would sort above every real block.
+/// A block number as it is written into a row key. Rejects negatives rather than letting them wrap
+/// into the top of the unsigned range, where they would sort above every real block.
 inline uint64_t toRowBlockNumber(int64_t block)
 {
     if (block < 0)
@@ -103,111 +136,257 @@ inline uint64_t toRowBlockNumber(int64_t block)
     return static_cast<uint64_t>(block);
 }
 
-/// Index row key: `<logical key bytes> <BE64 block>`. No length prefix — see
-/// indexRowBelongsTo for why none is needed (spec B.2(c)).
-inline std::string indexRowKey(std::span<const bcos::byte> key, int64_t block)
+/// The single row key the retention-boundary table holds. A fixed literal: the table has exactly
+/// one row, so nothing has to be encoded into its key, and a name rather than an empty string
+/// makes the row legible in a dump.
+inline constexpr std::string_view kRetentionBoundaryRowKey = "boundary";
+
+/// Retention-boundary row value: BE64 of the oldest block the store can still answer for.
+inline std::string retentionBoundaryValue(int64_t oldestIntactBlock)
+{
+    std::string value;
+    value.reserve(kBlockNumberBytes);
+    appendBigEndian<kBlockNumberBytes>(value, toRowBlockNumber(oldestIntactBlock));
+    return value;
+}
+
+/// Inverse of retentionBoundaryValue.
+/// @throws MPTInvariantViolation on a row that is not exactly one BE64 field — a boundary the
+/// reader cannot trust must not be read as a permissive one.
+inline int64_t decodeRetentionBoundary(std::string_view value)
+{
+    if (value.size() != kBlockNumberBytes)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history retention-boundary row is not a single BE64 field"));
+    }
+    return static_cast<int64_t>(readBigEndian<kBlockNumberBytes>(value));
+}
+
+/// Meta row key: `<BE64 block>`, eight bytes.
+inline std::string metaRowKey(int64_t block)
 {
     std::string rowKey;
-    rowKey.reserve(key.size() + kBlockNumberBytes);
-    rowKey.append(asStringView(key));
+    rowKey.reserve(kMetaRowKeyBytes);
     appendBigEndian<kBlockNumberBytes>(rowKey, toRowBlockNumber(block));
     return rowKey;
 }
 
-/// Manifest row key: `<BE64 block> <BE16 shard>`.
-inline std::string manifestRowKey(int64_t block, std::size_t shard)
+/// Shard row key: `<BE64 block> <BE16 shard>`, ten bytes. Two bytes longer than the meta row key
+/// of the same block, and sharing its first eight bytes, so one seek at the meta key walks meta
+/// then shard 0, 1, ...
+inline std::string shardRowKey(int64_t block, std::size_t shard)
 {
     if (shard > kMaxShardIndex)
     {
-        BOOST_THROW_EXCEPTION(
-            MPTInvariantViolation() << bcos::errinfo_comment(
-                "history manifest shard ordinal overflows the 2-byte shard field"));
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history shard ordinal overflows the 2-byte shard field"));
     }
     std::string rowKey;
-    rowKey.reserve(kManifestRowKeyBytes);
+    rowKey.reserve(kShardRowKeyBytes);
     appendBigEndian<kBlockNumberBytes>(rowKey, toRowBlockNumber(block));
     appendBigEndian<kShardIndexBytes>(rowKey, static_cast<uint64_t>(shard));
     return rowKey;
 }
 
-/// Index row value: the tag byte, followed by the old value when there is one.
-/// @param oldValue nullopt means the key did not exist before the indexed block.
-inline std::string indexRowValue(std::optional<std::span<const bcos::byte>> oldValue)
+/// Meta row value, the 41 fixed bytes.
+inline std::string metaRowValue(
+    uint32_t shardCount, uint32_t recordCount, bcos::h256 const& blockHash)
 {
     std::string value;
-    if (!oldValue)
-    {
-        value.push_back(kTagAbsent);
-        return value;
-    }
-    value.reserve(kTagBytes + oldValue->size());
-    value.push_back(kTagValue);
-    value.append(asStringView(*oldValue));
+    value.reserve(kMetaRowValueBytes);
+    value.push_back(kMetaFormatVersion);
+    appendBigEndian<kRecordLengthBytes>(value, shardCount);
+    appendBigEndian<kRecordLengthBytes>(value, recordCount);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    value.append(reinterpret_cast<const char*>(blockHash.data()), bcos::h256::SIZE);
     return value;
 }
 
-/// spec B.2(c): a row key @p rowKey belongs to @p key exactly when it starts with @p key AND is
-/// eight bytes longer. That second clause is the whole reason the layout can skip a length
-/// prefix: if the row belonged to some other key k', then |k'| = |rowKey| - 8 = |key|, and k' is
-/// also the first |key| bytes of rowKey, so k' == key.
-inline bool indexRowBelongsTo(std::string_view rowKey, std::string_view key) noexcept
+/// Inverse of metaRowValue.
+/// @throws MPTInvariantViolation on a wrong length or an unknown format version. The version byte
+/// is the gate a future layout change goes through: a reader that guessed at an unknown version
+/// would report counts that do not describe the shards it is about to walk.
+inline BlockMeta decodeMeta(std::string_view value)
 {
-    return rowKey.size() == key.size() + kBlockNumberBytes && rowKey.starts_with(key);
-}
-
-/// True when @p rowKey is a manifest row of @p block: `<BE64 block> <BE16 shard>`, exactly ten
-/// bytes. The same shape argument as indexRowBelongsTo, with both fields fixed-width.
-inline bool manifestRowBelongsTo(std::string_view rowKey, int64_t block)
-{
-    if (rowKey.size() != kManifestRowKeyBytes)
+    if (value.size() != kMetaRowValueBytes)
     {
-        return false;
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation()
+                              << bcos::errinfo_comment("history meta row is not exactly 41 bytes"));
     }
-    return readBigEndian<kBlockNumberBytes>(rowKey) == toRowBlockNumber(block);
-}
-
-/// Append one `<BE32 len> <key>` record to a manifest shard payload.
-inline void appendManifestRecord(std::string& payload, std::span<const bcos::byte> key)
-{
-    if (key.size() > std::numeric_limits<uint32_t>::max())
+    if (value.front() != kMetaFormatVersion)
     {
         BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
-                                  "history manifest record length overflows its 4-byte field"));
+                                  "history meta row carries an unknown format version"));
     }
+    BlockMeta meta;
+    meta.shardCount = static_cast<uint32_t>(readBigEndian<kRecordLengthBytes>(value.substr(1)));
+    meta.recordCount = static_cast<uint32_t>(
+        readBigEndian<kRecordLengthBytes>(value.substr(1 + kRecordLengthBytes)));
+    auto const hashBytes = value.substr(1 + kRecordLengthBytes + kRecordLengthBytes);
+    std::copy(hashBytes.begin(), hashBytes.end(), meta.blockHash.data());
+    return meta;
+}
+
+/// True when @p rowKey is the meta row of @p block. Length first: an 8-byte key in the shard
+/// table is a meta row and nothing else.
+inline bool isMetaRowKey(std::string_view rowKey, int64_t block)
+{
+    return rowKey.size() == kMetaRowKeyBytes &&
+           readBigEndian<kBlockNumberBytes>(rowKey) == toRowBlockNumber(block);
+}
+
+/// True when @p rowKey is a shard row of @p block: ten bytes whose first eight name the block.
+inline bool isShardRowKey(std::string_view rowKey, int64_t block)
+{
+    return rowKey.size() == kShardRowKeyBytes &&
+           readBigEndian<kBlockNumberBytes>(rowKey) == toRowBlockNumber(block);
+}
+
+/// The block a meta or shard row key names, whatever its length. Used by the rebuild walk, which
+/// does not know the block up front — it discovers it from the rows.
+inline int64_t rowKeyBlock(std::string_view rowKey)
+{
+    if (rowKey.size() != kMetaRowKeyBytes && rowKey.size() != kShardRowKeyBytes)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history shard-table row key is neither 8 nor 10 bytes"));
+    }
+    return static_cast<int64_t>(readBigEndian<kBlockNumberBytes>(rowKey));
+}
+
+/// The shard ordinal a 10-byte shard row key names.
+inline std::size_t rowKeyShard(std::string_view rowKey)
+{
+    if (rowKey.size() != kShardRowKeyBytes)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation()
+                              << bcos::errinfo_comment("history shard row key is not ten bytes"));
+    }
+    return static_cast<std::size_t>(
+        readBigEndian<kShardIndexBytes>(rowKey.substr(kBlockNumberBytes)));
+}
+
+/// The number of bytes one record occupies in a shard payload. Callers size their shards with
+/// this BEFORE appending, so it must agree with appendRecord byte for byte.
+inline std::size_t recordSize(
+    std::span<const bcos::byte> key, std::optional<std::span<const bcos::byte>> oldValue) noexcept
+{
+    return kRecordLengthBytes + key.size() + kTagBytes +
+           (oldValue ? kRecordLengthBytes + oldValue->size() : 0);
+}
+
+/// Append one record to a shard payload and return the OFFSET it starts at — the byte position of
+/// its `BE32 keyLen`, which is what the in-memory index stores so a query can decode exactly this
+/// record without scanning the shard.
+inline std::size_t appendRecord(std::string& payload, std::span<const bcos::byte> key,
+    std::optional<std::span<const bcos::byte>> oldValue)
+{
+    if (key.size() > std::numeric_limits<uint32_t>::max() ||
+        (oldValue && oldValue->size() > std::numeric_limits<uint32_t>::max()))
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history record length overflows its 4-byte field"));
+    }
+    auto const offset = payload.size();
     appendBigEndian<kRecordLengthBytes>(payload, static_cast<uint64_t>(key.size()));
     payload.append(asStringView(key));
+    if (!oldValue)
+    {
+        payload.push_back(kTagAbsent);
+        return offset;
+    }
+    payload.push_back(kTagValue);
+    appendBigEndian<kRecordLengthBytes>(payload, static_cast<uint64_t>(oldValue->size()));
+    payload.append(asStringView(*oldValue));
+    return offset;
 }
 
-/// The size one key occupies in a manifest shard payload.
-inline std::size_t manifestRecordSize(std::span<const bcos::byte> key) noexcept
+/// One decoded record. The two byte fields are VIEWS into the payload they were decoded from —
+/// the caller copies if it needs to outlive the row.
+struct DecodedRecord
 {
-    return kRecordLengthBytes + key.size();
+    std::string_view key;
+    /// nullopt when the record is tagged ABSENT: the key did not exist before the block.
+    std::optional<std::string_view> oldValue;
+    /// Where the NEXT record starts, so a whole-shard walk needs no second length computation.
+    std::size_t nextOffset{};
+};
+
+/// Decode the record at @p offset. Every failure is loud (G6): a payload that ends inside a
+/// record, an offset past the end, or an unknown tag means the query about to be answered from
+/// this record would otherwise get bytes from the wrong place.
+inline DecodedRecord decodeRecordAt(std::string_view payload, std::size_t offset)
+{
+    if (offset > payload.size())
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history record offset points past the end of its shard"));
+    }
+    DecodedRecord record;
+    auto cursor = offset;
+    auto const keyLength =
+        static_cast<std::size_t>(readBigEndian<kRecordLengthBytes>(payload.substr(cursor)));
+    cursor += kRecordLengthBytes;
+    if (payload.size() - cursor < keyLength)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation()
+                              << bcos::errinfo_comment("history shard ends inside a record key"));
+    }
+    record.key = payload.substr(cursor, keyLength);
+    cursor += keyLength;
+    if (cursor >= payload.size())
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation()
+                              << bcos::errinfo_comment("history record is missing its tag byte"));
+    }
+    auto const tag = payload[cursor];
+    cursor += kTagBytes;
+    if (tag == kTagAbsent)
+    {
+        record.nextOffset = cursor;
+        return record;
+    }
+    if (tag != kTagValue)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history record carries an unknown tag byte"));
+    }
+    auto const valueLength =
+        static_cast<std::size_t>(readBigEndian<kRecordLengthBytes>(payload.substr(cursor)));
+    cursor += kRecordLengthBytes;
+    if (payload.size() - cursor < valueLength)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation()
+                              << bcos::errinfo_comment("history shard ends inside a record value"));
+    }
+    record.oldValue = payload.substr(cursor, valueLength);
+    record.nextOffset = cursor + valueLength;
+    return record;
 }
 
-/// Split one manifest shard payload back into the keys it lists. A payload that ends mid-record
-/// is an index corruption, not an empty tail: it fails loud (G6) rather than returning a short
-/// list that would leave index rows orphaned at expiry.
-inline std::vector<bcos::bytes> decodeManifestShard(std::string_view payload)
+/// One record as the whole-shard walk sees it: the decoded fields plus where it started, which is
+/// what the rebuild stores in the index.
+struct ShardRecord
 {
-    std::vector<bcos::bytes> keys;
+    std::string_view key;
+    std::optional<std::string_view> oldValue;
+    std::size_t offset{};
+};
+
+/// Split a whole shard payload into its records, in payload order. Views into @p payload.
+inline std::vector<ShardRecord> decodeShard(std::string_view payload)
+{
+    std::vector<ShardRecord> records;
     std::size_t offset = 0;
     while (offset < payload.size())
     {
-        auto length =
-            static_cast<std::size_t>(readBigEndian<kRecordLengthBytes>(payload.substr(offset)));
-        offset += kRecordLengthBytes;
-        if (payload.size() - offset < length)
-        {
-            BOOST_THROW_EXCEPTION(
-                MPTInvariantViolation() << bcos::errinfo_comment(
-                    "history manifest shard ends inside a record: declared key length exceeds "
-                    "the remaining payload"));
-        }
-        auto record = payload.substr(offset, length);
-        keys.emplace_back(record.begin(), record.end());
-        offset += length;
+        auto decoded = decodeRecordAt(payload, offset);
+        records.push_back(
+            ShardRecord{.key = decoded.key, .oldValue = decoded.oldValue, .offset = offset});
+        offset = decoded.nextOffset;
     }
-    return keys;
+    return records;
 }
 
 }  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryRowCodec.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryRowCodec.h
@@ -1,0 +1,213 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryRowCodec.h
+ * @brief Byte-exact layout of the four reverse-history row kinds (spec B.2)
+ *
+ * ```text
+ *   index    <table>: <logical key bytes> <block 8B big endian>  ->  <1B tag> <old value>
+ *   manifest <table>: <block 8B big endian> <shard 2B big endian> ->  [<len 4B BE> <key>, ...]
+ *
+ *   tag 0x00 = the key did not exist before this block (ABSENT), no bytes follow
+ *   tag 0x01 = the old value bytes follow
+ * ```
+ */
+#pragma once
+
+#include "../Errors.h"
+#include "HistoryErrors.h"
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Exceptions.h>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bcos::ledger::mpt::history
+{
+
+/// Block numbers are 8 bytes big endian so that byte order equals numeric order — the property
+/// every seek in this component stands on. Little endian would make 255 sort after 256 and break
+/// the query outright (spec B.2(b)).
+inline constexpr std::size_t kBlockNumberBytes = 8;
+/// Shard ordinal inside one block's manifest, 2 bytes big endian.
+inline constexpr std::size_t kShardIndexBytes = 2;
+/// Manifest row key = BE64(block) ‖ BE16(shard).
+inline constexpr std::size_t kManifestRowKeyBytes = kBlockNumberBytes + kShardIndexBytes;
+/// Length prefix of one manifest record, 4 bytes big endian.
+inline constexpr std::size_t kRecordLengthBytes = 4;
+/// The tag byte that opens every index row value.
+inline constexpr std::size_t kTagBytes = 1;
+/// tag 0x00: the key did not exist before the indexed block.
+inline constexpr char kTagAbsent = '\x00';
+/// tag 0x01: the bytes after the tag are the key's value before the indexed block.
+inline constexpr char kTagValue = '\x01';
+/// The largest shard ordinal a 2-byte field can name.
+inline constexpr std::size_t kMaxShardIndex = 0xFFFF;
+
+/// Reinterpret a byte span as the character view every storage key/value API in this repo takes.
+/// A view, not a copy — the caller keeps ownership.
+inline std::string_view asStringView(std::span<const bcos::byte> bytes) noexcept
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+/// Append @p value as exactly @p Width big-endian bytes.
+template <std::size_t Width>
+inline void appendBigEndian(std::string& out, uint64_t value)
+{
+    std::array<char, Width> buffer{};
+    bcos::toBigEndian(value, buffer);
+    out.append(buffer.data(), buffer.size());
+}
+
+/// Read exactly @p Width big-endian bytes from the front of @p bytes.
+template <std::size_t Width>
+inline uint64_t readBigEndian(std::string_view bytes)
+{
+    if (bytes.size() < Width)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history row truncated: fewer bytes than a big-endian field"));
+    }
+    return bcos::fromBigEndian<uint64_t>(bytes.substr(0, Width));
+}
+
+/// A block number as it is written into a row key. Rejects negatives rather than letting them
+/// wrap into the top of the unsigned range, where they would sort above every real block.
+inline uint64_t toRowBlockNumber(int64_t block)
+{
+    if (block < 0)
+    {
+        BOOST_THROW_EXCEPTION(InvalidHistoryBlock() << bcos::errinfo_comment(
+                                  "history block number must not be negative"));
+    }
+    return static_cast<uint64_t>(block);
+}
+
+/// Index row key: `<logical key bytes> <BE64 block>`. No length prefix — see
+/// indexRowBelongsTo for why none is needed (spec B.2(c)).
+inline std::string indexRowKey(std::span<const bcos::byte> key, int64_t block)
+{
+    std::string rowKey;
+    rowKey.reserve(key.size() + kBlockNumberBytes);
+    rowKey.append(asStringView(key));
+    appendBigEndian<kBlockNumberBytes>(rowKey, toRowBlockNumber(block));
+    return rowKey;
+}
+
+/// Manifest row key: `<BE64 block> <BE16 shard>`.
+inline std::string manifestRowKey(int64_t block, std::size_t shard)
+{
+    if (shard > kMaxShardIndex)
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTInvariantViolation() << bcos::errinfo_comment(
+                "history manifest shard ordinal overflows the 2-byte shard field"));
+    }
+    std::string rowKey;
+    rowKey.reserve(kManifestRowKeyBytes);
+    appendBigEndian<kBlockNumberBytes>(rowKey, toRowBlockNumber(block));
+    appendBigEndian<kShardIndexBytes>(rowKey, static_cast<uint64_t>(shard));
+    return rowKey;
+}
+
+/// Index row value: the tag byte, followed by the old value when there is one.
+/// @param oldValue nullopt means the key did not exist before the indexed block.
+inline std::string indexRowValue(std::optional<std::span<const bcos::byte>> oldValue)
+{
+    std::string value;
+    if (!oldValue)
+    {
+        value.push_back(kTagAbsent);
+        return value;
+    }
+    value.reserve(kTagBytes + oldValue->size());
+    value.push_back(kTagValue);
+    value.append(asStringView(*oldValue));
+    return value;
+}
+
+/// spec B.2(c): a row key @p rowKey belongs to @p key exactly when it starts with @p key AND is
+/// eight bytes longer. That second clause is the whole reason the layout can skip a length
+/// prefix: if the row belonged to some other key k', then |k'| = |rowKey| - 8 = |key|, and k' is
+/// also the first |key| bytes of rowKey, so k' == key.
+inline bool indexRowBelongsTo(std::string_view rowKey, std::string_view key) noexcept
+{
+    return rowKey.size() == key.size() + kBlockNumberBytes && rowKey.starts_with(key);
+}
+
+/// True when @p rowKey is a manifest row of @p block: `<BE64 block> <BE16 shard>`, exactly ten
+/// bytes. The same shape argument as indexRowBelongsTo, with both fields fixed-width.
+inline bool manifestRowBelongsTo(std::string_view rowKey, int64_t block)
+{
+    if (rowKey.size() != kManifestRowKeyBytes)
+    {
+        return false;
+    }
+    return readBigEndian<kBlockNumberBytes>(rowKey) == toRowBlockNumber(block);
+}
+
+/// Append one `<BE32 len> <key>` record to a manifest shard payload.
+inline void appendManifestRecord(std::string& payload, std::span<const bcos::byte> key)
+{
+    if (key.size() > std::numeric_limits<uint32_t>::max())
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                  "history manifest record length overflows its 4-byte field"));
+    }
+    appendBigEndian<kRecordLengthBytes>(payload, static_cast<uint64_t>(key.size()));
+    payload.append(asStringView(key));
+}
+
+/// The size one key occupies in a manifest shard payload.
+inline std::size_t manifestRecordSize(std::span<const bcos::byte> key) noexcept
+{
+    return kRecordLengthBytes + key.size();
+}
+
+/// Split one manifest shard payload back into the keys it lists. A payload that ends mid-record
+/// is an index corruption, not an empty tail: it fails loud (G6) rather than returning a short
+/// list that would leave index rows orphaned at expiry.
+inline std::vector<bcos::bytes> decodeManifestShard(std::string_view payload)
+{
+    std::vector<bcos::bytes> keys;
+    std::size_t offset = 0;
+    while (offset < payload.size())
+    {
+        auto length =
+            static_cast<std::size_t>(readBigEndian<kRecordLengthBytes>(payload.substr(offset)));
+        offset += kRecordLengthBytes;
+        if (payload.size() - offset < length)
+        {
+            BOOST_THROW_EXCEPTION(
+                MPTInvariantViolation() << bcos::errinfo_comment(
+                    "history manifest shard ends inside a record: declared key length exceeds "
+                    "the remaining payload"));
+        }
+        auto record = payload.substr(offset, length);
+        keys.emplace_back(record.begin(), record.end());
+        offset += length;
+    }
+    return keys;
+}
+
+}  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryTables.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryTables.h
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryTables.h
+ * @brief The four state tables the reverse-history index lives in (spec B.2, B.8)
+ */
+#pragma once
+
+#include <string_view>
+
+namespace bcos::ledger::mpt::history
+{
+
+/// The pair of state tables one reverse-history instance owns: the (key, block)-ordered index
+/// that answers point queries, and the (block, shard)-ordered manifest that answers whole-block
+/// traversal. Spec B.1: one sort order cannot serve both access patterns, so the same diff is
+/// stored twice — values only in the index, keys only in the manifest (B.2(a)).
+struct HistoryTables
+{
+    std::string_view index;
+    std::string_view manifest;
+};
+
+/// State history: the pre-images of ordinary state rows, retained for H_state blocks.
+inline constexpr HistoryTables kStateHistory{.index = "/mptsi/", .manifest = "/mpths/"};
+
+/// Trie history: the pre-images of path-addressed trie-node rows, retained for H_proof blocks.
+/// Same mechanism, second instantiation (spec B.8).
+inline constexpr HistoryTables kTrieHistory{.index = "/mptti/", .manifest = "/mptth/"};
+
+/// A table name must not contain ':': StateKeyResolver splits a physical key at its FIRST colon
+/// to rebuild the (table, rowKey) pair, so a colon in the table name would corrupt the split.
+/// History row keys DO contain arbitrary bytes (0x3A among them) — that is safe precisely
+/// because every colon in them sits after the first one. Same rule and reasoning as
+/// bcos-storage/KeyPrefixes.h:43.
+static_assert(kStateHistory.index.find(':') == std::string_view::npos &&
+                  kStateHistory.manifest.find(':') == std::string_view::npos &&
+                  kTrieHistory.index.find(':') == std::string_view::npos &&
+                  kTrieHistory.manifest.find(':') == std::string_view::npos,
+    "a history table name must not contain ':'");
+
+/// The four tables must stay distinct: rows are located by seeking into a table and walking
+/// forward until the table changes, so a shared name would let one instance's scan consume the
+/// other's rows. All four names are the same length, so distinctness also rules out one being a
+/// prefix of another.
+static_assert(kStateHistory.index.size() == kStateHistory.manifest.size() &&
+                  kStateHistory.index.size() == kTrieHistory.index.size() &&
+                  kStateHistory.index.size() == kTrieHistory.manifest.size(),
+    "the four history table names are asserted distinct below on the strength of being equal "
+    "length; if that stops holding, the prefix case needs its own check");
+static_assert(kStateHistory.index != kStateHistory.manifest &&
+                  kStateHistory.index != kTrieHistory.index &&
+                  kStateHistory.index != kTrieHistory.manifest &&
+                  kStateHistory.manifest != kTrieHistory.index &&
+                  kStateHistory.manifest != kTrieHistory.manifest &&
+                  kTrieHistory.index != kTrieHistory.manifest,
+    "the four history table names must be distinct");
+
+}  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryTables.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryTables.h
@@ -101,8 +101,8 @@ inline constexpr std::string_view kBlockHistoryCoverageContract =
 /// A table name must not contain ':': StateKeyResolver splits a physical key at its FIRST colon to
 /// rebuild the (table, rowKey) pair, so a colon in the table name would corrupt the split. History
 /// row keys DO contain arbitrary bytes (0x3A among them) — that is safe precisely because every
-/// colon in them sits after the first one. Same rule and reasoning as
-/// bcos-storage/KeyPrefixes.h:43.
+/// colon in them sits after the first one. Same rule and reasoning as the trie-node table names
+/// in bcos-ledger/bcos-ledger/mpt/PathKey.h:56.
 static_assert(kStateHistory.shard.find(':') == std::string_view::npos &&
                   kStateHistory.boundary.find(':') == std::string_view::npos &&
                   kTrieHistory.shard.find(':') == std::string_view::npos &&

--- a/bcos-ledger/bcos-ledger/mpt/history/HistoryTables.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/HistoryTables.h
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  * @file HistoryTables.h
- * @brief The four state tables the reverse-history index lives in (spec B.2, B.8)
+ * @brief The four state tables the reverse history lives in (layout spec §1.1)
  */
 #pragma once
 
@@ -23,49 +23,107 @@
 namespace bcos::ledger::mpt::history
 {
 
-/// The pair of state tables one reverse-history instance owns: the (key, block)-ordered index
-/// that answers point queries, and the (block, shard)-ordered manifest that answers whole-block
-/// traversal. Spec B.1: one sort order cannot serve both access patterns, so the same diff is
-/// stored twice — values only in the index, keys only in the manifest (B.2(a)).
+/// The pair of state tables one reverse-history instance owns.
+///
+/// The optimized layout (spec §1.1) keeps the old values themselves inside the per-block shards
+/// and answers point queries from an in-memory index (HistoryIndex.h), so the (key, block)-ordered
+/// index TABLE the earlier layout needed is gone: one sort order now serves the disk, and the
+/// second sort order lives in RAM where it costs no writes and no expiry point-deletes.
+///
+/// ```text
+/// shard     StateKey{"/mpths/" | "/mptth/", <BE64 block>}                 -> meta,  41 bytes
+/// shard     StateKey{"/mpths/" | "/mptth/", <BE64 block> <BE16 shard>}    -> records
+/// boundary  StateKey{"/mptsr/" | "/mpttr/", "boundary"}                   -> <BE64 block>
+/// ```
+///
+/// Meta rows and shard rows share the `shard` table on purpose: an 8-byte key sorts before every
+/// 10-byte key that starts with the same 8 bytes, so ONE `RANGE_SEEK(BE64(block))` yields the
+/// block's meta row and then its shards in ordinal order — which is exactly what both the
+/// whole-block read and the startup rebuild walk. The two kinds are told apart by key length
+/// (isMetaRowKey / isShardRowKey), never by content.
+///
+/// The boundary table holds ONE row, the retention boundary (spec §13's "保留边界与记录的 H_state
+/// / H_proof 元数据一致"). Its value is the OLDEST block this store can still ANSWER FOR:
+/// everything below it has been expired. Answerable, not "whose own rows survive" — a query for B
+/// is served from the first change AFTER B, so dropping block E leaves E answerable from E+1's
+/// rows and takes E-1 away. It only ever grows; expired data does not come back. It is written in
+/// the SAME batch as the expiry deletes that advance it, so no crash can leave a boundary that
+/// disagrees with the rows.
+///
+/// **Only expiry from the BOTTOM moves it** (ReverseHistoryStore::RetentionBoundary). Two callers
+/// discard a block's history, from opposite ends of the chain:
+///
+///  - the commit path drops E = N - H, the block leaving the window from below, so E becomes the
+///    oldest block the store can answer for — `RetentionBoundary::Advance`;
+///  - an operational rollback walks the tip DOWNWARDS, reverse-applying block N and then dropping
+///    N's record. Discarding the newest block does not change which is the oldest, and advancing
+///    here would break the walk's own next step: rollback reads at N-2 immediately after
+///    discarding N, and a boundary at N refuses it — `RetentionBoundary::Keep`, which is the
+///    default so that only the one caller that knows better has to say so.
+///
+/// It lives in its own TABLE rather than in a reserved row of the shard table, and under this
+/// layout that separation is load-bearing rather than merely tidy. Meta rows and shard rows are
+/// told apart by key LENGTH — and the boundary row key `"boundary"` is eight bytes, exactly a meta
+/// row key's length. Sharing the table would make it indistinguishable from the meta row of block
+/// 0x626F756E64617279 to every walker, with no signal. The rebuild also reads the boundary to
+/// decide where to START its shard walk, so the boundary must not be inside the range being
+/// walked.
 struct HistoryTables
 {
-    std::string_view index;
-    std::string_view manifest;
+    std::string_view shard;
+    std::string_view boundary;
 };
 
 /// State history: the pre-images of ordinary state rows, retained for H_state blocks.
-inline constexpr HistoryTables kStateHistory{.index = "/mptsi/", .manifest = "/mpths/"};
+inline constexpr HistoryTables kStateHistory{.shard = "/mpths/", .boundary = "/mptsr/"};
 
 /// Trie history: the pre-images of path-addressed trie-node rows, retained for H_proof blocks.
 /// Same mechanism, second instantiation (spec B.8).
-inline constexpr HistoryTables kTrieHistory{.index = "/mptti/", .manifest = "/mptth/"};
+inline constexpr HistoryTables kTrieHistory{.shard = "/mptth/", .boundary = "/mpttr/"};
 
-/// A table name must not contain ':': StateKeyResolver splits a physical key at its FIRST colon
-/// to rebuild the (table, rowKey) pair, so a colon in the table name would corrupt the split.
-/// History row keys DO contain arbitrary bytes (0x3A among them) — that is safe precisely
-/// because every colon in them sits after the first one. Same rule and reasoning as
+/// **Block-history coverage contract** — what a consumer (PR-D's rollback and audit) may assume.
+///
+/// A Meta row exists for block N in store S **iff** S's retention depth was > 0 when N committed
+/// AND N built an MPT delta. Both commit paths gate on exactly that, and a block that meets both
+/// conditions but changed nothing still gets `Meta{shardCount = 1, recordCount = 0}` plus an empty
+/// shard 0 (spec B.10 ②), so "no Meta row" is never ambiguous with "changed nothing".
+///
+/// The converse is what matters to a consumer: a chain has blocks with NO Meta row in either store
+/// — every pre-MPT block of a scenario-A chain, and every block committed while the depth was 0.
+/// Empty records are deliberately NOT written for them: a Meta row asserts "this block's
+/// pre-images are recorded here", and for a block whose pre-images were never captured that
+/// assertion would be false, which is worse than its absence. A rollback or an audit that spans
+/// such a block therefore has no data to work from and must REFUSE rather than treat the gap as an
+/// empty diff.
+inline constexpr std::string_view kBlockHistoryCoverageContract =
+    "a Meta row exists for block N in store S iff S's depth was > 0 and N built an MPT delta";
+
+/// A table name must not contain ':': StateKeyResolver splits a physical key at its FIRST colon to
+/// rebuild the (table, rowKey) pair, so a colon in the table name would corrupt the split. History
+/// row keys DO contain arbitrary bytes (0x3A among them) — that is safe precisely because every
+/// colon in them sits after the first one. Same rule and reasoning as
 /// bcos-storage/KeyPrefixes.h:43.
-static_assert(kStateHistory.index.find(':') == std::string_view::npos &&
-                  kStateHistory.manifest.find(':') == std::string_view::npos &&
-                  kTrieHistory.index.find(':') == std::string_view::npos &&
-                  kTrieHistory.manifest.find(':') == std::string_view::npos,
+static_assert(kStateHistory.shard.find(':') == std::string_view::npos &&
+                  kStateHistory.boundary.find(':') == std::string_view::npos &&
+                  kTrieHistory.shard.find(':') == std::string_view::npos &&
+                  kTrieHistory.boundary.find(':') == std::string_view::npos,
     "a history table name must not contain ':'");
 
 /// The four tables must stay distinct: rows are located by seeking into a table and walking
-/// forward until the table changes, so a shared name would let one instance's scan consume the
-/// other's rows. All four names are the same length, so distinctness also rules out one being a
-/// prefix of another.
-static_assert(kStateHistory.index.size() == kStateHistory.manifest.size() &&
-                  kStateHistory.index.size() == kTrieHistory.index.size() &&
-                  kStateHistory.index.size() == kTrieHistory.manifest.size(),
+/// forward until the table changes, so a shared name would let one instance's walk consume the
+/// other's rows — and the boundary row must be unreachable from either walk. All four names are
+/// the same length, so distinctness also rules out one being a prefix of another.
+static_assert(kStateHistory.shard.size() == kStateHistory.boundary.size() &&
+                  kStateHistory.shard.size() == kTrieHistory.shard.size() &&
+                  kStateHistory.shard.size() == kTrieHistory.boundary.size(),
     "the four history table names are asserted distinct below on the strength of being equal "
     "length; if that stops holding, the prefix case needs its own check");
-static_assert(kStateHistory.index != kStateHistory.manifest &&
-                  kStateHistory.index != kTrieHistory.index &&
-                  kStateHistory.index != kTrieHistory.manifest &&
-                  kStateHistory.manifest != kTrieHistory.index &&
-                  kStateHistory.manifest != kTrieHistory.manifest &&
-                  kTrieHistory.index != kTrieHistory.manifest,
+static_assert(kStateHistory.shard != kStateHistory.boundary &&
+                  kStateHistory.shard != kTrieHistory.shard &&
+                  kStateHistory.shard != kTrieHistory.boundary &&
+                  kStateHistory.boundary != kTrieHistory.shard &&
+                  kStateHistory.boundary != kTrieHistory.boundary &&
+                  kTrieHistory.shard != kTrieHistory.boundary,
     "the four history table names must be distinct");
 
 }  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -34,6 +34,7 @@
 #include "HistoryIndex.h"
 #include "HistoryRowCodec.h"
 #include "HistoryTables.h"
+#include "ShardTableWalk.h"
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <bcos-framework/storage/Entry.h>
 #include <bcos-framework/storage2/Storage.h>
@@ -66,14 +67,6 @@ concept WritableStateStorage = requires(Storage& storage,
     std::vector<executor_v1::StateKey> keys) {
     { storage2::writeSome(storage, keyValues) } -> task::IsAwaitable;
     { storage2::removeSome(storage, keys) } -> task::IsAwaitable;
-};
-
-/// A storage that can position an iterator at the first row at or after a key and walk forward.
-/// Every whole-block walk and the startup rebuild need it; a plain point-read storage serves
-/// neither.
-template <class Storage>
-concept SeekableStateStorage = requires(Storage& storage, executor_v1::StateKey key) {
-    { storage2::range(storage, storage2::RANGE_SEEK, key) } -> task::IsAwaitable;
 };
 
 /// A storage a history QUERY or an expiry runs against. Two capabilities, needed by different
@@ -121,10 +114,11 @@ using ReadAtResult = std::variant<bcos::bytes, HistoryAbsent, HistoryUseCurrent>
 enum class RetentionBoundary : uint8_t
 {
     /// Leave the boundary alone. The caller is discarding history from the TOP — an operational
-    /// rollback walks tip downwards, reverse-applying block N and then dropping N's record. The
-    /// oldest block the store can answer for does not move when the newest one goes, and moving it
-    /// would refuse the very next step of the walk: rollback reads at N-2 right after discarding
-    /// N, which a boundary at N rejects.
+    /// rollback walks tip downwards, reverse-applying block N from N's own records and then
+    /// dropping them. Which block is the OLDEST answerable does not change when the newest one
+    /// goes, so the boundary must not move; and because it only ever grows, advancing it once per
+    /// block would ratchet it all the way to the pre-rollback tip, leaving the store refusing
+    /// every historical read below that height while the shards that answer them are still there.
     Keep,
     /// Advance the boundary to the expired block. The caller is the commit path, where E = N - H
     /// is the block LEAVING the window from the bottom, so everything below E is now gone. The
@@ -161,25 +155,6 @@ struct RebuildReport
     std::size_t records{};
     std::size_t bytesScanned{};
 };
-
-namespace detail
-{
-/// Storage iterators hand back either a `StorageValueType<Value>` variant (MemoryStorage,
-/// RocksDBStorage2) or a bare value. Reduce both to "the entry, or nullptr when this row carries a
-/// deletion sentinel instead of bytes".
-template <class RowValue>
-inline const executor_v1::StateValue* asStateValue(RowValue const& value) noexcept
-{
-    if constexpr (requires { std::get_if<executor_v1::StateValue>(std::addressof(value)); })
-    {
-        return std::get_if<executor_v1::StateValue>(std::addressof(value));
-    }
-    else
-    {
-        return std::addressof(value);
-    }
-}
-}  // namespace detail
 
 /// The reverse history of one key space: every block's pre-images packed into that block's shard
 /// rows, plus the in-memory index that says which shard and which byte offset answers a query.
@@ -611,9 +586,11 @@ public:
             if (shardsSeen != staged.meta.shardCount || recordsSeen != staged.meta.recordCount)
             {
                 BOOST_THROW_EXCEPTION(
-                    MPTInvariantViolation() << bcos::errinfo_comment(
-                        "history block holds a different number of shards or records than its "
-                        "meta row declares"));
+                    MPTInvariantViolation()
+                    << bcos::errinfo_comment(
+                           "history block holds a different number of shards or records than its "
+                           "meta row declares")
+                    << errinfo_historyBlock(staged.block));
             }
             rebuilt.publish(std::move(staged), std::nullopt, std::nullopt);
             ++report.blocks;
@@ -621,17 +598,22 @@ public:
             inBlock = false;
         };
 
-        report.bytesScanned = co_await walkShardTable(backend, start,
+        // Every throw below carries the block it happened at (errinfo_historyBlock), because the
+        // caller that reports a failed rebuild is the B.10 audit and "the index cannot be rebuilt"
+        // is not actionable without the height to look at. The row key is decoded FIRST, before the
+        // sentinel check, so even that case can name its block.
+        report.bytesScanned = co_await walkShardTable(backend, Tables.shard, metaRowKey(start),
             [&](executor_v1::StateKeyView const& rowKeyView,
                 executor_v1::StateValue const* entry) -> bool {
+                auto const rowBlock = rowKeyBlock(rowKeyView.m_key);
                 if (entry == nullptr)
                 {
                     BOOST_THROW_EXCEPTION(
-                        MPTInvariantViolation() << bcos::errinfo_comment(
-                            "history shard table holds a deletion sentinel; the records it "
-                            "carried cannot be indexed"));
+                        MPTInvariantViolation()
+                        << bcos::errinfo_comment("history shard table holds a deletion sentinel; "
+                                                 "the records it carried cannot be indexed")
+                        << errinfo_historyBlock(rowBlock));
                 }
-                auto const rowBlock = rowKeyBlock(rowKeyView.m_key);
                 if (isMetaRowKey(rowKeyView.m_key, rowBlock))
                 {
                     finishBlock();
@@ -646,23 +628,29 @@ public:
                 if (!inBlock || rowBlock != staged.block)
                 {
                     BOOST_THROW_EXCEPTION(
-                        MPTInvariantViolation() << bcos::errinfo_comment(
-                            "history shard row is not preceded by its block's meta row"));
+                        MPTInvariantViolation()
+                        << bcos::errinfo_comment(
+                               "history shard row is not preceded by its block's meta row")
+                        << errinfo_historyBlock(rowBlock));
                 }
                 auto const shard = rowKeyShard(rowKeyView.m_key);
                 if (shard != shardsSeen)
                 {
                     BOOST_THROW_EXCEPTION(
-                        MPTInvariantViolation() << bcos::errinfo_comment(
-                            "history shard ordinals are not the contiguous 0..n-1 run the meta "
-                            "row describes"));
+                        MPTInvariantViolation()
+                        << bcos::errinfo_comment(
+                               "history shard ordinals are not the contiguous 0..n-1 run the meta "
+                               "row describes")
+                        << errinfo_historyBlock(rowBlock));
                 }
                 ++shardsSeen;
                 if (shardsSeen > staged.meta.shardCount)
                 {
                     BOOST_THROW_EXCEPTION(
-                        MPTInvariantViolation() << bcos::errinfo_comment(
-                            "history block holds more shards than its meta row declares"));
+                        MPTInvariantViolation()
+                        << bcos::errinfo_comment(
+                               "history block holds more shards than its meta row declares")
+                        << errinfo_historyBlock(rowBlock));
                 }
                 for (auto const& record : decodeShard(entry->get()))
                 {
@@ -737,47 +725,6 @@ private:
         }
     }
 
-    /// Seek to `BE64(@p fromBlock)` in the shard table and hand every row forward to @p visitor as
-    /// (row key view, entry or nullptr), stopping at the end of the table or when the visitor
-    /// returns false. Returns the payload bytes read.
-    ///
-    /// The seek positions at the block's META row, because an 8-byte key sorts before every
-    /// 10-byte key sharing its first eight bytes — so one seek yields meta, shard 0, shard 1, ...
-    /// and then the next block. The iterator runs on past the table, so the VISITOR, not the seek,
-    /// defines where a walk ends.
-    template <SeekableStateStorage Storage, class Visitor>
-    static task::Task<std::size_t> walkShardTable(
-        Storage& backend, protocol::BlockNumber fromBlock, Visitor&& visitor)
-    {
-        std::size_t bytesScanned = 0;
-        auto iterator = co_await storage2::range(backend, storage2::RANGE_SEEK,
-            executor_v1::StateKey{Tables.shard, metaRowKey(fromBlock)});
-        while (true)
-        {
-            auto row = co_await iterator.next();
-            if (!row)
-            {
-                break;
-            }
-            auto const& [rowKey, rowValue] = *row;
-            executor_v1::StateKeyView rowKeyView{rowKey};
-            if (rowKeyView.m_table != Tables.shard)
-            {
-                break;
-            }
-            auto const* entry = detail::asStateValue(rowValue);
-            if (entry != nullptr)
-            {
-                bytesScanned += entry->get().size();
-            }
-            if (!visitor(rowKeyView, entry))
-            {
-                break;
-            }
-        }
-        co_return bytesScanned;
-    }
-
     /// Walk exactly one block's rows, handing each record to @p sink as (record, version).
     /// @p sink lets each caller materialize only what it needs: readBlock copies the values,
     /// expire copies only the keys, and neither pays for the other's copies.
@@ -786,7 +733,7 @@ private:
         DeletedShardPolicy deletedShards, RecordSink&& sink)
     {
         BlockScan scan;
-        co_await walkShardTable(backend, block,
+        co_await walkShardTable(backend, Tables.shard, metaRowKey(block),
             [&](executor_v1::StateKeyView const& rowKeyView,
                 executor_v1::StateValue const* entry) -> bool {
                 if (rowKeyBlock(rowKeyView.m_key) != block)

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -50,6 +50,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
@@ -69,15 +70,23 @@ concept WritableStateStorage = requires(Storage& storage,
     { storage2::removeSome(storage, keys) } -> task::IsAwaitable;
 };
 
-/// A storage a history QUERY or an expiry runs against. Two capabilities, needed by different
-/// members: `readOne` is all readAt uses — it locates the record in memory and reads exactly one
-/// shard row — while the seek comes from expire, which walks a block's rows before deleting them,
-/// and from the retention-boundary point read.
+/// A storage a point read runs against — one key in, one value out. This is all `readAt` needs:
+/// the version is located in memory, so the disk work is a single `readOne` of a single shard
+/// row. The retention-boundary read is a `readOne` too.
 template <class Storage>
-concept QueryableStateStorage =
-    SeekableStateStorage<Storage> && requires(Storage& storage, executor_v1::StateKey key) {
-        { storage2::readOne(storage, key) } -> task::IsAwaitable;
-    };
+concept ReadableStateStorage = requires(Storage& storage, executor_v1::StateKey key) {
+    { storage2::readOne(storage, key) } -> task::IsAwaitable;
+};
+
+/// A storage a whole-block WALK runs against: `expire` reads a block's rows before deleting them
+/// and the rebuild walks the shard table end to end, and both position an iterator and go
+/// forward. Point reads come with it because `expire` also reads the boundary row.
+///
+/// Kept separate from ReadableStateStorage because the two are genuinely different requirements
+/// on a caller: a query plane only has to answer point reads, and demanding a seek of it would
+/// exclude storages that can serve every query this component makes.
+template <class Storage>
+concept QueryableStateStorage = SeekableStateStorage<Storage> && ReadableStateStorage<Storage>;
 
 /// One key changed by one block, paired with the value it held when the block began.
 /// Both fields are non-owning views into the caller's diff — put() copies out of them.
@@ -100,7 +109,24 @@ struct HistoryAbsent
 /// block; without both, "not in the index" is silence, not evidence (G6, G10).
 struct HistoryUseCurrent
 {
-    friend bool operator==(HistoryUseCurrent, HistoryUseCurrent) noexcept { return true; }
+    /// The index's publish generation as it stood BEFORE the lookup that produced this answer,
+    /// and always even — readAt refuses to conclude "unchanged" while a commit is mid-publish.
+    ///
+    /// The caller must read the current value and then check this against `index().generation()`
+    /// again: equal means no commit moved underneath the query and the current value really is
+    /// block B's; different means the disk it just read may already be ahead of the index, and
+    /// the answer has to be recomputed or refused. HistoryRead.h::readAtOrCurrent is the one
+    /// place that does this, and every caller goes through it.
+    uint64_t generation{};
+
+    /// Equality IGNORES the generation, on purpose: it is provenance for the caller's own
+    /// re-check, not part of the answer. Two "this key has not changed since B" outcomes are the
+    /// same outcome whichever index generation produced them — and a test comparing answers
+    /// across two indexes (the rebuild cases) would otherwise be comparing counters.
+    friend bool operator==(HistoryUseCurrent const&, HistoryUseCurrent const&) noexcept
+    {
+        return true;
+    }
 };
 
 /// readAt outcome, third case: the key's value at the queried block, as `bcos::bytes`.
@@ -214,6 +240,17 @@ public:
             BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
                                       "history shard byte cap must be positive"));
         }
+        // Checked HERE rather than left to the codec: metaRowKey/shardRowKey do refuse a negative
+        // block, but only after every record has been encoded and every version staged, so the
+        // failure would arrive with a batch already half-built and a message about a row key
+        // rather than about the argument that was wrong.
+        if (block < 0)
+        {
+            BOOST_THROW_EXCEPTION(MPTInvariantViolation()
+                                  << bcos::errinfo_comment("history block number must not be "
+                                                           "negative")
+                                  << errinfo_historyBlock(block));
+        }
 
         StagedBlock staged{.block = block, .meta = {}, .versions = {}};
         staged.versions.reserve(entries.size());
@@ -299,6 +336,13 @@ public:
     /// history reads are refused, which is the difference between a degraded node and a dead one.
     void markUnavailable() { m_index.markUnavailable(); }
 
+    /// The publish window a commit holds between its merge and its publish (HistoryIndex.h).
+    /// Opened by HistoryCommit.h's RAII guard immediately before the merge and closed by the
+    /// publish or by that guard; readers observe it through `index().generation()`.
+    void openPublishWindow() noexcept { m_index.openPublishWindow(); }
+    void closePublishWindow() noexcept { m_index.closePublishWindow(); }
+    [[nodiscard]] uint64_t generation() const noexcept { return m_index.generation(); }
+
     /// The value @p key held at block @p block.
     ///
     /// The answer is the OLD value recorded by the first change after @p block: between @p block
@@ -306,21 +350,25 @@ public:
     /// value (spec §0.4). One in-memory lookup, one row read, one record decoded, independent of
     /// how far back @p block is.
     ///
-    /// Three hard rules, in order (layout spec §1.4):
+    /// Four hard rules, in order (layout spec §1.4):
     ///
     ///  1. the window guard runs BEFORE anything else (G5);
     ///  2. the state check, the boundary check and the lookup happen under ONE shared lock;
     ///  3. a located version whose shard row is gone throws HistoryPruned — it never falls back to
-    ///     the current value.
+    ///     the current value;
+    ///  4. an "unchanged since B" answer is only reached while the index's publish generation is
+    ///     EVEN, and it reports the generation it saw so the caller can prove no commit moved
+    ///     underneath the current-value read that follows.
     ///
     /// @param tip the chain's current block number.
     /// @param depth the retention window, i.e. H_state or H_proof for this instance.
     /// @throws HistoryPruned when @p block predates the retained window or the located shard is
     ///         gone.
-    /// @throws HistoryIndexUnavailable when the index has not been rebuilt or is unusable.
+    /// @throws HistoryIndexUnavailable when the index has not been rebuilt or is unusable, or
+    ///         when a commit stayed mid-publish for the whole retry budget below.
     /// @throws InvalidHistoryBlock when @p block is negative, when @p block is ahead of @p tip,
     ///         or when @p depth is negative.
-    template <QueryableStateStorage Storage>
+    template <ReadableStateStorage Storage>
     task::Task<ReadAtResult> readAt(Storage& backend, std::span<const bcos::byte> key,
         protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth) const
     {
@@ -334,14 +382,61 @@ public:
         checkWindow(block, tip, depth);
 #endif
 
-        // Throws when the index is not entitled to answer, so everything below this line is
-        // reasoning about a Ready index whose boundary covers @p block (G10).
-        auto const located = m_index.locate(key, block);
+        // A "nothing recorded after B" answer sends the caller to the CURRENT value, and that is
+        // only sound while the index is not behind the disk. Between a block's merge and its
+        // publish it IS behind — the disk already holds block N, the index does not know N — and
+        // a miss there would hand back N's bytes labelled B. So sample the generation first and
+        // only conclude "unchanged" from an even one; an odd one means wait, never answer.
+        //
+        // Bounded, and fail-closed at the bound: the window is a few microseconds of in-memory
+        // work on the single committer, so a budget this size is only ever exhausted by a commit
+        // that died mid-window without closing it. Refusing then is right — the node genuinely
+        // cannot say what block B held.
+        constexpr std::size_t kPublishWindowYieldBudget = 4096;
+        std::optional<HistoryVersion> located;
+        uint64_t generation = 0;
+        for (std::size_t attempt = 0;; ++attempt)
+        {
+            generation = m_index.generation();
+            if ((generation % 2) == 0)
+            {
+                // Throws when the index is not entitled to answer, so everything below this line
+                // is reasoning about a Ready index whose boundary covers @p block (G10).
+                located = m_index.locate(key, block);
+                if (located)
+                {
+                    break;
+                }
+                // A miss is only trustworthy if no publish started while we were looking it up.
+                if (m_index.generation() == generation)
+                {
+                    break;
+                }
+            }
+            if (attempt >= kPublishWindowYieldBudget)
+            {
+                BOOST_THROW_EXCEPTION(
+                    HistoryIndexUnavailable() << bcos::errinfo_comment(
+                        "a commit is publishing; retry — if this persists, a commit died between "
+                        "its merge and its publish and the node must be restarted"));
+            }
+            std::this_thread::yield();
+        }
+
         if (block >= tip || !located)
         {
             // At or above the tip no later block can have recorded a pre-image, and below it an
             // empty lookup means the key has not changed since — both are the current value.
-            co_return HistoryUseCurrent{};
+            //
+            // The tip arm is checked AFTER locate, not before, so even a query that needs no
+            // history at all still requires an available index. Same reading as
+            // HistoryRead.h::historyCoversBlock: a node whose index is unusable does not know
+            // what it holds, and a tip answer from it would look like a healthy node's.
+            //
+            // The generation rides along: the caller has still to READ the current value, and a
+            // commit landing between here and that read would make it wrong. Only
+            // HistoryRead.h::readAtOrCurrent may act on this outcome.
+            co_return HistoryUseCurrent{.generation = generation};
         }
 
         auto row = co_await storage2::readOne(backend,

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -43,6 +43,7 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -50,7 +51,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <thread>
 #include <tuple>
 #include <unordered_set>
 #include <utility>
@@ -342,6 +342,11 @@ public:
     void openPublishWindow() noexcept { m_index.openPublishWindow(); }
     void closePublishWindow() noexcept { m_index.closePublishWindow(); }
     [[nodiscard]] uint64_t generation() const noexcept { return m_index.generation(); }
+    /// Tests only; production leaves it at kPublishWindowWaitBudget (HistoryIndex.h).
+    void setPublishWindowWaitBudget(std::chrono::milliseconds budget) noexcept
+    {
+        m_index.setPublishWindowWaitBudget(budget);
+    }
 
     /// The value @p key held at block @p block.
     ///
@@ -382,20 +387,28 @@ public:
         checkWindow(block, tip, depth);
 #endif
 
-        // A "nothing recorded after B" answer sends the caller to the CURRENT value, and that is
-        // only sound while the index is not behind the disk. Between a block's merge and its
-        // publish it IS behind — the disk already holds block N, the index does not know N — and
-        // a miss there would hand back N's bytes labelled B. So sample the generation first and
-        // only conclude "unchanged" from an even one; an odd one means wait, never answer.
+        // The publish-window gate, and it runs BEFORE `locate` for two reasons.
         //
-        // Bounded, and fail-closed at the bound: the window is a few microseconds of in-memory
-        // work on the single committer, so a budget this size is only ever exhausted by a commit
-        // that died mid-window without closing it. Refusing then is right — the node genuinely
-        // cannot say what block B held.
-        constexpr std::size_t kPublishWindowYieldBudget = 4096;
+        // One: a "nothing recorded after B" answer sends the caller to the CURRENT value, and that
+        // is only sound while the index is not behind the disk. Between a block's merge and its
+        // publish it IS behind — the disk already holds block N, the index does not know N — so a
+        // miss there would hand back N's bytes labelled B.
+        //
+        // Two: the same batch also carries the expiry of the block leaving the window, so inside
+        // it the shard rows the index still names may ALREADY be deleted. Locating first would
+        // find a version and then fail its row read as HistoryPruned — a refusal, but for the
+        // wrong reason and at a height the node can in fact still answer once the publish lands.
+        //
+        // Waiting rather than spinning: the window spans the block's RocksDB write, the commit
+        // observer and a getLedgerConfig round trip, because the publish must be the LAST fallible
+        // step before the tip advances (HistoryCommit.h). Milliseconds, not microseconds. A reader
+        // that merely overlapped an ordinary commit therefore SLEEPS through it and then answers;
+        // only a committer stuck for longer than kPublishWindowWaitBudget produces a refusal, and
+        // that refusal says "retry", not "restart the node".
+        auto const deadline = std::chrono::steady_clock::now() + m_index.publishWindowWaitBudget();
         std::optional<HistoryVersion> located;
         uint64_t generation = 0;
-        for (std::size_t attempt = 0;; ++attempt)
+        for (;;)
         {
             generation = m_index.generation();
             if ((generation % 2) == 0)
@@ -403,24 +416,24 @@ public:
                 // Throws when the index is not entitled to answer, so everything below this line
                 // is reasoning about a Ready index whose boundary covers @p block (G10).
                 located = m_index.locate(key, block);
-                if (located)
-                {
-                    break;
-                }
                 // A miss is only trustworthy if no publish started while we were looking it up.
-                if (m_index.generation() == generation)
+                if (located || m_index.generation() == generation)
                 {
                     break;
                 }
             }
-            if (attempt >= kPublishWindowYieldBudget)
+            auto const remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - std::chrono::steady_clock::now());
+            if (remaining <= std::chrono::milliseconds::zero() ||
+                !m_index.waitForEvenGeneration(remaining))
             {
                 BOOST_THROW_EXCEPTION(
-                    HistoryIndexUnavailable() << bcos::errinfo_comment(
-                        "a commit is publishing; retry — if this persists, a commit died between "
-                        "its merge and its publish and the node must be restarted"));
+                    HistoryIndexUnavailable()
+                    << bcos::errinfo_comment(std::string("a commit's publish window on the ")
+                               .append(Tables.shard)
+                               .append(" history stayed open longer than the wait budget; the "
+                                       "query was not answered and should be retried")));
             }
-            std::this_thread::yield();
         }
 
         if (block >= tip || !located)

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -369,13 +369,19 @@ public:
     /// @param depth the retention window, i.e. H_state or H_proof for this instance.
     /// @throws HistoryPruned when @p block predates the retained window or the located shard is
     ///         gone.
+    /// @param waitBudget how long this call may wait for an open publish window; nullopt means
+    ///        the store's own (kPublishWindowWaitBudget). A caller that is itself running against
+    ///        a deadline — readAtOrCurrent, which may call this more than once — passes what is
+    ///        LEFT of its budget, so the total wait a query can incur stays one budget rather
+    ///        than one per attempt.
     /// @throws HistoryIndexUnavailable when the index has not been rebuilt or is unusable, or
-    ///         when a commit stayed mid-publish for the whole retry budget below.
+    ///         when a commit stayed mid-publish for longer than @p waitBudget.
     /// @throws InvalidHistoryBlock when @p block is negative, when @p block is ahead of @p tip,
     ///         or when @p depth is negative.
     template <ReadableStateStorage Storage>
     task::Task<ReadAtResult> readAt(Storage& backend, std::span<const bcos::byte> key,
-        protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth) const
+        protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth,
+        std::optional<std::chrono::milliseconds> waitBudget = std::nullopt) const
     {
         // The window guard runs BEFORE the lookup, and that order is the whole point (spec B.3,
         // G5): a lookup that finds nothing cannot tell "never changed after B, so the current
@@ -405,7 +411,8 @@ public:
         // that merely overlapped an ordinary commit therefore SLEEPS through it and then answers;
         // only a committer stuck for longer than kPublishWindowWaitBudget produces a refusal, and
         // that refusal says "retry", not "restart the node".
-        auto const deadline = std::chrono::steady_clock::now() + m_index.publishWindowWaitBudget();
+        auto const deadline = std::chrono::steady_clock::now() +
+                              waitBudget.value_or(m_index.publishWindowWaitBudget());
         std::optional<HistoryVersion> located;
         uint64_t generation = 0;
         for (;;)

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -14,13 +14,24 @@
  *  limitations under the License.
  *
  * @file ReverseHistoryStore.h
- * @brief One block's diff, stored twice under two sort orders, so that both a point query and a
- *        whole-block sweep are one seek (spec B.1-B.8)
+ * @brief One block's pre-images packed into per-block shards on disk, located by an in-memory
+ *        index that is rebuilt from those shards at startup (layout spec §1.1-§1.5)
+ *
+ * The earlier layout stored each pre-image twice — once in a `(key, block)` index row that
+ * answered point queries, once in a `(block, shard)` manifest that listed the block's keys. This
+ * one stores it once, in the shard, and keeps the `(key, block)` order in RAM. Three consequences
+ * drive the whole file:
+ *
+ *  - a commit writes `shardCount + 1` rows instead of `keyCount + shardCount`;
+ *  - an expiry deletes `shardCount + 1` rows instead of one per key plus the shards;
+ *  - the index is derived, so it must be REBUILT at startup and must refuse to answer until it
+ *    has been (G10) — "not in the index" is never allowed to mean "the key never changed".
  */
 #pragma once
 
 #include "../Errors.h"
 #include "HistoryErrors.h"
+#include "HistoryIndex.h"
 #include "HistoryRowCodec.h"
 #include "HistoryTables.h"
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
@@ -29,14 +40,18 @@
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-task/Task.h>
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <span>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <unordered_set>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -54,11 +69,22 @@ concept WritableStateStorage = requires(Storage& storage,
 };
 
 /// A storage that can position an iterator at the first row at or after a key and walk forward.
-/// Both readAt and the manifest sweep need it; a plain point-read storage cannot serve either.
+/// Every whole-block walk and the startup rebuild need it; a plain point-read storage serves
+/// neither.
 template <class Storage>
 concept SeekableStateStorage = requires(Storage& storage, executor_v1::StateKey key) {
     { storage2::range(storage, storage2::RANGE_SEEK, key) } -> task::IsAwaitable;
 };
+
+/// A storage a history QUERY or an expiry runs against. Two capabilities, needed by different
+/// members: `readOne` is all readAt uses — it locates the record in memory and reads exactly one
+/// shard row — while the seek comes from expire, which walks a block's rows before deleting them,
+/// and from the retention-boundary point read.
+template <class Storage>
+concept QueryableStateStorage =
+    SeekableStateStorage<Storage> && requires(Storage& storage, executor_v1::StateKey key) {
+        { storage2::readOne(storage, key) } -> task::IsAwaitable;
+    };
 
 /// One key changed by one block, paired with the value it held when the block began.
 /// Both fields are non-owning views into the caller's diff — put() copies out of them.
@@ -69,16 +95,16 @@ struct HistoryEntry
     std::optional<std::span<const bcos::byte>> oldValue;
 };
 
-/// readAt outcome: the key did not exist at the queried block (the index row's tag is 0x00).
+/// readAt outcome: the key did not exist at the queried block (the record's tag is 0x00).
 struct HistoryAbsent
 {
     friend bool operator==(HistoryAbsent, HistoryAbsent) noexcept { return true; }
 };
 
-/// readAt outcome: no index row exists after the queried block, so the key has not changed since
-/// — the current value IS the historical one and the caller should read it from the live plane
-/// (spec B.3). Only trustworthy because the window guard already ruled out "the row existed and
-/// was expired".
+/// readAt outcome: no change was recorded after the queried block, so the key has not changed
+/// since — the current value IS the historical one and the caller should read it from the live
+/// plane (spec B.3). Only trustworthy because the index was Ready and its boundary covers the
+/// block; without both, "not in the index" is silence, not evidence (G6, G10).
 struct HistoryUseCurrent
 {
     friend bool operator==(HistoryUseCurrent, HistoryUseCurrent) noexcept { return true; }
@@ -87,23 +113,60 @@ struct HistoryUseCurrent
 /// readAt outcome, third case: the key's value at the queried block, as `bcos::bytes`.
 using ReadAtResult = std::variant<bcos::bytes, HistoryAbsent, HistoryUseCurrent>;
 
+/// What expire() does to the retention boundary — the row recording the OLDEST block this store
+/// can still answer for (HistoryTables.h).
+///
+/// The parameter exists because "discard block E's history" has two callers that move in opposite
+/// directions along the chain, and only one of them changes which block is the oldest.
+enum class RetentionBoundary : uint8_t
+{
+    /// Leave the boundary alone. The caller is discarding history from the TOP — an operational
+    /// rollback walks tip downwards, reverse-applying block N and then dropping N's record. The
+    /// oldest block the store can answer for does not move when the newest one goes, and moving it
+    /// would refuse the very next step of the walk: rollback reads at N-2 right after discarding
+    /// N, which a boundary at N rejects.
+    Keep,
+    /// Advance the boundary to the expired block. The caller is the commit path, where E = N - H
+    /// is the block LEAVING the window from the bottom, so everything below E is now gone. The
+    /// write rides the same batch as the deletes.
+    Advance,
+};
+
+/// One block's whole recorded diff, as readBlock hands it back: the meta row plus every record in
+/// shard order. Rollback and the B.10 audits both need this to be COMPLETE, which is why readBlock
+/// verifies the counts the meta row declares.
+struct BlockHistory
+{
+    BlockMeta meta;
+    std::vector<std::pair<bcos::bytes, std::optional<bcos::bytes>>> records;
+};
+
 /// What one expire() pass did.
 struct ExpireReport
 {
-    /// Keys the block's manifest listed. Zero also means "already expired" — expire is idempotent.
+    /// Records the block's shards listed. Zero also means "already expired" — expire is idempotent.
     std::size_t keyCount{};
-    /// Index-row deletes issued, one per listed key. On a replay of an interrupted expiry some of
-    /// them target rows that are already gone, which is a no-op — hence "issued", not "removed".
-    std::size_t indexDeletesIssued{};
-    /// Manifest shards found and deleted. These did exist: the sweep read them.
-    std::size_t manifestShardsDeleted{};
+    /// Shard rows found live and deleted. The meta row goes with them, so the deletes issued are
+    /// `shardsDeleted + 1` when the meta row was live too.
+    std::size_t shardsDeleted{};
+    /// The block as the in-memory index must now forget it — nullopt when the pass found nothing
+    /// live, i.e. the block was never recorded or was already expired. Handed to publish().
+    std::optional<RetiredBlock> retired;
+};
+
+/// What one rebuild() pass walked.
+struct RebuildReport
+{
+    std::size_t blocks{};
+    std::size_t records{};
+    std::size_t bytesScanned{};
 };
 
 namespace detail
 {
 /// Storage iterators hand back either a `StorageValueType<Value>` variant (MemoryStorage,
-/// RocksDBStorage2) or a bare value. Reduce both to "the entry, or nullptr when this row carries
-/// a deletion sentinel instead of bytes".
+/// RocksDBStorage2) or a bare value. Reduce both to "the entry, or nullptr when this row carries a
+/// deletion sentinel instead of bytes".
 template <class RowValue>
 inline const executor_v1::StateValue* asStateValue(RowValue const& value) noexcept
 {
@@ -118,60 +181,76 @@ inline const executor_v1::StateValue* asStateValue(RowValue const& value) noexce
 }
 }  // namespace detail
 
-/// The reverse history of one key space: every key a block changed, keyed both by (key, block)
-/// for point queries and by (block, shard) for whole-block sweeps (spec B.1).
+/// The reverse history of one key space: every block's pre-images packed into that block's shard
+/// rows, plus the in-memory index that says which shard and which byte offset answers a query.
 ///
 /// Instantiated twice over the same code — `StateHistoryStore` for state rows, `TrieHistoryStore`
 /// for path-addressed trie nodes (spec B.8). @p Tables selects which pair of state tables the
 /// instance owns; everything else is identical, which is the point.
 ///
-/// All members are static: the store owns no state of its own. The rows live in whatever storage
-/// the caller passes, and each call takes the storage it should act on — in production the
-/// block's mutable layer for writes and the backend view for reads.
+/// Unlike the earlier all-static store this one is an OBJECT: it owns the index, so a node holds
+/// exactly one instance per key space (PR-C's `MPTHistory`) and every reader shares it. Disk still
+/// arrives as a parameter — in production the block's mutable layer for writes and the committed
+/// backend for reads.
 template <HistoryTables const& Tables>
 class ReverseHistoryStore
 {
 public:
-    /// Record @p entries as the pre-images of block @p block, plus the manifest that lists them.
+    ReverseHistoryStore() = default;
+    // The index carries a shared_mutex, so neither it nor this wrapper can be copied or moved.
+    ReverseHistoryStore(const ReverseHistoryStore&) = delete;
+    ReverseHistoryStore(ReverseHistoryStore&&) = delete;
+    ReverseHistoryStore& operator=(const ReverseHistoryStore&) = delete;
+    ReverseHistoryStore& operator=(ReverseHistoryStore&&) = delete;
+    ~ReverseHistoryStore() = default;
+
+    /// Record @p entries as the pre-images of block @p block: the shard rows that hold them, plus
+    /// the one meta row that says how many of each to expect.
     ///
     /// Pure append: every row is a fresh Put and nothing is read first, so write amplification is
     /// the size of this block's diff and does not grow with the retention depth (spec B.4). All
-    /// rows go out in ONE writeSome, which in production is one contribution to the block's
-    /// single WriteBatch (G3).
+    /// rows go out in ONE writeSome, which in production is one contribution to the block's single
+    /// WriteBatch (G3).
+    ///
+    /// It does NOT touch the index. The returned StagedBlock is the index update this write
+    /// implies, and the caller applies it with publish() only after the batch has landed (G9); if
+    /// the merge fails, dropping the StagedBlock leaves the index exactly as it was.
     ///
     /// @param entries one record per key the block changed, each carrying the value the key held
-    ///        when the block BEGAN. A key must appear at most once: a second row for the same
-    ///        (key, block) would overwrite the block-start value with a mid-block one and hand
-    ///        every later query a wrong answer, so a duplicate throws instead of being ignored.
-    ///        The caller does the intra-block deduplication (spec B.4).
-    /// @param shardByteCap the manifest payload size at which a new shard starts. A key whose own
-    ///        record exceeds the cap still gets a shard — the cap bounds row size, it cannot
-    ///        split a record.
+    ///        when the block BEGAN. A key must appear at most once: a second record for the same
+    ///        (key, block) would give the key two index versions for one block, and every later
+    ///        query would resolve to whichever came second — so a duplicate throws rather than
+    ///        being ignored. The caller does the intra-block deduplication (spec B.4).
+    /// @param shardByteCap the payload size at which a new shard starts. A key whose own record
+    ///        exceeds the cap still gets a shard — the cap bounds row size, it cannot split a
+    ///        record.
     ///
-    /// A block that changed nothing still gets an empty shard 0. Spec B.10 ② audits the window
-    /// for a manifest per block and treats a gap as fatal, so "no changes" must be recorded as
-    /// such rather than being indistinguishable from a lost manifest.
+    /// A block that changed nothing still gets `Meta{shardCount = 1, recordCount = 0}` and an
+    /// empty shard 0 (spec B.10 ②): the audit reads the window as one meta row per block and
+    /// treats a gap as fatal, so "no changes" must be recorded as such rather than being
+    /// indistinguishable from a lost block.
     template <WritableStateStorage Storage>
-    static task::Task<void> put(Storage& mutableLayer, protocol::BlockNumber block,
-        std::span<HistoryEntry const> entries, std::size_t shardByteCap)
+    task::Task<StagedBlock> put(Storage& batch, protocol::BlockNumber block,
+        bcos::h256 const& blockHash, std::span<HistoryEntry const> entries,
+        std::size_t shardByteCap) const
     {
         if (shardByteCap == 0)
         {
             BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
-                                      "history manifest shard byte cap must be positive"));
+                                      "history shard byte cap must be positive"));
         }
 
-        std::vector<std::tuple<executor_v1::StateKey, executor_v1::StateValue>> rows;
-        rows.reserve(entries.size() + 1);
+        StagedBlock staged{.block = block, .meta = {}, .versions = {}};
+        staged.versions.reserve(entries.size());
 
+        std::vector<std::tuple<executor_v1::StateKey, executor_v1::StateValue>> rows;
         std::unordered_set<std::string_view> seenKeys;
         seenKeys.reserve(entries.size());
 
         std::string shardPayload;
         std::size_t shardIndex = 0;
         auto flushShard = [&]() {
-            rows.emplace_back(
-                executor_v1::StateKey{Tables.manifest, manifestRowKey(block, shardIndex)},
+            rows.emplace_back(executor_v1::StateKey{Tables.shard, shardRowKey(block, shardIndex)},
                 executor_v1::StateValue{std::move(shardPayload)});
             shardPayload.clear();
             ++shardIndex;
@@ -179,8 +258,7 @@ public:
 
         for (auto const& entry : entries)
         {
-            auto keyView = asStringView(entry.key);
-            if (!seenKeys.insert(keyView).second)
+            if (!seenKeys.insert(asStringView(entry.key)).second)
             {
                 BOOST_THROW_EXCEPTION(
                     MPTInvariantViolation() << bcos::errinfo_comment(
@@ -188,168 +266,445 @@ public:
                         "block-start value may be recorded"));
             }
 
-            rows.emplace_back(executor_v1::StateKey{Tables.index, indexRowKey(entry.key, block)},
-                executor_v1::StateValue{indexRowValue(entry.oldValue)});
-
-            if (!shardPayload.empty() &&
-                shardPayload.size() + manifestRecordSize(entry.key) > shardByteCap)
+            auto const size = recordSize(entry.key, entry.oldValue);
+            if (!shardPayload.empty() && shardPayload.size() + size > shardByteCap)
             {
                 flushShard();
             }
-            appendManifestRecord(shardPayload, entry.key);
+            // shardRowKey enforces the 2-byte shard field, but the ordinal is narrowed into the
+            // index version BEFORE the row key is built, so it is checked here too.
+            if (shardIndex > kMaxShardIndex)
+            {
+                BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                          "history shard ordinal overflows the 2-byte field"));
+            }
+            auto const offset = appendRecord(shardPayload, entry.key, entry.oldValue);
+            if (offset > std::numeric_limits<uint32_t>::max())
+            {
+                BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                          "history record offset overflows its 4-byte field"));
+            }
+            staged.versions.emplace_back(bcos::bytes(entry.key.begin(), entry.key.end()),
+                HistoryVersion{.block = block,
+                    .shard = static_cast<uint16_t>(shardIndex),
+                    .offset = static_cast<uint32_t>(offset)});
         }
         flushShard();
 
-        co_await storage2::writeSome(mutableLayer, std::move(rows));
+        staged.meta = BlockMeta{.shardCount = static_cast<uint32_t>(shardIndex),
+            .recordCount = static_cast<uint32_t>(entries.size()),
+            .blockHash = blockHash};
+        // Appended last because shardCount is only known once the loop is done; the batch applies
+        // the rows as a set, so position carries no meaning on disk.
+        rows.emplace_back(executor_v1::StateKey{Tables.shard, metaRowKey(block)},
+            executor_v1::StateValue{metaRowValue(
+                staged.meta.shardCount, staged.meta.recordCount, staged.meta.blockHash)});
+
+        co_await storage2::writeSome(batch, std::move(rows));
+        co_return staged;
     }
+
+    /// Apply to the index what @p recorded, @p retired and @p boundaryWritten already did to disk.
+    ///
+    /// G9: the commit path calls this ONLY after the block's WriteBatch has landed. A merge that
+    /// throws leaves the StagedBlock unpublished, and the index therefore never learns about rows
+    /// that are not there — the next query answers exactly as it did before the failed block.
+    void publish(StagedBlock&& recorded, std::optional<RetiredBlock> retired,
+        std::optional<protocol::BlockNumber> boundaryWritten)
+    {
+        m_index.publish(std::move(recorded), std::move(retired), boundaryWritten);
+    }
+
+    /// The index this store answers from. Read-only: it is mutated through publish, rebuild and
+    /// markUnavailable.
+    [[nodiscard]] HistoryIndex const& index() const { return m_index; }
+
+    /// Refuse every history query from here on. The startup path calls this when rebuild() throws
+    /// (layout spec §1.5): the node keeps running and keeps committing blocks, and only the
+    /// history reads are refused, which is the difference between a degraded node and a dead one.
+    void markUnavailable() { m_index.markUnavailable(); }
 
     /// The value @p key held at block @p block.
     ///
     /// The answer is the OLD value recorded by the first change after @p block: between @p block
     /// and that change the key was untouched, so that old value is exactly the block-@p block
-    /// value (spec §0.4). One seek, one row read, independent of how far back @p block is.
+    /// value (spec §0.4). One in-memory lookup, one row read, one record decoded, independent of
+    /// how far back @p block is.
+    ///
+    /// Three hard rules, in order (layout spec §1.4):
+    ///
+    ///  1. the window guard runs BEFORE anything else (G5);
+    ///  2. the state check, the boundary check and the lookup happen under ONE shared lock;
+    ///  3. a located version whose shard row is gone throws HistoryPruned — it never falls back to
+    ///     the current value.
     ///
     /// @param tip the chain's current block number.
     /// @param depth the retention window, i.e. H_state or H_proof for this instance.
-    /// @throws HistoryPruned when @p block predates the retained window.
-    /// @throws InvalidHistoryBlock when @p block is negative or ahead of @p tip.
-    template <SeekableStateStorage Storage>
-    static task::Task<ReadAtResult> readAt(Storage& backend, std::span<const bcos::byte> key,
-        protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth)
+    /// @throws HistoryPruned when @p block predates the retained window or the located shard is
+    ///         gone.
+    /// @throws HistoryIndexUnavailable when the index has not been rebuilt or is unusable.
+    /// @throws InvalidHistoryBlock when @p block is negative, when @p block is ahead of @p tip,
+    ///         or when @p depth is negative.
+    template <QueryableStateStorage Storage>
+    task::Task<ReadAtResult> readAt(Storage& backend, std::span<const bcos::byte> key,
+        protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth) const
     {
-        // The window guard runs BEFORE the seek, and that order is the whole point (spec B.3,
-        // G5): a seek that finds nothing cannot tell "never changed after B, so the current
-        // value is the answer" from "the record was expired away, so the current value is a
-        // wrong answer" — the index holds no evidence either way. Only the window bound
-        // separates them. HISTORY_GUARD_DISABLED exists solely so the test suite can compile a
-        // build without the guard and demonstrate that the out-of-window case then returns a
-        // plausible-looking wrong value; nothing defines it.
+        // The window guard runs BEFORE the lookup, and that order is the whole point (spec B.3,
+        // G5): a lookup that finds nothing cannot tell "never changed after B, so the current
+        // value is the answer" from "the record was expired away, so the current value is a wrong
+        // answer". Only the window bound separates them. HISTORY_GUARD_DISABLED exists solely so
+        // the test suite can compile a build without the guard and demonstrate that the
+        // out-of-window case then returns a plausible-looking wrong value; nothing defines it.
 #ifndef HISTORY_GUARD_DISABLED
         checkWindow(block, tip, depth);
 #endif
 
-        auto keyView = asStringView(key);
-        executor_v1::StateKey seekKey{Tables.index, indexRowKey(key, block + 1)};
+        // Throws when the index is not entitled to answer, so everything below this line is
+        // reasoning about a Ready index whose boundary covers @p block (G10).
+        auto const located = m_index.locate(key, block);
+        if (block >= tip || !located)
+        {
+            // At or above the tip no later block can have recorded a pre-image, and below it an
+            // empty lookup means the key has not changed since — both are the current value.
+            co_return HistoryUseCurrent{};
+        }
 
-        auto iterator = co_await storage2::range(backend, storage2::RANGE_SEEK, seekKey);
-        auto row = co_await iterator.next();
+        auto row = co_await storage2::readOne(backend,
+            executor_v1::StateKey{Tables.shard, shardRowKey(located->block, located->shard)});
         if (!row)
         {
-            co_return HistoryUseCurrent{};
+            // The index located a version and the shard is not there — an expiry landed between
+            // the lookup and this read, or on a logical-deletion layer the row is a sentinel
+            // (readOne reports both as absent). Falling through to the current value here is the
+            // silent wrong answer the whole layout exists to prevent (G6, G10).
+            BOOST_THROW_EXCEPTION(
+                HistoryPruned() << bcos::errinfo_comment(
+                    "the shard holding the requested pre-image was deleted after the index "
+                    "located it"));
         }
-
-        auto const& [rowKey, rowValue] = *row;
-        executor_v1::StateKeyView rowKeyView{rowKey};
-        if (rowKeyView.m_table != Tables.index || !indexRowBelongsTo(rowKeyView.m_key, keyView))
+        auto const record = decodeRecordAt(row->get(), located->offset);
+        if (record.key != asStringView(key))
         {
-            co_return HistoryUseCurrent{};
-        }
-
-        auto const* entry = detail::asStateValue(rowValue);
-        if (entry == nullptr)
-        {
-            // The row is present but carries a deletion sentinel rather than bytes: the
-            // pre-image this query needs was removed while the window still claims to cover it.
-            // Fail loud (G6) — falling through to the current value is the silent wrong answer
-            // B.3 exists to prevent.
+            // The offset the index held no longer names this key's record: the index and the
+            // shard disagree about the layout of the same bytes. Returning the record found there
+            // would answer with another key's value.
             BOOST_THROW_EXCEPTION(
                 MPTInvariantViolation() << bcos::errinfo_comment(
-                    "history index row is deleted inside the retention window; the pre-image "
-                    "chain has a hole"));
+                    "the history record at the indexed offset belongs to a different key"));
         }
-        co_return decodeIndexValue(entry->get());
+        if (!record.oldValue)
+        {
+            co_return HistoryAbsent{};
+        }
+        co_return bcos::bytes(record.oldValue->begin(), record.oldValue->end());
     }
 
-    /// Every key block @p block changed, read off that block's manifest. Used by rollback and by
-    /// the B.10 audits, both of which need the list to be COMPLETE.
+    /// Was block @p block's history ever RECORDED here? Pure memory — the index holds one entry
+    /// per retained block, put there by publish or by the rebuild walk.
     ///
-    /// Empty when the block changed nothing, and empty on a plane where the block's manifest rows
-    /// are physically gone — the backend after a merge, for instance.
-    ///
-    /// @throws MPTInvariantViolation when a shard row is present but carries a deletion sentinel
-    ///         rather than bytes. That is what an expiry looks like on the mutable layer, whose
-    ///         removeSome marks rather than erases (MemoryStorage LOGICAL_DELETION, the mode
-    ///         GlobalStateMutableStorage runs in). The keys such a shard listed are unreadable, so
-    ///         a caller that needs the complete list must not be handed a short one (G6). Callers
-    ///         wanting the expiry-tolerant reading use expire(), which skips those shards.
-    template <SeekableStateStorage Storage>
-    static task::Task<std::vector<bcos::bytes>> keysOfBlock(
-        Storage& backend, protocol::BlockNumber block)
+    /// This answers a question the window guard cannot: readAt's window bound says "block B is
+    /// young enough not to have been expired", which is a statement about the RETENTION PARAMETER,
+    /// not about what was ever written. A node whose history began after block B — the depth was
+    /// raised, the MPT was enabled mid-life, the era predates this feature — has blocks inside its
+    /// nominal window that were never recorded, and for those every key misses the index and
+    /// reports HistoryUseCurrent: today's value, presented as block B's. Probing the record itself
+    /// is what turns that into a refusal (G6).
+    [[nodiscard]] bool recordedBlock(protocol::BlockNumber block) const
     {
-        auto scan = co_await scanManifest(backend, block, DeletedShardPolicy::Reject);
-        co_return std::move(scan.keys);
+        return m_index.hasBlock(block);
     }
 
-    /// Drop block @p block from the retained window: delete its index rows, then its manifest.
+    /// Block @p block's whole recorded diff: the meta row plus every record, in shard order. Used
+    /// by rollback and by the B.10 audits, both of which need the list to be COMPLETE — so the
+    /// counts the meta row declares are verified against what the walk actually read.
     ///
-    /// Deletions are written to @p mutableLayer, so in the default mode they land in the
-    /// committing block's WriteBatch and the whole expiry is atomic with the commit (spec B.5).
+    /// @throws MPTInvariantViolation when the meta row is missing, when the shard count or the
+    ///         record count disagrees with it, or when a row is present but carries a deletion
+    ///         sentinel rather than bytes. That last shape is what an expiry looks like on the
+    ///         mutable layer, whose removeSome marks rather than erases (MemoryStorage
+    ///         LOGICAL_DELETION, the mode GlobalStateMutableStorage runs in): the records such a
+    ///         shard held are unreadable, and a caller that needs the complete diff must not be
+    ///         handed a short one (G6). expire() takes the opposite reading of the same row.
+    template <SeekableStateStorage Storage>
+    task::Task<BlockHistory> readBlock(Storage& backend, protocol::BlockNumber block) const
+    {
+        BlockHistory history;
+        auto const scan = co_await scanBlock(backend, block, DeletedShardPolicy::Reject,
+            [&](ShardRecord const& record, HistoryVersion const&) {
+                std::optional<bcos::bytes> oldValue;
+                if (record.oldValue)
+                {
+                    oldValue.emplace(record.oldValue->begin(), record.oldValue->end());
+                }
+                history.records.emplace_back(
+                    bcos::bytes(record.key.begin(), record.key.end()), std::move(oldValue));
+            });
+
+        if (!scan.metaFound)
+        {
+            BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                      "history block has no meta row; its diff cannot be read"));
+        }
+        if (scan.shardsRead != scan.meta.shardCount)
+        {
+            BOOST_THROW_EXCEPTION(
+                MPTInvariantViolation() << bcos::errinfo_comment(
+                    "history block holds a different number of shards than its meta row declares"));
+        }
+        if (scan.recordsRead != scan.meta.recordCount)
+        {
+            BOOST_THROW_EXCEPTION(
+                MPTInvariantViolation() << bcos::errinfo_comment(
+                    "history block holds a different number of records than its meta row "
+                    "declares"));
+        }
+        history.meta = scan.meta;
+        co_return history;
+    }
+
+    /// Drop block @p block from the retained window: delete its shard rows and its meta row.
     ///
-    /// The manifest is deleted LAST, and that ordering is what makes the deferred mode (expiry
-    /// split out of the commit batch) safe to interrupt: a crash after some index rows are gone
-    /// leaves the manifest, so re-running finds the same key list and re-issues deletes that are
-    /// no-ops for the rows already gone. Deleting the manifest first would strand the surviving
-    /// index rows permanently — nothing else records which keys the block touched.
+    /// This is the saving the layout was reshaped for. The old layout had to delete one index row
+    /// per key, so an expiry cost as much as the commit that created it; here the pre-images live
+    /// inside the shards, so `shardCount + 1` removes take the whole block — and the in-memory
+    /// versions go with them, without a single point-delete.
+    ///
+    /// Deletions are written to @p batch, so in the default mode they land in the committing
+    /// block's WriteBatch and the whole expiry is atomic with the commit (spec B.5).
     ///
     /// Idempotent on every storage, including the one G3 puts it on. The production mutable layer
     /// is MemoryStorage with LOGICAL_DELETION (GlobalStateStorageInitializer.h:15-19), where a
-    /// removed row stays in the container as a deletion sentinel and the iterator still yields
-    /// it; so a second expire() of the same block sees its own shards coming back as sentinels.
-    /// It skips them instead of failing, and that is sound rather than merely convenient: the
-    /// index-then-manifest order above means a shard can only be deleted after the index rows of
-    /// every key it listed were deleted, so a skipped shard has nothing left to clean up.
-    /// keysOfBlock() takes the opposite reading of the same row, because a short key list would
-    /// silently break rollback.
-    template <SeekableStateStorage ReadStorage, WritableStateStorage WriteStorage>
-    static task::Task<ExpireReport> expire(
-        ReadStorage& backend, WriteStorage& mutableLayer, protocol::BlockNumber block)
+    /// removed row stays in the container as a deletion sentinel and the iterator still yields it;
+    /// so a second expire() of the same block sees its own rows coming back as sentinels. It skips
+    /// them, reports nothing retired, and issues no deletes.
+    ///
+    /// @param boundaryPolicy which end of the chain this call is discarding from, and therefore
+    ///        whether the retention boundary moves. DEFAULTS to Keep, the answer for every caller
+    ///        that is not the commit path.
+    ///
+    ///        **Precondition for Advance: at most ONE Advance call per @p batch, and @p block must
+    ///        be the oldest block leaving the window.** The max that keeps the boundary from moving
+    ///        down is computed against @p backend, which does not yet see this batch's write, so
+    ///        two Advance calls in one batch both read the pre-batch value and the second one wins
+    ///        outright — a lower second block would then lower the boundary. The commit path issues
+    ///        exactly one expiry per block, which is what makes the max claim true; a caller that
+    ///        needs several must expire them lowest-first in separate batches, or pass Keep for all
+    ///        but the highest.
+    template <QueryableStateStorage ReadStorage, WritableStateStorage WriteStorage>
+    task::Task<ExpireReport> expire(ReadStorage& backend, WriteStorage& batch,
+        protocol::BlockNumber block,
+        RetentionBoundary boundaryPolicy = RetentionBoundary::Keep) const
     {
-        auto scan = co_await scanManifest(backend, block, DeletedShardPolicy::Skip);
+        std::vector<bcos::bytes> keys;
+        auto scan = co_await scanBlock(backend, block, DeletedShardPolicy::Skip,
+            [&](ShardRecord const& record, HistoryVersion const&) {
+                keys.emplace_back(record.key.begin(), record.key.end());
+            });
 
-        ExpireReport report{.keyCount = scan.keys.size(),
-            .indexDeletesIssued = scan.keys.size(),
-            .manifestShardsDeleted = scan.manifestKeys.size()};
-
-        if (!scan.keys.empty())
+        ExpireReport report{
+            .keyCount = keys.size(), .shardsDeleted = scan.shardsRead, .retired = std::nullopt};
+        if (!scan.rowKeys.empty())
         {
-            std::vector<executor_v1::StateKey> indexKeys;
-            indexKeys.reserve(scan.keys.size());
-            for (auto const& key : scan.keys)
-            {
-                indexKeys.emplace_back(Tables.index, indexRowKey(key, block));
-            }
-            co_await storage2::removeSome(mutableLayer, std::move(indexKeys));
+            report.retired = RetiredBlock{
+                .block = block, .keys = std::move(keys), .shardsDeleted = scan.shardsRead};
+            co_await storage2::removeSome(batch, std::move(scan.rowKeys));
         }
-        if (!scan.manifestKeys.empty())
+
+        // Under Advance the boundary moves with the deletes, in the same batch and therefore the
+        // same Write. Doing it inside expire rather than at the call site is what makes it
+        // impossible for the commit path to expire without advancing it.
+        //
+        // The new boundary is @p block ITSELF, not block + 1. "The value at B" is answered by the
+        // first change AFTER B, so block B's own records are not what answers B — they answer the
+        // blocks below it. Dropping block B therefore leaves B answerable (from B+1's records,
+        // which are still here) and takes B-1 away.
+        //
+        // Written whenever the policy allows it, including when the block had nothing to expire:
+        // the claim is "nothing below @p block is left", which is true either way.
+        //
+        // MAX, not assignment. The boundary only ever grows — expired data does not come back —
+        // and @p block is not monotonic across every caller: a chain re-committing after a
+        // rollback replays lower heights, and an operator RAISING mpt_history_*_blocks makes N - H
+        // jump backwards on the next commit. Assigning would then claim heights are intact whose
+        // shards an earlier expiry already deleted.
+        if (boundaryPolicy == RetentionBoundary::Advance)
         {
-            co_await storage2::removeSome(mutableLayer, std::move(scan.manifestKeys));
+            auto const current = co_await retentionBoundary(backend);
+            if (!current || *current < block)
+            {
+                co_await writeRetentionBoundary(batch, block);
+            }
         }
         co_return report;
     }
 
-private:
-    /// One manifest sweep: the keys the block changed and the manifest rows that list them.
-    struct ManifestScan
+    /// The oldest block this store can still ANSWER FOR, read off disk — everything below it has
+    /// been expired away. Nullopt when the row was never written, which means no expiry has ever
+    /// run against this store.
+    template <class Storage>
+    static task::Task<std::optional<protocol::BlockNumber>> retentionBoundary(Storage& backend)
     {
-        std::vector<bcos::bytes> keys;
-        std::vector<executor_v1::StateKey> manifestKeys;
-    };
+        auto row = co_await storage2::readOne(
+            backend, executor_v1::StateKey{Tables.boundary, kRetentionBoundaryRowKey});
+        if (!row)
+        {
+            co_return std::nullopt;
+        }
+        co_return decodeRetentionBoundary(row->get());
+    }
 
-    /// What a manifest sweep does with a shard row that is present but carries a deletion
-    /// sentinel instead of bytes — the shape an expired shard has on a logical-deletion layer.
-    /// The row is the same; the two callers need opposite readings of it, so the choice is a
-    /// parameter rather than a rule baked into the sweep.
+    /// Record that @p oldestIntactBlock is the oldest block this store can still answer for.
+    ///
+    /// It must ride the same batch as whatever made that true. expire() calls it itself, so an
+    /// expiry cannot land without the boundary moving with it.
+    template <WritableStateStorage Storage>
+    static task::Task<void> writeRetentionBoundary(
+        Storage& batch, protocol::BlockNumber oldestIntactBlock)
+    {
+        std::vector<std::tuple<executor_v1::StateKey, executor_v1::StateValue>> rows;
+        rows.emplace_back(executor_v1::StateKey{Tables.boundary, kRetentionBoundaryRowKey},
+            executor_v1::StateValue{retentionBoundaryValue(oldestIntactBlock)});
+        co_await storage2::writeSome(batch, std::move(rows));
+    }
+
+    /// Recompute the whole in-memory index from the shard rows on disk (layout spec §1.5).
+    ///
+    /// Runs once, at startup, BEFORE any reader exists — which is what removes the window the
+    /// derived index would otherwise have: there is no moment at which a query can miss a version
+    /// because the rebuild has not reached it yet and read that miss as "unmodified".
+    ///
+    /// It starts at `boundary + 1` rather than at block 0 so that rows left below the boundary by
+    /// an interrupted expiry are skipped instead of resurrecting heights the store has already
+    /// promised not to answer for.
+    ///
+    /// Every inconsistency is fatal, and deliberately so: a shard row before its meta row, a
+    /// missing or extra shard, a record count that disagrees with the meta row, an unknown format
+    /// version, a truncated record. Each of them means some pre-image would be absent from the
+    /// index, and an absent pre-image reads as "the key never changed" (G6). The caller catches
+    /// MPTInvariantViolation and calls markUnavailable() — a store that refuses is recoverable, a
+    /// store that answers from a short index is not.
+    ///
+    /// @p Storage is constrained on seeking only, per the spec; the boundary read below also needs
+    /// `readOne`, which every backend this runs on has (readAt requires it on the same storage).
+    template <SeekableStateStorage Storage>
+    task::Task<RebuildReport> rebuild(Storage& backend)
+    {
+        auto const boundary = co_await retentionBoundary(backend);
+        auto const start =
+            boundary ? std::max<protocol::BlockNumber>(0, *boundary + 1) : protocol::BlockNumber{0};
+
+        HistoryIndex rebuilt;
+        rebuilt.setBoundary(boundary);
+
+        RebuildReport report;
+        StagedBlock staged;
+        bool inBlock = false;
+        std::size_t shardsSeen = 0;
+        std::size_t recordsSeen = 0;
+
+        // Close off the block the walk has been accumulating, checking it against its meta row.
+        auto finishBlock = [&]() {
+            if (!inBlock)
+            {
+                return;
+            }
+            if (shardsSeen != staged.meta.shardCount || recordsSeen != staged.meta.recordCount)
+            {
+                BOOST_THROW_EXCEPTION(
+                    MPTInvariantViolation() << bcos::errinfo_comment(
+                        "history block holds a different number of shards or records than its "
+                        "meta row declares"));
+            }
+            rebuilt.publish(std::move(staged), std::nullopt, std::nullopt);
+            ++report.blocks;
+            report.records += recordsSeen;
+            inBlock = false;
+        };
+
+        report.bytesScanned = co_await walkShardTable(backend, start,
+            [&](executor_v1::StateKeyView const& rowKeyView,
+                executor_v1::StateValue const* entry) -> bool {
+                if (entry == nullptr)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        MPTInvariantViolation() << bcos::errinfo_comment(
+                            "history shard table holds a deletion sentinel; the records it "
+                            "carried cannot be indexed"));
+                }
+                auto const rowBlock = rowKeyBlock(rowKeyView.m_key);
+                if (isMetaRowKey(rowKeyView.m_key, rowBlock))
+                {
+                    finishBlock();
+                    staged = StagedBlock{
+                        .block = rowBlock, .meta = decodeMeta(entry->get()), .versions = {}};
+                    staged.versions.reserve(staged.meta.recordCount);
+                    shardsSeen = 0;
+                    recordsSeen = 0;
+                    inBlock = true;
+                    return true;
+                }
+                if (!inBlock || rowBlock != staged.block)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        MPTInvariantViolation() << bcos::errinfo_comment(
+                            "history shard row is not preceded by its block's meta row"));
+                }
+                auto const shard = rowKeyShard(rowKeyView.m_key);
+                if (shard != shardsSeen)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        MPTInvariantViolation() << bcos::errinfo_comment(
+                            "history shard ordinals are not the contiguous 0..n-1 run the meta "
+                            "row describes"));
+                }
+                ++shardsSeen;
+                if (shardsSeen > staged.meta.shardCount)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        MPTInvariantViolation() << bcos::errinfo_comment(
+                            "history block holds more shards than its meta row declares"));
+                }
+                for (auto const& record : decodeShard(entry->get()))
+                {
+                    staged.versions.emplace_back(bcos::bytes(record.key.begin(), record.key.end()),
+                        HistoryVersion{.block = rowBlock,
+                            .shard = static_cast<uint16_t>(shard),
+                            .offset = static_cast<uint32_t>(record.offset)});
+                    ++recordsSeen;
+                }
+                return true;
+            });
+        finishBlock();
+
+        m_index.replace(std::move(rebuilt));
+        co_return report;
+    }
+
+private:
+    /// What a block walk does with a row that is present but carries a deletion sentinel instead
+    /// of bytes — the shape an expired row has on a logical-deletion layer. The row is the same;
+    /// the two callers need opposite readings of it, so the choice is a parameter rather than a
+    /// rule baked into the walk.
     enum class DeletedShardPolicy : uint8_t
     {
-        /// The caller needs the block's complete key list (rollback, the B.10 audits). A deleted
-        /// shard makes part of that list unreadable, so fail loud instead of returning a short
-        /// one (G6).
+        /// The caller needs the block's complete diff (readBlock, and through it rollback and the
+        /// B.10 audits). A deleted row makes part of that diff unreadable, so fail loud (G6).
         Reject,
-        /// The caller only re-issues deletes (expire). A shard is deleted only after the index
-        /// rows of every key it listed were deleted — B.5's index-then-manifest order — so a
-        /// deleted shard has nothing left to clean up and skipping it is what makes a replay a
-        /// no-op rather than an error.
+        /// The caller only re-issues deletes (expire). A row that is already a sentinel has
+        /// nothing left to clean up, and skipping it is what makes a replay a no-op.
         Skip,
+    };
+
+    /// What one single-block walk saw.
+    struct BlockScan
+    {
+        bool metaFound{};
+        BlockMeta meta;
+        std::size_t shardsRead{};
+        std::size_t recordsRead{};
+        /// Every LIVE row of the block — the meta row and the shard rows — as the keys an expiry
+        /// deletes.
+        std::vector<executor_v1::StateKey> rowKeys;
     };
 
     /// spec B.3, first two lines. Kept as its own function so the one call site above can be
@@ -382,50 +737,21 @@ private:
         }
     }
 
-    /// Decode an index row value: tag byte, then the old value when the tag says there is one.
-    static ReadAtResult decodeIndexValue(std::string_view value)
+    /// Seek to `BE64(@p fromBlock)` in the shard table and hand every row forward to @p visitor as
+    /// (row key view, entry or nullptr), stopping at the end of the table or when the visitor
+    /// returns false. Returns the payload bytes read.
+    ///
+    /// The seek positions at the block's META row, because an 8-byte key sorts before every
+    /// 10-byte key sharing its first eight bytes — so one seek yields meta, shard 0, shard 1, ...
+    /// and then the next block. The iterator runs on past the table, so the VISITOR, not the seek,
+    /// defines where a walk ends.
+    template <SeekableStateStorage Storage, class Visitor>
+    static task::Task<std::size_t> walkShardTable(
+        Storage& backend, protocol::BlockNumber fromBlock, Visitor&& visitor)
     {
-        if (value.empty())
-        {
-            BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
-                                      "history index row value is empty; the tag byte is "
-                                      "mandatory"));
-        }
-        switch (value.front())
-        {
-        case kTagAbsent:
-            if (value.size() != kTagBytes)
-            {
-                BOOST_THROW_EXCEPTION(
-                    MPTInvariantViolation() << bcos::errinfo_comment(
-                        "history index row is tagged ABSENT but carries value bytes"));
-            }
-            return HistoryAbsent{};
-        case kTagValue:
-        {
-            auto payload = value.substr(kTagBytes);
-            return bcos::bytes(payload.begin(), payload.end());
-        }
-        default:
-            BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
-                                      "history index row carries an unknown tag byte"));
-        }
-    }
-
-    /// Walk the manifest shards of one block, in shard order, collecting both the keys they list
-    /// and the row keys of the shards themselves. Stops at the first row that is not a manifest
-    /// row of this block — the iterator runs on into the rest of the table and then into other
-    /// tables, so the loop, not the seek, defines the range. A shard carrying a deletion sentinel
-    /// is not such a boundary: it is skipped or rejected per @p deletedShards, and the walk goes
-    /// on either way, because live shards can follow a deleted one.
-    template <SeekableStateStorage Storage>
-    static task::Task<ManifestScan> scanManifest(
-        Storage& backend, protocol::BlockNumber block, DeletedShardPolicy deletedShards)
-    {
-        ManifestScan scan;
-        executor_v1::StateKey seekKey{Tables.manifest, manifestRowKey(block, 0)};
-
-        auto iterator = co_await storage2::range(backend, storage2::RANGE_SEEK, seekKey);
+        std::size_t bytesScanned = 0;
+        auto iterator = co_await storage2::range(backend, storage2::RANGE_SEEK,
+            executor_v1::StateKey{Tables.shard, metaRowKey(fromBlock)});
         while (true)
         {
             auto row = co_await iterator.next();
@@ -435,31 +761,72 @@ private:
             }
             auto const& [rowKey, rowValue] = *row;
             executor_v1::StateKeyView rowKeyView{rowKey};
-            if (rowKeyView.m_table != Tables.manifest ||
-                !manifestRowBelongsTo(rowKeyView.m_key, block))
+            if (rowKeyView.m_table != Tables.shard)
             {
                 break;
             }
             auto const* entry = detail::asStateValue(rowValue);
-            if (entry == nullptr)
+            if (entry != nullptr)
             {
-                if (deletedShards == DeletedShardPolicy::Skip)
-                {
-                    continue;
-                }
-                BOOST_THROW_EXCEPTION(
-                    MPTInvariantViolation() << bcos::errinfo_comment(
-                        "history manifest shard is deleted; the keys it listed cannot be "
-                        "recovered from this storage layer"));
+                bytesScanned += entry->get().size();
             }
-            scan.manifestKeys.emplace_back(rowKeyView);
-            for (auto& key : decodeManifestShard(entry->get()))
+            if (!visitor(rowKeyView, entry))
             {
-                scan.keys.emplace_back(std::move(key));
+                break;
             }
         }
+        co_return bytesScanned;
+    }
+
+    /// Walk exactly one block's rows, handing each record to @p sink as (record, version).
+    /// @p sink lets each caller materialize only what it needs: readBlock copies the values,
+    /// expire copies only the keys, and neither pays for the other's copies.
+    template <SeekableStateStorage Storage, class RecordSink>
+    static task::Task<BlockScan> scanBlock(Storage& backend, protocol::BlockNumber block,
+        DeletedShardPolicy deletedShards, RecordSink&& sink)
+    {
+        BlockScan scan;
+        co_await walkShardTable(backend, block,
+            [&](executor_v1::StateKeyView const& rowKeyView,
+                executor_v1::StateValue const* entry) -> bool {
+                if (rowKeyBlock(rowKeyView.m_key) != block)
+                {
+                    return false;
+                }
+                if (entry == nullptr)
+                {
+                    if (deletedShards == DeletedShardPolicy::Skip)
+                    {
+                        // Live rows can follow a deleted one, so the walk goes on.
+                        return true;
+                    }
+                    BOOST_THROW_EXCEPTION(
+                        MPTInvariantViolation() << bcos::errinfo_comment(
+                            "history block row is deleted; the records it carried cannot be "
+                            "recovered from this storage layer"));
+                }
+                scan.rowKeys.emplace_back(rowKeyView);
+                if (isMetaRowKey(rowKeyView.m_key, block))
+                {
+                    scan.meta = decodeMeta(entry->get());
+                    scan.metaFound = true;
+                    return true;
+                }
+                auto const shard = rowKeyShard(rowKeyView.m_key);
+                ++scan.shardsRead;
+                for (auto const& record : decodeShard(entry->get()))
+                {
+                    sink(record, HistoryVersion{.block = block,
+                                     .shard = static_cast<uint16_t>(shard),
+                                     .offset = static_cast<uint32_t>(record.offset)});
+                    ++scan.recordsRead;
+                }
+                return true;
+            });
         co_return scan;
     }
+
+    HistoryIndex m_index;
 };
 
 /// The two instantiations spec B.8 calls for.

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -30,6 +30,7 @@
 #include <bcos-task/Task.h>
 #include <bcos-utilities/Common.h>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <span>
 #include <string>
@@ -259,13 +260,23 @@ public:
         co_return decodeIndexValue(entry->get());
     }
 
-    /// Every key block @p block changed, read off that block's manifest. Empty when the block has
-    /// been expired, or when it changed nothing. Used by rollback and by the B.10 audits.
+    /// Every key block @p block changed, read off that block's manifest. Used by rollback and by
+    /// the B.10 audits, both of which need the list to be COMPLETE.
+    ///
+    /// Empty when the block changed nothing, and empty on a plane where the block's manifest rows
+    /// are physically gone — the backend after a merge, for instance.
+    ///
+    /// @throws MPTInvariantViolation when a shard row is present but carries a deletion sentinel
+    ///         rather than bytes. That is what an expiry looks like on the mutable layer, whose
+    ///         removeSome marks rather than erases (MemoryStorage LOGICAL_DELETION, the mode
+    ///         GlobalStateMutableStorage runs in). The keys such a shard listed are unreadable, so
+    ///         a caller that needs the complete list must not be handed a short one (G6). Callers
+    ///         wanting the expiry-tolerant reading use expire(), which skips those shards.
     template <SeekableStateStorage Storage>
     static task::Task<std::vector<bcos::bytes>> keysOfBlock(
         Storage& backend, protocol::BlockNumber block)
     {
-        auto scan = co_await scanManifest(backend, block);
+        auto scan = co_await scanManifest(backend, block, DeletedShardPolicy::Reject);
         co_return std::move(scan.keys);
     }
 
@@ -279,11 +290,21 @@ public:
     /// leaves the manifest, so re-running finds the same key list and re-issues deletes that are
     /// no-ops for the rows already gone. Deleting the manifest first would strand the surviving
     /// index rows permanently — nothing else records which keys the block touched.
+    ///
+    /// Idempotent on every storage, including the one G3 puts it on. The production mutable layer
+    /// is MemoryStorage with LOGICAL_DELETION (GlobalStateStorageInitializer.h:15-19), where a
+    /// removed row stays in the container as a deletion sentinel and the iterator still yields
+    /// it; so a second expire() of the same block sees its own shards coming back as sentinels.
+    /// It skips them instead of failing, and that is sound rather than merely convenient: the
+    /// index-then-manifest order above means a shard can only be deleted after the index rows of
+    /// every key it listed were deleted, so a skipped shard has nothing left to clean up.
+    /// keysOfBlock() takes the opposite reading of the same row, because a short key list would
+    /// silently break rollback.
     template <SeekableStateStorage ReadStorage, WritableStateStorage WriteStorage>
     static task::Task<ExpireReport> expire(
         ReadStorage& backend, WriteStorage& mutableLayer, protocol::BlockNumber block)
     {
-        auto scan = co_await scanManifest(backend, block);
+        auto scan = co_await scanManifest(backend, block, DeletedShardPolicy::Skip);
 
         ExpireReport report{.keyCount = scan.keys.size(),
             .indexDeletesIssued = scan.keys.size(),
@@ -312,6 +333,23 @@ private:
     {
         std::vector<bcos::bytes> keys;
         std::vector<executor_v1::StateKey> manifestKeys;
+    };
+
+    /// What a manifest sweep does with a shard row that is present but carries a deletion
+    /// sentinel instead of bytes — the shape an expired shard has on a logical-deletion layer.
+    /// The row is the same; the two callers need opposite readings of it, so the choice is a
+    /// parameter rather than a rule baked into the sweep.
+    enum class DeletedShardPolicy : uint8_t
+    {
+        /// The caller needs the block's complete key list (rollback, the B.10 audits). A deleted
+        /// shard makes part of that list unreadable, so fail loud instead of returning a short
+        /// one (G6).
+        Reject,
+        /// The caller only re-issues deletes (expire). A shard is deleted only after the index
+        /// rows of every key it listed were deleted — B.5's index-then-manifest order — so a
+        /// deleted shard has nothing left to clean up and skipping it is what makes a replay a
+        /// no-op rather than an error.
+        Skip,
     };
 
     /// spec B.3, first two lines. Kept as its own function so the one call site above can be
@@ -377,9 +415,12 @@ private:
     /// Walk the manifest shards of one block, in shard order, collecting both the keys they list
     /// and the row keys of the shards themselves. Stops at the first row that is not a manifest
     /// row of this block — the iterator runs on into the rest of the table and then into other
-    /// tables, so the loop, not the seek, defines the range.
+    /// tables, so the loop, not the seek, defines the range. A shard carrying a deletion sentinel
+    /// is not such a boundary: it is skipped or rejected per @p deletedShards, and the walk goes
+    /// on either way, because live shards can follow a deleted one.
     template <SeekableStateStorage Storage>
-    static task::Task<ManifestScan> scanManifest(Storage& backend, protocol::BlockNumber block)
+    static task::Task<ManifestScan> scanManifest(
+        Storage& backend, protocol::BlockNumber block, DeletedShardPolicy deletedShards)
     {
         ManifestScan scan;
         executor_v1::StateKey seekKey{Tables.manifest, manifestRowKey(block, 0)};
@@ -402,13 +443,14 @@ private:
             auto const* entry = detail::asStateValue(rowValue);
             if (entry == nullptr)
             {
-                // A deleted shard among live ones: a partially-applied expiry that a replay will
-                // finish. Skipping it would silently drop the keys it listed, so stop here and
-                // let the caller see the inconsistency (G6).
+                if (deletedShards == DeletedShardPolicy::Skip)
+                {
+                    continue;
+                }
                 BOOST_THROW_EXCEPTION(
                     MPTInvariantViolation() << bcos::errinfo_comment(
-                        "history manifest shard is deleted while the block's manifest is still "
-                        "being read"));
+                        "history manifest shard is deleted; the keys it listed cannot be "
+                        "recovered from this storage layer"));
             }
             scan.manifestKeys.emplace_back(rowKeyView);
             for (auto& key : decodeManifestShard(entry->get()))

--- a/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ReverseHistoryStore.h
@@ -1,0 +1,427 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ReverseHistoryStore.h
+ * @brief One block's diff, stored twice under two sort orders, so that both a point query and a
+ *        whole-block sweep are one seek (spec B.1-B.8)
+ */
+#pragma once
+
+#include "../Errors.h"
+#include "HistoryErrors.h"
+#include "HistoryRowCodec.h"
+#include "HistoryTables.h"
+#include <bcos-framework/protocol/ProtocolTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt::history
+{
+
+/// A storage the component writes history rows and expiry deletions into. In production this is
+/// the block's mutable layer, so those rows ride the block's single WriteBatch (G3).
+template <class Storage>
+concept WritableStateStorage = requires(Storage& storage,
+    std::vector<std::tuple<executor_v1::StateKey, executor_v1::StateValue>> keyValues,
+    std::vector<executor_v1::StateKey> keys) {
+    { storage2::writeSome(storage, keyValues) } -> task::IsAwaitable;
+    { storage2::removeSome(storage, keys) } -> task::IsAwaitable;
+};
+
+/// A storage that can position an iterator at the first row at or after a key and walk forward.
+/// Both readAt and the manifest sweep need it; a plain point-read storage cannot serve either.
+template <class Storage>
+concept SeekableStateStorage = requires(Storage& storage, executor_v1::StateKey key) {
+    { storage2::range(storage, storage2::RANGE_SEEK, key) } -> task::IsAwaitable;
+};
+
+/// One key changed by one block, paired with the value it held when the block began.
+/// Both fields are non-owning views into the caller's diff — put() copies out of them.
+struct HistoryEntry
+{
+    std::span<const bcos::byte> key;
+    /// nullopt when the key did not exist before this block (written as tag 0x00).
+    std::optional<std::span<const bcos::byte>> oldValue;
+};
+
+/// readAt outcome: the key did not exist at the queried block (the index row's tag is 0x00).
+struct HistoryAbsent
+{
+    friend bool operator==(HistoryAbsent, HistoryAbsent) noexcept { return true; }
+};
+
+/// readAt outcome: no index row exists after the queried block, so the key has not changed since
+/// — the current value IS the historical one and the caller should read it from the live plane
+/// (spec B.3). Only trustworthy because the window guard already ruled out "the row existed and
+/// was expired".
+struct HistoryUseCurrent
+{
+    friend bool operator==(HistoryUseCurrent, HistoryUseCurrent) noexcept { return true; }
+};
+
+/// readAt outcome, third case: the key's value at the queried block, as `bcos::bytes`.
+using ReadAtResult = std::variant<bcos::bytes, HistoryAbsent, HistoryUseCurrent>;
+
+/// What one expire() pass did.
+struct ExpireReport
+{
+    /// Keys the block's manifest listed. Zero also means "already expired" — expire is idempotent.
+    std::size_t keyCount{};
+    /// Index-row deletes issued, one per listed key. On a replay of an interrupted expiry some of
+    /// them target rows that are already gone, which is a no-op — hence "issued", not "removed".
+    std::size_t indexDeletesIssued{};
+    /// Manifest shards found and deleted. These did exist: the sweep read them.
+    std::size_t manifestShardsDeleted{};
+};
+
+namespace detail
+{
+/// Storage iterators hand back either a `StorageValueType<Value>` variant (MemoryStorage,
+/// RocksDBStorage2) or a bare value. Reduce both to "the entry, or nullptr when this row carries
+/// a deletion sentinel instead of bytes".
+template <class RowValue>
+inline const executor_v1::StateValue* asStateValue(RowValue const& value) noexcept
+{
+    if constexpr (requires { std::get_if<executor_v1::StateValue>(std::addressof(value)); })
+    {
+        return std::get_if<executor_v1::StateValue>(std::addressof(value));
+    }
+    else
+    {
+        return std::addressof(value);
+    }
+}
+}  // namespace detail
+
+/// The reverse history of one key space: every key a block changed, keyed both by (key, block)
+/// for point queries and by (block, shard) for whole-block sweeps (spec B.1).
+///
+/// Instantiated twice over the same code — `StateHistoryStore` for state rows, `TrieHistoryStore`
+/// for path-addressed trie nodes (spec B.8). @p Tables selects which pair of state tables the
+/// instance owns; everything else is identical, which is the point.
+///
+/// All members are static: the store owns no state of its own. The rows live in whatever storage
+/// the caller passes, and each call takes the storage it should act on — in production the
+/// block's mutable layer for writes and the backend view for reads.
+template <HistoryTables const& Tables>
+class ReverseHistoryStore
+{
+public:
+    /// Record @p entries as the pre-images of block @p block, plus the manifest that lists them.
+    ///
+    /// Pure append: every row is a fresh Put and nothing is read first, so write amplification is
+    /// the size of this block's diff and does not grow with the retention depth (spec B.4). All
+    /// rows go out in ONE writeSome, which in production is one contribution to the block's
+    /// single WriteBatch (G3).
+    ///
+    /// @param entries one record per key the block changed, each carrying the value the key held
+    ///        when the block BEGAN. A key must appear at most once: a second row for the same
+    ///        (key, block) would overwrite the block-start value with a mid-block one and hand
+    ///        every later query a wrong answer, so a duplicate throws instead of being ignored.
+    ///        The caller does the intra-block deduplication (spec B.4).
+    /// @param shardByteCap the manifest payload size at which a new shard starts. A key whose own
+    ///        record exceeds the cap still gets a shard — the cap bounds row size, it cannot
+    ///        split a record.
+    ///
+    /// A block that changed nothing still gets an empty shard 0. Spec B.10 ② audits the window
+    /// for a manifest per block and treats a gap as fatal, so "no changes" must be recorded as
+    /// such rather than being indistinguishable from a lost manifest.
+    template <WritableStateStorage Storage>
+    static task::Task<void> put(Storage& mutableLayer, protocol::BlockNumber block,
+        std::span<HistoryEntry const> entries, std::size_t shardByteCap)
+    {
+        if (shardByteCap == 0)
+        {
+            BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                      "history manifest shard byte cap must be positive"));
+        }
+
+        std::vector<std::tuple<executor_v1::StateKey, executor_v1::StateValue>> rows;
+        rows.reserve(entries.size() + 1);
+
+        std::unordered_set<std::string_view> seenKeys;
+        seenKeys.reserve(entries.size());
+
+        std::string shardPayload;
+        std::size_t shardIndex = 0;
+        auto flushShard = [&]() {
+            rows.emplace_back(
+                executor_v1::StateKey{Tables.manifest, manifestRowKey(block, shardIndex)},
+                executor_v1::StateValue{std::move(shardPayload)});
+            shardPayload.clear();
+            ++shardIndex;
+        };
+
+        for (auto const& entry : entries)
+        {
+            auto keyView = asStringView(entry.key);
+            if (!seenKeys.insert(keyView).second)
+            {
+                BOOST_THROW_EXCEPTION(
+                    MPTInvariantViolation() << bcos::errinfo_comment(
+                        "the same key appears twice in one block's history entries; only the "
+                        "block-start value may be recorded"));
+            }
+
+            rows.emplace_back(executor_v1::StateKey{Tables.index, indexRowKey(entry.key, block)},
+                executor_v1::StateValue{indexRowValue(entry.oldValue)});
+
+            if (!shardPayload.empty() &&
+                shardPayload.size() + manifestRecordSize(entry.key) > shardByteCap)
+            {
+                flushShard();
+            }
+            appendManifestRecord(shardPayload, entry.key);
+        }
+        flushShard();
+
+        co_await storage2::writeSome(mutableLayer, std::move(rows));
+    }
+
+    /// The value @p key held at block @p block.
+    ///
+    /// The answer is the OLD value recorded by the first change after @p block: between @p block
+    /// and that change the key was untouched, so that old value is exactly the block-@p block
+    /// value (spec §0.4). One seek, one row read, independent of how far back @p block is.
+    ///
+    /// @param tip the chain's current block number.
+    /// @param depth the retention window, i.e. H_state or H_proof for this instance.
+    /// @throws HistoryPruned when @p block predates the retained window.
+    /// @throws InvalidHistoryBlock when @p block is negative or ahead of @p tip.
+    template <SeekableStateStorage Storage>
+    static task::Task<ReadAtResult> readAt(Storage& backend, std::span<const bcos::byte> key,
+        protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth)
+    {
+        // The window guard runs BEFORE the seek, and that order is the whole point (spec B.3,
+        // G5): a seek that finds nothing cannot tell "never changed after B, so the current
+        // value is the answer" from "the record was expired away, so the current value is a
+        // wrong answer" — the index holds no evidence either way. Only the window bound
+        // separates them. HISTORY_GUARD_DISABLED exists solely so the test suite can compile a
+        // build without the guard and demonstrate that the out-of-window case then returns a
+        // plausible-looking wrong value; nothing defines it.
+#ifndef HISTORY_GUARD_DISABLED
+        checkWindow(block, tip, depth);
+#endif
+
+        auto keyView = asStringView(key);
+        executor_v1::StateKey seekKey{Tables.index, indexRowKey(key, block + 1)};
+
+        auto iterator = co_await storage2::range(backend, storage2::RANGE_SEEK, seekKey);
+        auto row = co_await iterator.next();
+        if (!row)
+        {
+            co_return HistoryUseCurrent{};
+        }
+
+        auto const& [rowKey, rowValue] = *row;
+        executor_v1::StateKeyView rowKeyView{rowKey};
+        if (rowKeyView.m_table != Tables.index || !indexRowBelongsTo(rowKeyView.m_key, keyView))
+        {
+            co_return HistoryUseCurrent{};
+        }
+
+        auto const* entry = detail::asStateValue(rowValue);
+        if (entry == nullptr)
+        {
+            // The row is present but carries a deletion sentinel rather than bytes: the
+            // pre-image this query needs was removed while the window still claims to cover it.
+            // Fail loud (G6) — falling through to the current value is the silent wrong answer
+            // B.3 exists to prevent.
+            BOOST_THROW_EXCEPTION(
+                MPTInvariantViolation() << bcos::errinfo_comment(
+                    "history index row is deleted inside the retention window; the pre-image "
+                    "chain has a hole"));
+        }
+        co_return decodeIndexValue(entry->get());
+    }
+
+    /// Every key block @p block changed, read off that block's manifest. Empty when the block has
+    /// been expired, or when it changed nothing. Used by rollback and by the B.10 audits.
+    template <SeekableStateStorage Storage>
+    static task::Task<std::vector<bcos::bytes>> keysOfBlock(
+        Storage& backend, protocol::BlockNumber block)
+    {
+        auto scan = co_await scanManifest(backend, block);
+        co_return std::move(scan.keys);
+    }
+
+    /// Drop block @p block from the retained window: delete its index rows, then its manifest.
+    ///
+    /// Deletions are written to @p mutableLayer, so in the default mode they land in the
+    /// committing block's WriteBatch and the whole expiry is atomic with the commit (spec B.5).
+    ///
+    /// The manifest is deleted LAST, and that ordering is what makes the deferred mode (expiry
+    /// split out of the commit batch) safe to interrupt: a crash after some index rows are gone
+    /// leaves the manifest, so re-running finds the same key list and re-issues deletes that are
+    /// no-ops for the rows already gone. Deleting the manifest first would strand the surviving
+    /// index rows permanently — nothing else records which keys the block touched.
+    template <SeekableStateStorage ReadStorage, WritableStateStorage WriteStorage>
+    static task::Task<ExpireReport> expire(
+        ReadStorage& backend, WriteStorage& mutableLayer, protocol::BlockNumber block)
+    {
+        auto scan = co_await scanManifest(backend, block);
+
+        ExpireReport report{.keyCount = scan.keys.size(),
+            .indexDeletesIssued = scan.keys.size(),
+            .manifestShardsDeleted = scan.manifestKeys.size()};
+
+        if (!scan.keys.empty())
+        {
+            std::vector<executor_v1::StateKey> indexKeys;
+            indexKeys.reserve(scan.keys.size());
+            for (auto const& key : scan.keys)
+            {
+                indexKeys.emplace_back(Tables.index, indexRowKey(key, block));
+            }
+            co_await storage2::removeSome(mutableLayer, std::move(indexKeys));
+        }
+        if (!scan.manifestKeys.empty())
+        {
+            co_await storage2::removeSome(mutableLayer, std::move(scan.manifestKeys));
+        }
+        co_return report;
+    }
+
+private:
+    /// One manifest sweep: the keys the block changed and the manifest rows that list them.
+    struct ManifestScan
+    {
+        std::vector<bcos::bytes> keys;
+        std::vector<executor_v1::StateKey> manifestKeys;
+    };
+
+    /// spec B.3, first two lines. Kept as its own function so the one call site above can be
+    /// compiled out wholesale for the negative-control test.
+    static void checkWindow(
+        protocol::BlockNumber block, protocol::BlockNumber tip, protocol::BlockNumber depth)
+    {
+        if (depth < 0)
+        {
+            BOOST_THROW_EXCEPTION(InvalidHistoryBlock() << bcos::errinfo_comment(
+                                      "history retention depth must not be negative"));
+        }
+        if (block < 0)
+        {
+            BOOST_THROW_EXCEPTION(InvalidHistoryBlock() << bcos::errinfo_comment(
+                                      "history block number must not be negative"));
+        }
+        // Signed arithmetic on purpose: a chain shorter than the window makes tip - depth + 1
+        // negative, which correctly admits every block down to genesis.
+        if (block < tip - depth + 1)
+        {
+            BOOST_THROW_EXCEPTION(HistoryPruned() << bcos::errinfo_comment(
+                                      "requested block is older than the retained history "
+                                      "window"));
+        }
+        if (block > tip)
+        {
+            BOOST_THROW_EXCEPTION(InvalidHistoryBlock() << bcos::errinfo_comment(
+                                      "requested block is ahead of the chain tip"));
+        }
+    }
+
+    /// Decode an index row value: tag byte, then the old value when the tag says there is one.
+    static ReadAtResult decodeIndexValue(std::string_view value)
+    {
+        if (value.empty())
+        {
+            BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                      "history index row value is empty; the tag byte is "
+                                      "mandatory"));
+        }
+        switch (value.front())
+        {
+        case kTagAbsent:
+            if (value.size() != kTagBytes)
+            {
+                BOOST_THROW_EXCEPTION(
+                    MPTInvariantViolation() << bcos::errinfo_comment(
+                        "history index row is tagged ABSENT but carries value bytes"));
+            }
+            return HistoryAbsent{};
+        case kTagValue:
+        {
+            auto payload = value.substr(kTagBytes);
+            return bcos::bytes(payload.begin(), payload.end());
+        }
+        default:
+            BOOST_THROW_EXCEPTION(MPTInvariantViolation() << bcos::errinfo_comment(
+                                      "history index row carries an unknown tag byte"));
+        }
+    }
+
+    /// Walk the manifest shards of one block, in shard order, collecting both the keys they list
+    /// and the row keys of the shards themselves. Stops at the first row that is not a manifest
+    /// row of this block — the iterator runs on into the rest of the table and then into other
+    /// tables, so the loop, not the seek, defines the range.
+    template <SeekableStateStorage Storage>
+    static task::Task<ManifestScan> scanManifest(Storage& backend, protocol::BlockNumber block)
+    {
+        ManifestScan scan;
+        executor_v1::StateKey seekKey{Tables.manifest, manifestRowKey(block, 0)};
+
+        auto iterator = co_await storage2::range(backend, storage2::RANGE_SEEK, seekKey);
+        while (true)
+        {
+            auto row = co_await iterator.next();
+            if (!row)
+            {
+                break;
+            }
+            auto const& [rowKey, rowValue] = *row;
+            executor_v1::StateKeyView rowKeyView{rowKey};
+            if (rowKeyView.m_table != Tables.manifest ||
+                !manifestRowBelongsTo(rowKeyView.m_key, block))
+            {
+                break;
+            }
+            auto const* entry = detail::asStateValue(rowValue);
+            if (entry == nullptr)
+            {
+                // A deleted shard among live ones: a partially-applied expiry that a replay will
+                // finish. Skipping it would silently drop the keys it listed, so stop here and
+                // let the caller see the inconsistency (G6).
+                BOOST_THROW_EXCEPTION(
+                    MPTInvariantViolation() << bcos::errinfo_comment(
+                        "history manifest shard is deleted while the block's manifest is still "
+                        "being read"));
+            }
+            scan.manifestKeys.emplace_back(rowKeyView);
+            for (auto& key : decodeManifestShard(entry->get()))
+            {
+                scan.keys.emplace_back(std::move(key));
+            }
+        }
+        co_return scan;
+    }
+};
+
+/// The two instantiations spec B.8 calls for.
+using StateHistoryStore = ReverseHistoryStore<kStateHistory>;
+using TrieHistoryStore = ReverseHistoryStore<kTrieHistory>;
+
+}  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/bcos-ledger/mpt/history/ShardTableWalk.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ShardTableWalk.h
@@ -37,6 +37,7 @@
 #include <bcos-task/Task.h>
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <variant>
 
@@ -89,9 +90,13 @@ inline const executor_v1::StateValue* asStateValue(RowValue const& value) noexce
 ///
 /// The byte count includes only rows that carry bytes; a sentinel contributes nothing, which is
 /// what makes `bytesScanned` "what was actually read" rather than "what was iterated over".
+/// @param fromRowKey taken BY VALUE: this is a coroutine, so a reference parameter would outlive
+///        nothing — every call site builds the key with metaRowKey(block), whose result is a
+///        temporary that dies at the end of the call expression, i.e. before the coroutine body
+///        first runs.
 template <SeekableStateStorage Storage, class Visitor>
 task::Task<std::size_t> walkShardTable(
-    Storage& backend, std::string_view table, std::string_view fromRowKey, Visitor&& visitor)
+    Storage& backend, std::string_view table, std::string fromRowKey, Visitor&& visitor)
 {
     std::size_t bytesScanned = 0;
     auto iterator = co_await storage2::range(

--- a/bcos-ledger/bcos-ledger/mpt/history/ShardTableWalk.h
+++ b/bcos-ledger/bcos-ledger/mpt/history/ShardTableWalk.h
@@ -1,0 +1,125 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ShardTableWalk.h
+ * @brief The ONE seek-walk over a reverse-history shard table (layout spec §1.2)
+ *
+ * Three components read the same rows in the same order: the whole-block read and the startup
+ * rebuild inside ReverseHistoryStore, and the offline B.10 audit. What they do with a row differs
+ * completely — one materializes a diff, one builds an index, one counts damage — but HOW the rows
+ * are reached does not: seek into the table, walk forward, stop when the table changes, and reduce
+ * each row to "these bytes" or "a deletion sentinel".
+ *
+ * It lives here, on its own, because the audit is the component that exists to detect layout damage
+ * and it must not read the layout through a second implementation of the walk. A copy that drifted
+ * — a different stop condition, a different reading of a sentinel — would make the audit agree with
+ * itself while disagreeing with the store it is auditing.
+ *
+ * Everything that CAN differ between callers is the visitor's: whether a sentinel is fatal or
+ * skipped, how rows are grouped into blocks, and where the walk stops early.
+ */
+#pragma once
+
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Task.h>
+#include <cstddef>
+#include <memory>
+#include <string_view>
+#include <variant>
+
+namespace bcos::ledger::mpt::history
+{
+
+/// A storage that can position an iterator at the first row at or after a key and walk forward.
+/// Every whole-block walk and the startup rebuild need it; a plain point-read storage serves
+/// neither.
+///
+/// Declared beside the walk rather than beside the store: it is the capability the walk requires,
+/// and the store's own `QueryableStateStorage` refines it.
+template <class Storage>
+concept SeekableStateStorage = requires(Storage& storage, executor_v1::StateKey key) {
+    { storage2::range(storage, storage2::RANGE_SEEK, key) } -> task::IsAwaitable;
+};
+
+namespace detail
+{
+/// Storage iterators hand back either a `StorageValueType<Value>` variant (MemoryStorage,
+/// RocksDBStorage2) or a bare value. Reduce both to "the entry, or nullptr when this row carries a
+/// deletion sentinel instead of bytes".
+template <class RowValue>
+inline const executor_v1::StateValue* asStateValue(RowValue const& value) noexcept
+{
+    if constexpr (requires { std::get_if<executor_v1::StateValue>(std::addressof(value)); })
+    {
+        return std::get_if<executor_v1::StateValue>(std::addressof(value));
+    }
+    else
+    {
+        return std::addressof(value);
+    }
+}
+}  // namespace detail
+
+/// Seek to (@p table, @p fromRowKey) and hand every row of @p table forward to @p visitor as
+/// (row key view, entry or nullptr), stopping at the end of the table or when the visitor returns
+/// false. Returns the payload bytes read.
+///
+/// @p fromRowKey is a RAW row key, not a block number, because the three callers start in two
+/// different places: a block walk seeks at that block's meta row key, while the audit sweeps the
+/// whole table from `""` — including rows an interrupted expiry left below the retention boundary,
+/// which are exactly what it has to see and the rebuild deliberately does not.
+///
+/// Seeking at a block's META row key positions before its shards, because an 8-byte key sorts
+/// before every 10-byte key sharing its first eight bytes — so one seek yields meta, shard 0,
+/// shard 1, ... and then the next block. The iterator runs on past the table, so the VISITOR, not
+/// the seek, defines where a walk ends.
+///
+/// The byte count includes only rows that carry bytes; a sentinel contributes nothing, which is
+/// what makes `bytesScanned` "what was actually read" rather than "what was iterated over".
+template <SeekableStateStorage Storage, class Visitor>
+task::Task<std::size_t> walkShardTable(
+    Storage& backend, std::string_view table, std::string_view fromRowKey, Visitor&& visitor)
+{
+    std::size_t bytesScanned = 0;
+    auto iterator = co_await storage2::range(
+        backend, storage2::RANGE_SEEK, executor_v1::StateKey{table, fromRowKey});
+    while (true)
+    {
+        auto row = co_await iterator.next();
+        if (!row)
+        {
+            break;
+        }
+        auto const& [rowKey, rowValue] = *row;
+        executor_v1::StateKeyView rowKeyView{rowKey};
+        if (rowKeyView.m_table != table)
+        {
+            break;
+        }
+        auto const* entry = detail::asStateValue(rowValue);
+        if (entry != nullptr)
+        {
+            bytesScanned += entry->get().size();
+        }
+        if (!visitor(rowKeyView, entry))
+        {
+            break;
+        }
+    }
+    co_return bytesScanned;
+}
+
+}  // namespace bcos::ledger::mpt::history

--- a/bcos-ledger/test/CMakeLists.txt
+++ b/bcos-ledger/test/CMakeLists.txt
@@ -29,7 +29,10 @@ target_include_directories(${TEST_BINARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/bcos-
 
 find_package(Boost REQUIRED unit_test_framework)
 
-target_link_libraries(${TEST_BINARY_NAME} PRIVATE ledger bcos-crypto protocol-tars Boost::unit_test_framework)
+# `storage` is a test-only link: HistoryRocksDBTest.cpp exercises the reverse-history layout
+# against RocksDBStorage2, the storage production seeks on. The `ledger` library itself still
+# avoids it (see bcos-ledger/CMakeLists.txt) so RocksDB stays out of the exported target.
+target_link_libraries(${TEST_BINARY_NAME} PRIVATE ledger storage bcos-crypto protocol-tars Boost::unit_test_framework)
 target_compile_definitions(${TEST_BINARY_NAME} PUBLIC _TESTS_)
 # ethereum/tests vectors (EthereumTrieVectorsTest.cpp), installed by the ethereum-tests
 # data port (ports-data/) under the tests manifest feature

--- a/bcos-ledger/test/unittests/mpt/history/HistoryExpiryTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryExpiryTest.cpp
@@ -14,20 +14,23 @@
  *  limitations under the License.
  *
  * @file HistoryExpiryTest.cpp
- * @brief Expiry: nothing left behind, replayable from either interruption point, idempotent, and
- *        confined to the block it was asked to drop (spec B.5, G4)
+ * @brief Expiry: shardCount + 1 deletes and not one per key, idempotent on the logical-deletion
+ *        layer, confined to the block it was asked to drop, and the retention boundary that moves
+ *        with it (spec B.5, §13, G4)
  */
 
 #include "HistoryTestHelpers.h"
 #include <bcos-framework/storage2/Storage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/history/HistoryErrors.h>
 #include <bcos-ledger/mpt/history/HistoryRowCodec.h>
 #include <bcos-ledger/mpt/history/HistoryTables.h>
 #include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
 #include <bcos-task/Wait.h>
 #include <boost/test/unit_test.hpp>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -42,39 +45,30 @@ BOOST_AUTO_TEST_SUITE(HistoryExpirySuite)
 
 namespace
 {
-constexpr int kSeededKeyCount = 7;
-/// A shard cap of 24 with 8-byte keys (record = 12 bytes) puts two keys per shard, so the
-/// seven-key block below spans four shards and the sweep really has to walk them.
-constexpr std::size_t kSmallShardCap = 24;
+constexpr int kExpirySeededKeys = 7;
+/// 8-byte keys with a 6-byte value make a 23-byte record, so a 50-byte cap puts two records per
+/// shard and the seven-key block below spans four shards — the walk really has to iterate.
+constexpr std::size_t kExpiryShardCap = 50;
 
-std::string seededKey(int index)
+std::string expirySeedKey(int index)
 {
     return "key-" + std::to_string(index) + "!!!";  // 8 bytes
 }
 
-/// Seed one block with kSeededKeyCount changes, sharded.
-void seedBlock(auto& storage, bcos::protocol::BlockNumber block)
+/// Seed one block with kExpirySeededKeys changes, sharded, and publish it.
+void seedExpiryBlock(auto& store, auto& storage, bcos::protocol::BlockNumber block)
 {
     Diff diff;
-    for (int index = 0; index < kSeededKeyCount; ++index)
+    for (int index = 0; index < kExpirySeededKeys; ++index)
     {
-        diff.change(seededKey(index), "old-at-" + std::to_string(block));
+        diff.change(expirySeedKey(index), "old-" + std::to_string(block));  // 6-byte values
     }
-    putBlock(storage, block, diff, kSmallShardCap);
-}
-
-/// Delete an index row behind the store's back, to stand in for a crash midway through an
-/// interrupted deferred expiry.
-void deleteIndexRow(auto& storage, bcos::protocol::BlockNumber block, std::string_view key)
-{
-    auto keyBytes = makeBytes(key);
-    bcos::task::syncWait(bcos::storage2::removeOne(
-        storage, bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(keyBytes, block)}));
+    putBlock(store, storage, block, diff, kExpiryShardCap);
 }
 }  // namespace
 
-// The replay and idempotence cases below run twice, once per deletion model, because the two
-// models are not interchangeable for this component and production uses the harder one.
+// The idempotence cases below run against both deletion models, because the two are not
+// interchangeable for this component and production uses the harder one.
 //
 //   HistoryMemStorage            ORDERED                      removeSome ERASES the row
 //   HistoryLogicalDeleteStorage  ORDERED|LOGICAL_DELETION      removeSome leaves a sentinel the
@@ -83,105 +77,90 @@ void deleteIndexRow(auto& storage, bcos::protocol::BlockNumber block, std::strin
 // G3 puts expiry on the block's mutable layer, and that layer is the second kind:
 // GlobalStateMutableStorage is MemoryStorage<StateKey, StateValue, ORDERED | LOGICAL_DELETION>
 // (libinitializer/GlobalStateStorageInitializer.h:15-19). So on the real thing an expired block's
-// own manifest shards come back on the next sweep, and "expire twice" only stays a no-op because
-// scanManifest is told to skip them.
+// own rows come back on the next walk, and "expire twice" only stays a no-op because the walk is
+// told to skip them.
 
-/// After expiry the block leaves nothing behind in either table (spec B.5).
-BOOST_AUTO_TEST_CASE(expireRemovesIndexAndManifest)
+/// The saving the layout was reshaped for: one delete per shard plus one for the meta row, and NOT
+/// one per key. The old layout issued keyCount + shardCount deletes for the same block, so this
+/// count IS the change — it is asserted on the storage's own call counter rather than inferred
+/// from the rows that disappeared.
+BOOST_AUTO_TEST_CASE(expireDeletesShardsAndMetaAndNothingPerKey)
+{
+    CountingStorage backend;
+    StateHistoryStore store;
+    seedExpiryBlock(store, backend, 10);
+    auto const before = rowsOfTable(backend.inner, kStateHistory.shard);
+    auto const shardCount = decodeMeta(before[0].second).shardCount;
+    BOOST_REQUIRE_EQUAL(shardCount, 4);
+    BOOST_REQUIRE_EQUAL(before.size(), shardCount + 1);
+
+    backend.removeCalls = 0;
+    backend.removedKeys = 0;
+    auto const report = bcos::task::syncWait(store.expire(backend, backend, 10));
+
+    BOOST_CHECK_EQUAL(report.keyCount, std::size_t{kExpirySeededKeys});
+    BOOST_CHECK_EQUAL(report.shardsDeleted, std::size_t{4});
+    // One removeSome, carrying exactly shardCount + 1 row keys.
+    BOOST_CHECK_EQUAL(backend.removeCalls, std::size_t{1});
+    BOOST_CHECK_EQUAL(backend.removedKeys, std::size_t{shardCount + 1});
+    BOOST_CHECK(rowsOfTable(backend.inner, kStateHistory.shard).empty());
+
+    // The report carries what the in-memory index must now forget.
+    BOOST_REQUIRE(report.retired.has_value());
+    BOOST_CHECK_EQUAL(report.retired->block, 10);
+    BOOST_CHECK_EQUAL(report.retired->keys.size(), std::size_t{kExpirySeededKeys});
+    BOOST_CHECK_EQUAL(report.retired->shardsDeleted, std::size_t{4});
+}
+
+/// Publishing the retirement is what takes the block out of RAM, and it rides the next block's
+/// publish because that is the only shape the commit path has. After it, the store neither
+/// remembers the block nor answers the heights it used to answer.
+BOOST_AUTO_TEST_CASE(publishingTheRetirementDropsTheBlockFromTheIndex)
 {
     HistoryMemStorage storage;
-    seedBlock(storage, 10);
-    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.index).size(), kSeededKeyCount);
-    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.manifest).size(), 4);
+    StateHistoryStore store;
+    seedExpiryBlock(store, storage, 10);
+    seedExpiryBlock(store, storage, 11);
+    BOOST_REQUIRE_EQUAL(store.index().versionCount(), std::size_t{2 * kExpirySeededKeys});
+    BOOST_REQUIRE(store.recordedBlock(10));
 
-    auto report = expireBlock(storage, 10);
-    BOOST_CHECK_EQUAL(report.keyCount, kSeededKeyCount);
-    BOOST_CHECK_EQUAL(report.indexDeletesIssued, kSeededKeyCount);
-    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 4);
+    auto const report = expireBlockAdvancing(store, storage, 10);
+    Diff at12;
+    at12.change("unrelated"sv, "v"sv);
+    store.publish(stageBlock(store, storage, 12, at12), report.retired,
+        std::optional<bcos::protocol::BlockNumber>{10});
 
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
-    BOOST_CHECK(keysOfBlock(storage, 10).empty());
+    BOOST_CHECK(!store.recordedBlock(10));
+    BOOST_CHECK(store.recordedBlock(11));
+    // Block 10's versions are gone; block 11's and block 12's remain.
+    BOOST_CHECK_EQUAL(store.index().versionCount(), std::size_t{kExpirySeededKeys + 1});
+    BOOST_REQUIRE(store.index().boundary().has_value());
+    BOOST_CHECK_EQUAL(*store.index().boundary(), 10);
+    BOOST_CHECK_THROW(readAt(store, storage, expirySeedKey(0), 9, 100, 100), HistoryPruned);
+    // Block 10 is still answerable, from block 11's surviving records.
+    auto const at10 = readAt(store, storage, expirySeedKey(0), 10, 100, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at10));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at10)), "old-11");
 }
 
-/// Interruption point one: some index rows are already gone, the manifest is still there. The
-/// manifest is what makes this recoverable — it still lists every key, so the replay re-issues
-/// the whole set and the already-deleted ones are no-ops.
-template <class Storage>
-void checkReplayAfterPartialIndexDeletion()
-{
-    Storage storage;
-    seedBlock(storage, 10);
-    for (int index = 0; index < kSeededKeyCount / 2; ++index)
-    {
-        deleteIndexRow(storage, 10, seededKey(index));
-    }
-    BOOST_REQUIRE_EQUAL(
-        rowsOfTable(storage, kStateHistory.index).size(), kSeededKeyCount - kSeededKeyCount / 2);
-
-    auto report = expireBlock(storage, 10);
-    // The manifest is intact, so the replay still sees every key.
-    BOOST_CHECK_EQUAL(report.keyCount, kSeededKeyCount);
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
-}
-BOOST_AUTO_TEST_CASE(replayAfterPartialIndexDeletion)
-{
-    checkReplayAfterPartialIndexDeletion<HistoryMemStorage>();
-    checkReplayAfterPartialIndexDeletion<HistoryLogicalDeleteStorage>();
-}
-
-/// Interruption point two: every index row is gone but the manifest survives — the state a crash
-/// leaves when expiry is deferred and the manifest is deleted last. The replay finishes the job.
-template <class Storage>
-void checkReplayAfterIndexDeletedButManifestKept()
-{
-    Storage storage;
-    seedBlock(storage, 10);
-    for (int index = 0; index < kSeededKeyCount; ++index)
-    {
-        deleteIndexRow(storage, 10, seededKey(index));
-    }
-    BOOST_REQUIRE(rowsOfTable(storage, kStateHistory.index).empty());
-    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.manifest).size(), 4);
-
-    auto report = expireBlock(storage, 10);
-    BOOST_CHECK_EQUAL(report.keyCount, kSeededKeyCount);
-    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 4);
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
-}
-BOOST_AUTO_TEST_CASE(replayAfterIndexDeletedButManifestKept)
-{
-    checkReplayAfterIndexDeletedButManifestKept<HistoryMemStorage>();
-    checkReplayAfterIndexDeletedButManifestKept<HistoryLogicalDeleteStorage>();
-}
-
-/// Whichever point it resumes from, expiry converges on the same final state, and running it
-/// again on an already-expired block does nothing at all.
+/// Running expiry again converges rather than erroring, on both deletion models. On the mutable
+/// layer the block's own rows come back as sentinels, and skipping them is what makes the replay a
+/// no-op: there is nothing left to clean up behind a row that is already deleted.
 template <class Storage>
 void checkExpireIsIdempotent()
 {
-    Storage clean;
-    seedBlock(clean, 10);
-    expireBlock(clean, 10);
+    Storage storage;
+    StateHistoryStore store;
+    seedExpiryBlock(store, storage, 10);
+    auto const first = bcos::task::syncWait(store.expire(storage, storage, 10));
+    BOOST_CHECK_EQUAL(first.keyCount, std::size_t{kExpirySeededKeys});
+    BOOST_CHECK(first.retired.has_value());
 
-    Storage interrupted;
-    seedBlock(interrupted, 10);
-    deleteIndexRow(interrupted, 10, seededKey(0));
-    deleteIndexRow(interrupted, 10, seededKey(3));
-    expireBlock(interrupted, 10);
-
-    BOOST_CHECK(
-        rowsOfTable(clean, kStateHistory.index) == rowsOfTable(interrupted, kStateHistory.index));
-    BOOST_CHECK(rowsOfTable(clean, kStateHistory.manifest) ==
-                rowsOfTable(interrupted, kStateHistory.manifest));
-
-    auto second = expireBlock(clean, 10);
-    BOOST_CHECK_EQUAL(second.keyCount, 0);
-    BOOST_CHECK_EQUAL(second.indexDeletesIssued, 0);
-    BOOST_CHECK_EQUAL(second.manifestShardsDeleted, 0);
-    BOOST_CHECK(rowsOfTable(clean, kStateHistory.index).empty());
-    BOOST_CHECK(rowsOfTable(clean, kStateHistory.manifest).empty());
+    auto const second = bcos::task::syncWait(store.expire(storage, storage, 10));
+    BOOST_CHECK_EQUAL(second.keyCount, std::size_t{0});
+    BOOST_CHECK_EQUAL(second.shardsDeleted, std::size_t{0});
+    BOOST_CHECK(!second.retired.has_value());
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.shard).empty());
 }
 BOOST_AUTO_TEST_CASE(expireIsIdempotent)
 {
@@ -189,72 +168,96 @@ BOOST_AUTO_TEST_CASE(expireIsIdempotent)
     checkExpireIsIdempotent<HistoryLogicalDeleteStorage>();
 }
 
-/// On the mutable layer an expired shard is still a row, carrying a deletion sentinel. expire()
-/// reads that as "already done" and skips it; keysOfBlock() reads the same row as "part of this
-/// block's key list is unreadable" and throws, because rollback and the B.10 audits cannot use a
-/// short list. The two readings are the point of the DeletedShardPolicy parameter, so both are
-/// pinned here — the sentinel is what production leaves behind, not a contrived state.
-BOOST_AUTO_TEST_CASE(expiredShardIsSkippedByExpireAndRejectedByKeysOfBlock)
+/// The two readings of the same sentinel row. expire() treats it as "already done" and skips it;
+/// readBlock() treats it as "part of this block's diff is unreadable" and throws, because rollback
+/// and the B.10 audits cannot use a short list. That is the whole reason the policy is a parameter
+/// — and the sentinel is what production leaves behind, not a contrived state.
+BOOST_AUTO_TEST_CASE(expiredRowIsSkippedByExpireAndRejectedByReadBlock)
 {
     HistoryLogicalDeleteStorage storage;
-    seedBlock(storage, 10);
-    expireBlock(storage, 10);
+    StateHistoryStore store;
+    seedExpiryBlock(store, storage, 10);
+    seedExpiryBlock(store, storage, 11);
+    bcos::task::syncWait(store.expire(storage, storage, 10));
 
-    // The shard rows are still present as sentinels; nothing live is left.
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
-
-    auto second = expireBlock(storage, 10);
-    BOOST_CHECK_EQUAL(second.keyCount, 0);
-    BOOST_CHECK_EQUAL(second.manifestShardsDeleted, 0);
-
-    BOOST_CHECK_THROW(keysOfBlock(storage, 10), MPTInvariantViolation);
-
-    // A block that was never written has no shard rows at all, so keysOfBlock is empty rather
-    // than throwing — the throw is about an unreadable shard, not about a missing block.
-    BOOST_CHECK(keysOfBlock(storage, 11).empty());
+    BOOST_CHECK_THROW(readBlock(store, storage, 10), MPTInvariantViolation);
+    // A block that was never written has no rows at all, so readBlock complains about the MISSING
+    // meta row instead — a different failure with a different cause.
+    BOOST_CHECK_THROW(readBlock(store, storage, 99), MPTInvariantViolation);
+    // The untouched neighbour still reads back whole.
+    BOOST_CHECK_EQUAL(readBlock(store, storage, 11).records.size(), std::size_t{kExpirySeededKeys});
 }
 
-/// G4, the asymmetry that matters: leaving a row behind is a wasted byte, deleting one row too
-/// many silently destroys a neighbouring block's history. Blocks 10 and 11 change the same keys,
-/// and expiring 10 must leave every one of block 11's rows — and its answers — untouched.
+/// readBlock verifies what the meta row promised. A shard that vanished, or a count that was
+/// tampered with, would otherwise hand rollback a short diff and it would reverse-apply the wrong
+/// state — so each mismatch is its own refusal.
+BOOST_AUTO_TEST_CASE(readBlockRejectsCountsThatDisagreeWithTheMetaRow)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    seedExpiryBlock(store, storage, 10);
+    BOOST_REQUIRE_EQUAL(
+        readBlock(store, storage, 10).records.size(), std::size_t{kExpirySeededKeys});
+    BOOST_CHECK_EQUAL(readBlock(store, storage, 10).meta.blockHash, blockHashOf(10));
+
+    // One shard gone: the walk reads three where the meta row declares four.
+    deleteRow(storage, kStateHistory.shard, shardRowKey(10, 3));
+    BOOST_CHECK_THROW(readBlock(store, storage, 10), MPTInvariantViolation);
+
+    // The meta row itself gone: nothing declares what to expect.
+    HistoryMemStorage noMeta;
+    StateHistoryStore noMetaStore;
+    seedExpiryBlock(noMetaStore, noMeta, 10);
+    deleteRow(noMeta, kStateHistory.shard, metaRowKey(10));
+    BOOST_CHECK_THROW(readBlock(noMetaStore, noMeta, 10), MPTInvariantViolation);
+
+    // A record count that lies, with every shard still present.
+    HistoryMemStorage tampered;
+    StateHistoryStore tamperedStore;
+    seedExpiryBlock(tamperedStore, tampered, 10);
+    overwriteRow(tampered, kStateHistory.shard, metaRowKey(10),
+        metaRowValue(4, kExpirySeededKeys + 1, blockHashOf(10)));
+    BOOST_CHECK_THROW(readBlock(tamperedStore, tampered, 10), MPTInvariantViolation);
+}
+
+/// G4, the asymmetry that matters: leaving a row behind is a wasted byte, deleting one row too many
+/// silently destroys a neighbouring block's history. Blocks 10, 11 and 12 change the same keys, and
+/// expiring 11 must leave every one of the others' rows — and their answers — untouched.
 BOOST_AUTO_TEST_CASE(expireTouchesOnlyTheRequestedBlock)
 {
     HistoryMemStorage storage;
-    seedBlock(storage, 10);
-    seedBlock(storage, 11);
-    seedBlock(storage, 12);
+    StateHistoryStore store;
+    seedExpiryBlock(store, storage, 10);
+    seedExpiryBlock(store, storage, 11);
+    seedExpiryBlock(store, storage, 12);
 
-    auto before = readAt(storage, seededKey(0), 10, 100, 100);
+    auto const before = readAt(store, storage, expirySeedKey(0), 10, 100, 100);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(before));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(before)), "old-at-11");
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(before)), "old-11");
 
-    expireBlock(storage, 11);
+    expireBlock(store, storage, 11);
 
-    // Blocks 10 and 12 keep every row.
-    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.index).size(), 2 * kSeededKeyCount);
-    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.manifest).size(), 8);
-    BOOST_CHECK_EQUAL(keysOfBlock(storage, 10).size(), kSeededKeyCount);
-    BOOST_CHECK_EQUAL(keysOfBlock(storage, 12).size(), kSeededKeyCount);
-    BOOST_CHECK(keysOfBlock(storage, 11).empty());
-
-    // And block 12's rows still answer queries — the deletion did not walk past its block.
-    auto after = readAt(storage, seededKey(0), 11, 100, 100);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(after));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(after)), "old-at-12");
+    // Ten rows per block survive for the other two: 4 shards + 1 meta, twice.
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.shard).size(), std::size_t{10});
+    BOOST_CHECK_EQUAL(readBlock(store, storage, 10).records.size(), std::size_t{kExpirySeededKeys});
+    BOOST_CHECK_EQUAL(readBlock(store, storage, 12).records.size(), std::size_t{kExpirySeededKeys});
 }
 
-/// Expiring a block that was never written is a no-op, not an error: the sweep finds no manifest
-/// and issues no deletes.
+/// Expiring a block that was never written is a no-op, not an error: the walk finds nothing, issues
+/// no deletes and reports nothing retired.
 BOOST_AUTO_TEST_CASE(expireUnknownBlockDoesNothing)
 {
-    HistoryMemStorage storage;
-    seedBlock(storage, 10);
+    CountingStorage backend;
+    StateHistoryStore store;
+    seedExpiryBlock(store, backend, 10);
+    backend.removeCalls = 0;
 
-    auto report = expireBlock(storage, 9);
-    BOOST_CHECK_EQUAL(report.keyCount, 0);
-    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 0);
-    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.index).size(), kSeededKeyCount);
+    auto const report = bcos::task::syncWait(store.expire(backend, backend, 9));
+    BOOST_CHECK_EQUAL(report.keyCount, std::size_t{0});
+    BOOST_CHECK_EQUAL(report.shardsDeleted, std::size_t{0});
+    BOOST_CHECK(!report.retired.has_value());
+    BOOST_CHECK_EQUAL(backend.removeCalls, std::size_t{0});
+    BOOST_CHECK_EQUAL(rowsOfTable(backend.inner, kStateHistory.shard).size(), std::size_t{5});
 }
 
 /// The two instantiations expire independently: dropping state history must not touch the trie
@@ -262,17 +265,101 @@ BOOST_AUTO_TEST_CASE(expireUnknownBlockDoesNothing)
 BOOST_AUTO_TEST_CASE(expiringStateHistoryLeavesTrieHistoryAlone)
 {
     HistoryMemStorage storage;
+    StateHistoryStore stateStore;
+    TrieHistoryStore trieStore;
     Diff diff;
     diff.change("shared"sv, "old"sv);
-    bcos::task::syncWait(StateHistoryStore::put(storage, 10, diff.entries(), kWideShardCap));
-    bcos::task::syncWait(TrieHistoryStore::put(storage, 10, diff.entries(), kWideShardCap));
+    putBlock(stateStore, storage, 10, diff);
+    putBlock(trieStore, storage, 10, diff);
 
-    bcos::task::syncWait(StateHistoryStore::expire(storage, storage, 10));
+    bcos::task::syncWait(stateStore.expire(storage, storage, 10));
 
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
-    BOOST_CHECK_EQUAL(rowsOfTable(storage, kTrieHistory.index).size(), 1);
-    BOOST_CHECK_EQUAL(rowsOfTable(storage, kTrieHistory.manifest).size(), 1);
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.shard).empty());
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kTrieHistory.shard).size(), std::size_t{2});
+    BOOST_CHECK(!boundaryOnDisk(trieStore, storage).has_value());
+}
+
+/// The boundary policy, all three readings on the same input. "Discard block E's history" has two
+/// callers moving in opposite directions along the chain, and only one of them changes which block
+/// is the OLDEST answerable — so the policy is an argument, not a rule baked into expire, and its
+/// default is the conservative one. Advance takes a MAX, because the block an expiry names is not
+/// monotonic across callers.
+BOOST_AUTO_TEST_CASE(expireBoundaryPolicyKeepsOrAdvancesByMaximum)
+{
+    {
+        HistoryMemStorage storage;
+        StateHistoryStore store;
+        seedExpiryBlock(store, storage, 10);
+        seedExpiryBlock(store, storage, 11);
+        // Absent before, and Keep must leave it absent — not "advance from nothing to E".
+        BOOST_REQUIRE(!boundaryOnDisk(store, storage).has_value());
+        expireBlock(store, storage, 11);  // default policy
+        BOOST_CHECK(!boundaryOnDisk(store, storage).has_value());
+        // The deletes still happened: Keep is about the metadata, not about the walk.
+        BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.shard).size(), std::size_t{5});
+    }
+    {
+        HistoryMemStorage storage;
+        StateHistoryStore store;
+        seedExpiryBlock(store, storage, 10);
+        // Present before, and Keep must not move it either.
+        bcos::task::syncWait(StateHistoryStore::writeRetentionBoundary(storage, 9));
+        expireBlock(store, storage, 10);
+        BOOST_CHECK_EQUAL(*boundaryOnDisk(store, storage), 9);
+    }
+    {
+        HistoryMemStorage storage;
+        StateHistoryStore store;
+        seedExpiryBlock(store, storage, 10);
+        seedExpiryBlock(store, storage, 11);
+        seedExpiryBlock(store, storage, 12);
+        bcos::task::syncWait(StateHistoryStore::writeRetentionBoundary(storage, 11));
+
+        // A LOWER block, with Advance: the max keeps 11. An operator raising the retention depth
+        // makes N - H jump backwards, and assigning here would claim block 10 is intact when its
+        // records were already deleted.
+        expireBlockAdvancing(store, storage, 5);
+        BOOST_CHECK_EQUAL(*boundaryOnDisk(store, storage), 11);
+        // The same block: still 11, not a rewrite that could drift.
+        expireBlockAdvancing(store, storage, 11);
+        BOOST_CHECK_EQUAL(*boundaryOnDisk(store, storage), 11);
+        // A higher block does move it — the max is a floor, not a freeze.
+        expireBlockAdvancing(store, storage, 12);
+        BOOST_CHECK_EQUAL(*boundaryOnDisk(store, storage), 12);
+    }
+}
+
+/// The shape an operational rollback walks (PR-D's HistoryRollback): descend from the tip,
+/// reverse-apply block N by reading each key at N-1, then discard N's record — and keep going
+/// downwards. Every step reads BELOW the block it just discarded, so advancing the boundary to the
+/// discarded block would refuse the walk's own next read. The default policy is what makes this
+/// terminate rather than throw HistoryPruned on step two.
+BOOST_AUTO_TEST_CASE(rollbackShapeDiscardsFromTheTopWithoutRefusingItself)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    seedExpiryBlock(store, storage, 10);
+    seedExpiryBlock(store, storage, 11);
+    seedExpiryBlock(store, storage, 12);
+    // The commit path's seed: history starts at block 10, so block 9 is the oldest answerable.
+    bcos::task::syncWait(StateHistoryStore::writeRetentionBoundary(storage, 9));
+
+    constexpr bcos::protocol::BlockNumber kTip = 12;
+    constexpr bcos::protocol::BlockNumber kDepth = 100;
+    for (bcos::protocol::BlockNumber block = kTip; block >= 10; --block)
+    {
+        // Reverse-apply: what the key held at block - 1, from block's own recorded pre-image.
+        auto const before = readAt(store, storage, expirySeedKey(0), block - 1, kTip, kDepth);
+        BOOST_REQUIRE_MESSAGE(std::holds_alternative<bcos::bytes>(before),
+            "block " << block - 1 << " must answer from block " << block << "'s pre-image");
+        BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(before)), "old-" + std::to_string(block));
+        // ...then discard the block just applied. Keep, because this is the NEWEST record going.
+        expireBlock(store, storage, block);
+    }
+
+    // The boundary never moved, so the walk was never refused by its own progress.
+    BOOST_CHECK_EQUAL(*boundaryOnDisk(store, storage), 9);
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.shard).empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/history/HistoryExpiryTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryExpiryTest.cpp
@@ -21,6 +21,7 @@
 #include "HistoryTestHelpers.h"
 #include <bcos-framework/storage2/Storage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Errors.h>
 #include <bcos-ledger/mpt/history/HistoryRowCodec.h>
 #include <bcos-ledger/mpt/history/HistoryTables.h>
 #include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
@@ -52,7 +53,7 @@ std::string seededKey(int index)
 }
 
 /// Seed one block with kSeededKeyCount changes, sharded.
-void seedBlock(HistoryMemStorage& storage, bcos::protocol::BlockNumber block)
+void seedBlock(auto& storage, bcos::protocol::BlockNumber block)
 {
     Diff diff;
     for (int index = 0; index < kSeededKeyCount; ++index)
@@ -64,14 +65,26 @@ void seedBlock(HistoryMemStorage& storage, bcos::protocol::BlockNumber block)
 
 /// Delete an index row behind the store's back, to stand in for a crash midway through an
 /// interrupted deferred expiry.
-void deleteIndexRow(
-    HistoryMemStorage& storage, bcos::protocol::BlockNumber block, std::string_view key)
+void deleteIndexRow(auto& storage, bcos::protocol::BlockNumber block, std::string_view key)
 {
     auto keyBytes = makeBytes(key);
     bcos::task::syncWait(bcos::storage2::removeOne(
         storage, bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(keyBytes, block)}));
 }
 }  // namespace
+
+// The replay and idempotence cases below run twice, once per deletion model, because the two
+// models are not interchangeable for this component and production uses the harder one.
+//
+//   HistoryMemStorage            ORDERED                      removeSome ERASES the row
+//   HistoryLogicalDeleteStorage  ORDERED|LOGICAL_DELETION      removeSome leaves a sentinel the
+//                                                              iterator still yields
+//
+// G3 puts expiry on the block's mutable layer, and that layer is the second kind:
+// GlobalStateMutableStorage is MemoryStorage<StateKey, StateValue, ORDERED | LOGICAL_DELETION>
+// (libinitializer/GlobalStateStorageInitializer.h:15-19). So on the real thing an expired block's
+// own manifest shards come back on the next sweep, and "expire twice" only stays a no-op because
+// scanManifest is told to skip them.
 
 /// After expiry the block leaves nothing behind in either table (spec B.5).
 BOOST_AUTO_TEST_CASE(expireRemovesIndexAndManifest)
@@ -94,9 +107,10 @@ BOOST_AUTO_TEST_CASE(expireRemovesIndexAndManifest)
 /// Interruption point one: some index rows are already gone, the manifest is still there. The
 /// manifest is what makes this recoverable — it still lists every key, so the replay re-issues
 /// the whole set and the already-deleted ones are no-ops.
-BOOST_AUTO_TEST_CASE(replayAfterPartialIndexDeletion)
+template <class Storage>
+void checkReplayAfterPartialIndexDeletion()
 {
-    HistoryMemStorage storage;
+    Storage storage;
     seedBlock(storage, 10);
     for (int index = 0; index < kSeededKeyCount / 2; ++index)
     {
@@ -111,12 +125,18 @@ BOOST_AUTO_TEST_CASE(replayAfterPartialIndexDeletion)
     BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
     BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
 }
+BOOST_AUTO_TEST_CASE(replayAfterPartialIndexDeletion)
+{
+    checkReplayAfterPartialIndexDeletion<HistoryMemStorage>();
+    checkReplayAfterPartialIndexDeletion<HistoryLogicalDeleteStorage>();
+}
 
 /// Interruption point two: every index row is gone but the manifest survives — the state a crash
 /// leaves when expiry is deferred and the manifest is deleted last. The replay finishes the job.
-BOOST_AUTO_TEST_CASE(replayAfterIndexDeletedButManifestKept)
+template <class Storage>
+void checkReplayAfterIndexDeletedButManifestKept()
 {
-    HistoryMemStorage storage;
+    Storage storage;
     seedBlock(storage, 10);
     for (int index = 0; index < kSeededKeyCount; ++index)
     {
@@ -130,16 +150,22 @@ BOOST_AUTO_TEST_CASE(replayAfterIndexDeletedButManifestKept)
     BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 4);
     BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
 }
+BOOST_AUTO_TEST_CASE(replayAfterIndexDeletedButManifestKept)
+{
+    checkReplayAfterIndexDeletedButManifestKept<HistoryMemStorage>();
+    checkReplayAfterIndexDeletedButManifestKept<HistoryLogicalDeleteStorage>();
+}
 
 /// Whichever point it resumes from, expiry converges on the same final state, and running it
 /// again on an already-expired block does nothing at all.
-BOOST_AUTO_TEST_CASE(expireIsIdempotent)
+template <class Storage>
+void checkExpireIsIdempotent()
 {
-    HistoryMemStorage clean;
+    Storage clean;
     seedBlock(clean, 10);
     expireBlock(clean, 10);
 
-    HistoryMemStorage interrupted;
+    Storage interrupted;
     seedBlock(interrupted, 10);
     deleteIndexRow(interrupted, 10, seededKey(0));
     deleteIndexRow(interrupted, 10, seededKey(3));
@@ -156,6 +182,37 @@ BOOST_AUTO_TEST_CASE(expireIsIdempotent)
     BOOST_CHECK_EQUAL(second.manifestShardsDeleted, 0);
     BOOST_CHECK(rowsOfTable(clean, kStateHistory.index).empty());
     BOOST_CHECK(rowsOfTable(clean, kStateHistory.manifest).empty());
+}
+BOOST_AUTO_TEST_CASE(expireIsIdempotent)
+{
+    checkExpireIsIdempotent<HistoryMemStorage>();
+    checkExpireIsIdempotent<HistoryLogicalDeleteStorage>();
+}
+
+/// On the mutable layer an expired shard is still a row, carrying a deletion sentinel. expire()
+/// reads that as "already done" and skips it; keysOfBlock() reads the same row as "part of this
+/// block's key list is unreadable" and throws, because rollback and the B.10 audits cannot use a
+/// short list. The two readings are the point of the DeletedShardPolicy parameter, so both are
+/// pinned here — the sentinel is what production leaves behind, not a contrived state.
+BOOST_AUTO_TEST_CASE(expiredShardIsSkippedByExpireAndRejectedByKeysOfBlock)
+{
+    HistoryLogicalDeleteStorage storage;
+    seedBlock(storage, 10);
+    expireBlock(storage, 10);
+
+    // The shard rows are still present as sentinels; nothing live is left.
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
+
+    auto second = expireBlock(storage, 10);
+    BOOST_CHECK_EQUAL(second.keyCount, 0);
+    BOOST_CHECK_EQUAL(second.manifestShardsDeleted, 0);
+
+    BOOST_CHECK_THROW(keysOfBlock(storage, 10), MPTInvariantViolation);
+
+    // A block that was never written has no shard rows at all, so keysOfBlock is empty rather
+    // than throwing — the throw is about an unreadable shard, not about a missing block.
+    BOOST_CHECK(keysOfBlock(storage, 11).empty());
 }
 
 /// G4, the asymmetry that matters: leaving a row behind is a wasted byte, deleting one row too

--- a/bcos-ledger/test/unittests/mpt/history/HistoryExpiryTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryExpiryTest.cpp
@@ -1,0 +1,223 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryExpiryTest.cpp
+ * @brief Expiry: nothing left behind, replayable from either interruption point, idempotent, and
+ *        confined to the block it was asked to drop (spec B.5, G4)
+ */
+
+#include "HistoryTestHelpers.h"
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
+#include <bcos-ledger/mpt/history/HistoryTables.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace std::string_view_literals;
+
+namespace bcos::ledger::mpt::history::test
+{
+
+BOOST_AUTO_TEST_SUITE(HistoryExpirySuite)
+
+namespace
+{
+constexpr int kSeededKeyCount = 7;
+/// A shard cap of 24 with 8-byte keys (record = 12 bytes) puts two keys per shard, so the
+/// seven-key block below spans four shards and the sweep really has to walk them.
+constexpr std::size_t kSmallShardCap = 24;
+
+std::string seededKey(int index)
+{
+    return "key-" + std::to_string(index) + "!!!";  // 8 bytes
+}
+
+/// Seed one block with kSeededKeyCount changes, sharded.
+void seedBlock(HistoryMemStorage& storage, bcos::protocol::BlockNumber block)
+{
+    Diff diff;
+    for (int index = 0; index < kSeededKeyCount; ++index)
+    {
+        diff.change(seededKey(index), "old-at-" + std::to_string(block));
+    }
+    putBlock(storage, block, diff, kSmallShardCap);
+}
+
+/// Delete an index row behind the store's back, to stand in for a crash midway through an
+/// interrupted deferred expiry.
+void deleteIndexRow(
+    HistoryMemStorage& storage, bcos::protocol::BlockNumber block, std::string_view key)
+{
+    auto keyBytes = makeBytes(key);
+    bcos::task::syncWait(bcos::storage2::removeOne(
+        storage, bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(keyBytes, block)}));
+}
+}  // namespace
+
+/// After expiry the block leaves nothing behind in either table (spec B.5).
+BOOST_AUTO_TEST_CASE(expireRemovesIndexAndManifest)
+{
+    HistoryMemStorage storage;
+    seedBlock(storage, 10);
+    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.index).size(), kSeededKeyCount);
+    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.manifest).size(), 4);
+
+    auto report = expireBlock(storage, 10);
+    BOOST_CHECK_EQUAL(report.keyCount, kSeededKeyCount);
+    BOOST_CHECK_EQUAL(report.indexDeletesIssued, kSeededKeyCount);
+    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 4);
+
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
+    BOOST_CHECK(keysOfBlock(storage, 10).empty());
+}
+
+/// Interruption point one: some index rows are already gone, the manifest is still there. The
+/// manifest is what makes this recoverable — it still lists every key, so the replay re-issues
+/// the whole set and the already-deleted ones are no-ops.
+BOOST_AUTO_TEST_CASE(replayAfterPartialIndexDeletion)
+{
+    HistoryMemStorage storage;
+    seedBlock(storage, 10);
+    for (int index = 0; index < kSeededKeyCount / 2; ++index)
+    {
+        deleteIndexRow(storage, 10, seededKey(index));
+    }
+    BOOST_REQUIRE_EQUAL(
+        rowsOfTable(storage, kStateHistory.index).size(), kSeededKeyCount - kSeededKeyCount / 2);
+
+    auto report = expireBlock(storage, 10);
+    // The manifest is intact, so the replay still sees every key.
+    BOOST_CHECK_EQUAL(report.keyCount, kSeededKeyCount);
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
+}
+
+/// Interruption point two: every index row is gone but the manifest survives — the state a crash
+/// leaves when expiry is deferred and the manifest is deleted last. The replay finishes the job.
+BOOST_AUTO_TEST_CASE(replayAfterIndexDeletedButManifestKept)
+{
+    HistoryMemStorage storage;
+    seedBlock(storage, 10);
+    for (int index = 0; index < kSeededKeyCount; ++index)
+    {
+        deleteIndexRow(storage, 10, seededKey(index));
+    }
+    BOOST_REQUIRE(rowsOfTable(storage, kStateHistory.index).empty());
+    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.manifest).size(), 4);
+
+    auto report = expireBlock(storage, 10);
+    BOOST_CHECK_EQUAL(report.keyCount, kSeededKeyCount);
+    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 4);
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
+}
+
+/// Whichever point it resumes from, expiry converges on the same final state, and running it
+/// again on an already-expired block does nothing at all.
+BOOST_AUTO_TEST_CASE(expireIsIdempotent)
+{
+    HistoryMemStorage clean;
+    seedBlock(clean, 10);
+    expireBlock(clean, 10);
+
+    HistoryMemStorage interrupted;
+    seedBlock(interrupted, 10);
+    deleteIndexRow(interrupted, 10, seededKey(0));
+    deleteIndexRow(interrupted, 10, seededKey(3));
+    expireBlock(interrupted, 10);
+
+    BOOST_CHECK(
+        rowsOfTable(clean, kStateHistory.index) == rowsOfTable(interrupted, kStateHistory.index));
+    BOOST_CHECK(rowsOfTable(clean, kStateHistory.manifest) ==
+                rowsOfTable(interrupted, kStateHistory.manifest));
+
+    auto second = expireBlock(clean, 10);
+    BOOST_CHECK_EQUAL(second.keyCount, 0);
+    BOOST_CHECK_EQUAL(second.indexDeletesIssued, 0);
+    BOOST_CHECK_EQUAL(second.manifestShardsDeleted, 0);
+    BOOST_CHECK(rowsOfTable(clean, kStateHistory.index).empty());
+    BOOST_CHECK(rowsOfTable(clean, kStateHistory.manifest).empty());
+}
+
+/// G4, the asymmetry that matters: leaving a row behind is a wasted byte, deleting one row too
+/// many silently destroys a neighbouring block's history. Blocks 10 and 11 change the same keys,
+/// and expiring 10 must leave every one of block 11's rows — and its answers — untouched.
+BOOST_AUTO_TEST_CASE(expireTouchesOnlyTheRequestedBlock)
+{
+    HistoryMemStorage storage;
+    seedBlock(storage, 10);
+    seedBlock(storage, 11);
+    seedBlock(storage, 12);
+
+    auto before = readAt(storage, seededKey(0), 10, 100, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(before));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(before)), "old-at-11");
+
+    expireBlock(storage, 11);
+
+    // Blocks 10 and 12 keep every row.
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.index).size(), 2 * kSeededKeyCount);
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.manifest).size(), 8);
+    BOOST_CHECK_EQUAL(keysOfBlock(storage, 10).size(), kSeededKeyCount);
+    BOOST_CHECK_EQUAL(keysOfBlock(storage, 12).size(), kSeededKeyCount);
+    BOOST_CHECK(keysOfBlock(storage, 11).empty());
+
+    // And block 12's rows still answer queries — the deletion did not walk past its block.
+    auto after = readAt(storage, seededKey(0), 11, 100, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(after));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(after)), "old-at-12");
+}
+
+/// Expiring a block that was never written is a no-op, not an error: the sweep finds no manifest
+/// and issues no deletes.
+BOOST_AUTO_TEST_CASE(expireUnknownBlockDoesNothing)
+{
+    HistoryMemStorage storage;
+    seedBlock(storage, 10);
+
+    auto report = expireBlock(storage, 9);
+    BOOST_CHECK_EQUAL(report.keyCount, 0);
+    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 0);
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.index).size(), kSeededKeyCount);
+}
+
+/// The two instantiations expire independently: dropping state history must not touch the trie
+/// history of the same block (spec B.8 — same mechanism, separate key spaces, separate depths).
+BOOST_AUTO_TEST_CASE(expiringStateHistoryLeavesTrieHistoryAlone)
+{
+    HistoryMemStorage storage;
+    Diff diff;
+    diff.change("shared"sv, "old"sv);
+    bcos::task::syncWait(StateHistoryStore::put(storage, 10, diff.entries(), kWideShardCap));
+    bcos::task::syncWait(TrieHistoryStore::put(storage, 10, diff.entries(), kWideShardCap));
+
+    bcos::task::syncWait(StateHistoryStore::expire(storage, storage, 10));
+
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.manifest).empty());
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kTrieHistory.index).size(), 1);
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kTrieHistory.manifest).size(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
@@ -262,6 +262,57 @@ BOOST_AUTO_TEST_CASE(publishingBlocksOutOfOrderIsRefused)
     BOOST_CHECK_EQUAL(lookup(fresh, "a"sv, 10)->offset, 200U);
 }
 
+/// The publish generation: the counter a reader uses to tell "the index is quiescent" from "a
+/// commit has already put its rows on disk and has not told me yet".
+///
+/// Everything about it is a parity claim, so the case is about parity: even at rest, odd while a
+/// window is open, and even again once the publish that closes the window has run. The value must
+/// also MOVE across a publish — a reader compares two samples across its own read of the current
+/// value, and a counter that only toggled parity without advancing would let an open-then-closed
+/// pair look like no publish at all.
+BOOST_AUTO_TEST_CASE(thePublishGenerationTracksTheWindow)
+{
+    HistoryIndex index;
+    BOOST_CHECK_EQUAL(index.generation() % 2, 0U);
+    auto const atRest = index.generation();
+
+    // Opening is idempotent: the commit path opens once per block, but a second open must not
+    // toggle the parity back to "quiescent" while the window is still held.
+    index.openPublishWindow();
+    BOOST_CHECK_EQUAL(index.generation() % 2, 1U);
+    auto const opened = index.generation();
+    index.openPublishWindow();
+    BOOST_CHECK_EQUAL(index.generation(), opened);
+    BOOST_CHECK_GT(opened, atRest);
+
+    // publish closes the window it finds open...
+    index.publish(stagedFor(10, {{"a"sv, 100}}), std::nullopt, std::nullopt);
+    BOOST_CHECK_EQUAL(index.generation() % 2, 0U);
+    auto const afterPublish = index.generation();
+    BOOST_CHECK_GT(afterPublish, opened);
+
+    // ...and closing is idempotent too, so the RAII guard's destructor after a successful publish
+    // does not open a phantom window by flipping the parity again.
+    index.closePublishWindow();
+    BOOST_CHECK_EQUAL(index.generation(), afterPublish);
+
+    // A publish with no window open still advances the counter, because a reader's two samples
+    // straddling it must differ.
+    index.publish(stagedFor(20, {{"a"sv, 200}}), std::nullopt, std::nullopt);
+    BOOST_CHECK_EQUAL(index.generation() % 2, 0U);
+    BOOST_CHECK_GT(index.generation(), afterPublish);
+
+    // A publish that THROWS must not leave the window open — the commit died, and a permanently
+    // open window would make every later "unchanged since B" query spin and then refuse forever
+    // rather than only until the node notices.
+    index.openPublishWindow();
+    BOOST_CHECK_EQUAL(index.generation() % 2, 1U);
+    BOOST_CHECK_THROW(index.publish(stagedFor(15, {{"a"sv, 150}}), std::nullopt, std::nullopt),
+        MPTInvariantViolation);
+    BOOST_CHECK(index.state() == IndexState::Unavailable);
+    BOOST_CHECK_EQUAL(index.generation() % 2, 0U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
@@ -14,22 +14,20 @@
  *  limitations under the License.
  *
  * @file HistoryIndexTest.cpp
- * @brief The row layout itself: big-endian block ordering, the length discriminator that lets
- *        the layout skip a length prefix, ABSENT round trip, manifest sharding, and the
- *        append-only write path (spec B.2, B.4)
+ * @brief The in-memory index on its own: append, retire, the upper_bound lookup, the hand-off from
+ *        a rebuild, and the state machine that decides whether it may answer at all
+ *        (layout spec §1.3, G10)
  */
 
 #include "HistoryTestHelpers.h"
 #include <bcos-ledger/mpt/Errors.h>
-#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
-#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
-#include <bcos-task/Wait.h>
+#include <bcos-ledger/mpt/history/HistoryErrors.h>
+#include <bcos-ledger/mpt/history/HistoryIndex.h>
 #include <boost/test/unit_test.hpp>
 #include <cstddef>
 #include <optional>
-#include <string>
 #include <string_view>
-#include <variant>
+#include <utility>
 #include <vector>
 
 using namespace std::string_view_literals;
@@ -39,232 +37,229 @@ namespace bcos::ledger::mpt::history::test
 
 BOOST_AUTO_TEST_SUITE(HistoryIndexSuite)
 
-/// spec B.2(b): the block field is 8 bytes big endian so that byte order equals numeric order.
-/// 255 -> 256 is the smallest carry that a little-endian field would invert (0xFF,0x00.. would
-/// sort above 0x00,0x01,0x00..), so it is the case that pins the encoding down.
-BOOST_AUTO_TEST_CASE(bigEndianBlockNumbersDoNotInvertAt255)
+namespace
 {
-    auto key = makeBytes("balance"sv);
-    auto row255 = indexRowKey(key, 255);
-    auto row256 = indexRowKey(key, 256);
-
-    BOOST_REQUIRE_EQUAL(row255.size(), key.size() + 8);
-    BOOST_REQUIRE_EQUAL(row256.size(), key.size() + 8);
-    BOOST_CHECK_EQUAL(
-        row255.substr(key.size()), std::string("\x00\x00\x00\x00\x00\x00\x00\xff", 8));
-    BOOST_CHECK_EQUAL(
-        row256.substr(key.size()), std::string("\x00\x00\x00\x00\x00\x00\x01\x00", 8));
-    BOOST_CHECK(row255 < row256);
-
-    // And the ordering is the one the seek actually rides on: with a change at both 255 and 256,
-    // a query at 254 must land on the 255 row, not the 256 one.
-    HistoryMemStorage storage;
-    Diff at255;
-    at255.change("balance"sv, "at-254"sv);
-    Diff at256;
-    at256.change("balance"sv, "at-255"sv);
-    putBlock(storage, 255, at255);
-    putBlock(storage, 256, at256);
-
-    auto result = readAt(storage, "balance"sv, 254, 300, 300);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(result));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(result)), "at-254");
-}
-
-/// spec B.2(c): a row belongs to key k only if it starts with k AND is exactly eight bytes
-/// longer. Without the length clause, a query for "abc" whose own next change lies before the
-/// queried block walks straight onto "abcde"'s row and answers with another key's value.
-BOOST_AUTO_TEST_CASE(lengthDiscriminatorSeparatesPrefixKeys)
+/// One block's worth of index update, without going anywhere near a storage: the index does not
+/// know what a row is, so its tests should not build any.
+StagedBlock stagedFor(bcos::protocol::BlockNumber block,
+    std::vector<std::pair<std::string_view, uint32_t>> const& keysAtOffsets)
 {
-    HistoryMemStorage storage;
-    // "abc" last changed at block 2, i.e. before the query point; "abcde" changed at block 10.
-    Diff shortKey;
-    shortKey.change("abc"sv, "abc-at-1"sv);
-    Diff longerKey;
-    longerKey.change("abcde"sv, "abcde-at-9"sv);
-    putBlock(storage, 2, shortKey);
-    putBlock(storage, 10, longerKey);
-
-    // The seek for "abc" at block 5 starts at "abc" + BE64(6). "abc" + BE64(2) sorts before it,
-    // so the first row the iterator yields is "abcde" + BE64(10) — a prefix match, and the wrong
-    // answer. The length check rejects it and the caller falls back to the current value.
-    auto result = readAt(storage, "abc"sv, 5, 20, 100);
-    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(result));
-
-    // Each key still resolves against its own rows.
-    auto abcAtZero = readAt(storage, "abc"sv, 0, 20, 100);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcAtZero));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcAtZero)), "abc-at-1");
-
-    auto abcdeAtFive = readAt(storage, "abcde"sv, 5, 20, 100);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcdeAtFive));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcdeAtFive)), "abcde-at-9");
-
-    // The predicate on its own, over the exact byte strings above.
-    BOOST_CHECK(indexRowBelongsTo(indexRowKey(makeBytes("abc"sv), 2), "abc"sv));
-    BOOST_CHECK(!indexRowBelongsTo(indexRowKey(makeBytes("abcde"sv), 10), "abc"sv));
-}
-
-/// tag 0x00 (the key did not exist yet) and tag 0x01 (here are the old bytes) must survive the
-/// round trip as two distinguishable answers — collapsing ABSENT into an empty value would make
-/// "account created in this block" read back as "account held the empty string".
-BOOST_AUTO_TEST_CASE(absentAndValueRoundTrip)
-{
-    HistoryMemStorage storage;
-    Diff diff;
-    diff.change("created"sv, std::nullopt).change("updated"sv, "old-bytes"sv);
-    putBlock(storage, 7, diff);
-
-    auto created = readAt(storage, "created"sv, 6, 50, 50);
-    BOOST_CHECK(std::holds_alternative<HistoryAbsent>(created));
-
-    auto updated = readAt(storage, "updated"sv, 6, 50, 50);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(updated));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(updated)), "old-bytes");
-
-    // The bytes on disk, spelled out: <1B tag><old value>.
-    auto rows = rowsOfTable(storage, kStateHistory.index);
-    BOOST_REQUIRE_EQUAL(rows.size(), 2);
-    for (auto const& [rowKey, rowValue] : rows)
+    StagedBlock staged{.block = block,
+        .meta = BlockMeta{.shardCount = 1,
+            .recordCount = static_cast<uint32_t>(keysAtOffsets.size()),
+            .blockHash = blockHashOf(block)},
+        .versions = {}};
+    for (auto const& [key, offset] : keysAtOffsets)
     {
-        if (rowKey.starts_with("created"))
-        {
-            BOOST_CHECK_EQUAL(rowValue, std::string("\x00", 1));
-        }
-        else
-        {
-            BOOST_CHECK_EQUAL(rowValue, std::string("\x01", 1) + "old-bytes");
-        }
+        staged.versions.emplace_back(
+            makeBytes(key), HistoryVersion{.block = block, .shard = 0, .offset = offset});
     }
-
-    // An empty old value is NOT the same row as ABSENT.
-    Diff emptyValueDiff;
-    emptyValueDiff.change("emptied"sv, ""sv);
-    putBlock(storage, 8, emptyValueDiff);
-    auto emptied = readAt(storage, "emptied"sv, 7, 50, 50);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(emptied));
-    BOOST_CHECK(std::get<bcos::bytes>(emptied).empty());
+    return staged;
 }
 
-/// The manifest splits at a byte cap and keysOfBlock rejoins the shards in order (spec B.2).
-BOOST_AUTO_TEST_CASE(manifestShardsSplitAtByteCapAndRejoin)
+std::optional<HistoryVersion> lookup(
+    HistoryIndex const& index, std::string_view key, bcos::protocol::BlockNumber block)
 {
-    HistoryMemStorage storage;
-    Diff diff;
-    std::vector<std::string> keys;
-    for (int index = 0; index < 5; ++index)
-    {
-        keys.push_back("key-" + std::to_string(index) + "!!!");  // 8 bytes each
-        diff.change(keys.back(), "old"sv);
-    }
-    // Record size is 4 + 8 = 12, so a 30-byte cap fits two records per shard.
-    constexpr std::size_t shardCap = 30;
-    putBlock(storage, 42, diff, shardCap);
+    auto const keyBytes = makeBytes(key);
+    return index.locate(keyBytes, block);
+}
+}  // namespace
 
-    auto manifestRows = rowsOfTable(storage, kStateHistory.manifest);
-    BOOST_REQUIRE_EQUAL(manifestRows.size(), 3);
-    for (std::size_t shard = 0; shard < manifestRows.size(); ++shard)
-    {
-        BOOST_CHECK_EQUAL(manifestRows[shard].first, manifestRowKey(42, shard));
-        BOOST_CHECK_LE(manifestRows[shard].second.size(), shardCap);
-    }
-
-    auto rejoined = keysOfBlock(storage, 42);
-    BOOST_REQUIRE_EQUAL(rejoined.size(), keys.size());
-    for (std::size_t index = 0; index < keys.size(); ++index)
-    {
-        BOOST_CHECK_EQUAL(toText(rejoined[index]), keys[index]);
-    }
+/// A fresh index has never been rebuilt, and that is NOT the same as "this chain recorded no
+/// history": an index that was never built cannot tell the two apart, and reading its silence as
+/// "the key never changed" is exactly the wrong answer G10 forbids.
+BOOST_AUTO_TEST_CASE(emptyIndexRefusesEveryQuery)
+{
+    HistoryIndex index;
+    BOOST_CHECK(index.state() == IndexState::Empty);
+    BOOST_CHECK_EQUAL(index.keyCount(), std::size_t{0});
+    BOOST_CHECK_EQUAL(index.versionCount(), std::size_t{0});
+    BOOST_CHECK_THROW(lookup(index, "k"sv, 5), HistoryIndexUnavailable);
+    // The plain accessor is not the guarded path and answers without refusing — which is why the
+    // query path uses locate() and not this.
+    auto const keyBytes = makeBytes("k"sv);
+    BOOST_CHECK(!index.firstChangeAfter(keyBytes, 5).has_value());
 }
 
-/// The cap bounds a shard, it cannot split a record: a key whose own record is larger than the
-/// cap still gets one shard to itself rather than looping forever trying to fit.
-BOOST_AUTO_TEST_CASE(oversizedRecordGetsItsOwnShard)
+/// publish appends, and the versions of one key stay in ascending block order — the order the
+/// upper_bound lookup and the front-of-vector retire both stand on.
+BOOST_AUTO_TEST_CASE(publishAppendsInBlockOrder)
 {
-    HistoryMemStorage storage;
-    std::string longKey(100, 'k');
-    Diff diff;
-    diff.change(longKey, "old"sv);
-    putBlock(storage, 3, diff, /*shardCap=*/30);
+    HistoryIndex index;
+    index.publish(stagedFor(10, {{"a"sv, 0}, {"b"sv, 12}}), std::nullopt, std::nullopt);
+    index.publish(stagedFor(20, {{"a"sv, 0}}), std::nullopt, std::nullopt);
+    index.publish(stagedFor(30, {{"a"sv, 4}, {"b"sv, 0}}), std::nullopt, std::nullopt);
 
-    auto manifestRows = rowsOfTable(storage, kStateHistory.manifest);
-    BOOST_REQUIRE_EQUAL(manifestRows.size(), 1);
-    BOOST_CHECK_EQUAL(manifestRows[0].second.size(), 4 + longKey.size());
-
-    auto rejoined = keysOfBlock(storage, 3);
-    BOOST_REQUIRE_EQUAL(rejoined.size(), 1);
-    BOOST_CHECK_EQUAL(toText(rejoined[0]), longKey);
+    BOOST_CHECK(index.state() == IndexState::Ready);
+    BOOST_CHECK_EQUAL(index.keyCount(), std::size_t{2});
+    BOOST_CHECK_EQUAL(index.versionCount(), std::size_t{5});
+    BOOST_CHECK_EQUAL(index.blockCount(), std::size_t{3});
+    BOOST_CHECK(index.hasBlock(20));
+    BOOST_CHECK(!index.hasBlock(21));
+    auto const meta = index.blockMeta(30);
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_CHECK_EQUAL(meta->recordCount, 2);
 }
 
-/// spec B.10 ②: the audit reads the window as "one manifest per block" and treats a gap as
-/// fatal, so a block that changed nothing must still say so.
-BOOST_AUTO_TEST_CASE(emptyBlockStillGetsAManifest)
+/// The lookup is `upper_bound`: the first version STRICTLY after the queried block. Block 20's own
+/// record answers block 19, not block 20 — block 20's value is what block 30 recorded as its
+/// pre-image. Getting this bound wrong is an off-by-one that returns a plausible neighbouring
+/// value, so every boundary is spelled out.
+BOOST_AUTO_TEST_CASE(firstChangeAfterIsAStrictUpperBound)
 {
-    HistoryMemStorage storage;
-    Diff nothingChanged;
-    putBlock(storage, 11, nothingChanged);
+    HistoryIndex index;
+    index.publish(stagedFor(10, {{"a"sv, 100}}), std::nullopt, std::nullopt);
+    index.publish(stagedFor(20, {{"a"sv, 200}}), std::nullopt, std::nullopt);
+    index.publish(stagedFor(30, {{"a"sv, 300}}), std::nullopt, std::nullopt);
 
-    auto manifestRows = rowsOfTable(storage, kStateHistory.manifest);
-    BOOST_REQUIRE_EQUAL(manifestRows.size(), 1);
-    BOOST_CHECK_EQUAL(manifestRows[0].first, manifestRowKey(11, 0));
-    BOOST_CHECK(manifestRows[0].second.empty());
-    BOOST_CHECK(keysOfBlock(storage, 11).empty());
-    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 0)->offset, 100U);
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 9)->offset, 100U);
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 10)->offset, 200U);
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 19)->offset, 200U);
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 20)->offset, 300U);
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 29)->offset, 300U);
+    // Nothing recorded after block 30: the caller reads the current value.
+    BOOST_CHECK(!lookup(index, "a"sv, 30).has_value());
+    BOOST_CHECK(!lookup(index, "a"sv, 999).has_value());
+    // A key the index has never seen is the same answer, and is only safe because the index is
+    // Ready and its boundary covers the block.
+    BOOST_CHECK(!lookup(index, "never"sv, 5).has_value());
+    // The located version names the block AND the shard, not just the offset.
+    BOOST_CHECK(
+        *lookup(index, "a"sv, 10) == (HistoryVersion{.block = 20, .shard = 0, .offset = 200}));
 }
 
-/// spec B.4: the write path is pure append. Not one read, not one seek — that is what keeps
-/// write amplification equal to the block's diff instead of growing with the window depth.
-BOOST_AUTO_TEST_CASE(putNeitherReadsNorSeeks)
+/// retire drops exactly the expired block's versions, from the FRONT of each key's vector, and
+/// leaves every other block's answers untouched. A key whose last version goes stops being a key.
+BOOST_AUTO_TEST_CASE(retireRemovesOnlyTheExpiredBlock)
 {
-    CountingStorage mutableLayer;
-    Diff diff;
-    for (int index = 0; index < 20; ++index)
-    {
-        diff.change("key-" + std::to_string(index), "old-" + std::to_string(index));
-    }
-    putBlock(mutableLayer, 100, diff, /*shardCap=*/40);
+    HistoryIndex index;
+    index.publish(stagedFor(10, {{"a"sv, 100}, {"gone"sv, 0}}), std::nullopt, std::nullopt);
+    index.publish(stagedFor(20, {{"a"sv, 200}}), std::nullopt, std::nullopt);
+    BOOST_REQUIRE_EQUAL(index.versionCount(), std::size_t{3});
 
-    BOOST_CHECK_EQUAL(mutableLayer.readCalls, 0);
-    BOOST_CHECK_EQUAL(mutableLayer.rangeCalls, 0);
-    // The rows did land: 20 index rows plus the manifest shards.
-    BOOST_CHECK_EQUAL(rowsOfTable(mutableLayer.inner, kStateHistory.index).size(), 20);
-    BOOST_CHECK(!rowsOfTable(mutableLayer.inner, kStateHistory.manifest).empty());
+    // The retirement rides the NEXT block's publish, which is how the commit path issues it.
+    RetiredBlock retired{
+        .block = 10, .keys = {makeBytes("a"sv), makeBytes("gone"sv)}, .shardsDeleted = 1};
+    index.publish(stagedFor(30, {{"a"sv, 300}}), std::move(retired),
+        std::optional<bcos::protocol::BlockNumber>{10});
+
+    BOOST_CHECK(!index.hasBlock(10));
+    BOOST_CHECK(index.hasBlock(20));
+    BOOST_CHECK(index.hasBlock(30));
+    BOOST_CHECK_EQUAL(index.versionCount(), std::size_t{2});
+    // "gone" had only block 10's version, so it is no longer a key at all.
+    BOOST_CHECK_EQUAL(index.keyCount(), std::size_t{1});
+    // Block 10 is the boundary now, so block 9 is refused while block 10 still answers from
+    // block 20's surviving record.
+    BOOST_REQUIRE(index.boundary().has_value());
+    BOOST_CHECK_EQUAL(*index.boundary(), 10);
+    BOOST_CHECK_THROW(lookup(index, "a"sv, 9), HistoryPruned);
+    BOOST_CHECK_EQUAL(lookup(index, "a"sv, 10)->offset, 200U);
 }
 
-/// A key recorded twice in one block would overwrite the block-start value with a mid-block one,
-/// and every later query for that block would silently get the wrong answer. The caller owns the
-/// deduplication (spec B.4); the store refuses the input rather than accepting it.
-BOOST_AUTO_TEST_CASE(duplicateKeyInOneBlockIsRejected)
+/// The boundary only ever grows. Two callers hand expire a LOWER block — an operator raising the
+/// retention depth, and a chain re-committing after a rollback — and assigning would then claim
+/// heights are intact whose shards an earlier, higher expiry already deleted.
+BOOST_AUTO_TEST_CASE(boundaryTakesTheMaximum)
 {
-    HistoryMemStorage storage;
-    Diff diff;
-    diff.change("balance"sv, "first"sv).change("balance"sv, "second"sv);
-    BOOST_CHECK_THROW(putBlock(storage, 5, diff), MPTInvariantViolation);
+    HistoryIndex index;
+    index.setBoundary(std::optional<bcos::protocol::BlockNumber>{50});
+    BOOST_CHECK_EQUAL(*index.boundary(), 50);
+    index.setBoundary(std::optional<bcos::protocol::BlockNumber>{20});
+    BOOST_CHECK_EQUAL(*index.boundary(), 50);
+    index.setBoundary(std::nullopt);
+    BOOST_CHECK_EQUAL(*index.boundary(), 50);
+    index.setBoundary(std::optional<bcos::protocol::BlockNumber>{60});
+    BOOST_CHECK_EQUAL(*index.boundary(), 60);
+
+    // The boundary alone does not entitle the index to answer: it is still Empty.
+    BOOST_CHECK(index.state() == IndexState::Empty);
+    BOOST_CHECK_THROW(lookup(index, "a"sv, 70), HistoryIndexUnavailable);
 }
 
-/// The two instantiations (spec B.8) share the code but not the rows: writing state history must
-/// leave the trie-history tables empty and vice versa.
-BOOST_AUTO_TEST_CASE(stateAndTrieInstancesUseSeparateTables)
+/// replace installs a whole rebuilt index and makes it Ready — reaching replace IS the proof that
+/// the rebuild walked its input end to end, because every inconsistency throws instead.
+BOOST_AUTO_TEST_CASE(replaceInstallsTheRebuiltIndexAsReady)
 {
-    HistoryMemStorage storage;
-    Diff stateDiff;
-    stateDiff.change("shared-key"sv, "state-old"sv);
-    Diff trieDiff;
-    trieDiff.change("shared-key"sv, "trie-old"sv);
-    bcos::task::syncWait(StateHistoryStore::put(storage, 9, stateDiff.entries(), kWideShardCap));
-    bcos::task::syncWait(TrieHistoryStore::put(storage, 9, trieDiff.entries(), kWideShardCap));
+    HistoryIndex live;
+    live.publish(stagedFor(10, {{"stale"sv, 0}}), std::nullopt, std::nullopt);
+    live.markUnavailable();
+    BOOST_REQUIRE(live.state() == IndexState::Unavailable);
+    BOOST_CHECK_THROW(lookup(live, "stale"sv, 5), HistoryIndexUnavailable);
 
-    auto stateRows = rowsOfTable(storage, kStateHistory.index);
-    auto trieRows = rowsOfTable(storage, kTrieHistory.index);
-    BOOST_REQUIRE_EQUAL(stateRows.size(), 1);
-    BOOST_REQUIRE_EQUAL(trieRows.size(), 1);
-    BOOST_CHECK_EQUAL(stateRows[0].second, std::string("\x01", 1) + "state-old");
-    BOOST_CHECK_EQUAL(trieRows[0].second, std::string("\x01", 1) + "trie-old");
+    HistoryIndex rebuilt;
+    rebuilt.setBoundary(std::optional<bcos::protocol::BlockNumber>{7});
+    rebuilt.publish(stagedFor(11, {{"fresh"sv, 40}}), std::nullopt, std::nullopt);
+    live.replace(std::move(rebuilt));
 
-    auto keyBytes = makeBytes("shared-key"sv);
-    auto trieResult = bcos::task::syncWait(TrieHistoryStore::readAt(storage, keyBytes, 8, 50, 50));
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(trieResult));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(trieResult)), "trie-old");
+    BOOST_CHECK(live.state() == IndexState::Ready);
+    // The old contents are gone, not merged.
+    BOOST_CHECK(!live.hasBlock(10));
+    BOOST_CHECK(live.hasBlock(11));
+    BOOST_CHECK_EQUAL(live.keyCount(), std::size_t{1});
+    // Above the rebuilt boundary, so this is the lookup missing rather than the boundary refusing.
+    BOOST_CHECK(!lookup(live, "stale"sv, 8).has_value());
+    BOOST_CHECK_EQUAL(lookup(live, "fresh"sv, 10)->offset, 40U);
+    BOOST_REQUIRE(live.boundary().has_value());
+    BOOST_CHECK_EQUAL(*live.boundary(), 7);
+
+    // A rebuild that found NOTHING still installs Ready: the walk saw the whole retained range,
+    // so "no recorded change" is a fact rather than an absence of knowledge.
+    HistoryIndex emptyRebuild;
+    live.replace(std::move(emptyRebuild));
+    BOOST_CHECK(live.state() == IndexState::Ready);
+    BOOST_CHECK(!lookup(live, "fresh"sv, 10).has_value());
+}
+
+/// A publish that throws leaves the maps in an unknown shape, and an index missing versions
+/// answers "the key never changed". So the failure is latched: everything refuses until a rebuild
+/// replaces it, and a second attempt at the same block does not quietly succeed.
+BOOST_AUTO_TEST_CASE(aFailedPublishLatchesUnavailable)
+{
+    HistoryIndex index;
+    index.publish(stagedFor(10, {{"a"sv, 0}}), std::nullopt, std::nullopt);
+    BOOST_REQUIRE(index.state() == IndexState::Ready);
+
+    // Publishing the same block twice would give key "a" two versions for block 10, and retiring
+    // block 10 would then leave one behind.
+    BOOST_CHECK_THROW(index.publish(stagedFor(10, {{"a"sv, 8}}), std::nullopt, std::nullopt),
+        MPTInvariantViolation);
+    BOOST_CHECK(index.state() == IndexState::Unavailable);
+    BOOST_CHECK_THROW(lookup(index, "a"sv, 5), HistoryIndexUnavailable);
+    // The duplicate did not land: the check runs before any version vector is touched.
+    BOOST_CHECK_EQUAL(index.versionCount(), std::size_t{1});
+}
+
+/// The ordering precondition the whole lookup rests on. Versions are appended with push_back, so a
+/// key's vector is sorted only because the block numbers arrived ascending; publish a block BELOW
+/// the current maximum and `upper_bound` is reading an unsorted range, which is undefined and comes
+/// back as a plausible wrong version rather than as an error.
+///
+/// So a descending publish is refused outright, and refused the same way a duplicate is — the two
+/// are one check, because a duplicate is the equality case of "not strictly ascending".
+BOOST_AUTO_TEST_CASE(publishingBlocksOutOfOrderIsRefused)
+{
+    HistoryIndex index;
+    index.publish(stagedFor(20, {{"a"sv, 200}}), std::nullopt, std::nullopt);
+    BOOST_REQUIRE(index.state() == IndexState::Ready);
+
+    BOOST_CHECK_THROW(index.publish(stagedFor(10, {{"a"sv, 100}}), std::nullopt, std::nullopt),
+        MPTInvariantViolation);
+    BOOST_CHECK(index.state() == IndexState::Unavailable);
+    BOOST_CHECK_THROW(lookup(index, "a"sv, 5), HistoryIndexUnavailable);
+    // Nothing landed: block 10 is absent and key "a" still has exactly block 20's version, so the
+    // vector the refused publish would have unsorted is still sorted.
+    BOOST_CHECK(!index.hasBlock(10));
+    BOOST_CHECK(index.hasBlock(20));
+    BOOST_CHECK_EQUAL(index.versionCount(), std::size_t{1});
+
+    // Ascending still works, on an index that has not been poisoned.
+    HistoryIndex fresh;
+    fresh.publish(stagedFor(10, {{"a"sv, 100}}), std::nullopt, std::nullopt);
+    fresh.publish(stagedFor(20, {{"a"sv, 200}}), std::nullopt, std::nullopt);
+    BOOST_CHECK_EQUAL(lookup(fresh, "a"sv, 9)->offset, 100U);
+    BOOST_CHECK_EQUAL(lookup(fresh, "a"sv, 10)->offset, 200U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
@@ -1,0 +1,272 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryIndexTest.cpp
+ * @brief The row layout itself: big-endian block ordering, the length discriminator that lets
+ *        the layout skip a length prefix, ABSENT round trip, manifest sharding, and the
+ *        append-only write path (spec B.2, B.4)
+ */
+
+#include "HistoryTestHelpers.h"
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace std::string_view_literals;
+
+namespace bcos::ledger::mpt::history::test
+{
+
+BOOST_AUTO_TEST_SUITE(HistoryIndexSuite)
+
+/// spec B.2(b): the block field is 8 bytes big endian so that byte order equals numeric order.
+/// 255 -> 256 is the smallest carry that a little-endian field would invert (0xFF,0x00.. would
+/// sort above 0x00,0x01,0x00..), so it is the case that pins the encoding down.
+BOOST_AUTO_TEST_CASE(bigEndianBlockNumbersDoNotInvertAt255)
+{
+    auto key = makeBytes("balance"sv);
+    auto row255 = indexRowKey(key, 255);
+    auto row256 = indexRowKey(key, 256);
+
+    BOOST_REQUIRE_EQUAL(row255.size(), key.size() + 8);
+    BOOST_REQUIRE_EQUAL(row256.size(), key.size() + 8);
+    BOOST_CHECK_EQUAL(
+        row255.substr(key.size()), std::string("\x00\x00\x00\x00\x00\x00\x00\xff", 8));
+    BOOST_CHECK_EQUAL(
+        row256.substr(key.size()), std::string("\x00\x00\x00\x00\x00\x00\x01\x00", 8));
+    BOOST_CHECK(row255 < row256);
+
+    // And the ordering is the one the seek actually rides on: with a change at both 255 and 256,
+    // a query at 254 must land on the 255 row, not the 256 one.
+    HistoryMemStorage storage;
+    Diff at255;
+    at255.change("balance"sv, "at-254"sv);
+    Diff at256;
+    at256.change("balance"sv, "at-255"sv);
+    putBlock(storage, 255, at255);
+    putBlock(storage, 256, at256);
+
+    auto result = readAt(storage, "balance"sv, 254, 300, 300);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(result));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(result)), "at-254");
+}
+
+/// spec B.2(c): a row belongs to key k only if it starts with k AND is exactly eight bytes
+/// longer. Without the length clause, a query for "abc" whose own next change lies before the
+/// queried block walks straight onto "abcde"'s row and answers with another key's value.
+BOOST_AUTO_TEST_CASE(lengthDiscriminatorSeparatesPrefixKeys)
+{
+    HistoryMemStorage storage;
+    // "abc" last changed at block 2, i.e. before the query point; "abcde" changed at block 10.
+    Diff shortKey;
+    shortKey.change("abc"sv, "abc-at-1"sv);
+    Diff longerKey;
+    longerKey.change("abcde"sv, "abcde-at-9"sv);
+    putBlock(storage, 2, shortKey);
+    putBlock(storage, 10, longerKey);
+
+    // The seek for "abc" at block 5 starts at "abc" + BE64(6). "abc" + BE64(2) sorts before it,
+    // so the first row the iterator yields is "abcde" + BE64(10) — a prefix match, and the wrong
+    // answer. The length check rejects it and the caller falls back to the current value.
+    auto result = readAt(storage, "abc"sv, 5, 20, 100);
+    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(result));
+
+    // Each key still resolves against its own rows.
+    auto abcAtZero = readAt(storage, "abc"sv, 0, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcAtZero));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcAtZero)), "abc-at-1");
+
+    auto abcdeAtFive = readAt(storage, "abcde"sv, 5, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcdeAtFive));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcdeAtFive)), "abcde-at-9");
+
+    // The predicate on its own, over the exact byte strings above.
+    BOOST_CHECK(indexRowBelongsTo(indexRowKey(makeBytes("abc"sv), 2), "abc"sv));
+    BOOST_CHECK(!indexRowBelongsTo(indexRowKey(makeBytes("abcde"sv), 10), "abc"sv));
+}
+
+/// tag 0x00 (the key did not exist yet) and tag 0x01 (here are the old bytes) must survive the
+/// round trip as two distinguishable answers — collapsing ABSENT into an empty value would make
+/// "account created in this block" read back as "account held the empty string".
+BOOST_AUTO_TEST_CASE(absentAndValueRoundTrip)
+{
+    HistoryMemStorage storage;
+    Diff diff;
+    diff.change("created"sv, std::nullopt).change("updated"sv, "old-bytes"sv);
+    putBlock(storage, 7, diff);
+
+    auto created = readAt(storage, "created"sv, 6, 50, 50);
+    BOOST_CHECK(std::holds_alternative<HistoryAbsent>(created));
+
+    auto updated = readAt(storage, "updated"sv, 6, 50, 50);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(updated));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(updated)), "old-bytes");
+
+    // The bytes on disk, spelled out: <1B tag><old value>.
+    auto rows = rowsOfTable(storage, kStateHistory.index);
+    BOOST_REQUIRE_EQUAL(rows.size(), 2);
+    for (auto const& [rowKey, rowValue] : rows)
+    {
+        if (rowKey.starts_with("created"))
+        {
+            BOOST_CHECK_EQUAL(rowValue, std::string("\x00", 1));
+        }
+        else
+        {
+            BOOST_CHECK_EQUAL(rowValue, std::string("\x01", 1) + "old-bytes");
+        }
+    }
+
+    // An empty old value is NOT the same row as ABSENT.
+    Diff emptyValueDiff;
+    emptyValueDiff.change("emptied"sv, ""sv);
+    putBlock(storage, 8, emptyValueDiff);
+    auto emptied = readAt(storage, "emptied"sv, 7, 50, 50);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(emptied));
+    BOOST_CHECK(std::get<bcos::bytes>(emptied).empty());
+}
+
+/// The manifest splits at a byte cap and keysOfBlock rejoins the shards in order (spec B.2).
+BOOST_AUTO_TEST_CASE(manifestShardsSplitAtByteCapAndRejoin)
+{
+    HistoryMemStorage storage;
+    Diff diff;
+    std::vector<std::string> keys;
+    for (int index = 0; index < 5; ++index)
+    {
+        keys.push_back("key-" + std::to_string(index) + "!!!");  // 8 bytes each
+        diff.change(keys.back(), "old"sv);
+    }
+    // Record size is 4 + 8 = 12, so a 30-byte cap fits two records per shard.
+    constexpr std::size_t shardCap = 30;
+    putBlock(storage, 42, diff, shardCap);
+
+    auto manifestRows = rowsOfTable(storage, kStateHistory.manifest);
+    BOOST_REQUIRE_EQUAL(manifestRows.size(), 3);
+    for (std::size_t shard = 0; shard < manifestRows.size(); ++shard)
+    {
+        BOOST_CHECK_EQUAL(manifestRows[shard].first, manifestRowKey(42, shard));
+        BOOST_CHECK_LE(manifestRows[shard].second.size(), shardCap);
+    }
+
+    auto rejoined = keysOfBlock(storage, 42);
+    BOOST_REQUIRE_EQUAL(rejoined.size(), keys.size());
+    for (std::size_t index = 0; index < keys.size(); ++index)
+    {
+        BOOST_CHECK_EQUAL(toText(rejoined[index]), keys[index]);
+    }
+}
+
+/// The cap bounds a shard, it cannot split a record: a key whose own record is larger than the
+/// cap still gets one shard to itself rather than looping forever trying to fit.
+BOOST_AUTO_TEST_CASE(oversizedRecordGetsItsOwnShard)
+{
+    HistoryMemStorage storage;
+    std::string longKey(100, 'k');
+    Diff diff;
+    diff.change(longKey, "old"sv);
+    putBlock(storage, 3, diff, /*shardCap=*/30);
+
+    auto manifestRows = rowsOfTable(storage, kStateHistory.manifest);
+    BOOST_REQUIRE_EQUAL(manifestRows.size(), 1);
+    BOOST_CHECK_EQUAL(manifestRows[0].second.size(), 4 + longKey.size());
+
+    auto rejoined = keysOfBlock(storage, 3);
+    BOOST_REQUIRE_EQUAL(rejoined.size(), 1);
+    BOOST_CHECK_EQUAL(toText(rejoined[0]), longKey);
+}
+
+/// spec B.10 ②: the audit reads the window as "one manifest per block" and treats a gap as
+/// fatal, so a block that changed nothing must still say so.
+BOOST_AUTO_TEST_CASE(emptyBlockStillGetsAManifest)
+{
+    HistoryMemStorage storage;
+    Diff nothingChanged;
+    putBlock(storage, 11, nothingChanged);
+
+    auto manifestRows = rowsOfTable(storage, kStateHistory.manifest);
+    BOOST_REQUIRE_EQUAL(manifestRows.size(), 1);
+    BOOST_CHECK_EQUAL(manifestRows[0].first, manifestRowKey(11, 0));
+    BOOST_CHECK(manifestRows[0].second.empty());
+    BOOST_CHECK(keysOfBlock(storage, 11).empty());
+    BOOST_CHECK(rowsOfTable(storage, kStateHistory.index).empty());
+}
+
+/// spec B.4: the write path is pure append. Not one read, not one seek — that is what keeps
+/// write amplification equal to the block's diff instead of growing with the window depth.
+BOOST_AUTO_TEST_CASE(putNeitherReadsNorSeeks)
+{
+    CountingStorage mutableLayer;
+    Diff diff;
+    for (int index = 0; index < 20; ++index)
+    {
+        diff.change("key-" + std::to_string(index), "old-" + std::to_string(index));
+    }
+    putBlock(mutableLayer, 100, diff, /*shardCap=*/40);
+
+    BOOST_CHECK_EQUAL(mutableLayer.readCalls, 0);
+    BOOST_CHECK_EQUAL(mutableLayer.rangeCalls, 0);
+    // The rows did land: 20 index rows plus the manifest shards.
+    BOOST_CHECK_EQUAL(rowsOfTable(mutableLayer.inner, kStateHistory.index).size(), 20);
+    BOOST_CHECK(!rowsOfTable(mutableLayer.inner, kStateHistory.manifest).empty());
+}
+
+/// A key recorded twice in one block would overwrite the block-start value with a mid-block one,
+/// and every later query for that block would silently get the wrong answer. The caller owns the
+/// deduplication (spec B.4); the store refuses the input rather than accepting it.
+BOOST_AUTO_TEST_CASE(duplicateKeyInOneBlockIsRejected)
+{
+    HistoryMemStorage storage;
+    Diff diff;
+    diff.change("balance"sv, "first"sv).change("balance"sv, "second"sv);
+    BOOST_CHECK_THROW(putBlock(storage, 5, diff), MPTInvariantViolation);
+}
+
+/// The two instantiations (spec B.8) share the code but not the rows: writing state history must
+/// leave the trie-history tables empty and vice versa.
+BOOST_AUTO_TEST_CASE(stateAndTrieInstancesUseSeparateTables)
+{
+    HistoryMemStorage storage;
+    Diff stateDiff;
+    stateDiff.change("shared-key"sv, "state-old"sv);
+    Diff trieDiff;
+    trieDiff.change("shared-key"sv, "trie-old"sv);
+    bcos::task::syncWait(StateHistoryStore::put(storage, 9, stateDiff.entries(), kWideShardCap));
+    bcos::task::syncWait(TrieHistoryStore::put(storage, 9, trieDiff.entries(), kWideShardCap));
+
+    auto stateRows = rowsOfTable(storage, kStateHistory.index);
+    auto trieRows = rowsOfTable(storage, kTrieHistory.index);
+    BOOST_REQUIRE_EQUAL(stateRows.size(), 1);
+    BOOST_REQUIRE_EQUAL(trieRows.size(), 1);
+    BOOST_CHECK_EQUAL(stateRows[0].second, std::string("\x01", 1) + "state-old");
+    BOOST_CHECK_EQUAL(trieRows[0].second, std::string("\x01", 1) + "trie-old");
+
+    auto keyBytes = makeBytes("shared-key"sv);
+    auto trieResult = bcos::task::syncWait(TrieHistoryStore::readAt(storage, keyBytes, 8, 50, 50));
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(trieResult));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(trieResult)), "trie-old");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryIndexTest.cpp
@@ -302,15 +302,32 @@ BOOST_AUTO_TEST_CASE(thePublishGenerationTracksTheWindow)
     BOOST_CHECK_EQUAL(index.generation() % 2, 0U);
     BOOST_CHECK_GT(index.generation(), afterPublish);
 
-    // A publish that THROWS must not leave the window open — the commit died, and a permanently
-    // open window would make every later "unchanged since B" query spin and then refuse forever
-    // rather than only until the node notices.
+    // A publish that THROWS must not leave the window open — the commit died, and a window that
+    // never closes makes every later "unchanged since B" query wait out the whole time budget and
+    // then refuse, instead of refusing only until the node notices.
     index.openPublishWindow();
     BOOST_CHECK_EQUAL(index.generation() % 2, 1U);
+    auto const beforeThrowWithWindow = index.generation();
     BOOST_CHECK_THROW(index.publish(stagedFor(15, {{"a"sv, 150}}), std::nullopt, std::nullopt),
         MPTInvariantViolation);
     BOOST_CHECK(index.state() == IndexState::Unavailable);
     BOOST_CHECK_EQUAL(index.generation() % 2, 0U);
+    BOOST_CHECK_GT(index.generation(), beforeThrowWithWindow);
+
+    // ...and a publish that throws with NO window open must advance the counter all the same.
+    // The throw can come after applyRetire has already removed a block's versions, so a reader
+    // that sampled the generation before this publish and re-samples after its own current-value
+    // read has to see a change — otherwise it accepts a value it read across a mutation. Closing
+    // a window that was never open would have been a no-op, which is the bug this pins.
+    HistoryIndex quiescent;
+    quiescent.publish(stagedFor(30, {{"b"sv, 300}}), std::nullopt, std::nullopt);
+    BOOST_REQUIRE_EQUAL(quiescent.generation() % 2, 0U);
+    auto const beforeThrowNoWindow = quiescent.generation();
+    BOOST_CHECK_THROW(quiescent.publish(stagedFor(20, {{"b"sv, 200}}), std::nullopt, std::nullopt),
+        MPTInvariantViolation);
+    BOOST_CHECK(quiescent.state() == IndexState::Unavailable);
+    BOOST_CHECK_EQUAL(quiescent.generation() % 2, 0U);
+    BOOST_CHECK_GT(quiescent.generation(), beforeThrowNoWindow);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/history/HistoryLayoutTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryLayoutTest.cpp
@@ -1,0 +1,395 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryLayoutTest.cpp
+ * @brief The bytes themselves: the 41-byte meta row, the record encoding, the meta-before-shard-0
+ *        sort order one seek rides on, and the shard split (layout spec §1.2)
+ */
+
+#include "HistoryTestHelpers.h"
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
+#include <bcos-ledger/mpt/history/HistoryTables.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace std::string_view_literals;
+
+namespace bcos::ledger::mpt::history::test
+{
+
+BOOST_AUTO_TEST_SUITE(HistoryLayoutSuite)
+
+namespace
+{
+/// `<BE32 keyLen> <key> <tag> [<BE32 valueLen> <value>]`, spelled out by hand so the assertions
+/// below do not merely re-run the encoder they are checking.
+std::string expectedRecord(std::string_view key, std::optional<std::string_view> oldValue)
+{
+    std::string record;
+    record.append("\x00\x00\x00", 3);
+    record.push_back(static_cast<char>(key.size()));
+    record.append(key);
+    if (!oldValue)
+    {
+        record.push_back('\x00');
+        return record;
+    }
+    record.push_back('\x01');
+    record.append("\x00\x00\x00", 3);
+    record.push_back(static_cast<char>(oldValue->size()));
+    record.append(*oldValue);
+    return record;
+}
+}  // namespace
+
+/// The meta row is 41 fixed bytes: version, shard count, record count, block hash. A reader that
+/// found a shorter or longer row would be reading counts out of the wrong offsets, so the length is
+/// asserted before the fields.
+BOOST_AUTO_TEST_CASE(metaRowIsFortyOneFixedBytes)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    diff.change("alpha"sv, "old-a"sv).change("beta"sv, std::nullopt);
+    putBlock(store, storage, 7, diff);
+
+    auto const rows = rowsOfTable(storage, kStateHistory.shard);
+    BOOST_REQUIRE_EQUAL(rows.size(), 2);  // meta + shard 0
+    BOOST_CHECK_EQUAL(rows[0].first, metaRowKey(7));
+    BOOST_CHECK_EQUAL(rows[0].first.size(), 8);
+    BOOST_REQUIRE_EQUAL(rows[0].second.size(), 41);
+
+    std::string expected;
+    expected.push_back('\x01');                // format version
+    expected.append("\x00\x00\x00\x01", 4);    // shardCount = 1
+    expected.append("\x00\x00\x00\x02", 4);    // recordCount = 2
+    expected.append(std::string(30, '\x00'));  // block hash, first 30 bytes
+    expected.push_back('\x00');
+    expected.push_back('\x07');
+    BOOST_CHECK_EQUAL(rows[0].second, expected);
+
+    auto const meta = decodeMeta(rows[0].second);
+    BOOST_CHECK_EQUAL(meta.shardCount, 1);
+    BOOST_CHECK_EQUAL(meta.recordCount, 2);
+    BOOST_CHECK(meta.blockHash == blockHashOf(7));
+}
+
+/// The record encoding, byte for byte, including the two cases that must stay distinguishable:
+/// tag 0x00 (the key did not exist yet) and tag 0x01 with an EMPTY value. Collapsing them would
+/// make "account created in this block" read back as "account held the empty string".
+BOOST_AUTO_TEST_CASE(recordEncodingIsByteExact)
+{
+    // A key carrying both bytes that have bitten this layout before: 0x00 (every BE64 block field
+    // is full of them) and 0x3A, the colon StateKeyResolver splits physical keys on.
+    auto const awkwardKey = std::string("/t/c:s") + '\0' + 'x';
+
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    diff.change("created"sv, std::nullopt).change("emptied"sv, ""sv).change(awkwardKey, "old"sv);
+    putBlock(store, storage, 3, diff);
+
+    auto const rows = rowsOfTable(storage, kStateHistory.shard);
+    BOOST_REQUIRE_EQUAL(rows.size(), 2);
+    BOOST_CHECK_EQUAL(rows[1].first, shardRowKey(3, 0));
+    BOOST_CHECK_EQUAL(rows[1].first.size(), 10);
+
+    auto const expected = expectedRecord("created"sv, std::nullopt) +
+                          expectedRecord("emptied"sv, ""sv) + expectedRecord(awkwardKey, "old"sv);
+    BOOST_CHECK_EQUAL(rows[1].second, expected);
+
+    // ...and the decoder puts the same three records back, with ABSENT still distinct from empty.
+    auto const decoded = decodeShard(rows[1].second);
+    BOOST_REQUIRE_EQUAL(decoded.size(), 3);
+    BOOST_CHECK_EQUAL(decoded[0].key, "created");
+    BOOST_CHECK(!decoded[0].oldValue.has_value());
+    BOOST_CHECK_EQUAL(decoded[0].offset, std::size_t{0});
+    BOOST_CHECK_EQUAL(decoded[1].key, "emptied");
+    BOOST_REQUIRE(decoded[1].oldValue.has_value());
+    BOOST_CHECK(decoded[1].oldValue->empty());
+    BOOST_CHECK_EQUAL(decoded[2].key, awkwardKey);
+    BOOST_REQUIRE(decoded[2].oldValue.has_value());
+    BOOST_CHECK_EQUAL(*decoded[2].oldValue, "old");
+    // Each offset is where its record starts, which is what the index stores.
+    BOOST_CHECK_EQUAL(decoded[1].offset, expectedRecord("created"sv, std::nullopt).size());
+    BOOST_CHECK_EQUAL(decoded[2].offset, expectedRecord("created"sv, std::nullopt).size() +
+                                             expectedRecord("emptied"sv, ""sv).size());
+}
+
+/// The whole one-seek property: an 8-byte meta key sorts before every 10-byte shard key sharing its
+/// first eight bytes, so ONE seek at BE64(block) walks meta, shard 0, shard 1, ... This is what
+/// readBlock, expire and rebuild all ride on, and it is a property of the STORAGE's comparator, so
+/// it is checked against a real seek rather than against std::string::operator<.
+BOOST_AUTO_TEST_CASE(metaRowSortsBeforeShardZeroUnderASeek)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    for (int index = 0; index < 5; ++index)
+    {
+        diff.change("key-" + std::to_string(index) + "!!!", "old"sv);  // 8-byte keys
+    }
+    // recordSize = 4 + 8 + 1 + 4 + 3 = 20, so a 45-byte cap fits two records per shard.
+    constexpr std::size_t kSplitCap = 45;
+    putBlock(store, storage, 42, diff, kSplitCap);
+
+    auto const seen = bcos::task::syncWait([&]() -> bcos::task::Task<std::vector<std::string>> {
+        std::vector<std::string> keys;
+        auto iterator = co_await bcos::storage2::range(storage, bcos::storage2::RANGE_SEEK,
+            bcos::executor_v1::StateKey{kStateHistory.shard, metaRowKey(42)});
+        while (true)
+        {
+            auto row = co_await iterator.next();
+            if (!row)
+            {
+                break;
+            }
+            auto const& [rowKey, rowValue] = *row;
+            bcos::executor_v1::StateKeyView view{rowKey};
+            if (view.m_table != kStateHistory.shard)
+            {
+                break;
+            }
+            keys.emplace_back(view.m_key);
+        }
+        co_return keys;
+    }());
+
+    BOOST_REQUIRE_EQUAL(seen.size(), 4);  // meta + 3 shards
+    BOOST_CHECK_EQUAL(seen[0], metaRowKey(42));
+    BOOST_CHECK_EQUAL(seen[1], shardRowKey(42, 0));
+    BOOST_CHECK_EQUAL(seen[2], shardRowKey(42, 1));
+    BOOST_CHECK_EQUAL(seen[3], shardRowKey(42, 2));
+
+    // The split really happened at the cap, and the meta row says so.
+    auto const rows = rowsOfTable(storage, kStateHistory.shard);
+    BOOST_CHECK_EQUAL(decodeMeta(rows[0].second).shardCount, 3);
+    BOOST_CHECK_EQUAL(decodeMeta(rows[0].second).recordCount, 5);
+    for (std::size_t shard = 0; shard < 3; ++shard)
+    {
+        BOOST_CHECK_LE(rows[shard + 1].second.size(), kSplitCap);
+    }
+}
+
+/// The cap bounds a shard, it cannot split a record: a key whose own record is larger than the cap
+/// still gets one shard to itself rather than looping forever trying to fit.
+BOOST_AUTO_TEST_CASE(oversizedRecordGetsItsOwnShard)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    std::string const longKey(100, 'k');
+    Diff diff;
+    diff.change(longKey, "old"sv);
+    putBlock(store, storage, 3, diff, /*shardCap=*/30);
+
+    auto const rows = rowsOfTable(storage, kStateHistory.shard);
+    BOOST_REQUIRE_EQUAL(rows.size(), 2);
+    BOOST_CHECK_EQUAL(decodeMeta(rows[0].second).shardCount, 1);
+    // 4 (key length) + 100 (key) + 1 (tag) + 4 (value length) + 3 (value) = 112 > the 30-byte cap.
+    BOOST_CHECK_EQUAL(rows[1].second.size(), std::size_t{112});
+}
+
+/// spec B.10 ②: the audit reads the window as one meta row per block and treats a gap as fatal, so
+/// a block that changed nothing must still say so — Meta{shardCount = 1, recordCount = 0} plus an
+/// empty shard 0, not an absent block.
+BOOST_AUTO_TEST_CASE(emptyBlockGetsMetaAndAnEmptyShardZero)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff const nothingChanged;
+    putBlock(store, storage, 11, nothingChanged);
+
+    auto const rows = rowsOfTable(storage, kStateHistory.shard);
+    BOOST_REQUIRE_EQUAL(rows.size(), 2);
+    auto const meta = decodeMeta(rows[0].second);
+    BOOST_CHECK_EQUAL(meta.shardCount, 1);
+    BOOST_CHECK_EQUAL(meta.recordCount, 0);
+    BOOST_CHECK_EQUAL(rows[1].first, shardRowKey(11, 0));
+    BOOST_CHECK(rows[1].second.empty());
+
+    BOOST_CHECK(store.recordedBlock(11));
+    BOOST_CHECK(!store.recordedBlock(12));
+    BOOST_CHECK(readBlock(store, storage, 11).records.empty());
+}
+
+/// spec B.2(b): the block field is 8 bytes big endian so that byte order equals numeric order.
+/// 255 -> 256 is the smallest carry a little-endian field would invert, so it is the case that pins
+/// the encoding down — and the shard walk is what would break.
+BOOST_AUTO_TEST_CASE(bigEndianBlockNumbersDoNotInvertAt255)
+{
+    BOOST_CHECK_EQUAL(metaRowKey(255), std::string("\x00\x00\x00\x00\x00\x00\x00\xff", 8));
+    BOOST_CHECK_EQUAL(metaRowKey(256), std::string("\x00\x00\x00\x00\x00\x00\x01\x00", 8));
+    BOOST_CHECK(metaRowKey(255) < metaRowKey(256));
+    BOOST_CHECK(metaRowKey(255) < shardRowKey(255, 0));
+    BOOST_CHECK(shardRowKey(255, 0xFFFF) < metaRowKey(256));
+
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff at255;
+    at255.change("balance"sv, "at-254"sv);
+    Diff at256;
+    at256.change("balance"sv, "at-255"sv);
+    putBlock(store, storage, 255, at255);
+    putBlock(store, storage, 256, at256);
+
+    auto const result = readAt(store, storage, "balance"sv, 254, 300, 300);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(result));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(result)), "at-254");
+}
+
+/// spec B.4: the write path is pure append. Not one read, not one seek — that is what keeps write
+/// amplification equal to the block's diff instead of growing with the window depth.
+BOOST_AUTO_TEST_CASE(putNeitherReadsNorSeeks)
+{
+    CountingStorage backend;
+    StateHistoryStore store;
+    Diff diff;
+    for (int index = 0; index < 20; ++index)
+    {
+        diff.change("key-" + std::to_string(index), "old-" + std::to_string(index));
+    }
+    putBlock(store, backend, 100, diff, /*shardCap=*/60);
+
+    BOOST_CHECK_EQUAL(backend.readCalls, 0);
+    BOOST_CHECK_EQUAL(backend.rangeCalls, 0);
+    // One row per shard plus the meta row, and nothing per key — the point of the layout.
+    auto const rows = rowsOfTable(backend.inner, kStateHistory.shard);
+    BOOST_CHECK_EQUAL(rows.size(), decodeMeta(rows[0].second).shardCount + 1);
+    BOOST_CHECK_EQUAL(decodeMeta(rows[0].second).recordCount, 20);
+}
+
+/// A key recorded twice in one block would get two index versions for one block, and every later
+/// query would resolve to whichever came second. The caller owns the deduplication (spec B.4); the
+/// store refuses the input rather than accepting it.
+BOOST_AUTO_TEST_CASE(duplicateKeyInOneBlockIsRejected)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    diff.change("balance"sv, "first"sv).change("balance"sv, "second"sv);
+    BOOST_CHECK_THROW(putBlock(store, storage, 5, diff), MPTInvariantViolation);
+}
+
+/// The two instantiations (spec B.8) share the code but not the rows: writing state history must
+/// leave the trie-history tables empty and vice versa.
+BOOST_AUTO_TEST_CASE(stateAndTrieInstancesUseSeparateTables)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore stateStore;
+    TrieHistoryStore trieStore;
+    Diff stateDiff;
+    stateDiff.change("shared-key"sv, "state-old"sv);
+    Diff trieDiff;
+    trieDiff.change("shared-key"sv, "trie-old"sv);
+    putBlock(stateStore, storage, 9, stateDiff);
+    putBlock(trieStore, storage, 9, trieDiff);
+
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.shard).size(), 2);
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kTrieHistory.shard).size(), 2);
+
+    auto const stateResult = readAt(stateStore, storage, "shared-key"sv, 8, 50, 50);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(stateResult));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(stateResult)), "state-old");
+    auto const trieResult = readAt(trieStore, storage, "shared-key"sv, 8, 50, 50);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(trieResult));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(trieResult)), "trie-old");
+}
+
+/// The retention-boundary row lives in its OWN table, and that is what keeps it out of every shard
+/// walk — including the rebuild's, which walks the shard table from the boundary UPWARDS and would
+/// otherwise have to skip its own input row.
+BOOST_AUTO_TEST_CASE(retentionBoundaryLivesOutsideTheShardTable)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    TrieHistoryStore trieStore;
+    Diff at100;
+    at100.change("k"sv, "old"sv);
+    putBlock(store, storage, 100, at100);
+    bcos::task::syncWait(StateHistoryStore::writeRetentionBoundary(storage, 42));
+
+    auto const boundaryRows = rowsOfTable(storage, kStateHistory.boundary);
+    BOOST_REQUIRE_EQUAL(boundaryRows.size(), 1);
+    BOOST_CHECK_EQUAL(boundaryRows.front().first, std::string(kRetentionBoundaryRowKey));
+    BOOST_CHECK_EQUAL(boundaryRows.front().second, retentionBoundaryValue(42));
+    BOOST_CHECK_EQUAL(decodeRetentionBoundary(boundaryRows.front().second), 42);
+    auto const readBack = boundaryOnDisk(store, storage);
+    BOOST_REQUIRE(readBack.has_value());
+    BOOST_CHECK_EQUAL(*readBack, 42);
+
+    // The walked table gained nothing, and its walk still reports exactly the block's own record.
+    BOOST_CHECK_EQUAL(rowsOfTable(storage, kStateHistory.shard).size(), 2);
+    BOOST_CHECK_EQUAL(readBlock(store, storage, 100).records.size(), 1);
+
+    // And the separate table is LOAD-BEARING under this layout, not merely tidy: "boundary" is
+    // eight bytes, exactly the length of a meta row key, so the length discriminator that tells
+    // meta rows from shard rows cannot tell a boundary row from a meta row at all. Put it in the
+    // shard table and every walker would read it as the meta row of block 0x626F756E64617279.
+    BOOST_CHECK_EQUAL(kRetentionBoundaryRowKey.size(), kMetaRowKeyBytes);
+    BOOST_CHECK(isMetaRowKey(kRetentionBoundaryRowKey, 0x626F756E64617279));
+
+    // The two instances keep separate boundaries, like their other table.
+    BOOST_CHECK(!boundaryOnDisk(trieStore, storage).has_value());
+}
+
+/// Every decoder failure the layout can produce, on hand-built bytes. Each of these would
+/// otherwise surface as a query answered from the wrong offset (G6).
+BOOST_AUTO_TEST_CASE(malformedRowsFailLoud)
+{
+    // Meta: wrong length, then an unknown format version — the gate a future layout goes through.
+    BOOST_CHECK_THROW(decodeMeta(std::string(40, '\x01')), MPTInvariantViolation);
+    auto badVersion = metaRowValue(1, 1, blockHashOf(1));
+    badVersion[0] = '\x02';
+    BOOST_CHECK_THROW(decodeMeta(badVersion), MPTInvariantViolation);
+
+    // Records: truncated key, missing tag, unknown tag, truncated value.
+    auto const whole = expectedRecord("abc"sv, "xy"sv);
+    BOOST_CHECK_THROW(decodeShard(whole.substr(0, 5)), MPTInvariantViolation);
+    BOOST_CHECK_THROW(decodeShard(whole.substr(0, 7)), MPTInvariantViolation);
+    auto unknownTag = whole;
+    unknownTag[7] = '\x09';
+    BOOST_CHECK_THROW(decodeShard(unknownTag), MPTInvariantViolation);
+    BOOST_CHECK_THROW(decodeShard(whole.substr(0, whole.size() - 1)), MPTInvariantViolation);
+    // ...and an offset that points past the end of its shard.
+    BOOST_CHECK_THROW(decodeRecordAt(whole, whole.size() + 1), MPTInvariantViolation);
+
+    // A row key in the shard table that is neither 8 nor 10 bytes has no reading at all.
+    BOOST_CHECK_THROW(rowKeyBlock(std::string(9, '\x00')), MPTInvariantViolation);
+    BOOST_CHECK(isMetaRowKey(metaRowKey(5), 5));
+    BOOST_CHECK(!isMetaRowKey(shardRowKey(5, 0), 5));
+    BOOST_CHECK(isShardRowKey(shardRowKey(5, 0), 5));
+    BOOST_CHECK(!isShardRowKey(shardRowKey(6, 0), 5));
+
+    // A zero shard cap would make the split loop meaningless rather than merely tight.
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    diff.change("k"sv, "v"sv);
+    BOOST_CHECK_THROW(putBlock(store, storage, 1, diff, /*shardCap=*/0), MPTInvariantViolation);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryQueryTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryQueryTest.cpp
@@ -14,8 +14,9 @@
  *  limitations under the License.
  *
  * @file HistoryQueryTest.cpp
- * @brief The point query: the spec §0.4 timeline, the UseCurrent case, and the window guard that
- *        has to run before the seek (spec B.3, G5)
+ * @brief The point query: the spec §0.4 timeline, the UseCurrent case, the window guard that has to
+ *        run before everything else, and the three ways a query must refuse rather than answer
+ *        from the current value (spec B.3, layout spec §1.4, G5, G6, G10)
  */
 
 #include "HistoryTestHelpers.h"
@@ -41,14 +42,14 @@ BOOST_AUTO_TEST_SUITE(HistoryQuerySuite)
 
 namespace
 {
-/// The spec §0.4 timeline: X's balance is changed by blocks 100, 107, 140 and 900. Each row
-/// records what the balance was BEFORE that block changed it.
+/// The spec §0.4 timeline: X's balance is changed by blocks 100, 107, 140 and 900. Each record
+/// holds what the balance was BEFORE that block changed it.
 ///
 /// ```text
 ///   block   100        107        140                900
 ///   before  "60"       "90"       "75"               "42"
 /// ```
-void seedSection04Timeline(HistoryMemStorage& storage)
+void seedQueryTimeline(StateHistoryStore& store, HistoryMemStorage& storage)
 {
     Diff at100;
     at100.change("X.balance"sv, "60"sv);
@@ -58,10 +59,10 @@ void seedSection04Timeline(HistoryMemStorage& storage)
     at140.change("X.balance"sv, "75"sv);
     Diff at900;
     at900.change("X.balance"sv, "42"sv);
-    putBlock(storage, 100, at100);
-    putBlock(storage, 107, at107);
-    putBlock(storage, 140, at140);
-    putBlock(storage, 900, at900);
+    putBlock(store, storage, 100, at100);
+    putBlock(store, storage, 107, at107);
+    putBlock(store, storage, 140, at140);
+    putBlock(store, storage, 900, at900);
 }
 }  // namespace
 
@@ -70,35 +71,36 @@ void seedSection04Timeline(HistoryMemStorage& storage)
 BOOST_AUTO_TEST_CASE(section04Timeline)
 {
     HistoryMemStorage storage;
-    seedSection04Timeline(storage);
+    StateHistoryStore store;
+    seedQueryTimeline(store, storage);
     constexpr bcos::protocol::BlockNumber tip = 1000;
     constexpr bcos::protocol::BlockNumber depth = 1000;
 
-    // Asked for block 107, the first change after it is block 140, whose row says "before = 75".
-    auto at107 = readAt(storage, "X.balance"sv, 107, tip, depth);
+    // Asked for block 107, the first change after it is block 140, whose record says "before = 75".
+    auto const at107 = readAt(store, storage, "X.balance"sv, 107, tip, depth);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at107));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at107)), "75");
 
     // Every block from 107 to 139 has the same answer — that is the property the layout buys.
     for (bcos::protocol::BlockNumber block : {107, 108, 120, 139})
     {
-        auto result = readAt(storage, "X.balance"sv, block, tip, depth);
+        auto const result = readAt(store, storage, "X.balance"sv, block, tip, depth);
         BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(result));
         BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(result)), "75");
     }
 
-    // Block 100 itself: the next change is 107, whose row says "before = 90".
-    auto at100 = readAt(storage, "X.balance"sv, 100, tip, depth);
+    // Block 100 itself: the next change is 107, whose record says "before = 90".
+    auto const at100 = readAt(store, storage, "X.balance"sv, 100, tip, depth);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at100));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at100)), "90");
 
-    // Just before the first recorded change, the 100 row applies.
-    auto at99 = readAt(storage, "X.balance"sv, 99, tip, depth);
+    // Just before the first recorded change, the block-100 record applies.
+    auto const at99 = readAt(store, storage, "X.balance"sv, 99, tip, depth);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at99));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at99)), "60");
 
     // Block 899: the next change is 900.
-    auto at899 = readAt(storage, "X.balance"sv, 899, tip, depth);
+    auto const at899 = readAt(store, storage, "X.balance"sv, 899, tip, depth);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at899));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at899)), "42");
 }
@@ -108,42 +110,61 @@ BOOST_AUTO_TEST_CASE(section04Timeline)
 BOOST_AUTO_TEST_CASE(noChangeAfterBlockReturnsUseCurrent)
 {
     HistoryMemStorage storage;
-    seedSection04Timeline(storage);
+    StateHistoryStore store;
+    seedQueryTimeline(store, storage);
 
     // Compared as a whole variant, not just probed for its alternative: PR-C's callers switch on
     // ReadAtResult, so it has to be an equality-comparable value.
-    BOOST_CHECK(
-        readAt(storage, "X.balance"sv, 950, 1000, 1000) == ReadAtResult{HistoryUseCurrent{}});
-    // The tip itself is always UseCurrent: no block after it can have recorded a pre-image.
+    BOOST_CHECK(readAt(store, storage, "X.balance"sv, 950, 1000, 1000) ==
+                ReadAtResult{HistoryUseCurrent{}});
+    // The tip itself is always UseCurrent: no block after it can have recorded a pre-image, so the
+    // query short-circuits instead of looking for a change above the tip.
     BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(
-        readAt(storage, "X.balance"sv, 1000, 1000, 1000)));
+        readAt(store, storage, "X.balance"sv, 1000, 1000, 1000)));
     // A key with no history at all is likewise UseCurrent.
     BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(
-        readAt(storage, "never-touched"sv, 500, 1000, 1000)));
+        readAt(store, storage, "never-touched"sv, 500, 1000, 1000)));
+}
+
+/// tag 0x00 and tag 0x01 stay two distinguishable answers all the way out of readAt: an account
+/// created in a block must not read back as an account that held the empty string.
+BOOST_AUTO_TEST_CASE(absentAndEmptyValueAreDifferentAnswers)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    diff.change("created"sv, std::nullopt).change("emptied"sv, ""sv);
+    putBlock(store, storage, 7, diff);
+
+    BOOST_CHECK(
+        std::holds_alternative<HistoryAbsent>(readAt(store, storage, "created"sv, 6, 50, 50)));
+    auto const emptied = readAt(store, storage, "emptied"sv, 6, 50, 50);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(emptied));
+    BOOST_CHECK(std::get<bcos::bytes>(emptied).empty());
 }
 
 /// G5 / spec B.3, the one place this design could return a wrong answer with no error and no
-/// warning. Block 872 has fallen out of a 128-block window at tip 1000, and its index rows are
-/// gone — but "gone" and "never changed" look identical from a seek. The guard is what separates
-/// them, and it has to run first.
+/// warning. Block 872 has fallen out of a 128-block window at tip 1000 — but "expired" and "never
+/// changed" look identical to a lookup. The guard is what separates them, and it has to run first.
 ///
 /// This case is also the positive half of a negative control: build the same binary with
-/// `-DHISTORY_GUARD_DISABLED` (see ReverseHistoryStore::readAt) and it fails, because without
-/// the guard the seek runs, lands on the block-900 row, and hands back "42" — a value that is
+/// `-DHISTORY_GUARD_DISABLED` (see ReverseHistoryStore::readAt) and it fails, because without the
+/// guard the lookup runs, finds the block-900 version, and hands back "42" — a value that is
 /// entirely plausible and entirely wrong for block 872, which predates the retained window.
 BOOST_AUTO_TEST_CASE(outOfWindowQueryThrowsHistoryPruned)
 {
     HistoryMemStorage storage;
-    seedSection04Timeline(storage);
+    StateHistoryStore store;
+    seedQueryTimeline(store, storage);
     constexpr bcos::protocol::BlockNumber tip = 1000;
     constexpr bcos::protocol::BlockNumber depth = 128;  // window = blocks 873..1000
 
-    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 872, tip, depth), HistoryPruned);
+    BOOST_CHECK_THROW(readAt(store, storage, "X.balance"sv, 872, tip, depth), HistoryPruned);
     // One block inside the boundary still answers, so the case above is testing the boundary and
-    // not simply a broken query.
-    // "42" is also exactly what the unguarded build hands back for block 872: the seek finds the
-    // block-900 row either way. Plausible, wrong, and unmarked — hence the guard.
-    auto at873 = readAt(storage, "X.balance"sv, 873, tip, depth);
+    // not simply a broken query. "42" is also exactly what the unguarded build hands back for
+    // block 872: the lookup finds the block-900 version either way. Plausible, wrong, and
+    // unmarked — hence the guard.
+    auto const at873 = readAt(store, storage, "X.balance"sv, 873, tip, depth);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at873));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at873)), "42");
 }
@@ -152,62 +173,175 @@ BOOST_AUTO_TEST_CASE(outOfWindowQueryThrowsHistoryPruned)
 BOOST_AUTO_TEST_CASE(blockAheadOfTipThrowsInvalidHistoryBlock)
 {
     HistoryMemStorage storage;
-    seedSection04Timeline(storage);
+    StateHistoryStore store;
+    seedQueryTimeline(store, storage);
 
-    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 1001, 1000, 1000), InvalidHistoryBlock);
-    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, -1, 1000, 1000), InvalidHistoryBlock);
+    BOOST_CHECK_THROW(readAt(store, storage, "X.balance"sv, 1001, 1000, 1000), InvalidHistoryBlock);
+    BOOST_CHECK_THROW(readAt(store, storage, "X.balance"sv, -1, 1000, 1000), InvalidHistoryBlock);
 }
 
 /// The window is [tip - depth + 1, tip], straight from spec B.3. Depth 0 makes it empty, so even
 /// the tip is refused; depth 1 is the smallest window that admits anything, and it admits exactly
-/// the tip. Spelling this out keeps the off-by-one honest: nothing here is a special case.
+/// the tip. Spelling this out keeps the off-by-one honest — including that the block == tip
+/// short-circuit does NOT run ahead of the guard.
 BOOST_AUTO_TEST_CASE(windowBoundsFollowTipMinusDepthPlusOne)
 {
     HistoryMemStorage storage;
-    seedSection04Timeline(storage);
+    StateHistoryStore store;
+    seedQueryTimeline(store, storage);
 
-    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 1000, 1000, 0), HistoryPruned);
-    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 999, 1000, 0), HistoryPruned);
+    BOOST_CHECK_THROW(readAt(store, storage, "X.balance"sv, 1000, 1000, 0), HistoryPruned);
+    BOOST_CHECK_THROW(readAt(store, storage, "X.balance"sv, 999, 1000, 0), HistoryPruned);
 
-    BOOST_CHECK(
-        std::holds_alternative<HistoryUseCurrent>(readAt(storage, "X.balance"sv, 1000, 1000, 1)));
-    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 999, 1000, 1), HistoryPruned);
+    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(
+        readAt(store, storage, "X.balance"sv, 1000, 1000, 1)));
+    BOOST_CHECK_THROW(readAt(store, storage, "X.balance"sv, 999, 1000, 1), HistoryPruned);
 }
 
-/// A chain shorter than the window: tip - depth + 1 goes negative and must admit every block
-/// down to genesis rather than wrapping and rejecting them all.
+/// A chain shorter than the window: tip - depth + 1 goes negative and must admit every block down
+/// to genesis rather than wrapping and rejecting them all.
 BOOST_AUTO_TEST_CASE(windowWiderThanTheChainAdmitsGenesis)
 {
     HistoryMemStorage storage;
+    StateHistoryStore store;
     Diff at3;
     at3.change("k"sv, "v0"sv);
-    putBlock(storage, 3, at3);
+    putBlock(store, storage, 3, at3);
 
-    auto atZero = readAt(storage, "k"sv, 0, 5, 128);
+    auto const atZero = readAt(store, storage, "k"sv, 0, 5, 128);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(atZero));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(atZero)), "v0");
 }
 
-/// G6: an index row that is present but logically deleted means the pre-image chain has a hole
-/// inside a window that claims to cover it. Falling through to the current value here would be
-/// the same silent wrong answer the window guard exists to prevent, so it throws.
-BOOST_AUTO_TEST_CASE(deletedIndexRowInsideTheWindowFailsLoud)
+/// G10, refusal one: the index has never been rebuilt. The rows are all on disk and a lookup would
+/// find nothing, which reads as "the key never changed" — today's value under an old block's
+/// number. A store that has not been rebuilt therefore refuses outright.
+BOOST_AUTO_TEST_CASE(unrebuiltStoreThrowsHistoryIndexUnavailable)
 {
-    HistoryLogicalDeleteStorage storage;
-    Diff at50;
-    at50.change("k"sv, "old"sv);
-    putBlock(storage, 50, at50);
+    HistoryMemStorage storage;
+    StateHistoryStore writer;
+    Diff at100;
+    at100.change("k"sv, "old"sv);
+    putBlock(writer, storage, 100, at100);
 
-    auto keyBytes = makeBytes("k"sv);
-    auto before = bcos::task::syncWait(StateHistoryStore::readAt(storage, keyBytes, 40, 100, 100));
+    // A second store over the same rows: same disk, empty index.
+    StateHistoryStore fresh;
+    BOOST_CHECK(fresh.index().state() == IndexState::Empty);
+    BOOST_CHECK_THROW(readAt(fresh, storage, "k"sv, 99, 200, 200), HistoryIndexUnavailable);
+    // ...and it does not answer UseCurrent for an untouched key either — the refusal is about the
+    // index, not about this key.
+    BOOST_CHECK_THROW(readAt(fresh, storage, "never"sv, 99, 200, 200), HistoryIndexUnavailable);
+
+    // Once rebuilt it answers, which is what makes the refusal above a state check and not a
+    // permanently broken store.
+    bcos::task::syncWait(fresh.rebuild(storage));
+    auto const answered = readAt(fresh, storage, "k"sv, 99, 200, 200);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(answered));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(answered)), "old");
+
+    // ...and a store the startup path marked unusable goes back to refusing.
+    fresh.markUnavailable();
+    BOOST_CHECK_THROW(readAt(fresh, storage, "k"sv, 99, 200, 200), HistoryIndexUnavailable);
+}
+
+/// G10, refusal two: the index located a version and the shard it named is gone. That is what an
+/// expiry landing between the lookup and the read looks like — and on the mutable layer it is also
+/// what a deletion sentinel looks like, since readOne reports both as absent. Falling through to
+/// the current value here is the silent wrong answer the layout exists to prevent.
+BOOST_AUTO_TEST_CASE(locatedButDeletedShardThrowsHistoryPruned)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff at100;
+    at100.change("k"sv, "value-at-99"sv);
+    putBlock(store, storage, 100, at100);
+
+    // Undisturbed, block 99 answers from block 100's record.
+    auto const before = readAt(store, storage, "k"sv, 99, 200, 200);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(before));
 
-    bcos::task::syncWait(bcos::storage2::removeOne(
-        storage, bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(keyBytes, 50)}));
+    // Now delete the shard behind the index's back — the disk moved, the index did not.
+    deleteRow(storage, kStateHistory.shard, shardRowKey(100, 0));
+    BOOST_CHECK_THROW(readAt(store, storage, "k"sv, 99, 200, 200), HistoryPruned);
+    // Emphatically NOT UseCurrent, which is the answer a fall-through would have produced.
+    BOOST_CHECK(store.index().state() == IndexState::Ready);
 
-    BOOST_CHECK_THROW(
-        bcos::task::syncWait(StateHistoryStore::readAt(storage, keyBytes, 40, 100, 100)),
-        MPTInvariantViolation);
+    // Same story on a logical-deletion layer, where the row is still there as a sentinel.
+    HistoryLogicalDeleteStorage mutableLayer;
+    StateHistoryStore layerStore;
+    Diff at50;
+    at50.change("k"sv, "old"sv);
+    putBlock(layerStore, mutableLayer, 50, at50);
+    BOOST_REQUIRE(
+        std::holds_alternative<bcos::bytes>(readAt(layerStore, mutableLayer, "k"sv, 40, 100, 100)));
+    deleteRow(mutableLayer, kStateHistory.shard, shardRowKey(50, 0));
+    BOOST_CHECK_THROW(readAt(layerStore, mutableLayer, "k"sv, 40, 100, 100), HistoryPruned);
+}
+
+/// G10, refusal three: the index's offset no longer names this key's record. The index and the
+/// shard disagree about the layout of the same bytes, and the record sitting at that offset belongs
+/// to some other key — returning it would answer with another key's value.
+///
+/// The corruption is built to be undetectable by length alone: the two records are the same size,
+/// so every offset the index holds still points at a valid record, just the wrong one.
+BOOST_AUTO_TEST_CASE(offsetPointingAtAnotherKeyFailsLoud)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff diff;
+    diff.change("aaa"sv, "111"sv).change("bbb"sv, "222"sv);
+    putBlock(store, storage, 10, diff);
+
+    // Sanity: each key resolves to its own value first.
+    BOOST_CHECK_EQUAL(
+        toText(std::get<bcos::bytes>(readAt(store, storage, "aaa"sv, 9, 20, 20))), "111");
+    BOOST_CHECK_EQUAL(
+        toText(std::get<bcos::bytes>(readAt(store, storage, "bbb"sv, 9, 20, 20))), "222");
+
+    // Rewrite the shard with the two records swapped: same bytes, same length, opposite order.
+    auto const keyA = makeBytes("aaa"sv);
+    auto const keyB = makeBytes("bbb"sv);
+    auto const valueA = makeBytes("111"sv);
+    auto const valueB = makeBytes("222"sv);
+    std::string swapped;
+    appendRecord(swapped, keyB, std::span<const bcos::byte>(valueB));
+    appendRecord(swapped, keyA, std::span<const bcos::byte>(valueA));
+    auto const original = rowsOfTable(storage, kStateHistory.shard);
+    BOOST_REQUIRE_EQUAL(original[1].second.size(), swapped.size());
+    overwriteRow(storage, kStateHistory.shard, shardRowKey(10, 0), swapped);
+
+    BOOST_CHECK_THROW(readAt(store, storage, "aaa"sv, 9, 20, 20), MPTInvariantViolation);
+    BOOST_CHECK_THROW(readAt(store, storage, "bbb"sv, 9, 20, 20), MPTInvariantViolation);
+}
+
+/// The boundary beats the retention parameter when they disagree: a depth wide enough to admit the
+/// block does not make records exist. The boundary is what the store actually did; the depth is
+/// only the configured intent.
+BOOST_AUTO_TEST_CASE(blockBelowTheBoundaryIsPrunedEvenInsideTheParameterWindow)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff at100;
+    at100.change("k"sv, "old"sv);
+    Diff at120;
+    at120.change("k"sv, "newer"sv);
+    putBlock(store, storage, 100, at100);
+    putBlock(store, storage, 120, at120);
+
+    // The commit path's shape: expire block 100 and publish the retirement with the next block.
+    auto const report = expireBlockAdvancing(store, storage, 100);
+    BOOST_REQUIRE(report.retired.has_value());
+    Diff at130;
+    at130.change("other"sv, "x"sv);
+    store.publish(stageBlock(store, storage, 130, at130), report.retired,
+        std::optional<bcos::protocol::BlockNumber>{100});
+
+    // depth 1000 admits block 99 outright, but the boundary says everything below 100 is gone.
+    BOOST_CHECK_THROW(readAt(store, storage, "k"sv, 99, 200, 1000), HistoryPruned);
+    // Block 100 itself is still answerable — expiring block 100 removes what answered 99.
+    auto const at100Result = readAt(store, storage, "k"sv, 100, 200, 1000);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at100Result));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at100Result)), "newer");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/history/HistoryQueryTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryQueryTest.cpp
@@ -1,0 +1,215 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryQueryTest.cpp
+ * @brief The point query: the spec §0.4 timeline, the UseCurrent case, and the window guard that
+ *        has to run before the seek (spec B.3, G5)
+ */
+
+#include "HistoryTestHelpers.h"
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/history/HistoryErrors.h>
+#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
+#include <bcos-ledger/mpt/history/HistoryTables.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <string_view>
+#include <variant>
+
+using namespace std::string_view_literals;
+
+namespace bcos::ledger::mpt::history::test
+{
+
+BOOST_AUTO_TEST_SUITE(HistoryQuerySuite)
+
+namespace
+{
+/// The spec §0.4 timeline: X's balance is changed by blocks 100, 107, 140 and 900. Each row
+/// records what the balance was BEFORE that block changed it.
+///
+/// ```text
+///   block   100        107        140                900
+///   before  "60"       "90"       "75"               "42"
+/// ```
+void seedSection04Timeline(HistoryMemStorage& storage)
+{
+    Diff at100;
+    at100.change("X.balance"sv, "60"sv);
+    Diff at107;
+    at107.change("X.balance"sv, "90"sv);
+    Diff at140;
+    at140.change("X.balance"sv, "75"sv);
+    Diff at900;
+    at900.change("X.balance"sv, "42"sv);
+    putBlock(storage, 100, at100);
+    putBlock(storage, 107, at107);
+    putBlock(storage, 140, at140);
+    putBlock(storage, 900, at900);
+}
+}  // namespace
+
+/// spec §0.4, worked through: "the old value recorded by the first change AFTER B is exactly the
+/// value at B", because nothing touched the key in between.
+BOOST_AUTO_TEST_CASE(section04Timeline)
+{
+    HistoryMemStorage storage;
+    seedSection04Timeline(storage);
+    constexpr bcos::protocol::BlockNumber tip = 1000;
+    constexpr bcos::protocol::BlockNumber depth = 1000;
+
+    // Asked for block 107, the first change after it is block 140, whose row says "before = 75".
+    auto at107 = readAt(storage, "X.balance"sv, 107, tip, depth);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at107));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at107)), "75");
+
+    // Every block from 107 to 139 has the same answer — that is the property the layout buys.
+    for (bcos::protocol::BlockNumber block : {107, 108, 120, 139})
+    {
+        auto result = readAt(storage, "X.balance"sv, block, tip, depth);
+        BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(result));
+        BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(result)), "75");
+    }
+
+    // Block 100 itself: the next change is 107, whose row says "before = 90".
+    auto at100 = readAt(storage, "X.balance"sv, 100, tip, depth);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at100));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at100)), "90");
+
+    // Just before the first recorded change, the 100 row applies.
+    auto at99 = readAt(storage, "X.balance"sv, 99, tip, depth);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at99));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at99)), "60");
+
+    // Block 899: the next change is 900.
+    auto at899 = readAt(storage, "X.balance"sv, 899, tip, depth);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at899));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at899)), "42");
+}
+
+/// spec §0.4: "block 950 — nothing changed after 900, so the current flat value is the answer."
+/// The store says so rather than guessing a value it does not hold.
+BOOST_AUTO_TEST_CASE(noChangeAfterBlockReturnsUseCurrent)
+{
+    HistoryMemStorage storage;
+    seedSection04Timeline(storage);
+
+    // Compared as a whole variant, not just probed for its alternative: PR-C's callers switch on
+    // ReadAtResult, so it has to be an equality-comparable value.
+    BOOST_CHECK(
+        readAt(storage, "X.balance"sv, 950, 1000, 1000) == ReadAtResult{HistoryUseCurrent{}});
+    // The tip itself is always UseCurrent: no block after it can have recorded a pre-image.
+    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(
+        readAt(storage, "X.balance"sv, 1000, 1000, 1000)));
+    // A key with no history at all is likewise UseCurrent.
+    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(
+        readAt(storage, "never-touched"sv, 500, 1000, 1000)));
+}
+
+/// G5 / spec B.3, the one place this design could return a wrong answer with no error and no
+/// warning. Block 872 has fallen out of a 128-block window at tip 1000, and its index rows are
+/// gone — but "gone" and "never changed" look identical from a seek. The guard is what separates
+/// them, and it has to run first.
+///
+/// This case is also the positive half of a negative control: build the same binary with
+/// `-DHISTORY_GUARD_DISABLED` (see ReverseHistoryStore::readAt) and it fails, because without
+/// the guard the seek runs, lands on the block-900 row, and hands back "42" — a value that is
+/// entirely plausible and entirely wrong for block 872, which predates the retained window.
+BOOST_AUTO_TEST_CASE(outOfWindowQueryThrowsHistoryPruned)
+{
+    HistoryMemStorage storage;
+    seedSection04Timeline(storage);
+    constexpr bcos::protocol::BlockNumber tip = 1000;
+    constexpr bcos::protocol::BlockNumber depth = 128;  // window = blocks 873..1000
+
+    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 872, tip, depth), HistoryPruned);
+    // One block inside the boundary still answers, so the case above is testing the boundary and
+    // not simply a broken query.
+    // "42" is also exactly what the unguarded build hands back for block 872: the seek finds the
+    // block-900 row either way. Plausible, wrong, and unmarked — hence the guard.
+    auto at873 = readAt(storage, "X.balance"sv, 873, tip, depth);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at873));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at873)), "42");
+}
+
+/// The second guard line: a block the chain has not reached is not a history question at all.
+BOOST_AUTO_TEST_CASE(blockAheadOfTipThrowsInvalidHistoryBlock)
+{
+    HistoryMemStorage storage;
+    seedSection04Timeline(storage);
+
+    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 1001, 1000, 1000), InvalidHistoryBlock);
+    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, -1, 1000, 1000), InvalidHistoryBlock);
+}
+
+/// The window is [tip - depth + 1, tip], straight from spec B.3. Depth 0 makes it empty, so even
+/// the tip is refused; depth 1 is the smallest window that admits anything, and it admits exactly
+/// the tip. Spelling this out keeps the off-by-one honest: nothing here is a special case.
+BOOST_AUTO_TEST_CASE(windowBoundsFollowTipMinusDepthPlusOne)
+{
+    HistoryMemStorage storage;
+    seedSection04Timeline(storage);
+
+    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 1000, 1000, 0), HistoryPruned);
+    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 999, 1000, 0), HistoryPruned);
+
+    BOOST_CHECK(
+        std::holds_alternative<HistoryUseCurrent>(readAt(storage, "X.balance"sv, 1000, 1000, 1)));
+    BOOST_CHECK_THROW(readAt(storage, "X.balance"sv, 999, 1000, 1), HistoryPruned);
+}
+
+/// A chain shorter than the window: tip - depth + 1 goes negative and must admit every block
+/// down to genesis rather than wrapping and rejecting them all.
+BOOST_AUTO_TEST_CASE(windowWiderThanTheChainAdmitsGenesis)
+{
+    HistoryMemStorage storage;
+    Diff at3;
+    at3.change("k"sv, "v0"sv);
+    putBlock(storage, 3, at3);
+
+    auto atZero = readAt(storage, "k"sv, 0, 5, 128);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(atZero));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(atZero)), "v0");
+}
+
+/// G6: an index row that is present but logically deleted means the pre-image chain has a hole
+/// inside a window that claims to cover it. Falling through to the current value here would be
+/// the same silent wrong answer the window guard exists to prevent, so it throws.
+BOOST_AUTO_TEST_CASE(deletedIndexRowInsideTheWindowFailsLoud)
+{
+    HistoryLogicalDeleteStorage storage;
+    Diff at50;
+    at50.change("k"sv, "old"sv);
+    putBlock(storage, 50, at50);
+
+    auto keyBytes = makeBytes("k"sv);
+    auto before = bcos::task::syncWait(StateHistoryStore::readAt(storage, keyBytes, 40, 100, 100));
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(before));
+
+    bcos::task::syncWait(bcos::storage2::removeOne(
+        storage, bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(keyBytes, 50)}));
+
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(StateHistoryStore::readAt(storage, keyBytes, 40, 100, 100)),
+        MPTInvariantViolation);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryRebuildTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryRebuildTest.cpp
@@ -1,0 +1,277 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryRebuildTest.cpp
+ * @brief The index is derived data, so a restart has to recompute it from the shards and get the
+ *        SAME answers — and refuse outright when the shards do not add up (layout spec §1.5, G9)
+ */
+
+#include "HistoryTestHelpers.h"
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/history/HistoryErrors.h>
+#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
+#include <bcos-ledger/mpt/history/HistoryTables.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+using namespace std::string_view_literals;
+
+namespace bcos::ledger::mpt::history::test
+{
+
+BOOST_AUTO_TEST_SUITE(HistoryRebuildSuite)
+
+namespace
+{
+constexpr bcos::protocol::BlockNumber kRebuildFirstBlock = 10;
+constexpr bcos::protocol::BlockNumber kRebuildBlockCount = 6;
+/// 6-byte keys with 8-byte values make a 23-byte record; a 40-byte cap puts one record per shard
+/// for most blocks, so the walk has to match several shard ordinals per block rather than one.
+constexpr std::size_t kRebuildShardCap = 40;
+
+std::string rebuildKey(int index)
+{
+    return "key-" + std::to_string(index) + "!";  // 6 bytes
+}
+
+/// Six blocks, each changing a rotating subset of five keys, so the version vectors have different
+/// lengths and the upper_bound lookups are not all trivially the same.
+void seedRebuildChain(auto& store, auto& storage)
+{
+    for (bcos::protocol::BlockNumber block = kRebuildFirstBlock;
+        block < kRebuildFirstBlock + kRebuildBlockCount; ++block)
+    {
+        Diff diff;
+        for (int index = 0; index < 5; ++index)
+        {
+            if ((block + index) % 2 == 0)
+            {
+                diff.change(rebuildKey(index), "old-" + std::to_string(block) + "!!");
+            }
+        }
+        putBlock(store, storage, block, diff, kRebuildShardCap);
+    }
+}
+
+/// Every (key, block) answer the two stores can be asked for, compared pair by pair.
+void checkSameAnswers(auto& expected, auto& actual, auto& storage)
+{
+    constexpr bcos::protocol::BlockNumber kTip = 100;
+    for (int index = 0; index < 6; ++index)
+    {
+        for (bcos::protocol::BlockNumber block = kRebuildFirstBlock - 1;
+            block <= kRebuildFirstBlock + kRebuildBlockCount; ++block)
+        {
+            auto const key = rebuildKey(index);
+            BOOST_REQUIRE_MESSAGE(readAt(expected, storage, key, block, kTip, kTip) ==
+                                      readAt(actual, storage, key, block, kTip, kTip),
+                "rebuilt index disagrees for " << key << " at block " << block);
+        }
+    }
+}
+}  // namespace
+
+/// A restart: the rows are on disk, the index is not. Walking the shards has to reproduce every
+/// answer the live index gave, because the index is nothing but a second reading of those rows.
+BOOST_AUTO_TEST_CASE(rebuildReproducesEveryAnswer)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore live;
+    seedRebuildChain(live, storage);
+
+    StateHistoryStore restarted;
+    auto const report = bcos::task::syncWait(restarted.rebuild(storage));
+
+    BOOST_CHECK_EQUAL(report.blocks, std::size_t{kRebuildBlockCount});
+    BOOST_CHECK_GT(report.bytesScanned, std::size_t{0});
+    // Every version came from a record, and every record was counted by a meta row.
+    std::size_t declaredRecords = 0;
+    for (auto const& [rowKey, rowValue] : rowsOfTable(storage, kStateHistory.shard))
+    {
+        if (rowKey.size() == kMetaRowKeyBytes)
+        {
+            declaredRecords += decodeMeta(rowValue).recordCount;
+        }
+    }
+    BOOST_CHECK_EQUAL(report.records, declaredRecords);
+    BOOST_CHECK_EQUAL(restarted.index().versionCount(), declaredRecords);
+    BOOST_CHECK_EQUAL(restarted.index().versionCount(), live.index().versionCount());
+    BOOST_CHECK_EQUAL(restarted.index().keyCount(), live.index().keyCount());
+    BOOST_CHECK_EQUAL(restarted.index().blockCount(), live.index().blockCount());
+    BOOST_CHECK(restarted.index().state() == IndexState::Ready);
+
+    checkSameAnswers(live, restarted, storage);
+}
+
+/// A rebuild starts at `boundary + 1`, not at block 0. Rows below the boundary are residue an
+/// interrupted expiry left behind, and indexing them would resurrect heights the store has already
+/// promised not to answer for — the boundary would say "pruned" while the index said "here it is".
+BOOST_AUTO_TEST_CASE(boundaryMakesRebuildSkipTheRowsBelowIt)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore live;
+    seedRebuildChain(live, storage);
+    // Blocks 10..12 were expired, but their rows were left behind by an interrupted pass.
+    bcos::task::syncWait(StateHistoryStore::writeRetentionBoundary(storage, 12));
+
+    StateHistoryStore restarted;
+    auto const report = bcos::task::syncWait(restarted.rebuild(storage));
+
+    // Only blocks 13, 14 and 15 are indexed; the residue below the boundary is not.
+    BOOST_CHECK_EQUAL(report.blocks, std::size_t{3});
+    BOOST_CHECK(!restarted.recordedBlock(12));
+    BOOST_CHECK(restarted.recordedBlock(13));
+    BOOST_REQUIRE(restarted.index().boundary().has_value());
+    BOOST_CHECK_EQUAL(*restarted.index().boundary(), 12);
+    // ...and the boundary it read is enforced, so a query below it refuses rather than answering
+    // from the residue.
+    BOOST_CHECK_THROW(readAt(restarted, storage, rebuildKey(0), 11, 100, 100), HistoryPruned);
+    BOOST_CHECK_NO_THROW(readAt(restarted, storage, rebuildKey(0), 13, 100, 100));
+}
+
+/// A rebuild over a store that recorded nothing installs an EMPTY Ready index, not a refusal: the
+/// walk covered the whole retained range and found no change, which is a fact. The boundary it read
+/// still stands, so a query below it is still refused.
+BOOST_AUTO_TEST_CASE(rebuildOverAnEmptyStoreIsReadyNotUnavailable)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    bcos::task::syncWait(StateHistoryStore::writeRetentionBoundary(storage, 50));
+
+    auto const report = bcos::task::syncWait(store.rebuild(storage));
+    BOOST_CHECK_EQUAL(report.blocks, std::size_t{0});
+    BOOST_CHECK_EQUAL(report.records, std::size_t{0});
+    BOOST_CHECK(store.index().state() == IndexState::Ready);
+    BOOST_CHECK(
+        std::holds_alternative<HistoryUseCurrent>(readAt(store, storage, "k"sv, 60, 100, 100)));
+    BOOST_CHECK_THROW(readAt(store, storage, "k"sv, 49, 100, 100), HistoryPruned);
+}
+
+/// Each way the shards can fail to add up, and the refusal it must produce. Every one of these
+/// would otherwise leave some pre-image out of the index, and a missing version reads as "the key
+/// never changed" — today's value under an old block's number (G6).
+///
+/// The store is left for the caller to mark unusable, which is what the startup path does; the
+/// point here is that the rebuild THROWS rather than returning a short index.
+BOOST_AUTO_TEST_CASE(anInconsistentShardTableRefusesToRebuild)
+{
+    auto const corruptThenRebuild = [](auto&& corrupt) {
+        HistoryMemStorage storage;
+        StateHistoryStore live;
+        seedRebuildChain(live, storage);
+        corrupt(storage);
+        StateHistoryStore restarted;
+        BOOST_CHECK_THROW(bcos::task::syncWait(restarted.rebuild(storage)), MPTInvariantViolation);
+        // The startup path's response: refuse every query rather than serve a short index.
+        restarted.markUnavailable();
+        BOOST_CHECK_THROW(
+            readAt(restarted, storage, rebuildKey(0), 12, 100, 100), HistoryIndexUnavailable);
+    };
+
+    // A block's meta row is gone, so its shard rows arrive with nothing declaring them.
+    corruptThenRebuild(
+        [](auto& storage) { deleteRow(storage, kStateHistory.shard, metaRowKey(12)); });
+
+    // The meta row declares MORE shards than are there.
+    corruptThenRebuild([](auto& storage) {
+        auto const meta = decodeMeta(readRowValue(storage, kStateHistory.shard, metaRowKey(12)));
+        overwriteRow(storage, kStateHistory.shard, metaRowKey(12),
+            metaRowValue(meta.shardCount + 1, meta.recordCount, meta.blockHash));
+    });
+
+    // The meta row declares FEWER shards than are there.
+    corruptThenRebuild([](auto& storage) {
+        auto const meta = decodeMeta(readRowValue(storage, kStateHistory.shard, metaRowKey(12)));
+        BOOST_REQUIRE_GT(meta.shardCount, 0U);
+        overwriteRow(storage, kStateHistory.shard, metaRowKey(12),
+            metaRowValue(meta.shardCount - 1, meta.recordCount, meta.blockHash));
+    });
+
+    // The meta row's record count disagrees with the records the shards hold.
+    corruptThenRebuild([](auto& storage) {
+        auto const meta = decodeMeta(readRowValue(storage, kStateHistory.shard, metaRowKey(12)));
+        overwriteRow(storage, kStateHistory.shard, metaRowKey(12),
+            metaRowValue(meta.shardCount, meta.recordCount + 1, meta.blockHash));
+    });
+
+    // A shard payload that ends inside a record.
+    corruptThenRebuild([](auto& storage) {
+        auto const payload = readRowValue(storage, kStateHistory.shard, shardRowKey(12, 0));
+        overwriteRow(storage, kStateHistory.shard, shardRowKey(12, 0),
+            payload.substr(0, payload.size() - 2));
+    });
+
+    // An unknown meta format version — the gate a future layout change goes through.
+    corruptThenRebuild([](auto& storage) {
+        auto value = metaRowValue(1, 0, blockHashOf(12));
+        value[0] = '\x07';
+        overwriteRow(storage, kStateHistory.shard, metaRowKey(12), std::move(value));
+    });
+
+    // A shard row whose ordinal skips ahead, so the 0..n-1 run has a hole.
+    corruptThenRebuild([](auto& storage) {
+        auto const payload = readRowValue(storage, kStateHistory.shard, shardRowKey(12, 0));
+        overwriteRow(storage, kStateHistory.shard, shardRowKey(12, 9), payload);
+        deleteRow(storage, kStateHistory.shard, shardRowKey(12, 0));
+    });
+}
+
+/// G9: the index learns about a block only after its WriteBatch has landed. A merge that throws
+/// leaves the StagedBlock unpublished, and the store must then answer exactly as it did before —
+/// not from rows that are on disk but were never committed as far as the caller is concerned.
+BOOST_AUTO_TEST_CASE(anUnpublishedBlockIsInvisibleToQueries)
+{
+    HistoryMemStorage storage;
+    StateHistoryStore store;
+    Diff at10;
+    at10.change("k"sv, "old-at-9"sv);
+    putBlock(store, storage, 10, at10);
+
+    // Stage block 20 — the rows land, the index update is held back.
+    Diff at20;
+    at20.change("k"sv, "old-at-19"sv);
+    auto staged = stageBlock(store, storage, 20, at20);
+    BOOST_REQUIRE_EQUAL(rowsOfTable(storage, kStateHistory.shard).size(), std::size_t{4});
+
+    // The merge "failed": nothing is published. Block 20 does not exist as far as queries go, and
+    // block 19 reads as unchanged since block 10 rather than as block 20's pre-image.
+    BOOST_CHECK(!store.recordedBlock(20));
+    BOOST_CHECK_EQUAL(store.index().versionCount(), std::size_t{1});
+    BOOST_CHECK(
+        std::holds_alternative<HistoryUseCurrent>(readAt(store, storage, "k"sv, 19, 100, 100)));
+    auto const at9 = readAt(store, storage, "k"sv, 9, 100, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at9));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at9)), "old-at-9");
+
+    // Publishing it afterwards is what makes it visible — so the invisibility above is the missing
+    // publish and not a broken write.
+    store.publish(std::move(staged), std::nullopt, std::nullopt);
+    BOOST_CHECK(store.recordedBlock(20));
+    auto const at19 = readAt(store, storage, "k"sv, 19, 100, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(at19));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(at19)), "old-at-19");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryRebuildTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryRebuildTest.cpp
@@ -27,8 +27,10 @@
 #include <bcos-ledger/mpt/history/HistoryTables.h>
 #include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
 #include <bcos-task/Wait.h>
+#include <boost/exception/get_error_info.hpp>
 #include <boost/test/unit_test.hpp>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -234,6 +236,85 @@ BOOST_AUTO_TEST_CASE(anInconsistentShardTableRefusesToRebuild)
         overwriteRow(storage, kStateHistory.shard, shardRowKey(12, 9), payload);
         deleteRow(storage, kStateHistory.shard, shardRowKey(12, 0));
     });
+}
+
+/// A refusal that does not say WHERE is not actionable: the caller reporting it is the offline
+/// B.10 audit, which files a finding against a block number. Every refusal the rebuild walk raises
+/// itself therefore carries errinfo_historyBlock.
+///
+/// The last two assertions pin the BOUNDARY of that promise rather than the promise: a refusal
+/// raised inside the row codec knows the bytes it was handed, not which block's row they came from,
+/// so the tag is absent there and a reader must handle its absence.
+BOOST_AUTO_TEST_CASE(everyRebuildRefusalNamesItsBlock)
+{
+    auto const blockOfRefusal = [](auto&& corrupt) -> std::optional<bcos::protocol::BlockNumber> {
+        HistoryMemStorage storage;
+        StateHistoryStore live;
+        seedRebuildChain(live, storage);
+        corrupt(storage);
+        StateHistoryStore restarted;
+        try
+        {
+            bcos::task::syncWait(restarted.rebuild(storage));
+        }
+        catch (MPTInvariantViolation const& error)
+        {
+            auto const* at = boost::get_error_info<errinfo_historyBlock>(error);
+            return at != nullptr ? std::optional<bcos::protocol::BlockNumber>{*at} : std::nullopt;
+        }
+        BOOST_FAIL("the rebuild was expected to refuse");
+        return std::nullopt;
+    };
+
+    // A shard row that no meta row introduced.
+    BOOST_CHECK(blockOfRefusal([](auto& storage) {
+        deleteRow(storage, kStateHistory.shard, metaRowKey(12));
+    }) == std::optional<bcos::protocol::BlockNumber>{12});
+
+    // The meta row declares more shards than are there — caught when the block is closed off.
+    BOOST_CHECK(blockOfRefusal([](auto& storage) {
+        auto const meta = decodeMeta(readRowValue(storage, kStateHistory.shard, metaRowKey(12)));
+        overwriteRow(storage, kStateHistory.shard, metaRowKey(12),
+            metaRowValue(meta.shardCount + 1, meta.recordCount, meta.blockHash));
+    }) == std::optional<bcos::protocol::BlockNumber>{12});
+
+    // A hole in the 0..n-1 ordinal run.
+    BOOST_CHECK(blockOfRefusal([](auto& storage) {
+        auto const payload = readRowValue(storage, kStateHistory.shard, shardRowKey(12, 0));
+        overwriteRow(storage, kStateHistory.shard, shardRowKey(12, 9), payload);
+        deleteRow(storage, kStateHistory.shard, shardRowKey(12, 0));
+    }) == std::optional<bcos::protocol::BlockNumber>{12});
+
+    // A deletion sentinel: the row key is decoded before the sentinel is rejected, so even this
+    // one names its block.
+    {
+        HistoryLogicalDeleteStorage storage;
+        StateHistoryStore live;
+        seedRebuildChain(live, storage);
+        deleteRow(storage, kStateHistory.shard, shardRowKey(12, 0));
+        StateHistoryStore restarted;
+        std::optional<bcos::protocol::BlockNumber> at;
+        try
+        {
+            bcos::task::syncWait(restarted.rebuild(storage));
+            BOOST_FAIL("the rebuild was expected to refuse a deletion sentinel");
+        }
+        catch (MPTInvariantViolation const& error)
+        {
+            if (auto const* found = boost::get_error_info<errinfo_historyBlock>(error))
+            {
+                at = *found;
+            }
+        }
+        BOOST_CHECK(at == std::optional<bcos::protocol::BlockNumber>{12});
+    }
+
+    // Raised by the codec, which never saw a row key: no block to name.
+    BOOST_CHECK(!blockOfRefusal([](auto& storage) {
+        auto value = metaRowValue(1, 0, blockHashOf(12));
+        value[0] = '\x07';
+        overwriteRow(storage, kStateHistory.shard, metaRowKey(12), std::move(value));
+    }).has_value());
 }
 
 /// G9: the index learns about a block only after its WriteBatch has landed. A merge that throws

--- a/bcos-ledger/test/unittests/mpt/history/HistoryRocksDBTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryRocksDBTest.cpp
@@ -1,0 +1,152 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryRocksDBTest.cpp
+ * @brief The same layout over the storage production actually runs on.
+ *
+ * MemoryStorage orders rows by the (table, rowKey) pair; RocksDB orders the single physical
+ * string "<table>:<rowKey>" bytewise, and reconstructs the pair by splitting at its FIRST colon
+ * (bcos-storage/StateKVResolver.h:44). History row keys carry arbitrary bytes — 0x00 from every
+ * BE64 block field, and 0x3A whenever a state key happens to contain one — so the seek order and
+ * the key round trip are worth pinning against the real thing rather than only against the
+ * in-memory stand-in.
+ */
+
+#include "HistoryTestHelpers.h"
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/history/HistoryRowCodec.h>
+#include <bcos-ledger/mpt/history/HistoryTables.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-storage/RocksDBStorage2.h>
+#include <bcos-storage/StateKVResolver.h>
+#include <bcos-task/Task.h>
+#include <bcos-task/Wait.h>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <random>
+#include <string>
+#include <string_view>
+#include <variant>
+
+using namespace std::string_view_literals;
+
+namespace bcos::ledger::mpt::history::test
+{
+
+BOOST_AUTO_TEST_SUITE(HistoryIndexSuite)
+
+namespace
+{
+using RocksDbHistoryStorage = bcos::storage2::rocksdb::RocksDBStorage2<bcos::executor_v1::StateKey,
+    bcos::executor_v1::StateValue, bcos::storage2::rocksdb::StateKeyResolver,
+    bcos::storage2::rocksdb::StateValueResolver>;
+
+struct RocksDbHistoryFixture
+{
+    std::string path = "./history-rocksdb-" + std::to_string(std::random_device{}());
+    std::unique_ptr<::rocksdb::DB> db;
+
+    RocksDbHistoryFixture()
+    {
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+        ::rocksdb::DB* raw = nullptr;
+        auto status = ::rocksdb::DB::Open(options, path, &raw);
+        BOOST_REQUIRE(status.ok());
+        db.reset(raw);
+    }
+    RocksDbHistoryFixture(const RocksDbHistoryFixture&) = delete;
+    RocksDbHistoryFixture(RocksDbHistoryFixture&&) = delete;
+    RocksDbHistoryFixture& operator=(const RocksDbHistoryFixture&) = delete;
+    RocksDbHistoryFixture& operator=(RocksDbHistoryFixture&&) = delete;
+    ~RocksDbHistoryFixture()
+    {
+        db.reset();
+        boost::filesystem::remove_all(path);
+    }
+};
+}  // namespace
+
+/// One end-to-end pass over RocksDB: put, read back across the length discriminator, sweep the
+/// manifest, expire. The keys carry a colon and a NUL on purpose.
+BOOST_AUTO_TEST_CASE(rocksDbBackendCarriesTheSameLayout)
+{
+    RocksDbHistoryFixture fixture;
+    RocksDbHistoryStorage storage(*fixture.db, bcos::storage2::rocksdb::StateKeyResolver{},
+        bcos::storage2::rocksdb::StateValueResolver{});
+
+    // "/tables/c:slot" is the shape a real state key has, colon included; the NUL makes sure
+    // nothing along the path treats the key as C string terminated.
+    const auto colonKey = std::string("/tables/c:slot") + '\0' + 'x';
+    Diff at2;
+    at2.change("abc"sv, "abc-at-1"sv);
+    at2.change(colonKey, "colon-at-1"sv);
+    Diff at10;
+    at10.change("abcde"sv, "abcde-at-9"sv);
+    putBlock(storage, 2, at2);
+    putBlock(storage, 10, at10);
+
+    // Byte ordering under RocksDB's own comparator: a query for "abc" at block 5 seeks to
+    // "abc"+BE64(6), and RocksDB really does hand back "abcde"+BE64(10) as the first row at or
+    // beyond it. Pinning the landing row keeps the UseCurrent assertion below from being vacuous
+    // — it is the length clause rejecting a prefix match, not a seek that found nothing.
+    auto firstRowKey = bcos::task::syncWait([&]() -> bcos::task::Task<std::string> {
+        auto abcKey = makeBytes("abc"sv);
+        auto iterator = co_await bcos::storage2::range(storage, bcos::storage2::RANGE_SEEK,
+            bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(abcKey, 6)});
+        auto row = co_await iterator.next();
+        if (!row)
+        {
+            co_return std::string{};
+        }
+        auto const& [rowKey, rowValue] = *row;
+        co_return std::string(bcos::executor_v1::StateKeyView{rowKey}.m_key);
+    }());
+    BOOST_CHECK_EQUAL(firstRowKey, indexRowKey(makeBytes("abcde"sv), 10));
+
+    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(readAt(storage, "abc"sv, 5, 20, 100)));
+
+    auto abcdeAtFive = readAt(storage, "abcde"sv, 5, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcdeAtFive));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcdeAtFive)), "abcde-at-9");
+
+    // The colon and the NUL survive the physical-key round trip in both directions.
+    auto colonAtOne = readAt(storage, colonKey, 1, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(colonAtOne));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(colonAtOne)), "colon-at-1");
+
+    auto block2Keys = keysOfBlock(storage, 2);
+    BOOST_REQUIRE_EQUAL(block2Keys.size(), 2);
+    BOOST_CHECK_EQUAL(toText(block2Keys[0]), "abc");
+    BOOST_CHECK_EQUAL(toText(block2Keys[1]), colonKey);
+
+    // Expiry, and the neighbouring block left intact.
+    auto report = expireBlock(storage, 2);
+    BOOST_CHECK_EQUAL(report.keyCount, 2);
+    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 1);
+    BOOST_CHECK(keysOfBlock(storage, 2).empty());
+    BOOST_CHECK_EQUAL(keysOfBlock(storage, 10).size(), 1);
+
+    auto abcdeAfterExpiry = readAt(storage, "abcde"sv, 5, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcdeAfterExpiry));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcdeAfterExpiry)), "abcde-at-9");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryRocksDBTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryRocksDBTest.cpp
@@ -16,12 +16,12 @@
  * @file HistoryRocksDBTest.cpp
  * @brief The same layout over the storage production actually runs on.
  *
- * MemoryStorage orders rows by the (table, rowKey) pair; RocksDB orders the single physical
- * string "<table>:<rowKey>" bytewise, and reconstructs the pair by splitting at its FIRST colon
- * (bcos-storage/StateKVResolver.h:44). History row keys carry arbitrary bytes — 0x00 from every
- * BE64 block field, and 0x3A whenever a state key happens to contain one — so the seek order and
- * the key round trip are worth pinning against the real thing rather than only against the
- * in-memory stand-in.
+ * MemoryStorage orders rows by the (table, rowKey) pair; RocksDB orders the single physical string
+ * "<table>:<rowKey>" bytewise, and reconstructs the pair by splitting at its FIRST colon
+ * (bcos-storage/StateKVResolver.h:44). The meta-before-shard-0 order that one seek rides on is a
+ * property of that comparator, and history row keys carry arbitrary bytes — 0x00 from every BE64
+ * block field, 0x3A whenever a state key contains one — so the whole cycle is pinned against the
+ * real thing rather than only against the in-memory stand-in.
  */
 
 #include "HistoryTestHelpers.h"
@@ -37,18 +37,21 @@
 #include <bcos-task/Wait.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <random>
 #include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 using namespace std::string_view_literals;
 
 namespace bcos::ledger::mpt::history::test
 {
 
-BOOST_AUTO_TEST_SUITE(HistoryIndexSuite)
+BOOST_AUTO_TEST_SUITE(HistoryRocksDBSuite)
 
 namespace
 {
@@ -82,8 +85,8 @@ struct RocksDbHistoryFixture
 };
 }  // namespace
 
-/// One end-to-end pass over RocksDB: put, read back across the length discriminator, sweep the
-/// manifest, expire. The keys carry a colon and a NUL on purpose.
+/// One end-to-end pass over RocksDB: put, query, restart-and-rebuild, expire. The keys carry a
+/// colon and a NUL on purpose.
 BOOST_AUTO_TEST_CASE(rocksDbBackendCarriesTheSameLayout)
 {
     RocksDbHistoryFixture fixture;
@@ -93,58 +96,93 @@ BOOST_AUTO_TEST_CASE(rocksDbBackendCarriesTheSameLayout)
     // "/tables/c:slot" is the shape a real state key has, colon included; the NUL makes sure
     // nothing along the path treats the key as C string terminated.
     const auto colonKey = std::string("/tables/c:slot") + '\0' + 'x';
+
+    StateHistoryStore live;
     Diff at2;
-    at2.change("abc"sv, "abc-at-1"sv);
-    at2.change(colonKey, "colon-at-1"sv);
+    at2.change("abc"sv, "abc-at-1"sv).change(colonKey, std::nullopt);
     Diff at10;
-    at10.change("abcde"sv, "abcde-at-9"sv);
-    putBlock(storage, 2, at2);
-    putBlock(storage, 10, at10);
+    at10.change("abcde"sv, "abcde-at-9"sv).change(colonKey, "colon-at-9"sv);
+    // A cap that splits block 2 across two shards, so the walk crosses a shard boundary here too.
+    putBlock(live, storage, 2, at2, /*shardCap=*/24);
+    putBlock(live, storage, 10, at10);
 
-    // Byte ordering under RocksDB's own comparator: a query for "abc" at block 5 seeks to
-    // "abc"+BE64(6), and RocksDB really does hand back "abcde"+BE64(10) as the first row at or
-    // beyond it. Pinning the landing row keeps the UseCurrent assertion below from being vacuous
-    // — it is the length clause rejecting a prefix match, not a seek that found nothing.
-    auto firstRowKey = bcos::task::syncWait([&]() -> bcos::task::Task<std::string> {
-        auto abcKey = makeBytes("abc"sv);
+    // RocksDB's own comparator puts the 8-byte meta key before the 10-byte shard keys of the same
+    // block, which is what makes one seek enough for readBlock, expire and rebuild.
+    auto const seen = bcos::task::syncWait([&]() -> bcos::task::Task<std::vector<std::string>> {
+        std::vector<std::string> keys;
         auto iterator = co_await bcos::storage2::range(storage, bcos::storage2::RANGE_SEEK,
-            bcos::executor_v1::StateKey{kStateHistory.index, indexRowKey(abcKey, 6)});
-        auto row = co_await iterator.next();
-        if (!row)
+            bcos::executor_v1::StateKey{kStateHistory.shard, metaRowKey(2)});
+        while (true)
         {
-            co_return std::string{};
+            auto row = co_await iterator.next();
+            if (!row)
+            {
+                break;
+            }
+            auto const& [rowKey, rowValue] = *row;
+            bcos::executor_v1::StateKeyView view{rowKey};
+            if (view.m_table != kStateHistory.shard)
+            {
+                break;
+            }
+            keys.emplace_back(view.m_key);
         }
-        auto const& [rowKey, rowValue] = *row;
-        co_return std::string(bcos::executor_v1::StateKeyView{rowKey}.m_key);
+        co_return keys;
     }());
-    BOOST_CHECK_EQUAL(firstRowKey, indexRowKey(makeBytes("abcde"sv), 10));
+    BOOST_REQUIRE_EQUAL(seen.size(), std::size_t{5});  // block 2: meta + 2 shards; block 10: meta +
+                                                       // 1
+    BOOST_CHECK_EQUAL(seen[0], metaRowKey(2));
+    BOOST_CHECK_EQUAL(seen[1], shardRowKey(2, 0));
+    BOOST_CHECK_EQUAL(seen[2], shardRowKey(2, 1));
+    BOOST_CHECK_EQUAL(seen[3], metaRowKey(10));
+    BOOST_CHECK_EQUAL(seen[4], shardRowKey(10, 0));
 
-    BOOST_CHECK(std::holds_alternative<HistoryUseCurrent>(readAt(storage, "abc"sv, 5, 20, 100)));
-
-    auto abcdeAtFive = readAt(storage, "abcde"sv, 5, 20, 100);
+    // The colon and the NUL survive the physical-key round trip in both directions.
+    auto const colonAtOne = readAt(live, storage, colonKey, 1, 20, 100);
+    BOOST_CHECK(std::holds_alternative<HistoryAbsent>(colonAtOne));
+    auto const colonAtNine = readAt(live, storage, colonKey, 9, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(colonAtNine));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(colonAtNine)), "colon-at-9");
+    auto const abcdeAtFive = readAt(live, storage, "abcde"sv, 5, 20, 100);
     BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcdeAtFive));
     BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcdeAtFive)), "abcde-at-9");
 
-    // The colon and the NUL survive the physical-key round trip in both directions.
-    auto colonAtOne = readAt(storage, colonKey, 1, 20, 100);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(colonAtOne));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(colonAtOne)), "colon-at-1");
+    // A restart: a fresh store over the same database walks the shards and answers identically.
+    StateHistoryStore restarted;
+    auto const report = bcos::task::syncWait(restarted.rebuild(storage));
+    BOOST_CHECK_EQUAL(report.blocks, std::size_t{2});
+    BOOST_CHECK_EQUAL(report.records, std::size_t{4});
+    BOOST_CHECK_EQUAL(restarted.index().versionCount(), std::size_t{4});
+    BOOST_CHECK(readAt(restarted, storage, colonKey, 9, 20, 100) == colonAtNine);
+    BOOST_CHECK(readAt(restarted, storage, colonKey, 1, 20, 100) == colonAtOne);
+    BOOST_CHECK(readAt(restarted, storage, "abcde"sv, 5, 20, 100) == abcdeAtFive);
 
-    auto block2Keys = keysOfBlock(storage, 2);
-    BOOST_REQUIRE_EQUAL(block2Keys.size(), 2);
-    BOOST_CHECK_EQUAL(toText(block2Keys[0]), "abc");
-    BOOST_CHECK_EQUAL(toText(block2Keys[1]), colonKey);
+    // Block 2's whole diff, in shard order across the split.
+    auto const block2 = readBlock(restarted, storage, 2);
+    BOOST_REQUIRE_EQUAL(block2.records.size(), std::size_t{2});
+    BOOST_CHECK_EQUAL(toText(block2.records[0].first), "abc");
+    BOOST_CHECK_EQUAL(toText(block2.records[1].first), colonKey);
+    BOOST_CHECK(!block2.records[1].second.has_value());
 
     // Expiry, and the neighbouring block left intact.
-    auto report = expireBlock(storage, 2);
-    BOOST_CHECK_EQUAL(report.keyCount, 2);
-    BOOST_CHECK_EQUAL(report.manifestShardsDeleted, 1);
-    BOOST_CHECK(keysOfBlock(storage, 2).empty());
-    BOOST_CHECK_EQUAL(keysOfBlock(storage, 10).size(), 1);
+    auto const expired =
+        bcos::task::syncWait(restarted.expire(storage, storage, 2, RetentionBoundary::Advance));
+    BOOST_CHECK_EQUAL(expired.keyCount, std::size_t{2});
+    BOOST_CHECK_EQUAL(expired.shardsDeleted, std::size_t{2});
+    BOOST_REQUIRE(expired.retired.has_value());
+    BOOST_CHECK_EQUAL(*boundaryOnDisk(restarted, storage), 2);
+    BOOST_CHECK_EQUAL(readBlock(restarted, storage, 10).records.size(), std::size_t{2});
 
-    auto abcdeAfterExpiry = readAt(storage, "abcde"sv, 5, 20, 100);
-    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(abcdeAfterExpiry));
-    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(abcdeAfterExpiry)), "abcde-at-9");
+    // The next restart picks the boundary up and starts above it, so block 2's answers are gone
+    // for good rather than reappearing from rows that were never deleted.
+    StateHistoryStore afterExpiry;
+    auto const secondReport = bcos::task::syncWait(afterExpiry.rebuild(storage));
+    BOOST_CHECK_EQUAL(secondReport.blocks, std::size_t{1});
+    BOOST_CHECK(!afterExpiry.recordedBlock(2));
+    BOOST_CHECK(afterExpiry.recordedBlock(10));
+    auto const stillAnswered = readAt(afterExpiry, storage, "abcde"sv, 5, 20, 100);
+    BOOST_REQUIRE(std::holds_alternative<bcos::bytes>(stillAnswered));
+    BOOST_CHECK_EQUAL(toText(std::get<bcos::bytes>(stillAnswered)), "abcde-at-9");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/history/HistoryTestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryTestHelpers.h
@@ -134,7 +134,7 @@ private:
 /// The suites assert on this directly: the layout is a byte-exact promise (spec B.2), so the
 /// tests read the bytes rather than only the accessors that produced them.
 inline std::vector<std::pair<std::string, std::string>> rowsOfTable(
-    HistoryMemStorage& storage, std::string_view table)
+    auto& storage, std::string_view table)
 {
     return bcos::task::syncWait(
         [&]() -> bcos::task::Task<std::vector<std::pair<std::string, std::string>>> {

--- a/bcos-ledger/test/unittests/mpt/history/HistoryTestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryTestHelpers.h
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  * @file HistoryTestHelpers.h
- * @brief Shared fixtures for the reverse-history suites: a seek-capable backend, a diff builder
+ * @brief Shared fixtures for the reverse-history suites: seek-capable backends, a diff builder
  *        that keeps HistoryEntry's views alive, and a raw row dump for asserting on the layout
  */
 #pragma once
@@ -27,10 +27,14 @@
 #include <bcos-task/Task.h>
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
 #include <cstddef>
 #include <deque>
 #include <memory>
 #include <optional>
+// CountingStorage below constrains its forwarders on ::ranges::input_range; MemoryStorage.h does
+// not promise to pull the concept in.
+#include <range/v3/range/concepts.hpp>
 #include <span>
 #include <string>
 #include <string_view>
@@ -46,29 +50,37 @@ namespace bcos::ledger::mpt::history::test
 /// index, so it is only a whole-storage seek when there is exactly one bucket
 /// (MemoryStorage.h:547 seek + MemoryStorage.h:97 getBucketSize).
 /// Rows are compared by (table, rowKey), which inside one table is the same byte order RocksDB
-/// applies to "<table>:<rowKey>".
+/// applies to "<table>:<rowKey>" — the order the meta-before-shard-0 layout stands on.
 using HistoryMemStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
     bcos::storage::Entry, bcos::storage2::memory_storage::ORDERED>;
 
-/// Same backend with logical deletion turned on, so a removed row stays visible to the iterator
-/// as a deletion sentinel instead of vanishing — the shape a mutable layer has before it is
-/// merged down.
+/// Same backend with logical deletion turned on, so a removed row stays visible to the iterator as
+/// a deletion sentinel instead of vanishing — the shape a mutable layer has before it is merged
+/// down.
 using HistoryLogicalDeleteStorage =
     bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey, bcos::storage::Entry,
         bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::LOGICAL_DELETION>;
 
-/// Backend wrapper that counts every read it is asked to perform. put() must never touch it.
+/// Backend wrapper that counts the calls it is asked to serve. put() must never read or seek, and
+/// expire() must delete whole rows rather than one key at a time — both are counted here.
 struct CountingStorage
 {
     HistoryMemStorage inner;
     std::size_t readCalls{};
     std::size_t rangeCalls{};
+    std::size_t removeCalls{};
+    std::size_t removedKeys{};
 
     auto writeSome(::ranges::input_range auto keyValues)
     {
         return inner.writeSome(std::move(keyValues));
     }
-    auto removeSome(::ranges::input_range auto keys) { return inner.removeSome(std::move(keys)); }
+    auto removeSome(::ranges::input_range auto keys, auto&&... args)
+    {
+        ++removeCalls;
+        removedKeys += static_cast<std::size_t>(::ranges::size(keys));
+        return inner.removeSome(std::move(keys), std::forward<decltype(args)>(args)...);
+    }
     auto readOne(auto key, auto&&... args)
     {
         ++readCalls;
@@ -92,9 +104,18 @@ inline bcos::bytes makeBytes(std::string_view text)
     return {text.begin(), text.end()};
 }
 
+/// A block hash that is distinguishable per block, so a meta row read back can be attributed.
+inline bcos::h256 blockHashOf(bcos::protocol::BlockNumber block)
+{
+    bcos::h256 hash;
+    hash.mutableData()[30] = static_cast<bcos::byte>((block >> 8) & 0xFF);
+    hash.mutableData()[31] = static_cast<bcos::byte>(block & 0xFF);
+    return hash;
+}
+
 /// Owns the key and value bytes a batch of HistoryEntry views point at. HistoryEntry is
-/// deliberately non-owning (put copies out of it), so the test needs somewhere stable to keep
-/// them; std::deque is used because push_back leaves references to existing elements valid.
+/// deliberately non-owning (put copies out of it), so the test needs somewhere stable to keep them;
+/// std::deque is used because push_back leaves references to existing elements valid.
 class Diff
 {
 public:
@@ -131,8 +152,9 @@ private:
 };
 
 /// Every row of @p table currently in @p storage, as (rowKey, value) in ascending key order.
-/// The suites assert on this directly: the layout is a byte-exact promise (spec B.2), so the
-/// tests read the bytes rather than only the accessors that produced them.
+/// The suites assert on this directly: the layout is a byte-exact promise (layout spec §1.2), so
+/// the tests read the bytes rather than only the accessors that produced them. Deletion sentinels
+/// are skipped, so on a logical-deletion backend this shows what is still LIVE.
 inline std::vector<std::pair<std::string, std::string>> rowsOfTable(
     auto& storage, std::string_view table)
 {
@@ -170,38 +192,91 @@ inline constexpr std::size_t kWideShardCap = 64 * 1024;
 // The suites share these wrappers rather than each defining its own: the ledger test binary is a
 // unity build, so per-file anonymous namespaces would land in one translation unit and collide.
 
-/// Write one block's state history.
-inline void putBlock(auto& storage, bcos::protocol::BlockNumber block, Diff const& diff,
-    std::size_t shardCap = kWideShardCap)
+/// Write one block's history rows and return the index update they imply, WITHOUT applying it —
+/// the state the commit path is in between staging and a successful merge (G9).
+inline StagedBlock stageBlock(auto& store, auto& storage, bcos::protocol::BlockNumber block,
+    Diff const& diff, std::size_t shardCap = kWideShardCap)
 {
-    bcos::task::syncWait(StateHistoryStore::put(storage, block, diff.entries(), shardCap));
+    return bcos::task::syncWait(
+        store.put(storage, block, blockHashOf(block), diff.entries(), shardCap));
 }
 
-/// Query the state history for @p key at @p block, against a chain at @p tip retaining @p depth.
-inline ReadAtResult readAt(auto& storage, std::string_view key, bcos::protocol::BlockNumber block,
-    bcos::protocol::BlockNumber tip, bcos::protocol::BlockNumber depth)
+/// Write one block's history and publish it, i.e. the whole commit path for a block that expires
+/// nothing.
+inline void putBlock(auto& store, auto& storage, bcos::protocol::BlockNumber block,
+    Diff const& diff, std::size_t shardCap = kWideShardCap)
+{
+    store.publish(stageBlock(store, storage, block, diff, shardCap), std::nullopt, std::nullopt);
+}
+
+/// Query the history for @p key at @p block, against a chain at @p tip retaining @p depth.
+inline ReadAtResult readAt(auto& store, auto& storage, std::string_view key,
+    bcos::protocol::BlockNumber block, bcos::protocol::BlockNumber tip,
+    bcos::protocol::BlockNumber depth)
 {
     auto keyBytes = makeBytes(key);
-    return bcos::task::syncWait(StateHistoryStore::readAt(storage, keyBytes, block, tip, depth));
+    return bcos::task::syncWait(store.readAt(storage, keyBytes, block, tip, depth));
 }
 
-/// The keys one block changed, per its manifest.
-inline std::vector<bcos::bytes> keysOfBlock(auto& storage, bcos::protocol::BlockNumber block)
+/// One block's whole recorded diff.
+inline BlockHistory readBlock(auto& store, auto& storage, bcos::protocol::BlockNumber block)
 {
-    return bcos::task::syncWait(StateHistoryStore::keysOfBlock(storage, block));
+    return bcos::task::syncWait(store.readBlock(storage, block));
 }
 
-/// Expire one block's state history, writing the deletions into the same storage they are read
-/// from — the deferred-mode shape, where a replay must converge on the same final state.
-inline ExpireReport expireBlock(auto& storage, bcos::protocol::BlockNumber block)
+/// Expire one block, writing the deletions into the same storage they are read from — the
+/// deferred-mode shape, where a replay must converge on the same final state. The retention
+/// boundary is left alone (expire's default), which is what a caller discarding from the TOP — an
+/// operational rollback — needs.
+inline ExpireReport expireBlock(auto& store, auto& storage, bcos::protocol::BlockNumber block)
 {
-    return bcos::task::syncWait(StateHistoryStore::expire(storage, storage, block));
+    return bcos::task::syncWait(store.expire(storage, storage, block));
+}
+
+/// The commit path's flavour of the same call: the expired block is the OLDEST one still recorded,
+/// so the retention boundary advances to it in the same batch.
+inline ExpireReport expireBlockAdvancing(
+    auto& store, auto& storage, bcos::protocol::BlockNumber block)
+{
+    return bcos::task::syncWait(store.expire(storage, storage, block, RetentionBoundary::Advance));
+}
+
+/// The retention boundary as it is on disk.
+inline std::optional<bcos::protocol::BlockNumber> boundaryOnDisk(auto& store, auto& storage)
+{
+    return bcos::task::syncWait(store.retentionBoundary(storage));
 }
 
 /// Bytes as text, for readable assertions.
 inline std::string toText(bcos::bytes const& value)
 {
     return {value.begin(), value.end()};
+}
+
+/// One row's value, as an owned copy. Owned on purpose: `readOne` hands back an optional whose
+/// lifetime ends with the full expression, so a string_view into it would dangle in the caller.
+/// @throws std::bad_optional_access when the row is absent.
+inline std::string readRowValue(auto& storage, std::string_view table, std::string const& rowKey)
+{
+    auto const row = bcos::task::syncWait(
+        bcos::storage2::readOne(storage, bcos::executor_v1::StateKey{table, rowKey}));
+    return std::string(row.value().get());
+}
+
+/// Overwrite one row behind the store's back, to stand in for on-disk corruption.
+inline void overwriteRow(
+    auto& storage, std::string_view table, std::string const& rowKey, std::string value)
+{
+    bcos::task::syncWait(
+        bcos::storage2::writeOne(storage, bcos::executor_v1::StateKey{table, rowKey},
+            bcos::executor_v1::StateValue{std::move(value)}));
+}
+
+/// Delete one row behind the store's back.
+inline void deleteRow(auto& storage, std::string_view table, std::string const& rowKey)
+{
+    bcos::task::syncWait(
+        bcos::storage2::removeOne(storage, bcos::executor_v1::StateKey{table, rowKey}));
 }
 
 }  // namespace bcos::ledger::mpt::history::test

--- a/bcos-ledger/test/unittests/mpt/history/HistoryTestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/history/HistoryTestHelpers.h
@@ -1,0 +1,207 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoryTestHelpers.h
+ * @brief Shared fixtures for the reverse-history suites: a seek-capable backend, a diff builder
+ *        that keeps HistoryEntry's views alive, and a raw row dump for asserting on the layout
+ */
+#pragma once
+
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/history/ReverseHistoryStore.h>
+#include <bcos-task/Task.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt::history::test
+{
+
+/// The unit backend. ORDERED (and therefore single-bucket, non-concurrent) is what makes
+/// MemoryStorage::range(RANGE_SEEK, key) usable: the seek positions inside one bucket's ordered
+/// index, so it is only a whole-storage seek when there is exactly one bucket
+/// (MemoryStorage.h:547 seek + MemoryStorage.h:97 getBucketSize).
+/// Rows are compared by (table, rowKey), which inside one table is the same byte order RocksDB
+/// applies to "<table>:<rowKey>".
+using HistoryMemStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+    bcos::storage::Entry, bcos::storage2::memory_storage::ORDERED>;
+
+/// Same backend with logical deletion turned on, so a removed row stays visible to the iterator
+/// as a deletion sentinel instead of vanishing — the shape a mutable layer has before it is
+/// merged down.
+using HistoryLogicalDeleteStorage =
+    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey, bcos::storage::Entry,
+        bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::LOGICAL_DELETION>;
+
+/// Backend wrapper that counts every read it is asked to perform. put() must never touch it.
+struct CountingStorage
+{
+    HistoryMemStorage inner;
+    std::size_t readCalls{};
+    std::size_t rangeCalls{};
+
+    auto writeSome(::ranges::input_range auto keyValues)
+    {
+        return inner.writeSome(std::move(keyValues));
+    }
+    auto removeSome(::ranges::input_range auto keys) { return inner.removeSome(std::move(keys)); }
+    auto readOne(auto key, auto&&... args)
+    {
+        ++readCalls;
+        return inner.readOne(std::move(key), std::forward<decltype(args)>(args)...);
+    }
+    auto readSome(::ranges::input_range auto keys, auto&&... args)
+    {
+        ++readCalls;
+        return inner.readSome(std::move(keys), std::forward<decltype(args)>(args)...);
+    }
+    auto range(auto&&... args)
+    {
+        ++rangeCalls;
+        return inner.range(std::forward<decltype(args)>(args)...);
+    }
+};
+
+/// Bytes of a printable test key or value.
+inline bcos::bytes makeBytes(std::string_view text)
+{
+    return {text.begin(), text.end()};
+}
+
+/// Owns the key and value bytes a batch of HistoryEntry views point at. HistoryEntry is
+/// deliberately non-owning (put copies out of it), so the test needs somewhere stable to keep
+/// them; std::deque is used because push_back leaves references to existing elements valid.
+class Diff
+{
+public:
+    Diff() = default;
+    // Neither copyable nor movable on purpose: m_entries holds views into m_owned, and any
+    // relocation of the Diff would leave those views pointing at the moved-from deque. Deleting
+    // the operations turns `auto d = Diff{}.change(...)` — which would silently dangle — into a
+    // compile error.
+    Diff(const Diff&) = delete;
+    Diff(Diff&&) = delete;
+    Diff& operator=(const Diff&) = delete;
+    Diff& operator=(Diff&&) = delete;
+    ~Diff() = default;
+
+    /// Record that @p key changed in this block, having held @p oldValue when the block began.
+    /// @p oldValue nullopt means the key did not exist yet.
+    Diff& change(std::string_view key, std::optional<std::string_view> oldValue)
+    {
+        auto const& keyBytes = m_owned.emplace_back(makeBytes(key));
+        std::optional<std::span<const bcos::byte>> valueView;
+        if (oldValue)
+        {
+            valueView = std::span<const bcos::byte>(m_owned.emplace_back(makeBytes(*oldValue)));
+        }
+        m_entries.push_back(HistoryEntry{.key = keyBytes, .oldValue = valueView});
+        return *this;
+    }
+
+    [[nodiscard]] std::span<HistoryEntry const> entries() const { return m_entries; }
+
+private:
+    std::deque<bcos::bytes> m_owned;
+    std::vector<HistoryEntry> m_entries;
+};
+
+/// Every row of @p table currently in @p storage, as (rowKey, value) in ascending key order.
+/// The suites assert on this directly: the layout is a byte-exact promise (spec B.2), so the
+/// tests read the bytes rather than only the accessors that produced them.
+inline std::vector<std::pair<std::string, std::string>> rowsOfTable(
+    HistoryMemStorage& storage, std::string_view table)
+{
+    return bcos::task::syncWait(
+        [&]() -> bcos::task::Task<std::vector<std::pair<std::string, std::string>>> {
+            std::vector<std::pair<std::string, std::string>> rows;
+            auto iterator = co_await bcos::storage2::range(storage);
+            while (true)
+            {
+                auto row = co_await iterator.next();
+                if (!row)
+                {
+                    break;
+                }
+                auto const& [rowKey, rowValue] = *row;
+                bcos::executor_v1::StateKeyView view{rowKey};
+                if (view.m_table != table)
+                {
+                    continue;
+                }
+                auto const* entry = std::get_if<bcos::storage::Entry>(std::addressof(rowValue));
+                if (entry == nullptr)
+                {
+                    continue;
+                }
+                rows.emplace_back(std::string(view.m_key), std::string(entry->get()));
+            }
+            co_return rows;
+        }());
+}
+
+/// A shard cap large enough that the cases which are not about sharding never split.
+inline constexpr std::size_t kWideShardCap = 64 * 1024;
+
+// The suites share these wrappers rather than each defining its own: the ledger test binary is a
+// unity build, so per-file anonymous namespaces would land in one translation unit and collide.
+
+/// Write one block's state history.
+inline void putBlock(auto& storage, bcos::protocol::BlockNumber block, Diff const& diff,
+    std::size_t shardCap = kWideShardCap)
+{
+    bcos::task::syncWait(StateHistoryStore::put(storage, block, diff.entries(), shardCap));
+}
+
+/// Query the state history for @p key at @p block, against a chain at @p tip retaining @p depth.
+inline ReadAtResult readAt(auto& storage, std::string_view key, bcos::protocol::BlockNumber block,
+    bcos::protocol::BlockNumber tip, bcos::protocol::BlockNumber depth)
+{
+    auto keyBytes = makeBytes(key);
+    return bcos::task::syncWait(StateHistoryStore::readAt(storage, keyBytes, block, tip, depth));
+}
+
+/// The keys one block changed, per its manifest.
+inline std::vector<bcos::bytes> keysOfBlock(auto& storage, bcos::protocol::BlockNumber block)
+{
+    return bcos::task::syncWait(StateHistoryStore::keysOfBlock(storage, block));
+}
+
+/// Expire one block's state history, writing the deletions into the same storage they are read
+/// from — the deferred-mode shape, where a replay must converge on the same final state.
+inline ExpireReport expireBlock(auto& storage, bcos::protocol::BlockNumber block)
+{
+    return bcos::task::syncWait(StateHistoryStore::expire(storage, storage, block));
+}
+
+/// Bytes as text, for readable assertions.
+inline std::string toText(bcos::bytes const& value)
+{
+    return {value.begin(), value.end()};
+}
+
+}  // namespace bcos::ledger::mpt::history::test


### PR DESCRIPTION
## Summary

Adds `ReverseHistoryStore<Tables>`, the reverse-history component of pruning option 3, in its **optimized layout** (`docs/superpowers/plans/mpt-pruning/four-pruning-schemes-optimized-comparison.md` §3, "old values on disk in per-block shards, the per-key index in memory"). A path-addressed MPT keeps one version per position, so history is served from "what this key/position held before block N" records. This PR is the component only — nothing is wired into commit or RPC yet (that is the follow-up wiring PR), and it does not touch any existing file under `bcos-ledger/bcos-ledger/mpt/`.

**What changed since the previous revision of this PR:** the per-key index tables (`/mptsi/`, `/mptti/`) are gone. Old values now live inside the per-block shard rows; a per-block Meta row records format version, shard count, record count and the block hash; the per-key index (key → sorted `(block, shard, offset)`) is an in-memory structure, rebuilt from the shards at startup and published only after the block's batch has landed; expiring a block deletes its shard rows and Meta row in one `removeSome` — no per-key point deletes. The retention-boundary row and the `Keep`/`Advance` policy (previously in the wiring PR) move here, next to the store that owns them.

Two instantiations share one implementation:

```text
StateHistoryStore = ReverseHistoryStore<kStateHistory>   shard table /mpths/   boundary /mptsr/
TrieHistoryStore  = ReverseHistoryStore<kTrieHistory>    shard table /mptth/   boundary /mpttr/
```

Row layout, byte-exact:

```text
Meta   key = BE64(block)              value = u8 version(1) ‖ BE32 shardCount ‖ BE32 recordCount ‖ blockHash(32)   (41 B fixed)
Shard  key = BE64(block) ‖ BE16(shard) value = record*   record = BE32 keyLen ‖ key ‖ u8 tag ‖ [BE32 valueLen ‖ value]
                                                          tag 0x00 = ABSENT before this block, 0x01 = old value follows
Boundary key "boundary" (own table)   value = BE64(oldest block the store can still answer for)
```

An 8-byte Meta key sorts before the 10-byte shard keys with the same block prefix, so one seek at `BE64(block)` yields the Meta row and then every shard in order. A block that changed nothing still writes `Meta{1, 0}` + an empty shard 0, so a missing Meta row is always a fault.

## API

- `put(batch, block, blockHash, entries, shardByteCap) -> StagedBlock` — append-only, one `writeSome` of `shardCount + 1` rows, zero reads and seeks; returns the index update WITHOUT applying it.
- `publish(StagedBlock&&, optional<RetiredBlock>, optional<BlockNumber> boundaryWritten)` — the only way a block enters the in-memory index; the commit path calls it after the block's WriteBatch succeeded. Blocks must be published in strictly ascending order; a duplicate or lower block number throws and latches the index `Unavailable`.
- `readAt(backend, key, block, tip, depth)` — window guard first (`HistoryPruned` / `InvalidHistoryBlock`, the `HISTORY_GUARD_DISABLED` negative-control mechanism is kept); then, under ONE shared lock, state check (`HistoryIndexUnavailable` unless `Ready`), boundary check (`HistoryPruned`) and the `upper_bound` lookup; then one `readOne` of the located shard and a decode at the recorded offset. A shard that vanished between lookup and read (an expiry landed) is `HistoryPruned`, never the current value; a decoded key that differs from the queried key is `MPTInvariantViolation`.
- `expire(backend, batch, block, RetentionBoundary = Keep) -> ExpireReport{keyCount, shardsDeleted, retired}` — deletes that block's shard rows + Meta in one `removeSome`; idempotent on a `LOGICAL_DELETION` mutable layer; `Advance` moves the boundary to `max(existing, block)` (precondition: one Advance per batch, with the oldest-leaving block).
- **Publish generation** (`HistoryIndex::generation()`, `openPublishWindow()` / `closePublishWindow()`): an even value means quiescent, an odd value means a commit is between its merge and its publish. `readAt` samples it BEFORE the lookup and hands it back inside `HistoryUseCurrent{generation}`; it never concludes "unchanged" on an odd generation: it waits on the index's condition variable, which the commit's publish (or the window's close) notifies, for at most one named time budget (`kPublishWindowWaitBudget`, seconds, typical windows are milliseconds) and then throws `HistoryIndexUnavailable` telling the caller to retry — fail-closed, never a wrong value. The wiring PR's `readAtOrCurrent` re-samples the generation after reading the live value and retries on a change, so a commit that lands between "the index says unchanged" and "read the current row" can never hand back the new block's value under an old block's number. `publish` always advances the counter, window or not, so two samples straddling a publish never match.
- `readBlock(backend, block) -> BlockHistory{meta, records}` — the complete pre-image list for rollback and audit; throws on a missing Meta, a shard/record count mismatch or a deletion sentinel.
- `rebuild(backend) -> RebuildReport{blocks, records, bytesScanned}` — scans the shard table from `boundary + 1`; Meta must precede its shards, shard ordinals must be contiguous, Σ records must equal `recordCount`, format version must be 1; any violation throws and the caller marks the store `Unavailable`. The rebuild runs synchronously at startup before any reader exists, so an index miss can never be read as "unchanged" during a rebuild.

`backend` must be a seek-capable plane for `expire`/`readBlock`/`rebuild` (`RocksDBStorage2`, or an ORDERED non-concurrent `MemoryStorage`); `readAt` only needs `readOne`.

## Review guide

1. `HistoryRowCodec.h` — Meta/Shard/record bytes and the length discriminator between Meta and Shard keys.
2. `HistoryIndex.h` — the in-memory index: `locate` (one lock for state + boundary + lookup), `publish` (retire → append → boundary max), the strictly-ascending check, the publish generation (`static_assert(sizeof(HistoryVersion) == 16)` pins the RAM figure the wiring PR quotes).
3. `ReverseHistoryStore.h` — `readAt`'s three rules, `expire`, `rebuild`; `ShardTableWalk.h` — the one shard-table walker (seek, walk, stop on table change, Meta/Shard by key length) that the store's `expire`/`readBlock`/`rebuild` and the audit PR both use; `rebuild`'s refusals carry the offending block number (`errinfo_historyBlock`).
4. Tests: `HistoryLayoutSuite` (byte-exact rows incl. 0x00/0x3A bytes, Meta-before-Shard0 under a real seek, shard splitting), `HistoryIndexSuite`, `HistoryQuerySuite` (the spec §0.4 timeline; guard negative control; located-then-deleted shard → `HistoryPruned`; equal-length records swapped → key mismatch fails loud), `HistoryExpirySuite` (`removeCalls == 1`, `removedKeys == shardCount + 1`; logical-deletion idempotence; boundary Keep/Advance/max), `HistoryRebuildSuite` (rebuilt index answers identically; every corruption shape refuses; an unpublished block is invisible), `HistoryRocksDBTest` (real RocksDB round trip).

## Evidence

```text
test-bcos-ledger   *** No errors detected
HistoryLayoutSuite 11 · HistoryIndexSuite 9 · HistoryQuerySuite 11 · HistoryExpirySuite 10 · HistoryRebuildSuite 6 · HistoryRocksDBSuite 1
```

Negative controls: with the window guard compiled out, `HistoryQuerySuite` fails 6 checks and the unguarded query for block 872 (window 128 at tip 1000) returns `42`, a plausible wrong balance; restoring the equality-only publish check turns `publishingBlocksOutOfOrderIsRefused` red (5 failures). GCC 16 `-fsyntax-only` is clean on every history TU (transparent-hash lookups and the reference-NTTP instantiations included).

Copilot's earlier comments on this PR: the `block + 1` seek key no longer exists (`block >= tip` returns `HistoryUseCurrent` after the state/boundary checks); `HistoryTestHelpers.h` now includes the range-v3 concepts header it uses.

check-commit: valid insertions 835 (limit 1024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8KSfdGf3szLUmbF2TN3tq
