### PR TITLE
refactor(gateway): convert AMOP topic subscribe/remove to coroutines

### DIFF
--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -133,11 +133,24 @@ public:
     virtual task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) = 0;
 
-    virtual void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,
-        std::function<void(Error::Ptr&&)> _callback) = 0;
-    virtual void asyncRemoveTopic(std::string const& _clientID,
-        std::vector<std::string> const& _topicList,
-        std::function<void(Error::Ptr&&)> _callback) = 0;
+    /**
+     * @brief: subscribe topics of _topicInfo for the client _clientID
+     * @return error: nullptr on success
+     * @note coroutine: the parameters are passed by reference and the coroutine frame holds the
+     *       references (not copies) across suspensions — the caller must keep them alive until the
+     *       returned task completes (e.g. own them in a task::wait frame); do not pass temporaries.
+     */
+    virtual task::Task<Error::Ptr> subscribeTopic(
+        std::string const& _clientID, std::string const& _topicInfo) = 0;
+    /**
+     * @brief: remove the topics _topicList of the client _clientID
+     * @return error: nullptr on success
+     * @note coroutine: the parameters are passed by reference and the coroutine frame holds the
+     *       references (not copies) across suspensions — the caller must keep them alive until the
+     *       returned task completes (e.g. own them in a task::wait frame); do not pass temporaries.
+     */
+    virtual task::Task<Error::Ptr> removeTopic(
+        std::string const& _clientID, std::vector<std::string> const& _topicList) = 0;
 
     // for the air-mode node
     virtual bool registerNode(const std::string&, bcos::crypto::NodeIDPtr, bcos::protocol::NodeType,

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -292,12 +292,16 @@ public:
     {
         co_return;
     }
-    void asyncSubscribeTopic(const std::string& _clientID, const std::string& _topicInfo,
-        std::function<void(Error::Ptr&&)> _callback) override
-    {}
-    void asyncRemoveTopic(const std::string& _clientID, const std::vector<std::string>& _topicList,
-        std::function<void(Error::Ptr&&)> _callback) override
-    {}
+    task::Task<Error::Ptr> subscribeTopic(
+        const std::string& _clientID, const std::string& _topicInfo) override
+    {
+        co_return nullptr;
+    }
+    task::Task<Error::Ptr> removeTopic(const std::string& _clientID,
+        const std::vector<std::string>& _topicList) override
+    {
+        co_return nullptr;
+    }
 
     FakeGateWay::Ptr m_gateWay = nullptr;
 };

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -103,12 +103,15 @@ public:
         co_return;
     }
 
-    void asyncSubscribeTopic(
-        std::string const&, std::string const&, std::function<void(Error::Ptr&&)>) override
-    {}
-    void asyncRemoveTopic(std::string const&, std::vector<std::string> const&,
-        std::function<void(Error::Ptr&&)>) override
-    {}
+    task::Task<Error::Ptr> subscribeTopic(std::string const&, std::string const&) override
+    {
+        co_return nullptr;
+    }
+    task::Task<Error::Ptr> removeTopic(
+        std::string const&, std::vector<std::string> const&) override
+    {
+        co_return nullptr;
+    }
 };
 
 }  // namespace bcos::front::test

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -597,25 +597,23 @@ bcos::task::Task<void> bcos::gateway::Gateway::sendBroadcastMessageByTopic(
     }
     co_return;
 }
