### PR TITLE
feat(rpc): one error shape for a refused eth_sendRawTransaction

### DIFF
--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -854,9 +854,21 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
         // (MemoryStorage::submitTransaction's await_resume); left alone it reaches the catch-all
         // above this method, which answers -32603 with the status name. Same table as the
         // mempool branch instead, so both pools refuse the same transaction the same way.
-        // bcos::Error only, where the mempool branch catches everything: the pool has already
-        // turned verify()'s throw into Unknown (verifyAndSubmitTransaction), so an Error is a
-        // verdict and anything else is not one -- it keeps going to the catch-all as before.
+        //
+        // Only for a code that is a verdict. This interface also carries faults that are the
+        // node's own -- a MAX/TARS deployment's TxPoolServiceClient throws "No value!" and TARS
+        // transport codes through it -- and those keep going to the catch-all, which answers
+        // -32603 with the message they came with, as they did before this table existed.
+        // bcos::Error only, where the mempool branch catches everything: an in-process pool has
+        // already turned verify()'s throw into Unknown (verifyAndSubmitTransaction), so anything
+        // that is not an Error is not a verdict either.
+        if (!isAdmissionVerdict(e.errorCode())) [[unlikely]]
+        {
+            WEB3_LOG(WARNING) << LOG_DESC("sendRawTransaction: pool fault, not a verdict")
+                              << LOG_KV("code", e.errorCode())
+                              << LOG_KV("message", e.errorMessage());
+            throw;
+        }
         BOOST_THROW_EXCEPTION(
             admissionError(static_cast<protocol::TransactionStatus>(e.errorCode())));
     }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -44,10 +44,12 @@
 #include <bcos-rpc/web3jsonrpc/model/CallRequest.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
+#include <bcos-rpc/web3jsonrpc/utils/AdmissionError.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-tx-validator/TxValidator.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/exception/diagnostic_information.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
@@ -728,15 +730,16 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     auto rawTx = toView(request[0U]);
     auto rawTxBytes = fromHexWithPrefix(rawTx);
     auto bytesRef = bcos::ref(rawTxBytes);
-    // Reject blob txs at the RPC gate. Deposits (0x7e) enter only via Engine API.
+    // Reject blob txs at the RPC gate. Deposits (0x7e) enter only via Engine API. Both answer
+    // as the type refusal verify() would give (AdmissionError.h), with the type named.
     switch (engine::dispatchRawTransaction(bytesRef))
     {
     case engine::RawTransactionKind::Blob:
         BOOST_THROW_EXCEPTION(
-            JsonRpcException(InvalidParams, "blob transactions are not supported"));
+            admissionError(protocol::TransactionStatus::BlobTxNotAllowed, "blob"));
     case engine::RawTransactionKind::Deposit:
-        BOOST_THROW_EXCEPTION(JsonRpcException(
-            InvalidParams, "deposit transactions cannot be submitted via eth_sendRawTransaction"));
+        BOOST_THROW_EXCEPTION(admissionError(
+            protocol::TransactionStatus::TxTypeNotSupported, "deposit, Engine API only"));
     default:
         break;
     }
@@ -751,8 +754,8 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     // derivation/engine path, never from a client RPC submission.
     if (web3Tx.type == TransactionType::Deposit) [[unlikely]]
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
-            "Deposit (0x7e) transactions are not supported via eth_sendRawTransaction"));
+        BOOST_THROW_EXCEPTION(admissionError(
+            protocol::TransactionStatus::TxTypeNotSupported, "deposit, Engine API only"));
     }
     auto encodeTxHash = web3Tx.txHash();
 
@@ -797,20 +800,36 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
         // Required, always: this transaction was built directly above, so m_tainted is still
         // true and no signature has been verified. tryAdd refuses a tainted transaction, and
         // the Signature check is what clears it.
-        if (auto status = co_await validator->verify(
-                *tx, m_nodeService->admissionContext(), txvalidator::SignaturePolicy::Required);
-            status != protocol::TransactionStatus::None)
+        auto status = protocol::TransactionStatus::None;
+        try
         {
-            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, protocol::toString(status)));
+            status = co_await validator->verify(
+                *tx, m_nodeService->admissionContext(), txvalidator::SignaturePolicy::Required);
+        }
+        catch (...)
+        {
+            // verify() throws, by contract, when the data it needs cannot be read
+            // (TxValidator.h). A storage fault is the node's fault, not a verdict on the
+            // transaction, and its diagnostic is for the log: the client gets the same answer
+            // the txpool branch gives, where verifyAndSubmitTransaction catches this and refuses
+            // with Unknown.
+            WEB3_LOG(ERROR) << LOG_DESC("sendRawTransaction: admission could not be decided")
+                            << LOG_KV("txHash", encodeTxHash.hexPrefixed())
+                            << LOG_KV("reason", boost::current_exception_diagnostic_information());
+            BOOST_THROW_EXCEPTION(admissionError(protocol::TransactionStatus::Unknown));
+        }
+        if (status != protocol::TransactionStatus::None)
+        {
+            BOOST_THROW_EXCEPTION(admissionError(status));
         }
         // tryAdd, not add: add() returns void and ends four different ways without saying so,
         // and this method answers with a transaction hash as soon as it returns. It is also
         // what reserves the (sender, nonce) pair -- checking first and adding second would let
         // two concurrent submissions through the gap between the two calls.
-        if (auto status = memPool->tryAdd(std::move(tx));
-            status != protocol::TransactionStatus::None)
+        if (auto const taken = memPool->tryAdd(std::move(tx));
+            taken != protocol::TransactionStatus::None)
         {
-            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, protocol::toString(status)));
+            BOOST_THROW_EXCEPTION(admissionError(taken));
         }
         Json::Value result = encodeTxHash.hexPrefixed();
         buildJsonContent(result, response);
@@ -824,7 +843,23 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
             JsonRpcException(JsonRpcError::InternalError, "TXPool not available!"));
     }
     co_await txpool->broadcastTransaction(*tx);
-    auto const txResult = co_await txpool->submitTransaction(std::move(tx), m_syncTransaction);
+    protocol::TransactionSubmitResult::Ptr txResult;
+    try
+    {
+        txResult = co_await txpool->submitTransaction(std::move(tx), m_syncTransaction);
+    }
+    catch (bcos::Error const& e)
+    {
+        // The pool's refusal arrives as an Error whose code is the TransactionStatus
+        // (MemoryStorage::submitTransaction's await_resume); left alone it reaches the catch-all
+        // above this method, which answers -32603 with the status name. Same table as the
+        // mempool branch instead, so both pools refuse the same transaction the same way.
+        // bcos::Error only, where the mempool branch catches everything: the pool has already
+        // turned verify()'s throw into Unknown (verifyAndSubmitTransaction), so an Error is a
+        // verdict and anything else is not one -- it keeps going to the catch-all as before.
+        BOOST_THROW_EXCEPTION(
+            admissionError(static_cast<protocol::TransactionStatus>(e.errorCode())));
+    }
     if (txResult->status() == 0)
     {
         Json::Value result = encodeTxHash.hexPrefixed();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.cpp
@@ -20,7 +20,9 @@
 
 #include "AdmissionError.h"
 #include "Common.h"
+#include <algorithm>
 #include <array>
+#include <functional>
 #include <string>
 
 namespace bcos::rpc
@@ -40,43 +42,47 @@ struct Entry
 // means the status name. The words are go-ethereum's: core/error.go, core/txpool/errors.go,
 // core/types/transaction.go and transaction_signing.go, core/vm/errors.go (the initcode size),
 // core/txpool/legacypool/legacypool.go.
+//
+// The rows ascend by TransactionStatus value -- which is also, today, the order the enum declares
+// them in -- because admissionError binary-searches them; the static_assert below holds a new row
+// to that ascent and rejects a second row for a status, which a linear scan would have left
+// silently unreachable. Which code a status gets, and why, is the code column and the header's
+// doc comment -- not the row order.
 constexpr auto c_table = std::to_array<Entry>({
-    // Not a transaction this node can accept as-is.
-    {TS::Malformed, InvalidParams, ""},
-    {TS::InvalidSignature, InvalidParams, "invalid sender"},
-    {TS::InvalidChainId, InvalidParams, "invalid chain id for signer"},
-    // The node's fault.
     {TS::Unknown, InternalError, "admission could not be decided"},
-    // Well-formed, refused by a rule geth has words for.
-    {TS::InsufficientFunds, Web3DefaultError, "insufficient funds for gas * price + value"},
-    {TS::AlreadyInTxPool, Web3DefaultError, "already known"},
-    {TS::TxPoolIsFull, Web3DefaultError, "txpool is full"},
     {TS::OutOfGasLimit, Web3DefaultError, "intrinsic gas too low"},
+    {TS::TxPoolIsFull, Web3DefaultError, "txpool is full"},
+    {TS::Malformed, InvalidParams, ""},
+    {TS::AlreadyInTxPool, Web3DefaultError, "already known"},
+    {TS::InvalidChainId, InvalidParams, "invalid chain id for signer"},
+    {TS::InvalidSignature, InvalidParams, "invalid sender"},
+    {TS::MaxInitCodeSizeExceeded, Web3DefaultError, "max initcode size exceeded"},
+    {TS::SenderNoEOA, Web3DefaultError, "sender not an eoa"},
+    {TS::InsufficientFunds, Web3DefaultError, "insufficient funds for gas * price + value"},
+    {TS::BlobTxNotAllowed, Web3DefaultError, "transaction type not supported"},
+    {TS::TxTypeNotSupported, Web3DefaultError, "transaction type not supported"},
     {TS::TipGreaterThanFeeCap, Web3DefaultError,
         "max priority fee per gas higher than max fee per gas"},
-    {TS::FeeCapLessThanBaseFee, Web3DefaultError, "max fee per gas less than block base fee"},
-    {TS::TxTypeNotSupported, Web3DefaultError, "transaction type not supported"},
-    {TS::BlobTxNotAllowed, Web3DefaultError, "transaction type not supported"},
-    {TS::SenderNoEOA, Web3DefaultError, "sender not an eoa"},
-    {TS::NonceHasMaxValue, Web3DefaultError, "nonce has max value"},
-    {TS::MaxInitCodeSizeExceeded, Web3DefaultError, "max initcode size exceeded"},
     {TS::CreateSetCodeTx, Web3DefaultError,
         "EIP-7702 transaction cannot be used to create contract"},
     {TS::EmptyAuthorizationList, Web3DefaultError, "EIP-7702 transaction with empty auth list"},
+    {TS::NonceHasMaxValue, Web3DefaultError, "nonce has max value"},
+    {TS::FeeCapLessThanBaseFee, Web3DefaultError, "max fee per gas less than block base fee"},
 });
+static_assert(std::ranges::adjacent_find(c_table, std::ranges::greater_equal{}, &Entry::status) ==
+                  c_table.end(),
+    "c_table must be strictly increasing in TransactionStatus: admissionError binary-searches it");
 }  // namespace
 
 JsonRpcException admissionError(protocol::TransactionStatus status)
 {
-    for (auto const& entry : c_table)
+    auto const entry = std::ranges::lower_bound(c_table, status, {}, &Entry::status);
+    if (entry == c_table.end() || entry->status != status)
     {
-        if (entry.status == status)
-        {
-            return {entry.code,
-                entry.message.empty() ? protocol::toString(status) : std::string(entry.message)};
-        }
+        return {Web3DefaultError, protocol::toString(status)};
     }
-    return {Web3DefaultError, protocol::toString(status)};
+    return {entry->code,
+        entry->message.empty() ? protocol::toString(status) : std::string(entry->message)};
 }
 
 JsonRpcException admissionError(protocol::TransactionStatus status, std::string_view detail)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.cpp
