### PR TITLE
chore(admission): post-merge hygiene from the #5555 review

### DIFF
--- a/bcos-tool/test/unittests/libtool/NodeConfigEestReplayTest.cpp
+++ b/bcos-tool/test/unittests/libtool/NodeConfigEestReplayTest.cpp
@@ -11,6 +11,7 @@
 // startup gate that keeps it off a chain producing blocks through consensus.
 
 #include "NodeConfigLoaderProbe.h"
+#include <boost/exception/diagnostic_information.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -34,7 +35,10 @@ BOOST_AUTO_TEST_CASE(refusedWithoutEngineDrivenBlockProduction)
 {
     LoaderProbe probe;
     auto pt = fromIni("[executor]\neest_replay_mode=true\n");
-    BOOST_CHECK_THROW(probe.loadOthersConfig(pt), InvalidConfig);
+    BOOST_CHECK_EXCEPTION(probe.loadOthersConfig(pt), InvalidConfig, [](InvalidConfig const& e) {
+        return boost::diagnostic_information(e).find("requires engine-driven block production") !=
+               std::string::npos;
+    });
 }
 
 BOOST_AUTO_TEST_CASE(acceptedUnderSingleNodeConsensus)

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.h
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.h
@@ -67,18 +67,15 @@ struct AccountState
 /// catching binary-wide -- into every module that admits a transaction.
 using SystemTxPredicate = std::function<bool(protocol::Transaction const&)>;
 
-/// The one place a transaction is judged admissible, for every ingress of the transaction pool:
-/// JSON-RPC (BCOS and Web3), P2P, and block-proposal verification. The pool's two ingresses call
-/// it -- verifyAndSubmitTransaction for submission and the peer fetch, enforceSubmitTransaction
-/// for proposal verification.
+/// The one place a transaction is judged admissible, for every ingress of both transaction
+/// pools: JSON-RPC (BCOS and Web3), P2P, and block-proposal verification. The txpool's two
+/// entry points call it -- verifyAndSubmitTransaction for submission and the peer fetch,
+/// enforceSubmitTransaction for proposal verification. The engine-driven mempool (single-node
+/// consensus or the OP engine RPC) has one, EthEndpoint::sendRawTransaction, which calls it and
+/// then reserves the (sender, nonce) with MemPoolImpl::tryAdd.
 ///
-/// NOT yet the engine-driven mempool. On a node with single-node consensus or the OP engine RPC,
-/// EthEndpoint::sendRawTransaction refuses blob and deposit envelopes, recovers the signature and
-/// checks the EIP-155 chain id inline, then hands the transaction to MemPoolImpl::add; neither
-/// runs verify(). #5555 wires that ingress.
-///
-/// It holds pointers to the shared nonce checkers rather than owning them: the pool reserves and
-/// clears nonces through the same instances without going near admission, and the admission
+/// It holds pointers to the shared nonce checkers rather than owning them: the txpool reserves
+/// and clears nonces through the same instances without going near admission, and the admission
 /// question is asked here. Nonce admission is the same question at every ingress, and routing it
 /// through a per-caller hook is how the pool and the RPC layer came to disagree about it in the
 /// first place.

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -148,10 +148,13 @@ public:
     using ViewType = typename GlobalStateStorageType::ViewType;
 
     /// @param ledgerConfigState the process-wide configuration snapshot transaction admission
