### PR TITLE
refactor(gateway): convert remaining callback-style async interfaces to coroutines

### DIFF
--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -109,9 +109,9 @@ public:
      * @brief receive the latest group information notification from the GroupManagerInterface
      *
      * @param _groupInfo the latest group information
+     * @return error: nullptr on success
      */
-    virtual void asyncNotifyGroupInfo(
-        bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(Error::Ptr&&)>) = 0;
+    virtual task::Task<Error::Ptr> notifyGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo) = 0;
 
     /// for AMOP
 

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -279,9 +279,10 @@ public:
     {
         co_return;
     };
-    void asyncNotifyGroupInfo(
-        bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(Error::Ptr&&)> function) override
-    {}
+    task::Task<Error::Ptr> notifyGroupInfo(bcos::group::GroupInfo::Ptr) override
+    {
+        co_return nullptr;
+    }
     task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
         const std::string& /*_topic*/, bcos::bytesConstRef /*_data*/) override
     {

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -89,9 +89,10 @@ public:
         const bcos::crypto::NodeID& srcNodeID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override;
 
-    void asyncNotifyGroupInfo(
-        bcos::group::GroupInfo::Ptr, std::function<void(Error::Ptr&&)>) override
-    {}
+    task::Task<Error::Ptr> notifyGroupInfo(bcos::group::GroupInfo::Ptr) override
+    {
+        co_return nullptr;
+    }
 
     task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
         const std::string&, bcos::bytesConstRef) override

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -329,22 +329,14 @@ bool Gateway::checkGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo)
     return true;
 }
 
-void Gateway::asyncNotifyGroupInfo(
-    bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(Error::Ptr&&)> _callback)
+bcos::task::Task<Error::Ptr> Gateway::notifyGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo)
 {
     if (!checkGroupInfo(_groupInfo))
     {
-        if (_callback)
-        {
-            _callback(nullptr);
-        }
-        return;
+        co_return nullptr;
     }
     m_gatewayNodeManager->updateFrontServiceInfo(_groupInfo);
-    if (_callback)
-    {
-        _callback(nullptr);
-    }
+    co_return nullptr;
 }
 
 void Gateway::onReceiveP2PMessage(

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -104,9 +104,9 @@ public:
      * @brief receive the latest group information notification from the GroupManagerInterface
      *
      * @param _groupInfo the latest group information
+     * @return error: nullptr on success
      */
-    void asyncNotifyGroupInfo(
-        bcos::group::GroupInfo::Ptr, std::function<void(Error::Ptr&&)>) override;
+    task::Task<Error::Ptr> notifyGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo) override;
 
     /// for AMOP
     task::Task<std::tuple<Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -32,6 +32,7 @@
 #include "bcos-utilities/DataConvertUtility.h"
 #include "bcos-utilities/FileUtility.h"
 #include "bcos-utilities/IOServicePool.h"
+#include <bcos-task/Wait.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 #include <exception>
@@ -965,16 +966,18 @@ void GatewayFactory::initFailOver(
                 << LOG_DESC("The leader entryPoint changed") << LOG_KV("key", _leaderKey)
                 << LOG_KV("memberID", _leader->memberID()) << LOG_KV("modifyIndex", _leader->seq())
                 << LOG_KV("groupID", groupInfo->groupID());
-            _gateWay->asyncNotifyGroupInfo(groupInfo, [](Error::Ptr&& _error) {
-                if (_error)
+            task::wait([](std::shared_ptr<Gateway> _gateWay,
+                           bcos::group::GroupInfo::Ptr _groupInfo) -> task::Task<void> {
+                auto error = co_await _gateWay->notifyGroupInfo(std::move(_groupInfo));
+                if (error)
                 {
                     GATEWAY_FACTORY_LOG(INFO) << LOG_DESC("memberChangedNotification failed")
-                                              << LOG_KV("code", _error->errorCode())
-                                              << LOG_KV("msg", _error->errorMessage());
-                    return;
+                                              << LOG_KV("code", error->errorCode())
+                                              << LOG_KV("msg", error->errorMessage());
+                    co_return;
                 }
                 GATEWAY_FACTORY_LOG(INFO) << LOG_DESC("memberChangedNotification success");
-            });
+            }(_gateWay, std::move(groupInfo)));
         });
 
     _entryPoint->addMemberDeleteNotificationHandler(

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -595,7 +595,30 @@ void Host::handshakeServer(const boost::system::error_code& error,
                        << LOG_KV("remote endpoint", socket->remoteEndpoint())
                        << LOG_KV("shortP2pid", printShortP2pID(info.p2pID))
                        << LOG_KV("rawP2pID", printShortP2pID(info.rawP2pID));
-        startPeerSession(info, socket, m_connectionHandler);
+        auto session = startPeerSession(info, socket);
+        if (!session)
+        {
+            return;
+        }
+        // inbound (accepted) connections have no awaiting connect() coroutine to receive the
+        // session, so deliver it to the registered connection handler — posted to the socket's
+        // io_context so the handler runs off the accept path
+        auto weakHost = weak_from_this();
+        boost::asio::post(socket->ioService(), [weakHost, session = std::move(session), info]() {
+            auto host = weakHost.lock();
+            if (!host)
+            {
+                return;
+            }
+            if (host->m_connectionHandler)
+            {
+                host->m_connectionHandler(NetworkException(0, ""), info, session);
+            }
+            else
+            {
+                HOST_LOG(WARNING) << LOG_DESC("No connectionHandler, new connection may lost");
+            }
+        });
     }
 }
 