-void bcos::gateway::Gateway::asyncSubscribeTopic(std::string const& _clientID,
-    std::string const& _topicInfo, std::function<void(Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> bcos::gateway::Gateway::subscribeTopic(
+    std::string const& _clientID, std::string const& _topicInfo)
 {
     if (m_amop)
     {
-        m_amop->asyncSubscribeTopic(_clientID, _topicInfo, std::move(_callback));
-        return;
+        co_return co_await m_amop->subscribeTopic(_clientID, _topicInfo);
     }
-    _callback(BCOS_ERROR_PTR(-1, "AMOP is not initialized"));
+    co_return BCOS_ERROR_PTR(-1, "AMOP is not initialized");
 }
-void bcos::gateway::Gateway::asyncRemoveTopic(std::string const& _clientID,
-    std::vector<std::string> const& _topicList, std::function<void(Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> bcos::gateway::Gateway::removeTopic(
+    std::string const& _clientID, std::vector<std::string> const& _topicList)
 {
     if (m_amop)
     {
-        m_amop->asyncRemoveTopic(_clientID, _topicList, std::move(_callback));
-        return;
+        co_return co_await m_amop->removeTopic(_clientID, _topicList);
     }
-    _callback(BCOS_ERROR_PTR(-1, "AMOP is not initialized"));
+    co_return BCOS_ERROR_PTR(-1, "AMOP is not initialized");
 }
 bcos::amop::AMOPImpl::Ptr bcos::gateway::Gateway::amop()
 {

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -114,11 +114,11 @@ public:
     task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) override;
 
-    void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,
-        std::function<void(Error::Ptr&&)> _callback) override;
+    task::Task<Error::Ptr> subscribeTopic(
+        std::string const& _clientID, std::string const& _topicInfo) override;
 
-    void asyncRemoveTopic(std::string const& _clientID, std::vector<std::string> const& _topicList,
-        std::function<void(Error::Ptr&&)> _callback) override;
+    task::Task<Error::Ptr> removeTopic(std::string const& _clientID,
+        std::vector<std::string> const& _topicList) override;
 
     bcos::amop::AMOPImpl::Ptr amop();
 

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -648,24 +648,16 @@ void AMOPImpl::dispatcherAMOPMessage(
     }
 }
 
-void AMOPImpl::asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,
-    std::function<void(Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> AMOPImpl::subscribeTopic(
+    std::string const& _clientID, std::string const& _topicInfo)
 {
     m_topicManager->subTopic(_clientID, _topicInfo);
-    if (!_callback)
-    {
-        return;
-    }
-    _callback(nullptr);
+    co_return nullptr;
 }
 
-void AMOPImpl::asyncRemoveTopic(std::string const& _clientID,
-    std::vector<std::string> const& _topicList, std::function<void(Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> AMOPImpl::removeTopic(
+    std::string const& _clientID, std::vector<std::string> const& _topicList)
 {
     m_topicManager->removeTopics(_clientID, _topicList);
-    if (!_callback)
-    {
-        return;
-    }
-    _callback(nullptr);
+    co_return nullptr;
 }

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
@@ -47,10 +47,10 @@ public:
 
     virtual void start();
     virtual void stop();
-    virtual void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,
-        std::function<void(Error::Ptr&&)> _callback);
-    virtual void asyncRemoveTopic(std::string const& _clientID,
-        std::vector<std::string> const& _topicList, std::function<void(Error::Ptr&&)> _callback);
+    virtual task::Task<Error::Ptr> subscribeTopic(
+        std::string const& _clientID, std::string const& _topicInfo);
+    virtual task::Task<Error::Ptr> removeTopic(
+        std::string const& _clientID, std::vector<std::string> const& _topicList);
 
     /**
      * @brief: send message to a random node subscribed to _topic

--- a/bcos-gateway/test/unittests/GatewayTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayTest.cpp
@@ -339,14 +339,11 @@ BOOST_AUTO_TEST_CASE(testAMOPMock)
             co_return std::make_tuple(bcos::Error::Ptr(nullptr), int16_t(0), bcos::bytes{});
         });
 
-    fakeit::When(Method(mockAMOP, asyncSubscribeTopic))
-        .AlwaysDo([](std::string const& /*clientID*/, std::string const& /*topicInfo*/,
-                      const std::function<void(bcos::Error::Ptr&&)>& callback) {
+    fakeit::When(Method(mockAMOP, subscribeTopic))
+        .AlwaysDo([](std::string const& /*clientID*/,
+                      std::string const& /*topicInfo*/) -> bcos::task::Task<bcos::Error::Ptr> {
             // Simulate successful subscription
-            if (callback)
-            {
-                callback(nullptr);
-            }
+            co_return bcos::Error::Ptr(nullptr);
         });
 
     // Test the mocked AMOP
@@ -364,16 +361,12 @@ BOOST_AUTO_TEST_CASE(testAMOPMock)
     BOOST_CHECK(sendResponse.empty());
 
     // Test topic subscription
-    bool subscriptionCallbackInvoked = false;
-    amopRef.asyncSubscribeTopic(
-        testClientID, testTopic, [&subscriptionCallbackInvoked](const bcos::Error::Ptr& /*error*/) {
-            subscriptionCallbackInvoked = true;
-        });
-    BOOST_CHECK(subscriptionCallbackInvoked);
+    auto subscribeError = bcos::task::syncWait(amopRef.subscribeTopic(testClientID, testTopic));
+    BOOST_CHECK(!subscribeError);
 
     // Verify methods were called
     fakeit::Verify(Method(mockAMOP, sendMessageByTopic)).Exactly(1);
-    fakeit::Verify(Method(mockAMOP, asyncSubscribeTopic)).Exactly(1);
+    fakeit::Verify(Method(mockAMOP, subscribeTopic)).Exactly(1);
 }
 
 BOOST_AUTO_TEST_CASE(testComplexGatewayScenario)

--- a/bcos-rpc/bcos-rpc/amop/AMOPClient.cpp
+++ b/bcos-rpc/bcos-rpc/amop/AMOPClient.cpp
@@ -471,21 +471,30 @@ void AMOPClient::subscribeTopicToAllNodes()
 
         auto serviceClient =
             std::make_shared<GatewayServiceClient>(servicePrx, m_gatewayServiceName);
-        serviceClient->asyncSubscribeTopic(
-            m_clientID, topicInfo, [this, endPoint](Error::Ptr&& _error) {
-                if (_error)
+        bcos::task::wait(
+            [](std::weak_ptr<AMOPClient> _self, std::shared_ptr<GatewayServiceClient> _client,
+                std::string _clientID, std::string _topicInfo,
+                tars::EndpointInfo _endPoint) -> bcos::task::Task<void> {
+                auto error = co_await _client->subscribeTopic(_clientID, _topicInfo);
+                auto self = _self.lock();
+                if (!self)
                 {
-                    AMOP_CLIENT_LOG(WARNING) << LOG_DESC("asyncSubScribeTopic failed")
-                                             << LOG_KV("gateway", endPoint.getEndpoint().toString())
-                                             << LOG_KV("code", _error->errorCode())
-                                             << LOG_KV("msg", _error->errorMessage());
-                    // set the notify topic flag to false when subscribeTopic failed
-                    m_notifyTopicSuccess.store(false);
-                    return;
+                    co_return;
                 }
-                AMOP_CLIENT_LOG(INFO) << LOG_DESC("asyncSubScribeTopic success")
-                                      << LOG_KV("gateway", endPoint.getEndpoint().toString());
-            });
+                if (error)
+                {
+                    AMOP_CLIENT_LOG(WARNING)
+                        << LOG_DESC("subscribeTopic failed")
+                        << LOG_KV("gateway", _endPoint.getEndpoint().toString())
+                        << LOG_KV("code", error->errorCode())
+                        << LOG_KV("msg", error->errorMessage());
+                    // set the notify topic flag to false when subscribeTopic failed
+                    self->m_notifyTopicSuccess.store(false);
+                    co_return;
+                }
+                AMOP_CLIENT_LOG(INFO) << LOG_DESC("subscribeTopic success")
+                                      << LOG_KV("gateway", _endPoint.getEndpoint().toString());
+            }(weak_from_this(), serviceClient, m_clientID, topicInfo, endPoint));
     }
 }
 void AMOPClient::removeTopicFromAllNodes(std::vector<std::string> const& topicsToRemove)
@@ -498,14 +507,17 @@ void AMOPClient::removeTopicFromAllNodes(std::vector<std::string> const& topicsT
 
         auto serviceClient =
             std::make_shared<GatewayServiceClient>(servicePrx, m_gatewayServiceName);
-        serviceClient->asyncRemoveTopic(
-            m_clientID, topicsToRemove, [topicsToRemove, endPoint](Error::Ptr&& _error) {
-                AMOP_CLIENT_LOG(INFO) << LOG_DESC("asyncRemoveTopic")
-                                      << LOG_KV("gateway", endPoint.getEndpoint().toString())
-                                      << LOG_KV("removedSize", topicsToRemove.size())
-                                      << LOG_KV("code", _error ? _error->errorCode() : 0)
-                                      << LOG_KV("msg", _error ? _error->errorMessage() : "success");
-            });
+        bcos::task::wait(
+            [](std::shared_ptr<GatewayServiceClient> _client, std::string _clientID,
+                std::vector<std::string> _topicsToRemove,
+                tars::EndpointInfo _endPoint) -> bcos::task::Task<void> {
+                auto error = co_await _client->removeTopic(_clientID, _topicsToRemove);
+                AMOP_CLIENT_LOG(INFO) << LOG_DESC("removeTopic")
+                                      << LOG_KV("gateway", _endPoint.getEndpoint().toString())
+                                      << LOG_KV("removedSize", _topicsToRemove.size())
+                                      << LOG_KV("code", error ? error->errorCode() : 0)
+                                      << LOG_KV("msg", error ? error->errorMessage() : "success");
+            }(serviceClient, m_clientID, topicsToRemove, endPoint));
     }
 }
 