@@ -1,0 +1,87 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AdmissionError.cpp
+ * @author: kyonGuo
+ * @date 2026/9/9
+ */
+
+#include "AdmissionError.h"
+#include "Common.h"
+#include <array>
+#include <string>
+
+namespace bcos::rpc
+{
+namespace
+{
+using TS = protocol::TransactionStatus;
+
+struct Entry
+{
+    TS status;
+    int32_t code;
+    std::string_view message;
+};
+
+// Every status that answers with something other than (-32000, its own name); an empty message
+// means the status name. The words are go-ethereum's: core/error.go, core/txpool/errors.go,
+// core/types/transaction.go and transaction_signing.go, core/vm/errors.go (the initcode size),
+// core/txpool/legacypool/legacypool.go.
+constexpr auto c_table = std::to_array<Entry>({
+    // Not a transaction this node can accept as-is.
+    {TS::Malformed, InvalidParams, ""},
+    {TS::InvalidSignature, InvalidParams, "invalid sender"},
+    {TS::InvalidChainId, InvalidParams, "invalid chain id for signer"},
+    // The node's fault.
+    {TS::Unknown, InternalError, "admission could not be decided"},
+    // Well-formed, refused by a rule geth has words for.
+    {TS::InsufficientFunds, Web3DefaultError, "insufficient funds for gas * price + value"},
+    {TS::AlreadyInTxPool, Web3DefaultError, "already known"},
+    {TS::TxPoolIsFull, Web3DefaultError, "txpool is full"},
+    {TS::OutOfGasLimit, Web3DefaultError, "intrinsic gas too low"},
+    {TS::TipGreaterThanFeeCap, Web3DefaultError,
+        "max priority fee per gas higher than max fee per gas"},
+    {TS::FeeCapLessThanBaseFee, Web3DefaultError, "max fee per gas less than block base fee"},
+    {TS::TxTypeNotSupported, Web3DefaultError, "transaction type not supported"},
+    {TS::BlobTxNotAllowed, Web3DefaultError, "transaction type not supported"},
+    {TS::SenderNoEOA, Web3DefaultError, "sender not an eoa"},
+    {TS::NonceHasMaxValue, Web3DefaultError, "nonce has max value"},
+    {TS::MaxInitCodeSizeExceeded, Web3DefaultError, "max initcode size exceeded"},
+    {TS::CreateSetCodeTx, Web3DefaultError,
+        "EIP-7702 transaction cannot be used to create contract"},
+    {TS::EmptyAuthorizationList, Web3DefaultError, "EIP-7702 transaction with empty auth list"},
+});
+}  // namespace
+
+JsonRpcException admissionError(protocol::TransactionStatus status)
+{
+    for (auto const& entry : c_table)
+    {
+        if (entry.status == status)
+        {
+            return {entry.code,
+                entry.message.empty() ? protocol::toString(status) : std::string(entry.message)};
+        }
+    }
+    return {Web3DefaultError, protocol::toString(status)};
+}
+
+JsonRpcException admissionError(protocol::TransactionStatus status, std::string_view detail)
+{
+    auto base = admissionError(status);
+    return {base.code(), base.msg() + " (" + std::string(detail) + ")"};
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.cpp
@@ -22,8 +22,11 @@
 #include "Common.h"
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <functional>
+#include <limits>
 #include <string>
+#include <utility>
 
 namespace bcos::rpc
 {
@@ -89,5 +92,28 @@ JsonRpcException admissionError(protocol::TransactionStatus status, std::string_
 {
     auto base = admissionError(status);
     return {base.code(), base.msg() + " (" + std::string(detail) + ")"};
+}
+
+bool isAdmissionVerdict(int64_t errorCode)
+{
+    // Error carries its code in an int64_t, TransactionStatus is an int32_t: a value that does
+    // not fit is not one of them, and must not become one by truncation.
+    if (std::cmp_less(errorCode, std::numeric_limits<int32_t>::min()) ||
+        std::cmp_greater(errorCode, std::numeric_limits<int32_t>::max()))
+    {
+        return false;
+    }
+    auto const status = static_cast<protocol::TransactionStatus>(errorCode);
+    if (status == TS::None)
+    {
+        return false;
+    }
+    // toString's switch ends in `case Unknown: default:`, so every value the enum does not
+    // declare comes back as "Unknown". That makes "this node has a name for it" the test for a
+    // declared status, with Unknown itself the one value that has to be named here -- and it
+    // reuses the enum's own switch instead of keeping a second copy of the enumerators in sync.
+    // What reusing it costs: a new enumerator whose case someone forgets to add to that switch
+    // is read here as a fault, and answered -32603 rather than -32000 with its name.
+    return status == TS::Unknown || protocol::toString(status) != "Unknown";
 }
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <bcos-protocol/TransactionStatus.h>
 #include <bcos-rpc/jsonrpc/Common.h>
+#include <cstdint>
 #include <string_view>
 
 namespace bcos::rpc
@@ -51,4 +52,16 @@ JsonRpcException admissionError(protocol::TransactionStatus status);
 /// The same, with a detail appended: "transaction type not supported (blob)". The detail follows
 /// geth's words so a client matching on them still does.
 JsonRpcException admissionError(protocol::TransactionStatus status, std::string_view detail);
+
+/// Whether an Error thrown out of a pool's submitTransaction is a verdict on the transaction, and
+/// so belongs to the table above, rather than a fault in the node or the transport. The two are
+/// the same C++ type carrying the same int field: MemoryStorage throws BCOS_ERROR(status,
+/// toString(status)), while a MAX/TARS deployment's TxPoolServiceClient throws BCOS_ERROR(-1,
+/// "No value!") and TARS transport codes through the same interface (TxPoolServiceClient.cpp's
+/// await_resume, ErrorConverter.h's toBcosError). Only a code this node can name is a verdict;
+/// anything else belongs to Web3JsonRpcImpl's catch-all, which answers -32603 with the message,
+/// as it did before the two pools shared this table. A MAX refusal is not among them: the txpool
+/// process answers it with the status as its code, and toBcosError carries that code back
+/// unchanged, so it is a verdict there for the same reason it is one in-process.
+bool isAdmissionVerdict(int64_t errorCode);
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.h
@@ -40,6 +40,12 @@ namespace bcos::rpc
 /// geth has no words for, or whose one name covers several of geth's sentences, keeps its own
 /// name. Unknown -- admission could not read what it needed -- is the node's fault, not the
 /// transaction's, and answers -32603 with a fixed sentence; the storage diagnostic is for the log.
+///
+/// A receipt-wait (sync_transaction = true) the pool's expiry sweep ended arrives the same way a
+/// refusal does -- an Error carrying TransactionPoolTimeout, from MemoryStorage::removeInvalidTxs
+/// through submitTransaction's await_resume -- so the txpool branch's catch maps it through this
+/// table too. Not a verdict on the transaction, but the same kind of answer: the pool no longer
+/// holds it and nothing executed. geth has no words for it; it keeps its name.
 JsonRpcException admissionError(protocol::TransactionStatus status);
 
 /// The same, with a detail appended: "transaction type not supported (blob)". The detail follows

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/AdmissionError.h
@@ -1,0 +1,48 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AdmissionError.h
+ * @author: kyonGuo
+ * @date 2026/9/9
+ */
+
+#pragma once
+#include <bcos-protocol/TransactionStatus.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <string_view>
+
+namespace bcos::rpc
+{
+/// The JSON-RPC error a refused eth_sendRawTransaction answers with -- one table for both pools,
+/// so the txpool branch and the mempool branch refuse the same transaction with the same code and
+/// the same words.
+///
+/// The split is the one #5555's review recorded. -32602 (InvalidParams) is for a parameter that
+/// is not a transaction this node can accept as-is: bytes that decode but carry no valid
+/// signature, or a chain id that is not this chain's. -32000 is for a well-formed transaction a
+/// protocol or pool rule turned away. (geth answers -32000 for all of these and keeps -32602 for
+/// arguments its RPC layer cannot decode.) Where geth has words for the refusal the message is
+/// geth's, because clients match on them: viem classifies "already known", "insufficient funds",
+/// "intrinsic gas too low", "nonce has max value" and the two fee-cap sentences by regex, ethers
+/// "insufficient funds"; either then shows the user something better than a status name. A status
+/// geth has no words for, or whose one name covers several of geth's sentences, keeps its own
+/// name. Unknown -- admission could not read what it needed -- is the node's fault, not the
+/// transaction's, and answers -32603 with a fixed sentence; the storage diagnostic is for the log.
+JsonRpcException admissionError(protocol::TransactionStatus status);
+
+/// The same, with a detail appended: "transaction type not supported (blob)". The detail follows
+/// geth's words so a client matching on them still does.
+JsonRpcException admissionError(protocol::TransactionStatus status, std::string_view detail);
+}  // namespace bcos::rpc

--- a/bcos-rpc/test/unittests/common/ThrowingTxPool.h
+++ b/bcos-rpc/test/unittests/common/ThrowingTxPool.h
@@ -1,0 +1,57 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ThrowingTxPool.h
+ * @author: kyonGuo
+ * @date 2026/9/10
+ */
+
+#pragma once
+#include <bcos-framework/testutils/faker/FakeTxPool.h>
+#include <bcos-utilities/Error.h>
+#include <string>
+#include <utility>
+
+namespace bcos::test
+{
+/// A pool whose submitTransaction always throws the Error it was built with, so a case about what
+/// an RPC face does with a throwing pool takes microseconds instead of the pool's own timing. The
+/// code is the point of the parameter: submitTransaction answers a refusal and a fault with the
+/// same type and the same int field -- a TransactionStatus for the first, a MAX/TARS client's
+/// "No value!" or a transport code for the second -- and the faces answer the two differently.
+class ThrowingTxPool : public FakeTxPool
+{
+public:
+    ThrowingTxPool(int32_t code, std::string message) : m_code(code), m_message(std::move(message))
+    {}
+
+    task::Task<protocol::TransactionSubmitResult::Ptr> submitTransaction(
+        protocol::Transaction::Ptr, bool waitForReceipt) override
+    {
+        m_waitedForReceipt = waitForReceipt;
+        BOOST_THROW_EXCEPTION(BCOS_ERROR(m_code, m_message));
+        co_return nullptr;
+    }
+    // Each face broadcasts before it submits -- the Web3 face the transaction
+    // (EthEndpoint::sendRawTransaction), the BCOS face its buffer (JsonRpcImpl_2_0's
+    // sendTransaction) -- and TxPoolInterface's defaults for both throw "Unimplemented!".
+    task::Task<void> broadcastTransaction(protocol::Transaction const&) override { co_return; }
+    task::Task<void> broadcastTransactionBuffer(bytesConstRef) override { co_return; }
+
+    int32_t m_code;
+    std::string m_message;
+    bool m_waitedForReceipt = false;
+};
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/common/Web3TxSamples.h
+++ b/bcos-rpc/test/unittests/common/Web3TxSamples.h
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Web3TxSamples.h
+ * @author: kyonGuo
+ * @date 2026/9/9
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace bcos::test
+{
+// A pre-EIP-155 transaction: it claims no chain, so the chainId rule stands down whatever the
+// node is configured with, and what is left is the pool's own answer.
+// Sender 0x7ee79be7871ff709d67baadbf1a45bbb65bd3f8b, value 8921810000000000000.
+inline constexpr std::string_view c_unprotectedRawTx =
+    "0xf86c808504a817c800825208945dc98fe6cd853f7f5a44399cfb1c60682d5d62ef887bd0a2ecdb872000801ca0"
+    "e90ef078b60e3a186fae6071c92dbfec1256f423f5a40cd5cba69ca423eb4e44a028e14398b1a1059388cbc5eb03"
+    "cfcb6f9493bdd1efd6a17e54dcabbb2eaace16";
+inline constexpr std::string_view c_unprotectedSender = "7ee79be7871ff709d67baadbf1a45bbb65bd3f8b";
+inline constexpr std::string_view c_unprotectedTxHash =
+    "0xf6ecaffaf808cdfe1d9ef02ec461f2ab5674f72f9c6f954743e0c2d74608b751";
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
@@ -106,6 +106,12 @@ BOOST_AUTO_TEST_CASE(statusWithoutGethWordsKeepsItsName)
     auto const timeout = admissionError(TS::TransactionPoolTimeout);
     BOOST_CHECK_EQUAL(timeout.code(), Web3DefaultError);
     BOOST_CHECK_EQUAL(timeout.msg(), "TransactionPoolTimeout");
+    // Below the table's first row (Unknown = 1), where the binary search stops at begin() without
+    // matching. EthEndpoint casts an Error's code straight to TransactionStatus, so an arbitrary
+    // int -- None among them -- reaches here.
+    auto const none = admissionError(TS::None);
+    BOOST_CHECK_EQUAL(none.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(none.msg(), "None");
 }
 
 BOOST_AUTO_TEST_CASE(detailIsAppendedInParentheses)

--- a/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
@@ -101,6 +101,11 @@ BOOST_AUTO_TEST_CASE(statusWithoutGethWordsKeepsItsName)
     auto const limit = admissionError(TS::BlockLimitCheckFail);
     BOOST_CHECK_EQUAL(limit.code(), Web3DefaultError);
     BOOST_CHECK_EQUAL(limit.msg(), "BlockLimitCheckFail");
+    // Not a verdict on the transaction: the pool admitted it and then ended a sync wait without
+    // executing it (MemoryStorage::removeInvalidTxs). geth has no words for it, it keeps its name.
+    auto const timeout = admissionError(TS::TransactionPoolTimeout);
+    BOOST_CHECK_EQUAL(timeout.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(timeout.msg(), "TransactionPoolTimeout");
 }
 
 BOOST_AUTO_TEST_CASE(detailIsAppendedInParentheses)

--- a/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
@@ -1,0 +1,114 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AdmissionErrorTest.cpp
+ * @author: kyonGuo
+ * @date 2026/9/9
+ */
+
+#include <bcos-protocol/TransactionStatus.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/AdmissionError.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+using TS = protocol::TransactionStatus;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(AdmissionErrorTest)
+
+// The three structural refusals are the only -32602 rows; geth's words where it has them.
+BOOST_AUTO_TEST_CASE(structuralRefusalsAreInvalidParams)
+{
+    auto const chain = admissionError(TS::InvalidChainId);
+    BOOST_CHECK_EQUAL(chain.code(), InvalidParams);
+    BOOST_CHECK_EQUAL(chain.msg(), "invalid chain id for signer");
+    auto const sig = admissionError(TS::InvalidSignature);
+    BOOST_CHECK_EQUAL(sig.code(), InvalidParams);
+    BOOST_CHECK_EQUAL(sig.msg(), "invalid sender");
+    // No geth words for this one: the code changes, the name stays.
+    auto const malformed = admissionError(TS::Malformed);
+    BOOST_CHECK_EQUAL(malformed.code(), InvalidParams);
+    BOOST_CHECK_EQUAL(malformed.msg(), protocol::toString(TS::Malformed));
+}
+
+// Unknown is the node failing to decide, not the transaction failing a rule.
+BOOST_AUTO_TEST_CASE(undecidedAdmissionIsTheNodesFault)
+{
+    auto const e = admissionError(TS::Unknown);
+    BOOST_CHECK_EQUAL(e.code(), InternalError);
+    BOOST_CHECK_EQUAL(e.msg(), "admission could not be decided");
+}
+
+// A well-formed transaction a rule turned away: -32000, in geth's words.
+BOOST_AUTO_TEST_CASE(refusedByRuleIsServerErrorInGethWords)
+{
+    struct Row
+    {
+        TS status;
+        std::string_view message;
+    };
+    for (auto const& [status, message] : {
+             Row{TS::InsufficientFunds, "insufficient funds for gas * price + value"},
+             Row{TS::AlreadyInTxPool, "already known"},
+             Row{TS::TxPoolIsFull, "txpool is full"},
+             Row{TS::OutOfGasLimit, "intrinsic gas too low"},
+             Row{TS::TipGreaterThanFeeCap, "max priority fee per gas higher than max fee per gas"},
+             Row{TS::FeeCapLessThanBaseFee, "max fee per gas less than block base fee"},
+             Row{TS::TxTypeNotSupported, "transaction type not supported"},
+             Row{TS::BlobTxNotAllowed, "transaction type not supported"},
+             Row{TS::SenderNoEOA, "sender not an eoa"},
+             Row{TS::NonceHasMaxValue, "nonce has max value"},
+             Row{TS::MaxInitCodeSizeExceeded, "max initcode size exceeded"},
+             Row{TS::CreateSetCodeTx, "EIP-7702 transaction cannot be used to create contract"},
+             Row{TS::EmptyAuthorizationList, "EIP-7702 transaction with empty auth list"},
+         })
+    {
+        auto const e = admissionError(status);
+        BOOST_CHECK_EQUAL(e.code(), Web3DefaultError);
+        BOOST_CHECK_EQUAL(e.msg(), message);
+    }
+}
+
+// A status geth has no words for keeps its name, still at -32000: the code says "refused", the
+// name says why, and nothing pretends to be a geth error it is not. NonceCheckFail and
+// MaxGasLimitExceeded are in this group deliberately: each covers several of geth's sentences
+// ("nonce too low" / "nonce too high" / a held (sender, nonce); "exceeds block gas limit" /
+// "transaction gas limit too high"), and claiming one would be wrong the rest of the time.
+BOOST_AUTO_TEST_CASE(statusWithoutGethWordsKeepsItsName)
+{
+    auto const nonce = admissionError(TS::NonceCheckFail);
+    BOOST_CHECK_EQUAL(nonce.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(nonce.msg(), "NonceCheckFail");
+    auto const gasLimit = admissionError(TS::MaxGasLimitExceeded);
+    BOOST_CHECK_EQUAL(gasLimit.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(gasLimit.msg(), "MaxGasLimitExceeded");
+    auto const limit = admissionError(TS::BlockLimitCheckFail);
+    BOOST_CHECK_EQUAL(limit.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(limit.msg(), "BlockLimitCheckFail");
+}
+
+BOOST_AUTO_TEST_CASE(detailIsAppendedInParentheses)
+{
+    auto const e = admissionError(TS::BlobTxNotAllowed, "blob");
+    BOOST_CHECK_EQUAL(e.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(e.msg(), "transaction type not supported (blob)");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/AdmissionErrorTest.cpp
@@ -23,6 +23,8 @@
 #include <bcos-rpc/web3jsonrpc/utils/AdmissionError.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <limits>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -119,6 +121,32 @@ BOOST_AUTO_TEST_CASE(detailIsAppendedInParentheses)
     auto const e = admissionError(TS::BlobTxNotAllowed, "blob");
     BOOST_CHECK_EQUAL(e.code(), Web3DefaultError);
     BOOST_CHECK_EQUAL(e.msg(), "transaction type not supported (blob)");
+}
+
+// Which codes the table is allowed to answer at all. An in-process pool only ever throws a
+// TransactionStatus, but the same interface carries a MAX/TARS client's own faults through the
+// same int field, and the table's fallback would name one of those "Unknown" -- a refusal's code
+// for a node fault. A code this node has no name for is not a verdict.
+BOOST_AUTO_TEST_CASE(onlyANamedStatusIsAVerdict)
+{
+    BOOST_TEST(isAdmissionVerdict(static_cast<int32_t>(TS::TxPoolIsFull)));
+    // Named, and refused by the fallback rather than by a row -- still a verdict.
+    BOOST_TEST(isAdmissionVerdict(static_cast<int32_t>(TS::NonceCheckFail)));
+    // The one status whose own name is the name every undeclared value gets.
+    BOOST_TEST(isAdmissionVerdict(static_cast<int32_t>(TS::Unknown)));
+    // Not a refusal: nothing refused it.
+    BOOST_TEST(!isAdmissionVerdict(static_cast<int32_t>(TS::None)));
+    // TxPoolServiceClient's await_resume when the tars callback left no value.
+    BOOST_TEST(!isAdmissionVerdict(-1));
+    // toBcosError(tars::Int32): a TARS transport code.
+    BOOST_TEST(!isAdmissionVerdict(-7));
+    BOOST_TEST(!isAdmissionVerdict(99999));
+    BOOST_TEST(!isAdmissionVerdict(std::numeric_limits<int32_t>::min()));
+    BOOST_TEST(!isAdmissionVerdict(std::numeric_limits<int32_t>::max()));
+    // Error's code is an int64_t: a value outside TransactionStatus's own type must not become a
+    // status by truncation. 0x1'0000'2712 truncates to TxPoolIsFull.
+    BOOST_TEST(!isAdmissionVerdict(int64_t{0x100002712}));
+    BOOST_TEST(!isAdmissionVerdict(std::numeric_limits<int64_t>::min()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/PoolTimeoutRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/PoolTimeoutRpcTest.cpp
@@ -19,9 +19,9 @@
  */
 
 #include "../common/RPCFixture.h"
+#include "../common/ThrowingTxPool.h"
 #include "../common/Web3TxSamples.h"
 #include <bcos-framework/testutils/faker/FakeTransaction.h>
-#include <bcos-framework/testutils/faker/FakeTxPool.h>
 #include <bcos-protocol/TransactionStatus.h>
 #include <bcos-rpc/jsonrpc/Common.h>
 #include <bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h>
@@ -43,37 +43,22 @@ namespace bcos::test
 // commit does so with a receipt (TxPool::asyncNotifyBlockResult); the expiry sweep
 // (MemoryStorage::removeInvalidTxs) does so the way a refusal ends it: an Error carrying
 // TransactionPoolTimeout, thrown from submitTransaction's await_resume. That shape is pinned in
-// TxpoolMemoryStorageTest; this pool produces it for every submission, so the cases here take
-// microseconds instead of txs_expiration_time and pin the two JSON faces' side of it: the catch
-// that answers a refusal answers a swept wait too. The tars face (RPCServer::sendTransaction) has
-// no harness in this tree; its catch is read, not run.
-class SweptTxPool : public FakeTxPool
-{
-public:
-    task::Task<protocol::TransactionSubmitResult::Ptr> submitTransaction(
-        protocol::Transaction::Ptr, bool waitForReceipt) override
-    {
-        m_waitedForReceipt = waitForReceipt;
-        constexpr auto swept = protocol::TransactionStatus::TransactionPoolTimeout;
-        BOOST_THROW_EXCEPTION(BCOS_ERROR(static_cast<int32_t>(swept), protocol::toString(swept)));
-        co_return nullptr;
-    }
-    task::Task<void> broadcastTransaction(protocol::Transaction const&) override { co_return; }
-    task::Task<void> broadcastTransactionBuffer(bytesConstRef) override { co_return; }
-
-    bool m_waitedForReceipt = false;
-};
-
+// TxpoolMemoryStorageTest; the pool here (ThrowingTxPool) produces it for every submission, so
+// the cases take microseconds instead of txs_expiration_time and pin the two JSON faces' side of
+// it: the catch that answers a refusal answers a swept wait too. The tars face
+// (RPCServer::sendTransaction) has no harness in this tree; its catch is read, not run.
 class PoolTimeoutFixture : public RPCFixture
 {
 public:
     PoolTimeoutFixture()
     {
-        pool = std::make_shared<SweptTxPool>();
+        constexpr auto swept = protocol::TransactionStatus::TransactionPoolTimeout;
+        pool = std::make_shared<ThrowingTxPool>(
+            static_cast<int32_t>(swept), protocol::toString(swept));
         service = std::make_shared<rpc::NodeService>(
             m_ledger, scheduler, pool, nullptr, nullptr, m_blockFactory, nullptr);
     }
-    std::shared_ptr<SweptTxPool> pool;
+    std::shared_ptr<ThrowingTxPool> pool;
     rpc::NodeService::Ptr service;
 };
 

--- a/bcos-rpc/test/unittests/rpc/PoolTimeoutRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/PoolTimeoutRpcTest.cpp
@@ -1,0 +1,122 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file PoolTimeoutRpcTest.cpp
+ * @author: kyonGuo
+ * @date 2026/9/9
+ */
+
+#include "../common/RPCFixture.h"
+#include "../common/Web3TxSamples.h"
+#include <bcos-framework/testutils/faker/FakeTransaction.h>
+#include <bcos-framework/testutils/faker/FakeTxPool.h>
+#include <bcos-protocol/TransactionStatus.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Error.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+// A receipt-wait (waitForReceipt = true: BCOS sendTransaction always, eth_sendRawTransaction
+// under sync_transaction=true) ends when the pool calls the transaction's submit callback. Block
+// commit does so with a receipt (TxPool::asyncNotifyBlockResult); the expiry sweep
+// (MemoryStorage::removeInvalidTxs) does so the way a refusal ends it: an Error carrying
+// TransactionPoolTimeout, thrown from submitTransaction's await_resume. That shape is pinned in
+// TxpoolMemoryStorageTest; this pool produces it for every submission, so the cases here take
+// microseconds instead of txs_expiration_time and pin the two JSON faces' side of it: the catch
+// that answers a refusal answers a swept wait too. The tars face (RPCServer::sendTransaction) has
+// no harness in this tree; its catch is read, not run.
+class SweptTxPool : public FakeTxPool
+{
+public:
+    task::Task<protocol::TransactionSubmitResult::Ptr> submitTransaction(
+        protocol::Transaction::Ptr, bool waitForReceipt) override
+    {
+        m_waitedForReceipt = waitForReceipt;
+        constexpr auto swept = protocol::TransactionStatus::TransactionPoolTimeout;
+        BOOST_THROW_EXCEPTION(BCOS_ERROR(static_cast<int32_t>(swept), protocol::toString(swept)));
+        co_return nullptr;
+    }
+    task::Task<void> broadcastTransaction(protocol::Transaction const&) override { co_return; }
+    task::Task<void> broadcastTransactionBuffer(bytesConstRef) override { co_return; }
+
+    bool m_waitedForReceipt = false;
+};
+
+class PoolTimeoutFixture : public RPCFixture
+{
+public:
+    PoolTimeoutFixture()
+    {
+        pool = std::make_shared<SweptTxPool>();
+        service = std::make_shared<rpc::NodeService>(
+            m_ledger, scheduler, pool, nullptr, nullptr, m_blockFactory, nullptr);
+    }
+    std::shared_ptr<SweptTxPool> pool;
+    rpc::NodeService::Ptr service;
+};
+
+BOOST_FIXTURE_TEST_SUITE(PoolTimeoutRpcTest, PoolTimeoutFixture)
+
+// The txpool branch's catch maps the Error's status through the admission-error table, where
+// TransactionPoolTimeout has no geth words and keeps its name at -32000. Not the "VM Exception"
+// reply: nothing executed.
+BOOST_AUTO_TEST_CASE(web3SweptReceiptWaitIsAnError)
+{
+    EthEndpoint endpoint(service, nullptr, /*syncTransaction=*/true);
+    Json::Value params(Json::arrayValue);
+    params.append(std::string(c_unprotectedRawTx));
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(task::syncWait(endpoint.sendRawTransaction(params, response)),
+        JsonRpcException, [](JsonRpcException const& e) {
+            return e.code() == Web3DefaultError && e.msg() == "TransactionPoolTimeout";
+        });
+    BOOST_TEST(pool->m_waitedForReceipt);
+}
+
+// The BCOS face answers a pool refusal as the Error itself (its code is the TransactionStatus);
+// a swept wait is answered the same way, not as a receipt that was never produced.
+BOOST_AUTO_TEST_CASE(bcosSweptReceiptWaitIsAnError)
+{
+    auto localRpc = factory->buildLocalRpc(groupInfo, service);
+    auto tx = fakeTransaction(cryptoSuite, "1", 1000023, chainId, groupId);
+    bytes encoded;
+    tx->encode(encoded);
+    Error::Ptr answer;
+    bool answered = false;
+    localRpc->jsonRpcImpl()->sendTransaction(
+        groupId, "", toHexStringWithPrefix(encoded), false, [&](Error::Ptr error, Json::Value&) {
+            answered = true;
+            answer = std::move(error);
+        });
+    BOOST_REQUIRE(answered);
+    BOOST_REQUIRE(answer != nullptr);
+    BOOST_CHECK_EQUAL(answer->errorCode(),
+        static_cast<int64_t>(protocol::TransactionStatus::TransactionPoolTimeout));
+    BOOST_CHECK_EQUAL(answer->errorMessage(), "TransactionPoolTimeout");
+    BOOST_TEST(pool->m_waitedForReceipt);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/TxPoolFaultRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/TxPoolFaultRpcTest.cpp
@@ -1,0 +1,159 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TxPoolFaultRpcTest.cpp
+ * @author: kyonGuo
+ * @date 2026/9/10
+ */
+
+#include "../common/RPCFixture.h"
+#include "../common/ThrowingTxPool.h"
+#include "../common/Web3TxSamples.h"
+#include <bcos-protocol/TransactionStatus.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Error.h>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <memory>
+#include <string>
+#include <variant>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+// submitTransaction answers a refusal and a fault with the same C++ type and the same int field.
+// An in-process pool only ever puts a TransactionStatus there, but a MAX/TARS deployment's
+// TxPoolServiceClient throws BCOS_ERROR(-1, "No value!") when the callback left no value, and
+// toBcosError(tarsRet)'s "TARS error!" when the call itself failed. Casting one of those to a
+// TransactionStatus reaches no row of the admission table and lands on its fallback, which would
+// answer a node fault as -32000 "Unknown" -- a refusal's code, a name that is not the fault's,
+// and the real message gone. These pin the split: only a code this node can name is answered
+// from the table, the rest reach Web3JsonRpcImpl's catch-all as they did before the table.
+class TxPoolFaultFixture : public RPCFixture
+{
+public:
+    // The Error sendRawTransaction lets out, or the JsonRpcException it turns it into.
+    std::variant<std::monostate, Error, JsonRpcException> answer(int32_t code, std::string message)
+    {
+        auto pool = std::make_shared<ThrowingTxPool>(code, std::move(message));
+        auto service = std::make_shared<rpc::NodeService>(
+            m_ledger, scheduler, pool, nullptr, nullptr, m_blockFactory, nullptr);
+        EthEndpoint endpoint(service, nullptr, /*syncTransaction=*/true);
+        Json::Value params(Json::arrayValue);
+        params.append(std::string(c_unprotectedRawTx));
+        Json::Value response;
+        try
+        {
+            task::syncWait(endpoint.sendRawTransaction(params, response));
+        }
+        catch (JsonRpcException const& e)
+        {
+            return e;
+        }
+        catch (bcos::Error const& e)
+        {
+            return e;
+        }
+        return std::monostate{};
+    }
+
+    // The same submission through the whole Web3 face, down to the bytes the client receives.
+    // answer() stops one hop short of this: it sees the exception leave sendRawTransaction, not
+    // what Web3JsonRpcImpl's catch-all makes of it.
+    Json::Value response(int32_t code, std::string message)
+    {
+        auto pool = std::make_shared<ThrowingTxPool>(code, std::move(message));
+        auto service = std::make_shared<rpc::NodeService>(
+            m_ledger, scheduler, pool, nullptr, nullptr, m_blockFactory, nullptr);
+        auto localRpc = factory->buildLocalRpc(groupInfo, service);
+        auto web3 = localRpc->web3JsonRpc();
+        BOOST_REQUIRE(web3 != nullptr);
+        auto const payload =
+            std::string(
+                R"({"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":[")") +
+            std::string(c_unprotectedRawTx) + R"("]})";
+        std::promise<bcos::bytes> promise;
+        web3->onRPCRequest(payload, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto const bytes = promise.get_future().get();
+        Json::Value parsed;
+        Json::Reader reader;
+        std::string_view json((char*)bytes.data(), bytes.size());
+        reader.parse(json.begin(), json.end(), parsed);
+        return parsed;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(TxPoolFaultRpcTest, TxPoolFaultFixture)
+
+// TxPoolServiceClient.cpp's await_resume, when the tars callback left the variant empty.
+BOOST_AUTO_TEST_CASE(poolFaultKeepsItsCodeAndMessage)
+{
+    auto const answered = answer(-1, "No value!");
+    BOOST_REQUIRE(std::holds_alternative<Error>(answered));
+    auto const& error = std::get<Error>(answered);
+    BOOST_CHECK_EQUAL(error.errorCode(), -1);
+    BOOST_CHECK_EQUAL(error.errorMessage(), "No value!");
+}
+
+// ErrorConverter.h's toBcosError(tars::Int32): a TARS transport code, negative and not a status.
+BOOST_AUTO_TEST_CASE(tarsTransportFaultKeepsItsCodeAndMessage)
+{
+    auto const answered = answer(-7, "TARS error!");
+    BOOST_REQUIRE(std::holds_alternative<Error>(answered));
+    auto const& error = std::get<Error>(answered);
+    BOOST_CHECK_EQUAL(error.errorCode(), -7);
+    BOOST_CHECK_EQUAL(error.errorMessage(), "TARS error!");
+}
+
+// A positive value the enum does not declare is no more a verdict than a negative one.
+BOOST_AUTO_TEST_CASE(undeclaredStatusValueIsNotAVerdict)
+{
+    auto const answered = answer(99999, "not a status");
+    BOOST_REQUIRE(std::holds_alternative<Error>(answered));
+    BOOST_CHECK_EQUAL(std::get<Error>(answered).errorCode(), 99999);
+    BOOST_CHECK_EQUAL(std::get<Error>(answered).errorMessage(), "not a status");
+}
+
+// What the client is left holding: Web3JsonRpcImpl's catch-all, -32603 and the message the fault
+// came with. This is the answer base 1f371d2f5 gave, before the txpool branch had a catch at all.
+BOOST_AUTO_TEST_CASE(poolFaultReachesTheClientAsAnInternalError)
+{
+    auto const answered = response(-1, "No value!");
+    BOOST_REQUIRE(answered.isMember("error"));
+    BOOST_CHECK_EQUAL(answered["error"]["code"].asInt(), InternalError);
+    BOOST_CHECK_EQUAL(answered["error"]["message"].asString(), "No value!");
+    BOOST_TEST(!answered.isMember("result"));
+}
+
+// The guard is not a way out of the table: a real refusal is still answered from it.
+BOOST_AUTO_TEST_CASE(refusalIsStillAnsweredFromTheTable)
+{
+    constexpr auto full = protocol::TransactionStatus::TxPoolIsFull;
+    auto const answered = answer(static_cast<int32_t>(full), protocol::toString(full));
+    BOOST_REQUIRE(std::holds_alternative<JsonRpcException>(answered));
+    auto const& refusal = std::get<JsonRpcException>(answered);
+    BOOST_CHECK_EQUAL(refusal.code(), Web3DefaultError);
+    BOOST_CHECK_EQUAL(refusal.msg(), "txpool is full");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -10,6 +10,7 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <boost/test/unit_test.hpp>
 #include <future>
 #include <string_view>
@@ -210,7 +211,8 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionRejectsBlobTransaction)
     // L2 never admits blob (type-3) transactions; rejected before RLP decoding.
     auto resp = call(req("eth_sendRawTransaction", R"(["0x03deadbeef"])"));
     BOOST_REQUIRE(resp.isMember("error"));
-    BOOST_CHECK_NE(resp["error"]["message"].asString().find("blob"), std::string::npos);
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), bcos::rpc::Web3DefaultError);
+    BOOST_CHECK_EQUAL(resp["error"]["message"].asString(), "transaction type not supported (blob)");
 }
 
 BOOST_AUTO_TEST_CASE(sendRawTransactionRejectsDepositTransaction)
@@ -218,7 +220,9 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionRejectsDepositTransaction)
     // Deposits (0x7e) are CL-injected via the Engine API only, never via the tx pool.
     auto resp = call(req("eth_sendRawTransaction", R"(["0x7edeadbeef"])"));
     BOOST_REQUIRE(resp.isMember("error"));
-    BOOST_CHECK_NE(resp["error"]["message"].asString().find("deposit"), std::string::npos);
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), bcos::rpc::Web3DefaultError);
+    BOOST_CHECK_EQUAL(resp["error"]["message"].asString(),
+        "transaction type not supported (deposit, Engine API only)");
 }
 
 BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -29,6 +29,7 @@
 #include <bcos-rpc/jwtAuth/JwtConfig.h>
 #include <bcos-rpc/jwtAuth/JwtVerifier.h>
 #include <bcos-rpc/web3jsonrpc/model/Web3FilterRequest.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <bcos-task/Task.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
@@ -503,7 +504,7 @@ BOOST_AUTO_TEST_CASE(handleMempoolChainIdGateUnconfiguredTest)
             "72f3e8f299379ce2802e64b1cbb55275ad9aaa81190b44");
         BOOST_TEST(response.isMember("error"));
         BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
-        BOOST_TEST(response["error"]["message"].asString() == "InvalidChainId");
+        BOOST_TEST(response["error"]["message"].asString() == "invalid chain id for signer");
     }
     // Typed EIP-1559 (chainId=1; etherscan 0x5b2f24...): rejected on the same rule.
     {
@@ -513,7 +514,7 @@ BOOST_AUTO_TEST_CASE(handleMempoolChainIdGateUnconfiguredTest)
             "0f6ed7d035397547aeac0e5130847570f4b607350f71c1391b7cb7f9dd604c");
         BOOST_TEST(response.isMember("error"));
         BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
-        BOOST_TEST(response["error"]["message"].asString() == "InvalidChainId");
+        BOOST_TEST(response["error"]["message"].asString() == "invalid chain id for signer");
     }
     // Pre-EIP-155 legacy (v=28; etherscan 0xf6ecaf...): exempt — accepted into the mempool.
     // Funded first: this path now runs the balance check, which it did not before.
@@ -550,7 +551,7 @@ BOOST_AUTO_TEST_CASE(handleSendRawTypedChainIdMismatchTest)
     auto response = onRPCRequestWrapper(request);
     BOOST_TEST(response.isMember("error"));
     BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
-    BOOST_TEST(response["error"]["message"].asString() == "InvalidChainId");
+    BOOST_TEST(response["error"]["message"].asString() == "invalid chain id for signer");
 }
 
 // The pre-EIP-155 transaction used by the two cases below: it claims no chain, so the chainId
@@ -587,8 +588,8 @@ BOOST_AUTO_TEST_CASE(handleMempoolRejectionIsReportedRatherThanHashed)
     // The same bytes again: one transaction, one hash, already held.
     auto second = onRPCRequestWrapper(request);
     BOOST_TEST(second.isMember("error"));
-    BOOST_TEST(second["error"]["code"].asInt() == InvalidParams);
-    BOOST_TEST(second["error"]["message"].asString() == "AlreadyInTxPool");
+    BOOST_TEST(second["error"]["code"].asInt() == Web3DefaultError);
+    BOOST_TEST(second["error"]["message"].asString() == "already known");
     BOOST_TEST(!second.isMember("result"));
 }
 
@@ -606,13 +607,102 @@ BOOST_AUTO_TEST_CASE(handleMempoolEestReplayContextDropsTheBalanceCheck)
     // Unfunded, under the ordinary column.
     auto rejected = onRPCRequestWrapper(request);
     BOOST_TEST(rejected.isMember("error"));
-    BOOST_TEST(rejected["error"]["message"].asString() == "InsufficientFunds");
+    BOOST_TEST(rejected["error"]["code"].asInt() == Web3DefaultError);
+    BOOST_TEST(
+        rejected["error"]["message"].asString() == "insufficient funds for gas * price + value");
 
     nodeService->setAdmissionValidator(
         m_admissionValidator, bcos::txvalidator::AdmissionContext::EESTReplay);
     auto accepted = onRPCRequestWrapper(request);
     validRespCheck(accepted);
     BOOST_TEST(accepted["result"].asString() == std::string(c_unprotectedTxHash));
+}
+
+// The typed EIP-1559 envelope for chain 1 the chain-id cases above use (etherscan 0x5b2f24...).
+static constexpr std::string_view c_typedChain1RawTx =
+    "0x02f871018308b3e6808501cd2ec1d7826ac194ba1951df0c0a52af23857c5ab48b4c43a57e7ed1872700f2d0"
+    "ba3db080c001a069be171dfa805790a28f1bfcd131eb2aa8f345f601c4a3659de4ae8d624a7b89a06e0f6ed7d0"
+    "35397547aeac0e5130847570f4b607350f71c1391b7cb7f9dd604c";
+
+// Both pools refuse through one table (AdmissionError.h). The txpool branch used to let the
+// pool's refusal escape as a bcos::Error into the catch-all, which answered -32603 with the status
+// name; the mempool branch answered -32602 with the same name. Same transaction, same rule, same
+// answer now: a structural refusal is -32602 in geth's words, a well-formed transaction a rule
+// turned away is -32000 in geth's words.
+BOOST_AUTO_TEST_CASE(handleTxpoolRefusalAnswersWithTheMempoolShape)
+{
+    // No mempool set: this is the txpool branch.
+    BOOST_REQUIRE(nodeService->memPool() == nullptr);
+    auto ledgerConfig = std::make_shared<bcos::ledger::LedgerConfig>();
+    ledgerConfig->setChainId(evmc::bytes32{999});
+    ledgerConfig->setGasPrice({"0", 0});
+    m_ledgerConfigState->set(std::move(ledgerConfig));
+    auto submit = [&](std::string_view rawTx) {
+        const std::string request =
+            R"({"jsonrpc":"2.0","id":1132123, "method":"eth_sendRawTransaction","params":[")" +
+            std::string(rawTx) + R"("]})";
+        return onRPCRequestWrapper(request);
+    };
+    // Signed for chain 1, sent to a node on chain 999: not a transaction for this chain.
+    {
+        auto response = submit(c_typedChain1RawTx);
+        BOOST_TEST(response.isMember("error"));
+        BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
+        BOOST_TEST(response["error"]["message"].asString() == "invalid chain id for signer");
+        BOOST_TEST(!response.isMember("result"));
+    }
+    // Pre-EIP-155 and unfunded: well-formed, turned away by the balance rule.
+    {
+        auto response = submit(c_unprotectedRawTx);
+        BOOST_TEST(response.isMember("error"));
+        BOOST_TEST(response["error"]["code"].asInt() == Web3DefaultError);
+        BOOST_TEST(response["error"]["message"].asString() ==
+                   "insufficient funds for gas * price + value");
+        BOOST_TEST(!response.isMember("result"));
+    }
+}
+
+// verify() throws when the data it needs cannot be read (TxValidator.h). That is the node's
+// fault, not a verdict on the transaction, and the storage diagnostic belongs in the log, not in
+// the response: the client gets the same -32603 sentence the txpool branch gives for it (there
+// verifyAndSubmitTransaction catches the throw and refuses with Unknown).
+BOOST_AUTO_TEST_CASE(handleMempoolAdmissionFaultIsAnsweredAsTheNodesFault)
+{
+    struct FaultingLedger : FakeLedger
+    {
+        using FakeLedger::FakeLedger;
+        task::Task<std::optional<ledger::StorageState>> getStorageState(
+            std::string_view, protocol::BlockNumber) override
+        {
+            throw std::runtime_error("storage unavailable");
+            co_return std::nullopt;
+        }
+    };
+    auto faulting = std::make_shared<FaultingLedger>(m_blockFactory, 20, 10, 10);
+    auto validator = std::make_shared<bcos::txvalidator::TxValidator>(
+        cryptoSuite, faulting, m_ledgerConfigState, /*txPoolNonceChecker=*/nullptr,
+        std::make_shared<bcos::txvalidator::Web3NonceChecker>(faulting),
+        [](bcos::protocol::Transaction const&) { return false; }, groupId, chainId);
+    validator->setScheduler(scheduler);
+    bcos::txpool::MemPoolImpl memPool;
+    nodeService->setMemPool(memPool);
+    nodeService->setAdmissionValidator(
+        validator, bcos::txvalidator::AdmissionContext::PoolAdmission);
+    // Funded in the fixture's ledger, so the only thing standing between this transaction and
+    // the pool is the read that faults.
+    std::optional<storage::Entry> balance = storage::Entry();
+    balance->set(asBytes("8921810000000000000"));
+    m_ledger->setStorageAt(std::string(c_unprotectedSender),
+        std::string(bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE), balance);
+
+    const std::string request =
+        R"({"jsonrpc":"2.0","id":1132123, "method":"eth_sendRawTransaction","params":[")" +
+        std::string(c_unprotectedRawTx) + R"("]})";
+    auto response = onRPCRequestWrapper(request);
+    BOOST_TEST(response.isMember("error"));
+    BOOST_TEST(response["error"]["code"].asInt() == InternalError);
+    BOOST_TEST(response["error"]["message"].asString() == "admission could not be decided");
+    BOOST_TEST(!response.isMember("result"));
 }
 
 BOOST_AUTO_TEST_CASE(handleEIP4844TxTest)