@@ -612,7 +635,6 @@ void Host::handshakeServer(const boost::system::error_code& error,
  * listenPort
  * @param _s : connected socket(used to init session object)
  */
-// TODO: asyncConnect pass handle to startPeerSession, make use of it
 // FIB-184: reserve a session slot under the global and per-IP caps. Returns false when either
 // cap is reached; the caller must then close the socket without creating a session.
 bool Host::tryAcquireSessionSlot(std::string const& _address)
@@ -727,8 +749,8 @@ struct SessionSlotGuard
 };
 }  // namespace
 
-void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> const& socket,
-    std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>)
+std::shared_ptr<SessionFace> Host::startPeerSession(
+    P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> const& socket)
 {
     auto weakHost = weak_from_this();
 
@@ -745,7 +767,7 @@ void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> 
                           << LOG_KV("maxConcurrentSessions", m_maxConcurrentSessions)
                           << LOG_KV("maxSessionsPerIP", m_maxSessionsPerIP);
         socket->close();
-        return;
+        return nullptr;
     }
 
     std::shared_ptr<SessionFace> session =
@@ -753,25 +775,11 @@ void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> 
     // Bind a slot-release guard to the session; the slot is freed when the session is destroyed.
     session->setLifetimeGuard(std::make_shared<SessionSlotGuard>(weakHost, remoteAddress));
 
-    boost::asio::post(socket->ioService(), [weakHost, session = std::move(session), p2pInfo]() {
-        auto host = weakHost.lock();
-        if (!host)
-        {
-            return;
-        }
-        if (host->m_connectionHandler)
-        {
-            host->m_connectionHandler(NetworkException(0, ""), p2pInfo, session);
-        }
-        else
-        {
-            HOST_LOG(WARNING) << LOG_DESC("No connectionHandler, new connection may lost");
-        }
-    });
     HOST_LOG(INFO) << LOG_DESC("startPeerSession, Remote=") << socket->remoteEndpoint()
                    << LOG_KV("local endpoint", socket->localEndpoint())
                    << LOG_KV("shortP2pid", printShortP2pID(p2pInfo.p2pID))
                    << LOG_KV("rawP2pID", printShortP2pID(p2pInfo.rawP2pID));
+    return session;
 }
 
 /**
@@ -796,12 +804,12 @@ void Host::start()
  * @brief : connect to the server
  * @param _nodeIPEndpoint : the endpoint of the connected server
  */
-void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
-    std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)> callback)
+task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> Host::connect(
+    NodeIPEndpoint _nodeIPEndpoint)
 {
     if (!m_run)
     {
-        return;
+        co_return std::make_tuple(NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
     }
     HOST_LOG(INFO) << LOG_DESC("Connecting to node") << LOG_KV("endpoint", _nodeIPEndpoint);
     {
@@ -809,21 +817,18 @@ void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
         auto it = m_pendingConns.find(_nodeIPEndpoint);
         if (it != m_pendingConns.end())
         {
-            BCOS_LOG(TRACE) << LOG_DESC("asyncConnected node is in the pending list")
+            BCOS_LOG(TRACE) << LOG_DESC("connected node is in the pending list")
                             << LOG_KV("endpoint", _nodeIPEndpoint);
-            return;
+            co_return std::make_tuple(NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
         }
     }
 
     std::shared_ptr<SocketFace> socket = m_asioInterface->newSocket(false, _nodeIPEndpoint);
-    // fire-and-forget: the coroutine frame owns the connect/handshake chain (and the strong Host
-    // reference) until it completes — the old nested-lambda chain did the same via captures.
-    task::wait(clientConnect(std::move(socket), _nodeIPEndpoint, std::move(callback)));
+    co_return co_await clientConnect(std::move(socket), std::move(_nodeIPEndpoint));
 }
 
-task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
-    NodeIPEndpoint _nodeIPEndpoint,
-    std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)> callback)
+task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> Host::clientConnect(
+    std::shared_ptr<SocketFace> socket, NodeIPEndpoint _nodeIPEndpoint)
 {
     auto self = shared_from_this();
     try
@@ -866,13 +871,12 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
             // the resolver's context (resolveConnect invokes the handler inline from the
             // resolver completion), while connectTimer's async_wait handler runs on the
             // socket's — close()/cancel() from here would race it ("Shared objects: Unsafe").
-            boost::asio::post(socket->ioService(),
-                [socket, connectTimer, callback = std::move(callback)]() mutable {
-                    socket->close();
-                    connectTimer->cancel();
-                    callback(NetworkException(ConnectError, "Connect failed"), {}, {});
-                });
-            co_return;
+            boost::asio::post(socket->ioService(), [socket, connectTimer]() {
+                socket->close();
+                connectTimer->cancel();
+            });
+            co_return std::make_tuple(NetworkException(ConnectError, "Connect failed"), P2PInfo{},
+                std::shared_ptr<SessionFace>());
         }
         insertPendingConns(_nodeIPEndpoint);
         /// get the public key of the server during handshake
@@ -882,10 +886,12 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
         auto [handshakeError] =
             co_await m_asioInterface->awaitableHandshake(socket, ba::ssl::stream_base::client);
         connectTimer->cancel();