-    /// reads, republished here after every block this service commits. In this mode nothing
-    /// else republishes it: MultiVersionScheduler is the hook for the txpool/consensus path,
-    /// and block production here does not go through it. Null in the tests and in any wiring
-    /// that has no admission to serve.
+    /// reads, republished from buildPayload, where the configuration for the block about to be
+    /// built is read anyway. In this mode nothing else republishes it: MultiVersionScheduler is
+    /// the hook for the txpool/consensus path, and block production here does not go through
+    /// it. A node that only executes externally built payloads never calls buildPayload, so
+    /// its snapshot stays at the boot read; its mempool RPC still admits against that
+    /// snapshot, into a pool nothing seals on such a node. Null in the tests and in any
+    /// wiring that has no admission to serve.
     EngineServiceImpl(MemPoolType& memPool, GlobalStateStorageType& globalStateStorage,
         ExecutorType& executor, SchedulerType& scheduler,
         bcos::protocol::BlockFactory::Ptr blockFactory,
@@ -1225,7 +1228,7 @@ private:
     /// is committed via newPayload(). Null in unit tests / for payloads without block
     /// persistence.
     bcos::ledger::LedgerInterface::Ptr m_ledger;
-    /// Republished after every commit; see the constructor.
+    /// Republished from buildPayload; see the constructor.
     bcos::ledger::LedgerConfigState::Ptr m_ledgerConfigState;
     ForkchoiceState m_forkchoiceState;
     std::optional<TrackedHeadBlock> m_trackedHeadBlock;

--- a/libinitializer/CMakeLists.txt
+++ b/libinitializer/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(init PUBLIC
     tool front
     txpool
     mempool
+    bcos-tx-validator
     single-consensus
     engine
     ledger

--- a/libinitializer/EngineServiceInitializer.h
+++ b/libinitializer/EngineServiceInitializer.h
@@ -2,6 +2,7 @@
 
 #include "GlobalStateStorageInitializer.h"
 #include "bcos-framework/engine/AnyEngineService.h"
+#include "bcos-framework/ledger/LedgerConfigState.h"
 #include "bcos-mempool/MemPoolImpl.h"
 #include "bcos-transaction-executor/TransactionExecutorImpl.h"
 #include "engine/bcos-engine/EngineServiceImpl.h"

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -725,8 +725,8 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         // which is the txpool's commit-time hook, so that cache is only ever raised by its own
         // storage misses. The effect is a lower bound that can lag behind the chain: a
         // transaction reusing an already-executed nonce is admitted here and refused at
-        // execution. That is where it is refused today too, since this path currently checks no
-        // nonce at all.
+        // execution. That is where it was refused before this validator was wired, when the
+        // path checked no nonce at all.
         auto web3NonceChecker = std::make_shared<bcos::txvalidator::Web3NonceChecker>(m_ledger);
         m_memPoolValidator = std::make_shared<bcos::txvalidator::TxValidator>(
             m_protocolInitializer->cryptoSuite(), m_ledger, m_ledgerConfigState,


### PR DESCRIPTION
### What

The comment, include and test-pin items the #5535 and #5555 reviews left open (ywy2090's C, D, F and the two untouched-path notes; the `TxValidator.h` class comment that #5555's merge made stale). No behaviour changes; the diff is six files, +22/−17.

- `TxValidator.h`: the class comment said the engine-driven mempool ingress was "NOT yet" wired and that #5555 would wire it. It now names that ingress among the callers of `verify()`, with `MemPoolImpl::tryAdd` reserving the (sender, nonce) afterwards.
- `EngineServiceImpl.h`: the constructor comment and the member comment said the snapshot is republished "after every commit". The only `set()` is in `buildPayload`, and both comments now say that, plus its consequence, in the words of ywy2090's finding A: a node that only executes externally built payloads never republishes, so its mempool RPC admits against the boot snapshot, into a pool nothing seals on such a node. (#5555's description said such a node "never admits transactions"; that was wrong — `AirNodeInitializer.cpp:115-124` wires the admission validator on every engine-driven node, and the RPC has no builder/verifier gate.)
- `Initializer.cpp`: "this path currently checks no nonce at all" described the path before the validator was wired there; past tense now.
- `EngineServiceInitializer.h`: `build()` takes `LedgerConfigState::Ptr`; the header is now included directly rather than through `EngineServiceImpl.h`.
- `libinitializer/CMakeLists.txt`: `Initializer.cpp` constructs `bcos::txvalidator::TxValidator`, so `init` links `bcos-tx-validator` directly instead of reaching its headers through `txpool` / `rpc` PUBLIC.
- `NodeConfigEestReplayTest`: the gate test pinned only the exception type; it now pins the `errinfo_comment` substring, so a different `InvalidConfig` thrown from the same loader cannot pass for it.

### Not in this PR

- ywy2090's H (skip the `LedgerConfig` copy in `buildPayload` when the block number is unchanged). Declined rather than deferred: the copy is a handful of scalars and the node lists, once per forkchoice update with attributes, and a skip keyed on block number would let the boot-time publish (`getLedgerConfig(*ledger)` in `Initializer`) stand in for the build-time one (`getLedgerConfig(view, …)` in `buildPayload`) on the first block. Those two readers would then have to be proven equal on every field admission reads, which is more than the branch saves.
- ywy2090's A and B (publish only in `buildPayload`; `Web3NonceWindow` without `updateNonceCache`) go with the PR that wires `EthEngineService` / `OpEngineService`, as its review said.
- ywy2090's E (a `runtime_error`'s text reaching the client) goes with the error-code mapping for admission refusals recorded in #5555's description, a separate PR. G (no test binary over `Initializer`'s four holder-pass sites) is unchanged from #5555's own disclosure.

### Test

`test-bcos-tool`, `test-bcos-engine`, `test-bcos-tx-validator` and `fisco-bcos` rebuilt from `4597bc62c` with the CMake change; `NodeConfigEestReplayTest` 4/4, `EngineServiceTest` 44/44, `test-bcos-tx-validator` 81/81. Negative control for the strengthened pin: changing the comment text in `NodeConfig.cpp:1855` turns `refusedWithoutEngineDrivenBlockProduction` red (predicate on the raised `InvalidConfig` fails); restored, 4/4. `Initializer.cpp`, `NodeConfigEestReplayTest.cpp` and `EngineServiceTest.cpp` — the translation units that include the changed headers — compile clean under GCC 16 `-Wall -Wextra -pedantic`.