@@ -629,7 +719,9 @@ BOOST_AUTO_TEST_CASE(handleEIP4844TxTest)
             rawTx + R"("]})";
         auto response = onRPCRequestWrapper(request);
         BOOST_REQUIRE(response.isMember("error"));
-        BOOST_CHECK_NE(response["error"]["message"].asString().find("blob"), std::string::npos);
+        BOOST_CHECK_EQUAL(response["error"]["code"].asInt(), Web3DefaultError);
+        BOOST_CHECK_EQUAL(
+            response["error"]["message"].asString(), "transaction type not supported (blob)");
         std::vector<crypto::HashType> hashes = {HashType(txHash)};
         task::wait([](Web3TestFixture* self, decltype(hashes) m_hashes) -> task::Task<void> {
             auto txs = co_await self->txPool->getTransactions(m_hashes);

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -20,6 +20,7 @@
 
 
 #include "../common/RPCFixture.h"
+#include "../common/Web3TxSamples.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-framework/testutils/faker/FakeLedger.h>
@@ -553,17 +554,6 @@ BOOST_AUTO_TEST_CASE(handleSendRawTypedChainIdMismatchTest)
     BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
     BOOST_TEST(response["error"]["message"].asString() == "invalid chain id for signer");
 }
-
-// The pre-EIP-155 transaction used by the two cases below: it claims no chain, so the chainId
-// rule stands down whatever the node is configured with, and what is left is the pool's own
-// answer. Sender 0x7ee79be7871ff709d67baadbf1a45bbb65bd3f8b, value 8921810000000000000.
-static constexpr std::string_view c_unprotectedRawTx =
-    "0xf86c808504a817c800825208945dc98fe6cd853f7f5a44399cfb1c60682d5d62ef887bd0a2ecdb872000801ca0"
-    "e90ef078b60e3a186fae6071c92dbfec1256f423f5a40cd5cba69ca423eb4e44a028e14398b1a1059388cbc5eb03"
-    "cfcb6f9493bdd1efd6a17e54dcabbb2eaace16";
-static constexpr std::string_view c_unprotectedSender = "7ee79be7871ff709d67baadbf1a45bbb65bd3f8b";
-static constexpr std::string_view c_unprotectedTxHash =
-    "0xf6ecaffaf808cdfe1d9ef02ec461f2ab5674f72f9c6f954743e0c2d74608b751";
 
 // A transaction the pool did not take must not come back as a transaction hash. MemPoolImpl::add
 // returned void and swallowed four different refusals, so this method answered every one of them

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -897,16 +897,33 @@ void MemoryStorage::removeInvalidTxs(std::span<bcos::protocol::Transaction::Ptr>
             return tx2Remove.second != nullptr;
         });
 