-        // Pass COPIES of socket/callback, not moves: if handshakeClient itself throws, the
-        // catch(...) below settles the operation through socket->close() and the callback —
-        // both would be moved-from (null) here had they been moved into the call.
-        handshakeClient(handshakeError, socket, endpointPublicKey, callback, _nodeIPEndpoint);
+        // Pass COPIES of socket/_nodeIPEndpoint, not moves: if handshakeClient itself throws, the
+        // catch(...) below settles the operation through socket->close() and
+        // erasePendingConns(_nodeIPEndpoint) — both would be moved-from here had they been moved
+        // into the call.
+        co_return handshakeClient(
+            handshakeError, socket, std::move(endpointPublicKey), _nodeIPEndpoint);
     }
     catch (...)
     {
@@ -893,25 +899,19 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
         HOST_LOG(ERROR) << LOG_DESC("client connect exception")
                         << LOG_KV("endpoint", _nodeIPEndpoint)
                         << LOG_KV("what", boost::current_exception_diagnostic_information());
-        // Total completion for the caller-facing callback: an exception between
-        // insertPendingConns() and handshakeClient() (bad_alloc on endpointPublicKey,
-        // setVerifyCallback, or an initiation failure rethrown by await_resume) would otherwise
-        // leak the pending-connection entry — permanently blocking every future reconnect to
-        // this peer — and orphan the caller's callback. Settle the operation exactly like the
-        // error paths do: erase the entry, close the socket and answer the callback. The
-        // socket teardown is POSTED to the socket's io_context — this catch is reachable on
-        // the resolver's thread (see the resolve-failure branch above) as well as on a
-        // producer's stack inside an await_suspend, and close() from here would race the
-        // connect timer's handler ("Shared objects: Unsafe").
+        // Total completion for the awaiting caller: an exception between insertPendingConns() and
+        // handshakeClient() (bad_alloc on endpointPublicKey, setVerifyCallback, or an initiation
+        // failure rethrown by await_resume) would otherwise leak the pending-connection entry —
+        // permanently blocking every future reconnect to this peer — and orphan the caller's
+        // co_await. Settle the operation exactly like the error paths do: erase the entry, close
+        // the socket and return the error. The socket teardown is POSTED to the socket's
+        // io_context — this catch is reachable on the resolver's thread (see the resolve-failure
+        // branch above) as well as on a producer's stack inside an await_suspend, and close()
+        // from here would race the connect timer's handler ("Shared objects: Unsafe").
         erasePendingConns(_nodeIPEndpoint);
-        boost::asio::post(socket->ioService(),
-            [socket, callback = std::move(callback)]() mutable {
-                socket->close();
-                if (callback)
-                {
-                    callback(NetworkException(ConnectError, "Connect failed"), {}, {});
-                }
-            });
+        boost::asio::post(socket->ioService(), [socket]() { socket->close(); });
+        co_return std::make_tuple(NetworkException(ConnectError, "Connect failed"), P2PInfo{},
+            std::shared_ptr<SessionFace>());
     }
 }
 