--- a/bcos-rpc/bcos-rpc/amop/AirAMOPClient.h
+++ b/bcos-rpc/bcos-rpc/amop/AirAMOPClient.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "AMOPClient.h"
 
+#include <bcos-task/Wait.h>
 #include <utility>
 #include <bcos-utilities/BoostLog.h>
 
@@ -55,25 +56,28 @@ protected:
         auto topicInfo = generateTopicInfo();
         AMOP_CLIENT_LOG(INFO) << LOG_DESC("subscribeTopicToAllNodes")
                               << LOG_KV("topicInfo", topicInfo);
-        m_gateway->asyncSubscribeTopic(m_clientID, topicInfo, [](Error::Ptr&& _error) {
-            if (_error)
+        bcos::task::wait([](bcos::gateway::GatewayInterface::Ptr _gateway, std::string _clientID,
+                             std::string _topicInfo) -> bcos::task::Task<void> {
+            auto error = co_await _gateway->subscribeTopic(_clientID, _topicInfo);
+            if (error)
             {
-                BCOS_LOG(WARNING) << LOG_DESC("asyncSubScribeTopic error")
-                                  << LOG_KV("code", _error->errorCode())
-                                  << LOG_KV("msg", _error->errorMessage());
+                BCOS_LOG(WARNING) << LOG_DESC("subscribeTopic error")
+                                  << LOG_KV("code", error->errorCode())
+                                  << LOG_KV("msg", error->errorMessage());
             }
-        });
+        }(m_gateway, m_clientID, std::move(topicInfo)));
     }
 
     void removeTopicFromAllNodes(std::vector<std::string> const& _topicsToRemove) override
     {
-        m_gateway->asyncRemoveTopic(
-            m_clientID, _topicsToRemove, [_topicsToRemove](Error::Ptr&& _error) {
-                BCOS_LOG(INFO) << LOG_DESC("asyncRemoveTopic")
-                               << LOG_KV("removedSize", _topicsToRemove.size())
-                               << LOG_KV("code", _error ? _error->errorCode() : 0)
-                               << LOG_KV("msg", _error ? _error->errorMessage() : "");
-            });
+        bcos::task::wait([](bcos::gateway::GatewayInterface::Ptr _gateway, std::string _clientID,
+                             std::vector<std::string> _topicsToRemove) -> bcos::task::Task<void> {
+            auto error = co_await _gateway->removeTopic(_clientID, _topicsToRemove);
+            BCOS_LOG(INFO) << LOG_DESC("removeTopic")
+                           << LOG_KV("removedSize", _topicsToRemove.size())
+                           << LOG_KV("code", error ? error->errorCode() : 0)
+                           << LOG_KV("msg", error ? error->errorMessage() : "");
+        }(m_gateway, m_clientID, _topicsToRemove));
     }
 };
 }  // namespace bcos::rpc

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -486,80 +486,155 @@ bcos::task::Task<void> bcostars::GatewayServiceClient::sendBroadcastMessageByTop
     m_prx->async_asyncSendBroadcastMessageByTopic(nullptr, _topic, tarsRequestData);
     co_return;
 }