-        for (const auto& [txHash, tx] : txs2Notify)
+        // A receipt-wait parked on one of these ends the way a refusal ends it: an Error carrying
+        // TransactionPoolTimeout -- the sweep's one status whichever check swept the transaction
+        // (expiry, blockLimit, committed nonce) -- which submitTransaction's completeOnce puts on
+        // await_resume's throwing branch, so every caller answers it through the catch it already
+        // has for a refusal. It used to end with a result carrying this status and no receipt; the
+        // tars result type fabricates a default receipt on read, and the RPC faces then reported a
+        // transaction the pool had dropped as executed. One Error for the batch: completeOnce
+        // keeps the pointer and await_resume throws a copy.
+        auto const swept = BCOS_ERROR_PTR((int32_t)TransactionStatus::TransactionPoolTimeout,
+            bcos::protocol::toString(TransactionStatus::TransactionPoolTimeout));
+        for (const auto& tx : txs2Notify | ::ranges::views::values)
         {
-            auto nonce = tx->nonce();
-            auto txResult = m_config->txResultFactory()->createTxSubmitResult();
-            txResult->setTxHash(txHash);
-            txResult->setStatus(static_cast<uint32_t>(TransactionStatus::TransactionPoolTimeout));
-            txResult->setNonce(std::string(nonce));
-            txResult->setType(tx->type());
-            txResult->setSender(std::string(tx->sender()));
-            notifyTxResult(*tx, std::move(txResult));
+            auto callback = tx->takeSubmitCallback();
+            if (!callback)
+            {
+                continue;
+            }
+            try
+            {
+                callback(swept, nullptr);
+            }
+            catch (std::exception const& e)
+            {
+                TXPOOL_LOG(WARNING) << LOG_DESC("removeInvalidTxs: notify failed")
+                                    << LOG_KV("tx", tx->hash().abridged())
+                                    << LOG_KV("message", boost::diagnostic_information(e));
+            }
         }
 
         TXPOOL_LOG(DEBUG) << LOG_DESC("removeInvalidTxs") << LOG_KV("size", txCnt);

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -178,8 +178,10 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
             catch (std::exception& e)
             {
                 TXPOOL_LOG(WARNING) << "Unexpected exception: " << boost::diagnostic_information(e);
+                // Unknown, not Malformed: nothing judged the transaction, and the RPC answers
+                // Unknown as the node's fault where Malformed would be an invalid-parameter reply.
                 completeOnce(
-                    BCOS_ERROR_PTR((int32_t)TransactionStatus::Malformed, "Unknown exception"),
+                    BCOS_ERROR_PTR((int32_t)TransactionStatus::Unknown, "Unknown exception"),
                     nullptr);
             }
         }

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -35,8 +35,10 @@
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <fakeit.hpp>
 #include <future>