@@ -923,10 +923,9 @@ task::Task<void> Host::clientConnect(std::shared_ptr<SocketFace> socket,
  * certificate
  * @param _nodeIPEndpoint : endpoint of the server to connect
  */
-void Host::handshakeClient(const boost::system::error_code& error,
-    std::shared_ptr<SocketFace> socket, std::shared_ptr<std::string> endpointPublicKey,
-    std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)> callback,
-    NodeIPEndpoint _nodeIPEndpoint)
+std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>> Host::handshakeClient(
+    const boost::system::error_code& error, std::shared_ptr<SocketFace> socket,
+    std::shared_ptr<std::string> endpointPublicKey, NodeIPEndpoint _nodeIPEndpoint)
 {
     erasePendingConns(_nodeIPEndpoint);
     if (error)
@@ -939,7 +938,8 @@ void Host::handshakeClient(const boost::system::error_code& error,
         {
             socket->close();
         }
-        return;
+        return std::make_tuple(NetworkException(ConnectError, "Handshake failed"), P2PInfo{},
+            std::shared_ptr<SessionFace>());
     }
     const std::string& nodeInfo = *endpointPublicKey;
     if (nodeInfo.empty())
@@ -947,7 +947,8 @@ void Host::handshakeClient(const boost::system::error_code& error,
         HOST_LOG(WARNING) << LOG_DESC("handshakeClient get p2pID failed")
                           << LOG_KV("local endpoint", socket->localEndpoint());
         socket->close();
-        return;
+        return std::make_tuple(NetworkException(ConnectError, "Handshake failed"), P2PInfo{},
+            std::shared_ptr<SessionFace>());
     }
 
     if (m_run)
@@ -956,8 +957,15 @@ void Host::handshakeClient(const boost::system::error_code& error,
         obtainNodeInfo(info, nodeInfo);
         HOST_LOG(INFO) << LOG_DESC("handshakeClient succ")
                        << LOG_KV("local endpoint", socket->localEndpoint());
-        startPeerSession(info, socket, std::move(callback));
+        auto session = startPeerSession(info, socket);
+        if (!session)
+        {
+            return std::make_tuple(NetworkException(ConnectError, "Session cap reached"), P2PInfo{},
+                std::shared_ptr<SessionFace>());
+        }
+        return std::make_tuple(NetworkException(0, ""), std::move(info), std::move(session));
     }
+    return std::make_tuple(NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
 }
 
 /// stop the network and worker thread

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -809,7 +809,8 @@ task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> 
 {
     if (!m_run)
     {
-        co_return std::make_tuple(NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
+        co_return std::make_tuple(
+            NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
     }
     HOST_LOG(INFO) << LOG_DESC("Connecting to node") << LOG_KV("endpoint", _nodeIPEndpoint);
     {
@@ -819,7 +820,8 @@ task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> 
         {
             BCOS_LOG(TRACE) << LOG_DESC("connected node is in the pending list")
                             << LOG_KV("endpoint", _nodeIPEndpoint);
-            co_return std::make_tuple(NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
+            co_return std::make_tuple(
+                NetworkException(0, ""), P2PInfo{}, std::shared_ptr<SessionFace>());
         }
     }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <tuple>
 
 
 namespace boost::asio::ssl
@@ -72,9 +73,19 @@ public:
     virtual void start();
     virtual void stop();
 
-    virtual void asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
-        std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
-            callback);
+    /**
+     * @brief: (coroutine) connect to the server
+     * @param _nodeIPEndpoint : the endpoint of the connected server
+     * @return {error, p2pInfo, session}: on success the error code is 0 and the session is the
+     *         established peer session; on failure the session is nullptr and the error describes
+     *         the failure. A skipped connect (host not running, or the endpoint is already in the
+     *         pending list) returns a success error with a nullptr session.
+     * @note the caller must keep this Host alive until the returned task completes (e.g. own a
+     *       shared_ptr in the awaiting coroutine frame); the task resumes on the connected
+     *       socket's io_context thread.
+     */
+    virtual task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> connect(
+        NodeIPEndpoint _nodeIPEndpoint);
 
     virtual bool haveNetwork() const;
 
@@ -255,27 +266,24 @@ protected:
     void handshakeServer(const boost::system::error_code& error,
         std::shared_ptr<std::string> endpointPublicKey, std::shared_ptr<SocketFace> socket);
 
-    void startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> const& socket,
-        std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
-            handler);
+    std::shared_ptr<SessionFace> startPeerSession(
+        P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> const& socket);
 
-    void handshakeClient(const boost::system::error_code& error, std::shared_ptr<SocketFace> socket,
-        std::shared_ptr<std::string> endpointPublicKey,
-        std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
-            callback,
-        NodeIPEndpoint _nodeIPEndpoint);
+    std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>> handshakeClient(
+        const boost::system::error_code& error, std::shared_ptr<SocketFace> socket,
+        std::shared_ptr<std::string> endpointPublicKey, NodeIPEndpoint _nodeIPEndpoint);
 
     void erasePendingConns(NodeIPEndpoint const& nodeIPEndpoint);
 
     void insertPendingConns(NodeIPEndpoint const& nodeIPEndpoint);
 
 private:
-    // Coroutine bodies for the accept/connect paths, launched fire-and-forget (task::wait) from
-    // startAccept()/asyncConnect(). Each frame holds a strong Host reference for its whole
-    // lifetime — structurally replacing the per-operation shared_from_this() captures of the old
-    // completion handlers. acceptLoop additionally keeps the Host alive until Host::stop()
-    // cancels the acceptor, which completes the pending async_accept with operation_aborted and
-    // lets the loop exit.
+    // Coroutine bodies for the accept/connect paths. The accept path is launched fire-and-forget
+    // (task::wait) from startAccept(); the connect path is co_awaited by connect()'s caller. Each
+    // frame holds a strong Host reference for its whole lifetime — structurally replacing the
+    // per-operation shared_from_this() captures of the old completion handlers. acceptLoop
+    // additionally keeps the Host alive until Host::stop() cancels the acceptor, which completes
+    // the pending async_accept with operation_aborted and lets the loop exit.
     task::Task<void> acceptLoop();
     // handshakeGuard owns the reserved FIB-186 in-flight-handshake admission slot (acquired in
     // acceptLoop so the slot/token admission ordering is preserved); it is released exactly when
@@ -283,10 +291,8 @@ private:
     // implementation detail of Host.cpp.
     task::Task<void> serverHandshake(
         std::shared_ptr<SocketFace> socket, std::shared_ptr<void> handshakeGuard);
-    task::Task<void> clientConnect(std::shared_ptr<SocketFace> socket,
-        NodeIPEndpoint _nodeIPEndpoint,
-        std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>
-            callback);
+    task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> clientConnect(
+        std::shared_ptr<SocketFace> socket, NodeIPEndpoint _nodeIPEndpoint);
 
 protected:
     // FIB-186 (vector D): dedicated single-thread executor for session-teardown notifications, kept

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -81,8 +81,9 @@ public:
      *         the failure. A skipped connect (host not running, or the endpoint is already in the
      *         pending list) returns a success error with a nullptr session.
      * @note the caller must keep this Host alive until the returned task completes (e.g. own a
-     *       shared_ptr in the awaiting coroutine frame); the task resumes on the connected
-     *       socket's io_context thread.
+     *       shared_ptr in the awaiting coroutine frame); on success the task resumes on the
+     *       connected socket's io_context thread, on failure it may resume on the resolver's
+     *       thread or complete synchronously on the caller's thread.
      */
     virtual task::Task<std::tuple<NetworkException, P2PInfo, std::shared_ptr<SessionFace>>> connect(
         NodeIPEndpoint _nodeIPEndpoint);

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -114,7 +114,7 @@ void Service::heartBeat()
     }
 
     // FIB-186 (vector D): snapshot the static-node list under x_nodes and release it BEFORE calling
-    // isConnected()/asyncConnect(), both of which take x_sessions. Holding x_nodes across an
+    // isConnected()/connect(), both of which take x_sessions. Holding x_nodes across an
     // x_sessions acquisition here is the reverse of the order onConnect uses (x_sessions ->
     // x_nodes, via updateStaticNodes), which deadlocks under connection churn: onConnect holds
     // x_sessions(W) waiting for x_nodes(W) while heartBeat holds x_nodes(R) waiting for
@@ -143,10 +143,26 @@ void Service::heartBeat()
         }
         SERVICE_LOG(DEBUG) << LOG_DESC("heartBeat try to reconnect")
                            << LOG_KV("endpoint", it.first);