-void bcostars::GatewayServiceClient::asyncSubscribeTopic(std::string const& _clientID,
-    std::string const& _topicInfo, std::function<void(bcos::Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::subscribeTopic(
+    std::string const& _clientID, std::string const& _topicInfo)
 {
-    class Callback : public bcostars::GatewayServicePrxCallback
+    struct SubscribeTopicAwaitable
     {
-    public:
-        Callback(std::function<void(bcos::Error::Ptr&&)> callback) : m_callback(std::move(callback))
-        {}
-        void callback_asyncSubscribeTopic(const bcostars::Error& ret) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            m_callback(toBcosError(ret));
-        }
-        void callback_asyncSubscribeTopic_exception(tars::Int32 ret) override
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+        };
+
+        class Callback : public bcostars::GatewayServicePrxCallback
         {
-            s_tarsTimeoutCount++;
-            return m_callback(toBcosError(ret));
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncSubscribeTopic(const bcostars::Error& ret) override
+            {
+                s_tarsTimeoutCount.store(0);
+                complete(toBcosError(ret));
+            }
+            void callback_asyncSubscribeTopic_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret));
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        GatewayServiceClient* m_self;
+        std::string m_clientID;
+        std::string m_topicInfo;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // see SendAwaitable::await_suspend for why this returns false on a synchronous
+        // connection-check failure
+        bool await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncSubscribeTopic", m_self->m_prx,
+                [state](bcos::Error::Ptr _error) { state->error = std::move(_error); },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            m_self->m_prx->async_asyncSubscribeTopic(new Callback(state), m_clientID, m_topicInfo);
+            return true;
         }
 