+#include <optional>
 #include <thread>
 
 using namespace bcos;
@@ -1356,6 +1358,73 @@ BOOST_AUTO_TEST_CASE(poolAdmissionRefusesInsteadOfThrowingOnAStorageFault)
     BOOST_CHECK(status == TransactionStatus::Unknown);
     BOOST_CHECK(!storageSig.exists(tx->hash()));
     BOOST_CHECK(!task::syncWait(faultingWeb3Nonces->existsMemoryNonce(tx->sender(), tx->nonce())));
+}
+
+// The expiry sweep ends a receipt-wait the way a refusal does: as an Error carrying
+// TransactionPoolTimeout, thrown from await_resume. It used to deliver a result with that status
+// and no receipt instead, and the tars result type fabricates a default receipt on read, so every
+// RPC face then reported a transaction the pool had dropped as executed: a VM exception on the
+// Web3 face, a status-0 receipt on the BCOS face.
+BOOST_AUTO_TEST_CASE(sweptReceiptWaitEndsAsTimeoutError)
+{
+    // submitTransaction() uses shared_from_this(); ten milliseconds to live.
+    auto ioServicePool = std::make_shared<IOServicePool>(1, "sweptWait");
+    auto sharedStorage = std::make_shared<MemoryStorage>(
+        config, *ioServicePool->getIOService(), /*notifyWorkerNum*/ 2, /*txsExpirationTime*/ 10);
+
+    // In the pool without a callback, then a receipt-wait hangs its callback on it
+    // (AlreadyInTxPoolAndAccept), the shape FIB48_SubmitTransactionResumesOnce uses.
+    auto tx = makeTx("swept_receipt_wait", false);
+    BOOST_REQUIRE_EQUAL(sharedStorage->insert(tx), TransactionStatus::None);
+    std::promise<void> done;
+    auto doneFuture = done.get_future();
+    std::optional<int64_t> errorCode;
+    std::string errorMessage;
+    bool gotResult = false;
+    bool unexpected = false;
+    std::thread waitThread([&]() {
+        try
+        {
+            auto result = task::syncWait(sharedStorage->submitTransaction(tx, true));
+            gotResult = (result != nullptr);
+        }
+        catch (bcos::Error const& e)
+        {
+            errorCode = e.errorCode();
+            errorMessage = e.errorMessage();
+        }
+        catch (...)
+        {
+            unexpected = true;
+        }
+        done.set_value();
+    });
+    for (size_t i = 0; i < 500 && !tx->submitCallback(); ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    BOOST_REQUIRE(tx->submitCallback());
+
+    // Sealing finds it past its expiration and sweeps it.
+    tx->setImportTime(static_cast<int64_t>(utcTime()) - 1000);
+    std::vector<protocol::TransactionMetaData::Ptr> txsList;
+    std::vector<protocol::TransactionMetaData::Ptr> sysTxsList;
+    sharedStorage->batchSealTransactions(txsList, sysTxsList, 100);
+
+    // A wait nothing ends cannot be joined: let it go and fail, rather than hang the binary.
+    if (doneFuture.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+    {
+        waitThread.detach();
+        BOOST_FAIL("the receipt-wait was not ended by the sweep");
+    }
+    waitThread.join();
+    BOOST_CHECK(!unexpected);
+    BOOST_CHECK(txsList.empty());
+    BOOST_CHECK(!sharedStorage->exists(tx->hash()));
+    BOOST_CHECK(!gotResult);
+    BOOST_REQUIRE(errorCode.has_value());
+    BOOST_CHECK_EQUAL(*errorCode, static_cast<int64_t>(TransactionStatus::TransactionPoolTimeout));
+    BOOST_CHECK_EQUAL(errorMessage, "TransactionPoolTimeout");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/test/unittests/txpool/TxPoolFixture.h
+++ b/bcos-txpool/test/unittests/txpool/TxPoolFixture.h
@@ -40,6 +40,7 @@
 #include <bcos-txpool/sync/TransactionSync.h>
 #include <bcos-txpool/txpool/storage/MemoryStorage.h>
 #include <bcos-utilities/BoostLog.h>
+#include <bcos-utilities/Error.h>
 #include <bcos-utilities/IOServicePool.h>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/test/unit_test.hpp>
@@ -407,10 +408,20 @@ inline void checkTxSubmit(TxPoolInterface::Ptr _txpool, TxPoolStorageInterface::
                       << std::endl;
             if (_maybeExpired)
             {
-                BOOST_CHECK(
-                    (submitResult->status() == _expectedStatus) ||
-                    (submitResult->status() == (int32_t)TransactionStatus::TransactionPoolTimeout));
+                // A wait the sweep ended never arrives as a result (see the catch below).
+                BOOST_CHECK_EQUAL(submitResult->status(), _expectedStatus);
             }
+        }
+        catch (bcos::Error& e)
+        {
+            // The expiry sweep ends a receipt-wait as an Error carrying TransactionPoolTimeout
+            // (MemoryStorage::removeInvalidTxs), the way a refusal ends it.
+            if (_maybeExpired)
+            {
+                BOOST_CHECK_EQUAL(
+                    e.errorCode(), (int64_t)TransactionStatus::TransactionPoolTimeout);
+            }
+            std::cout << "Submit transaction exception! " << boost::diagnostic_information(e);
         }
         catch (std::exception& e)
         {


### PR DESCRIPTION
### What

The error-shape unification #5555's description deferred, with the mapping morebtcg recorded there and ywy2090's finding E.

`eth_sendRawTransaction` answered a refusal three ways. The mempool branch mapped every status to `InvalidParams` (-32602) with the status name. The txpool branch let the pool's refusal — a `bcos::Error` whose code is the `TransactionStatus`, thrown by `MemoryStorage::submitTransaction`'s `await_resume` — escape into `Web3JsonRpcImpl`'s catch-all, which answered `InternalError` (-32603) with the same status name. And on the mempool branch a storage fault inside `verify()` reached the client as the raw diagnostic text. A wallet that branches on the error code (retry, "top up your balance", "already sent") got a different code for the same refusal depending on which pool the node runs.

Both branches now refuse through one table, `bcos-rpc/web3jsonrpc/utils/AdmissionError.{h,cpp}`:

| Refusal | Code | Message |
|---|---|---|
| `Malformed`, `InvalidSignature`, `InvalidChainId` — not a transaction this node can accept as-is | -32602 `InvalidParams` | `MalformTx` (the status name) / `invalid sender` / `invalid chain id for signer` |
| `Unknown` — admission could not read what it needed | -32603 `InternalError` | `admission could not be decided` |
| `InsufficientFunds`, `AlreadyInTxPool`, `TxPoolIsFull`, `OutOfGasLimit`, `TipGreaterThanFeeCap`, `FeeCapLessThanBaseFee`, `TxTypeNotSupported`, `BlobTxNotAllowed`, `SenderNoEOA`, `NonceHasMaxValue`, `MaxInitCodeSizeExceeded`, `CreateSetCodeTx`, `EmptyAuthorizationList` | -32000 | geth's words: `insufficient funds for gas * price + value`, `already known`, `txpool is full`, `intrinsic gas too low`, `max priority fee per gas higher than max fee per gas`, `max fee per gas less than block base fee`, `transaction type not supported`, `sender not an eoa`, `nonce has max value`, `max initcode size exceeded`, `EIP-7702 transaction cannot be used to create contract`, `EIP-7702 transaction with empty auth list` |
| every other status (`NonceCheckFail`, `MaxGasLimitExceeded`, `BlockLimitCheckFail`, …) | -32000 | the status name, as before |

The words are go-ethereum's, read at master from `core/error.go`, `core/txpool/errors.go`, `core/types/transaction.go`, `core/types/transaction_signing.go`, `core/vm/errors.go` (the initcode size) and `core/txpool/legacypool/legacypool.go`. They matter because clients match on them: viem (`src/errors/node.ts`) classifies `already known`, `insufficient funds`, `intrinsic gas too low`, `nonce has max value` and the two fee-cap sentences by regex; ethers v6 (`provider-jsonrpc.ts`) matches `insufficient funds`. Either then shows the user something better than a status name. Two statuses keep their name deliberately because one name covers several of geth's sentences: `NonceCheckFail` (a nonce below the account's, one beyond the window, a (sender, nonce) already held — geth's `nonce too low`, `nonce too high`, `replacement transaction underpriced`) and `MaxGasLimitExceeded` (`checkMaxGasLimit` covers the block limit and the EIP-7825 cap — geth's `exceeds block gas limit` and `transaction gas limit too high`). Claiming one sentence would be wrong the rest of the time.

What else changes on the path:

- The blob and deposit gates ahead of RLP decoding used to answer -32602 with their own sentences. They now answer as the type refusal `verify()` gives — -32000 `transaction type not supported (blob)` / `(deposit, Engine API only)` — so a client sees one code for "this node does not take that type" wherever it is caught.
- The mempool branch catches `verify()`'s throw. It logs the diagnostic and answers `admissionError(Unknown)`, which is what the txpool branch already produced for the same fault through `verifyAndSubmitTransaction`'s catch (#5535).
- The txpool branch catches the `bcos::Error` from `submitTransaction` and maps its code through the same table — but only when that code is a verdict. An in-process pool puts nothing else there (`MemoryStorage.cpp`: the refusal in `await_ready` and `await_suspend`, the sentinel for an unexpected exception, and the sweep), but the interface is shared: on MAX/TARS the RPC process holds a `TxPoolServiceClient` (`NodeService.cpp`), which throws `BCOS_ERROR(-1, "No value!")` when the tars callback left no value, and `toBcosError(tarsRet)`'s `"TARS error!"` when the call itself failed. Cast to a status, neither reaches a row, and the table's fallback would answer a node fault -32000 `Unknown` — a refusal's code, under a name that is not the fault's, with the real message gone. `isAdmissionVerdict` (`AdmissionError.{h,cpp}`) admits a code only if it fits `TransactionStatus`'s `int32_t`, is not `None`, and is either `Unknown` or a value `toString` has a name for: `TransactionStatus`'s `operator<<` ends in `case Unknown: default:`, so every undeclared value stringifies to `Unknown`, which makes "this node has a name for it" the test for a declared enumerator without keeping a second copy of the enumerator list. Anything else is rethrown — and logged at WARNING, since it is the node's own fault — and reaches `Web3JsonRpcImpl`'s catch-all as -32603 with its own message, which is what base `1f371d2f5` answered. A MAX refusal is untouched by this: the txpool process answers it with the status as its code, and `toBcosError` carries that code back unchanged. It catches `bcos::Error` only, where the mempool branch catches everything: an in-process pool has already turned `verify()`'s throw into `Unknown`, so anything that is not an `Error` is not a verdict either.
- A receipt-wait (`web3_rpc.sync_transaction = true`; the BCOS `sendTransaction` always) that the pool's sweep ends is now an error, not a receipt. Block commit completes the wait with a receipt; `MemoryStorage::removeInvalidTxs` — reached from `batchSealTransactions`, `getTxsHash` and `cleanUpExpiredTransactions` — completed it with a result carrying `TransactionPoolTimeout` and no receipt, and the tars result type fabricates a default receipt on read, so the faces reported a transaction the pool had dropped as executed: `eth_sendRawTransaction` answered -32603 `VM Exception while processing transaction, reason: TransactionPoolTimeout, msg: 0x`, `sendTransaction` answered a receipt-shaped object with `status: 0` and `hash: "0x"` (`toJsonResp` reads the receipt's own status), and the tars RPC returned that empty receipt. The sweep now ends the wait the way a refusal ends it — an `Error` whose code is `TransactionPoolTimeout`, thrown from `await_resume` — and the catch every sync caller already has for a refusal answers it: `eth_sendRawTransaction` through the table above, where the status has no geth words and keeps its name at -32000; `sendTransaction`, the tars RPC and the MAX txpool service as the `Error` with code 10010 (carried back through `TxPoolServiceClient`); the two P2P push handlers in `FrontServiceInitializer.cpp` log it at DEBUG as they log any refusal; the lightnode hop answers it as it answers any refusal. One place produces the answer; no caller changes. For BCOS SDK and tars clients a swept sync wait is a JSON-RPC error 10010 now, the shape they already get for a pool refusal, instead of a status-0 receipt. In-tree nothing read the old shape: `TransactionPoolTimeout` appears in product code only in the enum, the sweep and a doc comment, and `bcos-cpp-sdk` has no `sendTransaction` client; out-of-tree SDKs were not checked.
- That sentinel (`MemoryStorage.cpp`, `await_suspend`'s `catch (std::exception&)`, reached only on the receipt-wait path) is now `Unknown` rather than `Malformed`. Through the table `Malformed` would have answered -32602, an invalid-parameter reply for what is the node's own exception; `Unknown` answers -32603. No test reaches that catch; the change is one line, verified by reading.
- The table is written in ascending `TransactionStatus` order and looked up with `lower_bound`. The ascent is a `static_assert`, which also makes a second row for one status a build error rather than a row a linear scan could never reach. No behaviour change: the reorder moved lines only, every row's (status, code, message) triple is unchanged, and the old scan and the new lookup were compared over every `int32` input with no divergence.

### Not in this PR

- `InvalidChainId` and `InvalidSignature` stay at -32602. geth answers -32000 for those too — its RPC layer keeps -32602 for arguments it cannot decode (`rpc/errors.go`, default code -32000) — and the split here is the one recorded in #5555's review, which keeps "signed for another chain" distinguishable from "refused by a rule of this chain" by code. Moving them to -32000 is a one-row change in the table if strict geth parity is wanted later.
- The BCOS JSON-RPC `sendTransaction` error shape is otherwise untouched: its refusals arrive as an `Error` whose code is the `TransactionStatus`, and a swept wait now joins them; nothing on that face is mapped to new words.
- The sweep reports one status, `TransactionPoolTimeout`, whichever check swept the transaction (expiry, `BlockLimitCheckFail`, a committed nonce). Pre-existing; only the shape changed here.
- No exhaustive `switch` over `TransactionStatus` was added to hold `isAdmissionVerdict` to the enum at compile time. That would mean either a second copy of the 47 enumerators in the RPC layer or a 47-case function in the public header `bcos-protocol/TransactionStatus.h`, to guard a path only the MAX/TARS deployment reaches — and MAX is deprecated in this version. Reusing the enum's own `operator<<` costs one drift mode instead, written down beside the predicate: a new enumerator whose `case` someone forgets to add there is read as a fault and answered -32603, rather than -32000 with its name.
- A sibling of the swept wait, not touched: `batchFetchTxs` (`MemoryStorage.cpp`, the `NonceCheckFail` branch) calls `takeSubmitCallback()` before handing the transaction to `removeInvalidTxs`, so a receipt-wait on a transaction whose (sender, nonce) was committed elsewhere is never resumed — the coroutine frame, and the HTTP session it holds, live until the process exits. The other caller of `removeInvalidTxs` in the same file notifies. Follow-up.

### Test

`AdmissionErrorTest` pins the table: the three -32602 rows, the -32603 row, the thirteen -32000 rows in geth's words, the name fallback (`NonceCheckFail`, `MaxGasLimitExceeded`, `BlockLimitCheckFail`), and the detail suffix. `Web3RpcTest` on the RPC: the existing mempool cases now expect the new words and codes (`invalid chain id for signer` at -32602, `already known` and `insufficient funds for gas * price + value` at -32000); `handleTxpoolRefusalAnswersWithTheMempoolShape` sends the same two transactions down the txpool branch and expects the same two answers; `handleMempoolAdmissionFaultIsAnsweredAsTheNodesFault` puts a ledger whose `getStorageState` throws under the mempool validator and expects -32603 `admission could not be decided`, not the diagnostic. The blob and deposit gates are pinned to their full message and code in `Web3RpcTest` and `Web3EthMethodsTest`, where they were substring checks that the old sentences also satisfied. `TxpoolMemoryStorageTest::sweptReceiptWaitEndsAsTimeoutError` parks a receipt-wait on a stored transaction (the `AlreadyInTxPoolAndAccept` path the FIB-48 case uses), sets its import time past a 10 ms expiration, seals, and expects the wait to end as an `Error` with code 10010 and the transaction gone from the pool; before the change it ended with a result. `PoolTimeoutRpcTest` pins each RPC face's side over a pool that ends every submission that way: `EthEndpoint::sendRawTransaction` under `syncTransaction = true` throws -32000 `TransactionPoolTimeout`, `JsonRpcImpl_2_0::sendTransaction` answers an `Error` with code 10010 and that name. `TxPoolFaultRpcTest` pins the other side of the same catch: `-1 "No value!"`, a TARS transport code and an undeclared positive value each leave `sendRawTransaction` as the `Error` they arrived as, one of them goes through the whole Web3 face and the client receives -32603 with the fault's own message and no `result`, and `TxPoolIsFull` is still answered -32000 `txpool is full` — the guard is not a way out of the table. The throwing pool both files use is one parameterised fake, `common/ThrowingTxPool.h`, rather than a second one beside the first. The raw-transaction sample the Web3 cases reuse moves from `Web3RpcTest.cpp` into `common/Web3TxSamples.h`; `TxPoolFixture.h`'s expired-mode helper now expects the `Error` where it accepted a timeout result. Negative controls, each run by removing only the change under test and rebuilding. With the table and the tests in place but `EthEndpoint.cpp` unchanged: six of the seven `testWeb3RPC` cases above are red on twelve assertions, every one a code or message check, and the fault case fails only on the message — the old catch-all already answered -32603, with the storage diagnostic as the text. With the verdict guard deleted: exactly the four `TxPoolFaultRpcTest` fault cases are red and the refusal case stays green. With two table rows swapped, and separately with a duplicate row added: the `static_assert` fires in both.

`test-bcos-rpc` and `test-bcos-txpool` rebuilt from `1f371d2f5` (a new test file needs a re-configure to be globbed in): `test-bcos-rpc` 322/322 cases, 2372/2372 assertions; `test-bcos-txpool` 73/73 cases (its assertion count varies run to run, 4308 and 4314 on two runs, all passing); within those, the seven `testWeb3RPC` cases above, the two `Web3EthMethodsTest` gate cases, `AdmissionErrorTest` 6 cases, `PoolTimeoutRpcTest` 2, `TxPoolFaultRpcTest` 5 and the swept-wait storage case. `AdmissionError.cpp`, `EthEndpoint.cpp`, `MemoryStorage.cpp`, `AdmissionErrorTest.cpp`, `PoolTimeoutRpcTest.cpp`, `TxPoolFaultRpcTest.cpp`, `MemoryStorageTest.cpp`, `Web3RpcTest.cpp` and `Web3EthMethodsTest.cpp` compile clean under GCC 16 `-Wall -Wextra -pedantic`.