-        m_host->asyncConnect(it.first,
-            [service = shared_from_this()](auto error, const P2PInfo& p2pInfo, auto session) {
-                service->onConnect(std::move(error), p2pInfo, std::move(session));
-            });
+        // detached: each reconnect runs in its own coroutine so a stalled connect cannot block the
+        // heartBeat pass; the connection result is fed to onConnect exactly like the old callback
+        // (error-only on failure; success carries the established session)
+        task::wait([](std::shared_ptr<Service> _service,
+                       NodeIPEndpoint _endpoint) -> task::Task<void> {
+            try
+            {
+                auto [error, p2pInfo, session] = co_await _service->m_host->connect(_endpoint);
+                if (session || error.errorCode() != 0)
+                {
+                    _service->onConnect(std::move(error), p2pInfo, std::move(session));
+                }
+            }
+            catch (std::exception const& e)
+            {
+                SERVICE_LOG(WARNING) << LOG_DESC("heartBeat reconnect exception")
+                                     << LOG_KV("endpoint", _endpoint)
+                                     << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(shared_from_this(), it.first));
     }
 
     std::shared_lock sessionLock(x_sessions);
@@ -272,7 +288,7 @@ void Service::onConnect(
         return;
     }
     p2pSession->start();
-    asyncSendProtocol(p2pSession);
+    sendProtocol(p2pSession);
     updateStaticNodes(session->socket(), p2pID);
 
     if (existedSession)
@@ -608,7 +624,7 @@ bcos::task::Task<void> Service::sendMessageByNodeIDs(uint16_t _type,
 }
 
 // send the protocolInfo
-void Service::asyncSendProtocol(P2PSession::Ptr _session)
+void Service::sendProtocol(P2PSession::Ptr _session)
 {
     auto self = shared_from_this();
     // value message in frame; payload owned by the frame. All state is passed as coroutine
@@ -626,7 +642,7 @@ void Service::asyncSendProtocol(P2PSession::Ptr _session)
             message.setPacketType(GatewayMessageType::Handshake);
             message.setSeq(_self->messageFactory()->newSeq());
             message.setPayload(std::move(payload));
-            SERVICE_LOG(INFO) << LOG_DESC("asyncSendProtocol")
+            SERVICE_LOG(INFO) << LOG_DESC("sendProtocol")
                               << LOG_KV("payload", message.payload().size())
                               << LOG_KV("seq", message.seq());
             co_await _session->fastSendP2PMessage(
@@ -634,7 +650,7 @@ void Service::asyncSendProtocol(P2PSession::Ptr _session)
         }
         catch (std::exception const& e)
         {
-            SERVICE_LOG(WARNING) << LOG_DESC("asyncSendProtocol send exception")
+            SERVICE_LOG(WARNING) << LOG_DESC("sendProtocol send exception")
                                  << LOG_KV("p2pid", printShortP2pID(_session->p2pID()))
                                  << LOG_KV("what", boost::diagnostic_information(e));
         }

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -129,7 +129,7 @@ protected:
     std::shared_ptr<P2PSession> getP2PSessionByNodeIdWithoutLock(P2pID const& _nodeID) const;
 
     // handshake protocol
-    void asyncSendProtocol(P2PSession::Ptr _session);
+    void sendProtocol(P2PSession::Ptr _session);
     void onReceiveProtocol(
         NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message);
     void onReceiveHeartbeat(

--- a/bcos-gateway/test/unittests/FIB186_HeartBeatLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_HeartBeatLockOrderTest.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(HeartBeatDoesNotHoldNodesLockWhileTakingSessionsLock)
         "FIB-186 vector D: heartBeat held x_nodes while calling isConnected() (which takes "
         "x_sessions). That is the reverse of onConnect's order (x_sessions -> x_nodes via "
         "updateStaticNodes) and deadlocks under connection churn. heartBeat must snapshot "
-        "m_staticNodes under x_nodes, release it, then do the isConnected()/asyncConnect() work.");
+        "m_staticNodes under x_nodes, release it, then do the isConnected()/connect() work.");
 
     service->disarm();
 }

--- a/bcos-gateway/test/unittests/ServiceAsyncSendProtocolThrowEscapeTest.cpp
+++ b/bcos-gateway/test/unittests/ServiceAsyncSendProtocolThrowEscapeTest.cpp
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- * @brief Regression test for round-3 review finding 1: Service::asyncSendProtocol must not let a
+ * @brief Regression test for round-3 review finding 1: Service::sendProtocol must not let a
  *        synchronous pre-send rejection (outgoing rate limit / max size) escape task::wait and
  *        abort Service::onConnect's session-registration tail (the session would stay
  *        live-but-unregistered, silently hidden from the routing layer).
@@ -23,7 +23,7 @@
  * The pre-send checks in Session::fastSendMessage (allowMaxMsgSize / beforeMessageHandler) run
  * synchronously on the caller thread and BOOST_THROW_EXCEPTION. That exception propagates out of
  * task::wait synchronously (the nested co_await chain unwinds inside AsyncTask::start()). If
- * asyncSendProtocol did not catch it, onConnect's lines after the handshake call —
+ * sendProtocol did not catch it, onConnect's lines after the handshake call —
  * updateStaticNodes, m_sessions[p2pID] = p2pSession, callNewSessionHandlers — would all be
  * skipped, leaving a started/live socket that the routing layer cannot see. This test is RED on
  * the pre-fix code (the rejection escapes) and GREEN after (caught inside the coroutine).
@@ -45,23 +45,23 @@ using namespace bcos;
 using namespace bcos::gateway;
 using namespace bcos::test;
 