-    private:
-        std::function<void(bcos::Error::Ptr&&)> m_callback;
+        bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
     };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncSubscribeTopic", m_prx,
-        [_callback](bcos::Error::Ptr _error) {
-            if (_callback)
-            {
-                _callback(std::move(_error));
-            }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    m_prx->async_asyncSubscribeTopic(new Callback(_callback), _clientID, _topicInfo);
+
+    // copy the arguments into the awaitable — the caller's references are not guaranteed to
+    // outlive the request
+    SubscribeTopicAwaitable awaitable{this, _clientID, _topicInfo,
+        std::make_shared<SubscribeTopicAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
-void bcostars::GatewayServiceClient::asyncRemoveTopic(std::string const& _clientID,
-    std::vector<std::string> const& _topicList, std::function<void(bcos::Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::removeTopic(
+    std::string const& _clientID, std::vector<std::string> const& _topicList)
 {
-    class Callback : public bcostars::GatewayServicePrxCallback
+    struct RemoveTopicAwaitable
     {
-    public:
-        Callback(std::function<void(bcos::Error::Ptr&&)> callback) : m_callback(callback) {}
-        void callback_asyncRemoveTopic(const bcostars::Error& ret) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            m_callback(toBcosError(ret));
-        }
-        void callback_asyncRemoveTopic_exception(tars::Int32 ret) override
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+        };
+
+        class Callback : public bcostars::GatewayServicePrxCallback
         {
-            s_tarsTimeoutCount++;
-            return m_callback(toBcosError(ret));
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncRemoveTopic(const bcostars::Error& ret) override
+            {
+                s_tarsTimeoutCount.store(0);
+                complete(toBcosError(ret));
+            }
+            void callback_asyncRemoveTopic_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret));
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        GatewayServiceClient* m_self;
+        std::string m_clientID;
+        std::vector<std::string> m_topicList;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // see SendAwaitable::await_suspend for why this returns false on a synchronous
+        // connection-check failure
+        bool await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncRemoveTopic", m_self->m_prx,
+                [state](bcos::Error::Ptr _error) { state->error = std::move(_error); },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            m_self->m_prx->async_asyncRemoveTopic(new Callback(state), m_clientID, m_topicList);
+            return true;
         }
 
-    private:
-        std::function<void(bcos::Error::Ptr&&)> m_callback;
+        bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
     };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncRemoveTopic", m_prx,
-        [_callback](bcos::Error::Ptr _error) {
-            if (_callback)
-            {
-                _callback(std::move(_error));
-            }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    m_prx->async_asyncRemoveTopic(new Callback(_callback), _clientID, _topicList);
+
+    // copy the arguments into the awaitable — the caller's references are not guaranteed to
+    // outlive the request
+    RemoveTopicAwaitable awaitable{this, _clientID, _topicList,
+        std::make_shared<RemoveTopicAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 bcostars::GatewayServicePrx bcostars::GatewayServiceClient::prx()
 {

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -66,11 +66,11 @@ public:
     bcos::task::Task<void> sendBroadcastMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) override;
 
-    void asyncSubscribeTopic(std::string const& _clientID, std::string const& _topicInfo,
-        std::function<void(bcos::Error::Ptr&&)> _callback) override;
+    bcos::task::Task<bcos::Error::Ptr> subscribeTopic(
+        std::string const& _clientID, std::string const& _topicInfo) override;
 
-    void asyncRemoveTopic(std::string const& _clientID, std::vector<std::string> const& _topicList,
-        std::function<void(bcos::Error::Ptr&&)> _callback) override;
+    bcos::task::Task<bcos::Error::Ptr> removeTopic(std::string const& _clientID,
+        std::vector<std::string> const& _topicList) override;
 
     bcostars::GatewayServicePrx prx();
 

--- a/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
+++ b/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
@@ -53,10 +53,22 @@ bcostars::Error GatewayServiceServer::asyncSubscribeTopic(
     const std::string& _clientID, const std::string& _topicInfo, tars::TarsCurrentPtr current)
 {
     current->setResponse(false);
-    m_gatewayInitializer->gateway()->asyncSubscribeTopic(
-        _clientID, _topicInfo, [current](bcos::Error::Ptr&& _error) {
-            async_response_asyncSubscribeTopic(current, toTarsError(_error));
-        });
+    auto gateway = m_gatewayInitializer->gateway();
+    // try/catch guarantees the RPC is always answered even if the subscribe throws
+    // (current->setResponse(false) already disabled the automatic reply)
+    bcos::task::wait([](auto _gateway, auto _clientID, auto _topicInfo,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _gateway->subscribeTopic(_clientID, _topicInfo);
+            async_response_asyncSubscribeTopic(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            async_response_asyncSubscribeTopic(
+                _current, toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(gateway, _clientID, _topicInfo, current));
     return {};
 }
 bcostars::Error GatewayServiceServer::asyncSendBroadcastMessageByTopic(
@@ -80,10 +92,22 @@ bcostars::Error GatewayServiceServer::asyncRemoveTopic(const std::string& _clien
     const std::vector<std::string>& _topicList, tars::TarsCurrentPtr current)
 {
     current->setResponse(false);
-    m_gatewayInitializer->gateway()->asyncRemoveTopic(
-        _clientID, _topicList, [current](bcos::Error::Ptr&& _error) {
-            async_response_asyncRemoveTopic(current, toTarsError(_error));
-        });
+    auto gateway = m_gatewayInitializer->gateway();
+    // try/catch guarantees the RPC is always answered even if the remove throws
+    // (current->setResponse(false) already disabled the automatic reply)
+    bcos::task::wait([](auto _gateway, auto _clientID, auto _topicList,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _gateway->removeTopic(_clientID, _topicList);
+            async_response_asyncRemoveTopic(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            async_response_asyncRemoveTopic(
+                _current, toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(gateway, _clientID, _topicList, current));
     return {};
 }
 bcostars::GatewayServiceServer::GatewayServiceServer(GatewayServiceParam const& _param)


### PR DESCRIPTION
## 背景

`GatewayInterface` 中其余接口已陆续协程化（`getPeers`、`getGroupNodeInfo`、`broadcastMessage`、`sendMessageByNodeID`、`sendMessageByTopic`、`sendBroadcastMessageByTopic`），仅剩 AMOP 的 `asyncSubscribeTopic` / `asyncRemoveTopic` 仍是异步 + callback 模式，接口风格不统一。

这两个接口的 callback 语义是「一次性、同步内联触发」：本地实现只是操作 `TopicManager` 后原地回调一次，订阅状态存于 `TopicManager`，与 callback 生命周期无关，完全符合 `task::Task<Error::Ptr>` 的单次完成模型。

## 改动内容

- **接口与本地实现**：`GatewayInterface` / `Gateway` / `AMOPImpl` 的两个接口改为协程 `subscribeTopic` / `removeTopic`，返回 `task::Task<Error::Ptr>`（nullptr 表示成功），与 `sendMessageByNodeID` 返回约定一致；接口注释补充协程参数生命周期说明
- **tars client（GatewayServiceClient）**：参照 `sendMessageByTopic` 的 `SendTopicAwaitable` 模式将 tars callback 包装为 awaitable；参数拷贝进协程帧以避免调用方引用悬垂；`checkConnection` 同步失败时 `await_suspend` 返回 false 立即恢复；`s_tarsTimeoutCount` 超时计数行为保持不变
- **tars server（GatewayServiceServer）**：改用 `bcos::task::wait` + try/catch 模式应答 RPC，与 `asyncSendMessageByTopic` 一致，保证 RPC 必定应答
- **调用方（AMOPClient / AirAMOPClient）**：循环内 fire-and-forget 调用改为每个 endpoint 一个 `task::wait` 协程；`subscribeTopicToAllNodes` 改用 `weak_from_this()`，消除原 callback 裸捕获 `this` 的潜在悬垂风险
- **测试**：`FakeGateway`、`FakeGateWayWrapper`（FakeFrontService.h）、`GatewayTest` 的 fakeit mock 同步适配

**tars 线协议（GatewayService.tars IDL）未做任何改动**，仅修改 C++ 侧签名，无跨版本兼容性问题。

## 验证

- `build`（ASan Debug）与 `build-tars` 两个构建目录全量编译通过（gateway、rpc、protocol-tars、BcosGatewayService、BcosRpcService 及相关测试目标）
- `GatewayUnitTest`（含改写后的 `testAMOPMock`）、test-bcos-front、test-bcos-rpc 全部通过
- test-bcos-rpc 退出时的 LSAN 泄漏报告经 stash 基线对比确认改动前即存在（jsoncpp/OpenSSL 相关），与本次改动无关