-BOOST_FIXTURE_TEST_SUITE(ServiceAsyncSendProtocolThrowEscapeTest, TestPromptFixture)
+BOOST_FIXTURE_TEST_SUITE(ServiceSendProtocolThrowEscapeTest, TestPromptFixture)
 
 namespace
 {
-// Service::asyncSendProtocol is protected; expose it for the test through a subclass (same pattern
+// Service::sendProtocol is protected; expose it for the test through a subclass (same pattern
 // as the FIB-186 lock-order tests).
 class ProbeService : public Service
 {
 public:
     explicit ProbeService(P2PInfo const& _info) : Service(_info) {}
-    void sendProtocol(P2PSession::Ptr _session) { asyncSendProtocol(std::move(_session)); }
+    using Service::sendProtocol;
 };
 
 // A SessionFace whose fastSendMessage rejects synchronously — the same way Session::
 // fastSendMessage throws NetworkException for a rate-limit / oversize rejection before any
 // suspension. P2PSession::fastSendP2PMessage therefore throws synchronously out of the co_await,
-// which (pre-fix) escaped task::wait inside Service::asyncSendProtocol.
+// which (pre-fix) escaped task::wait inside Service::sendProtocol.
 class RejectingSession : public SessionFace
 {
 public:
@@ -86,9 +86,9 @@ public:
 };
 }  // namespace
 
-BOOST_AUTO_TEST_CASE(AsyncSendProtocolDoesNotEscapeSendRejection)
+BOOST_AUTO_TEST_CASE(SendProtocolDoesNotEscapeSendRejection)
 {
-    // asyncSendProtocol encodes the local protocol via g_BCOSConfig's codec — the same global the
+    // sendProtocol encodes the local protocol via g_BCOSConfig's codec — the same global the
     // Service constructor reads. Production initializers set it before building the gateway; the
     // unit-test harness does not, so set it here (idempotent).
     bcos::protocol::g_BCOSConfig.setCodec(
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(AsyncSendProtocolDoesNotEscapeSendRejection)
     p2pSession->setProtocolInfo(
         g_BCOSConfig.protocolInfo(bcos::protocol::ProtocolModuleID::GatewayService));
 
-    // Pre-fix: the handshake rejection escapes task::wait and propagates out of asyncSendProtocol
+    // Pre-fix: the handshake rejection escapes task::wait and propagates out of sendProtocol
     // (synchronously aborting onConnect's registration tail). Post-fix: caught inside the
     // coroutine and logged — a failed handshake is a recoverable per-session failure and the
     // session registration in onConnect must proceed.

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -346,8 +346,7 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::notifyGroupIn
         class Callback : public bcostars::GatewayServicePrxCallback
         {
         public:
-            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
-            {}
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state)) {}
 
             void callback_asyncNotifyGroupInfo(const bcostars::Error& ret) override
             {
@@ -370,6 +369,15 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::notifyGroupIn
                     m_state->error = std::move(error);
                     m_state->handle.resume();
                 }
+                else if (error)
+                {
+                    // the coroutine is already settled; do not silently drop a gateway that
+                    // failed to receive the group info
+                    BCOS_LOG(WARNING)
+                        << LOG_DESC("notifyGroupInfo: answer from another gateway endpoint")
+                        << LOG_KV("code", error->errorCode())
+                        << LOG_KV("msg", error->errorMessage());
+                }
             }
             std::shared_ptr<CompletionState> m_state;
         };
@@ -387,31 +395,58 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::notifyGroupIn
             m_state->handle = _handle;
             auto state = m_state;
             auto shouldBlockCall = m_self->shouldStopCall();
-            auto ret = checkConnection(m_self->c_moduleName, "asyncNotifyGroupInfo", m_self->m_prx,
+            auto ret = checkConnection(
+                m_self->c_moduleName, "asyncNotifyGroupInfo", m_self->m_prx,
                 [state](bcos::Error::Ptr _error) { state->error = std::move(_error); },
                 shouldBlockCall);
             if (!ret && shouldBlockCall)
             {
                 return false;
             }
+            // Copy everything the fan-out needs out of the coroutine frame BEFORE the first
+            // dispatch: once the first async_* call is in flight, its callback may resume and
+            // destroy this coroutine on the tars callback thread, so nothing below the first
+            // dispatch may touch m_self, m_groupInfo or m_state.
+            auto serviceName = m_self->m_gatewayServiceName;
+            auto groupInfo = std::move(m_groupInfo);
             // notify groupInfo to all gateway nodes
             auto activeEndPoints = tarsProxyAvailableEndPoints(m_self->m_prx);
+            size_t dispatched = 0;
+            bcos::Error::Ptr dispatchError;
             for (auto const& endPoint : activeEndPoints)
             {
-                auto prx = bcostars::createServantProxy<GatewayServicePrx>(
-                    m_self->m_gatewayServiceName, endPoint);
-                prx->async_asyncNotifyGroupInfo(new Callback(state), m_groupInfo);
+                try
+                {
+                    auto prx =
+                        bcostars::createServantProxy<GatewayServicePrx>(serviceName, endPoint);
+                    prx->async_asyncNotifyGroupInfo(new Callback(state), groupInfo);
+                    ++dispatched;
+                }
+                catch (std::exception const& e)
+                {
+                    // keep fanning out to the remaining endpoints: an exception unwinding out
+                    // of await_suspend would resume the coroutine while earlier RPCs are
+                    // still in flight, and their callbacks would resume a finished coroutine
+                    BCOS_LOG(WARNING)
+                        << LOG_DESC("asyncNotifyGroupInfo dispatch to endpoint failed")
+                        << LOG_KV("endpoint", endPoint.toString()) << LOG_KV("what", e.what());
+                    dispatchError = BCOS_ERROR_PTR(-1, e.what());
+                }
             }
-            // no gateway endpoint to notify: nothing is in flight, so resume inline with the
-            // (unset, i.e. success) result instead of suspending forever
-            return !activeEndPoints.empty();
+            if (dispatched == 0)
+            {
+                // nothing is in flight: resume inline instead of suspending forever. With zero
+                // active endpoints dispatchError is unset, i.e. success.
+                state->error = std::move(dispatchError);
+            }
+            return dispatched > 0;
         }
 
         bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
     };
 
-    NotifyGroupInfoAwaitable awaitable{
-        this, toTarsGroupInfo(_groupInfo), std::make_shared<NotifyGroupInfoAwaitable::CompletionState>()};
+    NotifyGroupInfoAwaitable awaitable{this, toTarsGroupInfo(_groupInfo),
+        std::make_shared<NotifyGroupInfoAwaitable::CompletionState>()};
     co_return co_await awaitable;
 }
 bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>>

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -331,52 +331,88 @@ bcostars::GatewayServiceClient::getGroupNodeInfo(const std::string& _groupID)
         this, _groupID, std::make_shared<GetGroupNodeInfoAwaitable::CompletionState>()};
     co_return co_await awaitable;
 }
-void bcostars::GatewayServiceClient::asyncNotifyGroupInfo(
-    bcos::group::GroupInfo::Ptr _groupInfo, std::function<void(bcos::Error::Ptr&&)> _callback)
+bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::notifyGroupInfo(
+    bcos::group::GroupInfo::Ptr _groupInfo)
 {
-    class Callback : public bcostars::GatewayServicePrxCallback
+    struct NotifyGroupInfoAwaitable
     {
-    public:
-        Callback(std::function<void(bcos::Error::Ptr&&)> callback) : m_callback(callback) {}
-
-        void callback_asyncNotifyGroupInfo(const bcostars::Error& ret) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            m_callback(toBcosError(ret));
-        }
-        void callback_asyncNotifyGroupInfo_exception(tars::Int32 ret) override
-        {
-            s_tarsTimeoutCount++;
-            m_callback(toBcosError(ret));
-        }
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+        };
 
-    private:
-        std::function<void(bcos::Error::Ptr&&)> m_callback;
-    };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncNotifyGroupInfo", m_prx,
-        [_callback](bcos::Error::Ptr _error) {
-            if (_callback)
+        class Callback : public bcostars::GatewayServicePrxCallback
+        {
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state))
+            {}
+
+            void callback_asyncNotifyGroupInfo(const bcostars::Error& ret) override
             {
-                _callback(std::move(_error));
+                s_tarsTimeoutCount.store(0);
+                complete(toBcosError(ret));
             }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
+            void callback_asyncNotifyGroupInfo_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret));
+            }
 
-    auto activeEndPoints = tarsProxyAvailableEndPoints(m_prx);
-    auto tarsGroupInfo = toTarsGroupInfo(_groupInfo);
+        private:
+            void complete(bcos::Error::Ptr error)
+            {
+                // the groupInfo is fanned out to every gateway endpoint (see await_suspend); the
+                // first answer settles the coroutine, later answers are discarded
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
 
-    // notify groupInfo to all gateway nodes
-    for (auto const& endPoint : activeEndPoints)
-    {
-        auto prx = bcostars::createServantProxy<GatewayServicePrx>(m_gatewayServiceName, endPoint);
-        prx->async_asyncNotifyGroupInfo(new Callback(_callback), tarsGroupInfo);
-    }
+        GatewayServiceClient* m_self;
+        bcostars::GroupInfo m_groupInfo;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        // see SendAwaitable::await_suspend for why this returns false on a synchronous
+        // connection-check failure
+        bool await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncNotifyGroupInfo", m_self->m_prx,
+                [state](bcos::Error::Ptr _error) { state->error = std::move(_error); },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return false;
+            }
+            // notify groupInfo to all gateway nodes
+            auto activeEndPoints = tarsProxyAvailableEndPoints(m_self->m_prx);
+            for (auto const& endPoint : activeEndPoints)
+            {
+                auto prx = bcostars::createServantProxy<GatewayServicePrx>(
+                    m_self->m_gatewayServiceName, endPoint);
+                prx->async_asyncNotifyGroupInfo(new Callback(state), m_groupInfo);
+            }
+            // no gateway endpoint to notify: nothing is in flight, so resume inline with the
+            // (unset, i.e. success) result instead of suspending forever
+            return !activeEndPoints.empty();
+        }
+
+        bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
+    };
+
+    NotifyGroupInfoAwaitable awaitable{
+        this, toTarsGroupInfo(_groupInfo), std::make_shared<NotifyGroupInfoAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>>
 bcostars::GatewayServiceClient::sendMessageByTopic(

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -57,8 +57,8 @@ public:
     bcos::task::Task<std::tuple<bcos::Error::Ptr, bcos::gateway::GroupNodeInfo::Ptr>>
     getGroupNodeInfo(const std::string& _groupID) override;
 
-    void asyncNotifyGroupInfo(bcos::group::GroupInfo::Ptr _groupInfo,
-        std::function<void(bcos::Error::Ptr&&)> _callback) override;
+    bcos::task::Task<bcos::Error::Ptr> notifyGroupInfo(
+        bcos::group::GroupInfo::Ptr _groupInfo) override;
 
     bcos::task::Task<std::tuple<bcos::Error::Ptr, int16_t, bcos::bytes>> sendMessageByTopic(
         const std::string& _topic, bcos::bytesConstRef _data) override;

--- a/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
+++ b/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
@@ -9,10 +9,22 @@ bcostars::Error GatewayServiceServer::asyncNotifyGroupInfo(
     current->setResponse(false);
     auto bcosGroupInfo = toBcosGroupInfo(m_gatewayInitializer->chainNodeInfoFactory(),
         m_gatewayInitializer->groupInfoFactory(), groupInfo);
-    m_gatewayInitializer->gateway()->asyncNotifyGroupInfo(
-        bcosGroupInfo, [current](bcos::Error::Ptr&& _error) {
-            async_response_asyncNotifyGroupInfo(current, toTarsError(_error));
-        });
+    auto gateway = m_gatewayInitializer->gateway();
+    // try/catch guarantees the RPC is always answered even if the notify throws
+    // (current->setResponse(false) already disabled the automatic reply)
+    bcos::task::wait([](auto _gateway, auto _groupInfo,
+                         auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            auto error = co_await _gateway->notifyGroupInfo(std::move(_groupInfo));
+            async_response_asyncNotifyGroupInfo(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            async_response_asyncNotifyGroupInfo(
+                _current, toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
+    }(gateway, std::move(bcosGroupInfo), current));
     return {};
 }
 

--- a/libinitializer/ProPBFTInitializer.cpp
+++ b/libinitializer/ProPBFTInitializer.cpp
@@ -25,6 +25,7 @@
 #include <bcos-sync/BlockSync.h>
 #include <bcos-tars-protocol/client/GatewayServiceClient.h>
 #include <bcos-tars-protocol/client/RpcServiceClient.h>
+#include <bcos-task/Wait.h>
 
 using namespace bcos;
 using namespace bcos::tool;
@@ -88,14 +89,17 @@ void ProPBFTInitializer::reportNodeInfo()
     });
 
     // notify groupInfo to gateway
-    m_gateway->asyncNotifyGroupInfo(m_groupInfo, [this](bcos::Error::Ptr&& _error) {
-        if (_error && m_running)
+    bcos::task::wait([](bcos::gateway::GatewayInterface::Ptr _gateway,
+                         bcos::group::GroupInfo::Ptr _groupInfo,
+                         ProPBFTInitializer* _self) -> bcos::task::Task<void> {
+        auto error = co_await _gateway->notifyGroupInfo(std::move(_groupInfo));
+        if (error && _self->m_running)
         {
             INITIALIZER_LOG(WARNING)
-                << LOG_DESC("asyncNotifyGroupInfo to gateway failed")
-                << LOG_KV("code", _error->errorCode()) << LOG_KV("msg", _error->errorMessage());
+                << LOG_DESC("notifyGroupInfo to gateway failed")
+                << LOG_KV("code", error->errorCode()) << LOG_KV("msg", error->errorMessage());
         }
-    });
+    }(m_gateway, m_groupInfo, this));
 }
 
 void ProPBFTInitializer::start()


### PR DESCRIPTION
## 概述

继 #5546（front 网络路径协程化）、#5565（AMOP topic 接口协程化）之后，本 PR 清掉 bcos-gateway 中最后两个回调式 async 接口，使 GatewayInterface 全部成员均为协程形式。TARS IDL 未做任何修改。

## 改动内容

### 1. `asyncNotifyGroupInfo` → `task::Task<Error::Ptr> notifyGroupInfo`

- `GatewayInterface` 抽象接口改为协程（该接口上最后一个回调式成员），`Gateway` 实现同步改为 `co_return`
- 全部实现者跟进：`GatewayServiceClient`（内部用 awaitable 桥接 tars 异步 RPC，与该文件既有 SendAwaitable/SubscribeTopicAwaitable 模式一致）、测试 fakes（`FakeGateway`、`FakeFrontService`）
- TARS IDL 未动：`GatewayServiceServer` 保留 IDL 生成的签名，内部 `task::wait` + `co_await` 后经 `async_response_asyncNotifyGroupInfo` 应答
- 直接调用方适配：`GatewayFactory`（initFailOver）、`ProPBFTInitializer` 改为 `task::wait` 包裹；`RPCInterface`/`Rpc::asyncNotifyGroupInfo` 属另一条契约线，未动

### 2. `Host::asyncConnect` → `task::Task<tuple<NetworkException, P2PInfo, SessionFace::Ptr>> connect`

- 返回值携带连接结果；参数改为值传递以规避协程跨悬挂点的引用生命周期问题
- 内部链路理顺：`clientConnect`/`handshakeClient` 去掉回调参数直接返回结果；`startPeerSession` 删除从未使用的 handler 参数并改为返回 session；入站路径由 `handshakeServer` 自行投递 `m_connectionHandler`（行为等价），出站成功经返回值进入 `Service::onConnect`，无双投递
- 调用方 `Service::heartBeat` 静态节点重连改为每端点一个独立协程（`task::wait`），含 try/catch 兜底

### 3. `Service::asyncSendProtocol` → `sendProtocol`（纯改名）

内部早已是协程 fire-and-forget 且无回调参数，仅清理残留的 async 前缀；测试套件名与相关注释同步更新。

## 验证

- 编译通过：`gateway`、`protocol-tars`、`test-bcos-gateway`、`test-bcos-front`、`test-bcos-pbft`、`test-bcos-sync`、`pbft_init`、`init`、`fisco-bcos` 全链路链接
- `test-bcos-gateway`、`test-bcos-front` 测试全部通过（含 FIB186 心跳锁序、sendProtocol 异常逃逸回归测试）
- tars service 在本构建配置下（`WITH_TARS_SERVICES=OFF`）做了语法级验证