### PR TITLE
fix: batch of ten issue fixes (EIP-161/1052 account semantics, MPT empty accounts, RLP canonical ints, receipt logIndex, config/front/block/sdk hardening)

### DIFF
--- a/bcos-codec/bcos-codec/rlp/RLPDecode.h
+++ b/bcos-codec/bcos-codec/rlp/RLPDecode.h
@@ -238,6 +238,13 @@ inline bcos::Error::UniquePtr decode(bytesRef& from, UnsignedIntegral auto& to) 
         return BCOS_ERROR_UNIQUE_PTR(DecodingError::UnexpectedLength,
             "integer wider than target type");
     }
+    // Canonical integers carry no leading zero byte, and zero is the empty string 0x80, never a
+    // single 0x00 (op-geth ErrCanonInt). decodeHeader only checks length prefixes (issue #5353).
+    if (header.payloadLength >= 1 && from[0] == 0)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(
+            DecodingError::NonCanonicalSize, "Non-canonical integer: leading zero byte");
+    }
     to = fromBigEndian<std::decay_t<decltype(to)>, bcos::bytesRef>(
         from.getCroppedData(0, header.payloadLength));
     from = from.getCroppedData(header.payloadLength);

--- a/bcos-codec/test/unittests/RLPNonCanonicalIntegerTest.cpp
+++ b/bcos-codec/test/unittests/RLPNonCanonicalIntegerTest.cpp
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5353: the RLP integer decoder must reject non-canonical
+ *        integer payloads (leading zero bytes, and the single byte 0x00 for zero), matching
+ *        go-ethereum's ErrCanonInt. Length prefixes were already checked; values were not.
+ */
+#include "bcos-codec/rlp/RLPDecode.h"
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::codec::rlp;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(RLPNonCanonicalIntegerTest)
+
+namespace
+{
+template <typename T>
+int32_t decodeError(std::string_view hex)
+{
+    bcos::bytes bytes = fromHex(hex);
+    auto ref = bcos::ref(bytes);
+    T value{};
+    auto error = bcos::codec::rlp::decode(ref, value);
+    return error ? error->errorCode() : -1;
+}
+template <typename T>
+T decodeOk(std::string_view hex)
+{
+    bcos::bytes bytes = fromHex(hex);
+    auto ref = bcos::ref(bytes);
+    T value{};
+    auto error = bcos::codec::rlp::decode(ref, value);
+    BOOST_REQUIRE(!error);
+    return value;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(leadingZeroPayloadRejected)
+{
+    // 0x820001: two-byte string 00 01 == value 1 written non-minimally
+    BOOST_CHECK_EQUAL(decodeError<uint64_t>("820001"), NonCanonicalSize);
+    BOOST_CHECK_EQUAL(decodeError<u256>("820001"), NonCanonicalSize);
+    // three-byte with leading zero
+    BOOST_CHECK_EQUAL(decodeError<uint64_t>("83000102"), NonCanonicalSize);
+    // 0x00 alone: zero must be the empty string 0x80, not a single zero byte
+    BOOST_CHECK_EQUAL(decodeError<uint64_t>("00"), NonCanonicalSize);
+    BOOST_CHECK_EQUAL(decodeError<u256>("00"), NonCanonicalSize);
+}
+
+BOOST_AUTO_TEST_CASE(canonicalPayloadsStillDecode)
+{
+    BOOST_CHECK_EQUAL(decodeOk<uint64_t>("80"), 0U);
+    BOOST_CHECK_EQUAL(decodeOk<uint64_t>("01"), 1U);
+    BOOST_CHECK_EQUAL(decodeOk<uint64_t>("8180"), 0x80U);
+    BOOST_CHECK_EQUAL(decodeOk<uint64_t>("820100"), 0x100U);  // trailing zero is fine
+    BOOST_CHECK_EQUAL(decodeOk<u256>("820100"), u256(0x100));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-crypto/bcos-crypto/hash/HashImpl.cpp
+++ b/bcos-crypto/bcos-crypto/hash/HashImpl.cpp
@@ -59,7 +59,7 @@ HashType sha256Hash(bytesConstRef _data)
 
 Sha256::Sha256()
 {
-    setHashImplType(HashImplType::Sha3);
+    setHashImplType(HashImplType::Sha256Hash);
 }
 
 HashType Sha256::hash(bytesConstRef _data) const
@@ -69,7 +69,7 @@ HashType Sha256::hash(bytesConstRef _data) const
 
 bcos::crypto::hasher::AnyHasher Sha256::hasher() const
 {
-    return bcos::crypto::hasher::AnyHasher{hasher::openssl::OpenSSL_SHA3_256_Hasher{}};
+    return bcos::crypto::hasher::AnyHasher{hasher::openssl::OpenSSL_SHA2_256_Hasher{}};
 }
 
 HashType sha3Hash(bytesConstRef _data)

--- a/bcos-crypto/bcos-crypto/interfaces/crypto/Hash.h
+++ b/bcos-crypto/bcos-crypto/interfaces/crypto/Hash.h
@@ -30,7 +30,10 @@ enum HashImplType : int
 {
     Keccak256Hash,
     Sm3Hash,
-    Sha3
+    Sha3,
+    // "Hash" suffix on purpose: this enum is unscoped, so a bare `Sha256` would shadow class
+    // Sha256 in bcos::crypto (the existing `Sha3` value already does that to class Sha3).
+    Sha256Hash
 };
 class Hash
 {

--- a/bcos-crypto/test/unittests/HashImplHasherTest.cpp
+++ b/bcos-crypto/test/unittests/HashImplHasherTest.cpp
@@ -54,36 +54,32 @@ BOOST_AUTO_TEST_CASE(hasherMatchesHashForConsistentImpls)
     }
 }
 
-// BUG (recorded, not fixed per task scope): Sha256::hash() computes SHA2-256
-// (OpenSSL_SHA2_256_Hasher) but Sha256::hasher() returns a SHA3-256 streaming
-// hasher (OpenSSL_SHA3_256_Hasher) -- a copy-paste from Sha3 in HashImpl.cpp.
-// The two therefore disagree, and Sha256::hasher() actually matches Sha3.
-// This is a pinning test of the current behavior; when HashImpl.cpp is fixed
-// so hasher() returns OpenSSL_SHA2_256_Hasher, this will fail and should be
-// changed to assert equality.
-BOOST_AUTO_TEST_CASE(sha256HasherInconsistentWithHash)
+// Sha256::hash() and Sha256::hasher() must both be SHA2-256 (issue #5356: hasher() used to
+// return a SHA3-256 streaming hasher, copy-pasted from Sha3).
+BOOST_AUTO_TEST_CASE(sha256HasherMatchesHash)
 {
     Sha256 sha256;
-    auto oneShot = sha256.hash(ref(c_input)).asBytes();       // SHA2-256
-    auto streaming = streamDigest(sha256.hasher(), c_input);  // SHA3-256 (bug)
-    BOOST_CHECK(oneShot != streaming);
+    auto oneShot = sha256.hash(ref(c_input)).asBytes();
+    auto streaming = streamDigest(sha256.hasher(), c_input);
+    BOOST_CHECK(oneShot == streaming);
 
-    // Sha256::hasher() is really a SHA3-256 hasher, so it matches Sha3.
+    // and it is SHA2-256, not SHA3-256: differs from Sha3 for the same input
     class Sha3 sha3;
-    BOOST_CHECK(streaming == streamDigest(sha3.hasher(), c_input));
-    BOOST_CHECK(streaming == sha3.hash(ref(c_input)).asBytes());
+    BOOST_CHECK(streaming != sha3.hash(ref(c_input)).asBytes());
+
+    // SHA2-256("abcdef") reference vector
+    BOOST_CHECK_EQUAL(sha256.hash(ref(c_input)).hex(),
+        "bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721");
 }
 
-// BUG (recorded): there is no Sha256 value in HashImplType; Sha256's ctor sets
-// the impl type to Sha3 (copy-paste from Sha3), so getHashImplType() cannot
-// distinguish a Sha256 from a Sha3 and mislabels the SHA2-256 one-shot path.
-BOOST_AUTO_TEST_CASE(sha256ReportsSha3ImplType)
+// getHashImplType() distinguishes Sha256 from Sha3 (issue #5356: Sha256's ctor used to set Sha3).
+BOOST_AUTO_TEST_CASE(sha256ReportsOwnImplType)
 {
     Sha256 sha256;
-    BOOST_CHECK(sha256.getHashImplType() == HashImplType::Sha3);
+    BOOST_CHECK(sha256.getHashImplType() == HashImplType::Sha256Hash);
 
     class Sha3 sha3;
-    BOOST_CHECK(sha3.getHashImplType() == HashImplType::Sha3);  // indistinguishable
+    BOOST_CHECK(sha3.getHashImplType() == HashImplType::Sha3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -37,25 +37,28 @@ public:
             m_storage.get(), executor_v1::StateKeyView(SYS_TABLES, m_tableName));
     }
 
-    /// Ethereum-style existence (EIP-161 Spurious Dragon+):
-    /// empty accounts (nonce=0, balance=0, code_hash=EMPTY) are treated as non-existent.
-    task::Task<bool> existsEthereum()
+    /// Ethereum-style existence (EIP-161 Spurious Dragon+): an account with nonce 0, balance 0
+    /// and no code is empty and counts as non-existent. "No code" is either a missing CODE_HASH
+    /// row (zero hash) or a row holding @p emptyCodeHash, the chain hasher's hash of "" (an
+    /// EIP-7702 delegation cleared back to an EOA is stored that way).
+    /// @param knownCodeHash the CODE_HASH row if the caller already read it, to avoid a second
+    ///        read on the EXTCODEHASH path.
+    task::Task<bool> existsEthereum(
+        const h256& emptyCodeHash, std::optional<h256> knownCodeHash = std::nullopt)
     {
+        auto ch = knownCodeHash ? *knownCodeHash : co_await codeHash();
+        if (ch != h256{} && ch != emptyCodeHash)
+            co_return true;  // has code: live regardless of nonce / balance
+
         if (!co_await exists())
             co_return false;
 
-        // Check if account is non-empty (EIP-161: empty accounts don't exist)
         auto nonceVal = co_await nonce();
         if (nonceVal.has_value() && u256(nonceVal.value()) != 0)
             co_return true;
 
         auto bal = co_await balance();
         if (bal != 0)
-            co_return true;
-
-        auto ch = co_await codeHash();
-        static const h256 EMPTY_CODE_HASH{};
-        if (ch != EMPTY_CODE_HASH)
             co_return true;
 
         co_return false;  // empty account → not exist in Ethereum sense

--- a/bcos-framework/bcos-framework/ledger/Features.cpp
+++ b/bcos-framework/bcos-framework/ledger/Features.cpp
@@ -195,15 +195,18 @@ void Features::setUpgradeFeatures(
                     Flag::bugfix_v1_timestamp}},
             {.to = protocol::BlockVersion::V3_16_4_VERSION, .flags = {Flag::bugfix_revert_logs}},
             {.to = protocol::BlockVersion::V3_17_0_VERSION,
-                .flags = {
-                    Flag::bugfix_auth_check,
-                    Flag::bugfix_v1_error_handling,
-                    Flag::bugfix_gas_payment_balance_precheck,
-                    Flag::bugfix_precompiled_feature_gate,
-                    Flag::bugfix_evm_storage_status,
-                    Flag::bugfix_statestorage_hash_v3_17,
-                    Flag::bugfix_nonce_ordering,
-                }}});
+                .flags =
+                    {
+                        Flag::bugfix_auth_check,
+                        Flag::bugfix_v1_error_handling,
+                        Flag::bugfix_gas_payment_balance_precheck,
+                        Flag::bugfix_precompiled_feature_gate,
+                        Flag::bugfix_evm_storage_status,
+                        Flag::bugfix_statestorage_hash_v3_17,
+                        Flag::bugfix_nonce_ordering,
+                    }},
+            {.to = protocol::BlockVersion::V3_18_0_VERSION,
+                .flags = {Flag::bugfix_eip161_1052_account_semantics}}});
     for (const auto& upgradeFeatures : upgradeRoadmap)
     {
         if (((toVersion < protocol::BlockVersion::V3_2_7_VERSION) &&

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -130,6 +130,12 @@ public:
                                      // timestamp-based fork activation); read at startup from
                                      // genesis [features], same channel as
                                      // feature_l2_ethereum_compat.
+        bugfix_eip161_1052_account_semantics = 61,  // #5371/#5372: v1 executor answers
+                                                    // account_exists per EIP-161 (empty == absent)
+                                                    // and EXTCODEHASH per EIP-1052: the chain
+                                                    // hasher's hash("") (keccak on a non-SM
+                                                    // chain) for a code-less live account, 0 for
+                                                    // an absent/empty one; was true / 0.
     };
 
     // feature_flags bit = enum value. Pin the newest flag so a value beyond
@@ -141,7 +147,7 @@ public:
     // and cannot catch gaps. The contiguous-from-zero rule is enforced by code review
     // and the comment on Flag above — the two range asserts catch the other failure
     // mode: a new flag pushed past magic_enum's reflection boundary.)
-    static_assert(magic_enum::enum_contains(Flag::feature_op_jovian),
+    static_assert(magic_enum::enum_contains(Flag::bugfix_eip161_1052_account_semantics),
         "newest Flag fell outside magic_enum's reflection range — check enum values");
     static_assert(magic_enum::enum_integer(
                       magic_enum::enum_value<Flag>(magic_enum::enum_count<Flag>() - 1)) <= 127,

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -215,6 +215,8 @@ BOOST_AUTO_TEST_CASE(feature)
         // feature_op_jovian = 60 (OP-Stack Jovian fork semantics), appended after the last
         // feature_/bugfix_ per the mirror-declaration-order rule above.
         "feature_op_jovian",
+        // bugfix_eip161_1052_account_semantics = 61 (#5371/#5372), next unused value.
+        "bugfix_eip161_1052_account_semantics",
     };
     // clang-format on
     BOOST_CHECK_EQUAL(keys.size(), compareKeys.size());

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -140,6 +140,7 @@ void FrontService::setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
 void FrontService::registerModuleMessageDispatcher(int _moduleID,
     std::function<void(bcos::crypto::NodeIDPtr, const std::string&, bytesConstRef)> _dispatcher)
 {
+    WriteGuard l(x_moduleID2MessageDispatcher);
     m_moduleID2MessageDispatcher[_moduleID] = std::move(_dispatcher);
 }
 
@@ -147,6 +148,7 @@ std::unordered_map<int,
     std::function<void(bcos::crypto::NodeIDPtr, const std::string&, bytesConstRef)>>
 FrontService::moduleID2MessageDispatcher() const
 {
+    ReadGuard l(x_moduleID2MessageDispatcher);
     return m_moduleID2MessageDispatcher;
 }
 
@@ -274,11 +276,14 @@ void FrontService::start()
     FRONT_LOG(INFO) << LOG_DESC("start") << LOG_KV("nodeID", m_nodeID->hex())
                     << LOG_KV("groupID", m_groupID);
 
-    FRONT_LOG(INFO) << LOG_DESC("register module")
-                    << LOG_KV("count", m_moduleID2MessageDispatcher.size());
-    for (const auto& module : m_moduleID2MessageDispatcher)
     {
-        FRONT_LOG(INFO) << LOG_DESC("register module") << LOG_KV("moduleID", module.first);
+        ReadGuard l(x_moduleID2MessageDispatcher);
+        FRONT_LOG(INFO) << LOG_DESC("register module")
+                        << LOG_KV("count", m_moduleID2MessageDispatcher.size());
+        for (const auto& module : m_moduleID2MessageDispatcher)
+        {
+            FRONT_LOG(INFO) << LOG_DESC("register module") << LOG_KV("moduleID", module.first);
+        }
     }
 }
 void FrontService::stop()
@@ -339,6 +344,22 @@ void FrontService::stop()
                                         "timed out flushing the send strand; "
                                         "pending sends may be dropped");
             }
+        }
+
+        // Drop both dispatcher tables (issue #5433). The lambdas registered by
+        // libinitializer/FrontServiceInitializer.cpp capture TxPool / BlockSync / PBFT by value,
+        // and those modules hold this FrontService back through their configs, so keeping the
+        // lambdas after stop() keeps the whole graph alive and its destructors (thread joins,
+        // io_context teardown) never run. In MAX the tars server joins its handle threads before
+        // destroyApp reaches us; in AIR the shared io pool may still be delivering a message that
+        // entered onReceiveMessage before Gateway::stop() returned, hence the locks.
+        {
+            WriteGuard l(x_moduleID2MessageDispatcher);
+            m_moduleID2MessageDispatcher.clear();
+        }
+        {
+            Guard l(x_notifierLock);
+            m_module2GroupNodeInfoNotifier.clear();
         }
     }
     catch (const std::exception& e)
@@ -811,10 +832,18 @@ task::Task<Error::Ptr> FrontService::onReceiveMessage(
         }
         else
         {
-            if (auto it = m_moduleID2MessageDispatcher.find(moduleID);
-                it != m_moduleID2MessageDispatcher.end())
+            std::function<void(bcos::crypto::NodeIDPtr, const std::string&, bytesConstRef)>
+                callback;
             {
-                auto callback = it->second;
+                ReadGuard l(x_moduleID2MessageDispatcher);
+                if (auto it = m_moduleID2MessageDispatcher.find(moduleID);
+                    it != m_moduleID2MessageDispatcher.end())
+                {
+                    callback = it->second;
+                }
+            }
+            if (callback)
+            {
                 // Copy the payload before dispatching asynchronously.
                 bytes buffer(message.payload().begin(), message.payload().end());
 

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -222,6 +222,10 @@ private:
     /// gateway interface
     std::shared_ptr<bcos::gateway::GatewayInterface> m_gatewayInterface;
 
+    // Written at init (registerModuleMessageDispatcher) and cleared in stop(); read on every
+    // received message from the io pool threads, which in AIR are still delivering when stop()
+    // runs (issue #5433 review), so reads take ReadGuard and writes WriteGuard.
+    mutable bcos::SharedMutex x_moduleID2MessageDispatcher;
     std::unordered_map<int,
         std::function<void(bcos::crypto::NodeIDPtr, const std::string&, bytesConstRef)>>
         m_moduleID2MessageDispatcher;

--- a/bcos-front/test/unittests/Issue5433_StopReleasesDispatchersTest.cpp
+++ b/bcos-front/test/unittests/Issue5433_StopReleasesDispatchersTest.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5433: FrontService::stop() must drop the registered module
+ *        dispatchers, otherwise the FrontService -> dispatcher lambda -> BlockSync/PBFT ->
+ *        FrontService reference cycle outlives stop() and those modules never destruct.
+ */
+#include "FakeGateway.h"
+#include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-front/FrontService.h>
+#include <bcos-front/FrontServiceFactory.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::front;
+
+namespace bcos::test
+{
+BOOST_FIXTURE_TEST_SUITE(Issue5433StopReleasesDispatchers, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(stopReleasesModuleDispatchers)
+{
+    auto keyFactory = std::make_shared<bcos::crypto::KeyFactoryImpl>();
+    auto nodeID = keyFactory->createKey(bytesConstRef((bcos::byte*)"n", 1));
+
+    auto factory = std::make_shared<FrontServiceFactory>();
+    factory->setGatewayInterface(std::make_shared<bcos::front::test::FakeGateway>());
+    factory->setIOServicePool(std::make_shared<bcos::IOServicePool>(1, "issue5433"));
+    auto front = factory->buildFrontService("group", nodeID);
+
+    // Stand-in for BlockSync/PBFT: the dispatcher lambda holds it strongly, exactly like
+    // libinitializer/FrontServiceInitializer.cpp captures `_blockSync` by value.
+    auto module = std::make_shared<int>(42);
+    std::weak_ptr<int> moduleAlive = module;
+    front->registerModuleMessageDispatcher(bcos::protocol::ModuleID::BlockSync,
+        [module](bcos::crypto::NodeIDPtr, const std::string&, bytesConstRef) { (void)*module; });
+    module.reset();
+    BOOST_CHECK(!moduleAlive.expired());  // held by the dispatcher
+
+    // Second table: FrontServiceInitializer::registerGroupNodeInfoNotification captures
+    // txpool/blockSync/pbft by value the same way.
+    auto notified = std::make_shared<int>(7);
+    std::weak_ptr<int> notifiedAlive = notified;
+    front->registerGroupNodeInfoNotification(
+        bcos::protocol::ModuleID::PBFT, [notified](bcos::gateway::GroupNodeInfo::Ptr,
+                                            bcos::front::ReceiveMsgFunc) { (void)*notified; });
+    notified.reset();
+    BOOST_CHECK(!notifiedAlive.expired());
+
+    front->start();
+    front->stop();
+
+    BOOST_CHECK(moduleAlive.expired());  // stop() dropped the dispatcher, cycle broken
+    BOOST_CHECK(front->moduleID2MessageDispatcher().empty());
+    BOOST_CHECK(notifiedAlive.expired());
+    BOOST_CHECK(front->module2GroupNodeInfoNotifier().empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -87,10 +87,13 @@ concept HistoricalStorageContext = requires(Storage& storage) {
 /// One consequence to know about: exists() means different things on the two paths, and the rooted
 /// one is the Ethereum meaning. With a root it is leaf presence, exactly as an Ethereum client
 /// answers "does this account exist". The inherited flat exists() (EVMAccount.h:27-31) tests for a
-/// SYS_TABLES row, a BCOS notion with no Ethereum counterpart, and the two can disagree: an
-/// account touched only by rows carrying no Ethereum state never produces a leaf (MPTBuilder.h:
-/// 92-97, 215-227 keep that one member of the EIP-161 empty-account class out of the trie), so it
-/// reads as absent historically and present flatly. Ethereum agrees with the historical answer.
+/// SYS_TABLES row, a BCOS notion with no Ethereum counterpart, and the two can disagree.
+/// MPTBuilder.h finalizeAccount keeps the whole EIP-161 empty-account class out of the trie: an
+/// account touched only by rows carrying no Ethereum state never produces a leaf (the
+/// sawEthereumRow early-out), and an account whose merged post-block triple is
+/// {0, 0, keccak256("")} has its leaf removed (the empty-triple check, storage ignored). Either
+/// kind still owns a SYS_TABLES row, so it reads as present flatly and absent historically.
+/// Ethereum agrees with the historical answer.
 ///
 /// abi() and increaseNonce() are inherited unchanged. abi is BCOS metadata outside the committed
 /// 4-tuple and is deliberately not historicised — a historical query returns the CURRENT abi,

--- a/bcos-ledger/bcos-ledger/mpt/MPTBuilder.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTBuilder.h
@@ -91,10 +91,9 @@ struct AccountRows
     /// extension rows leave it false: an account touched only by those has no Ethereum state
     /// change, and finalizeAccount must not invent a leaf for it (see there).
     ///
-    /// This closes ONE member of the EIP-161 empty-account class, not the class. A block that
-    /// writes a zero balance to an otherwise-untouched account still produces {0, 0,
-    /// emptyCodeHash, emptyRoot}, because EIP-158/161 empty-account clearing is not implemented
-    /// (see finalizeAccount's tombstone comment).
+    /// This closes the "no Ethereum row at all" member of the EIP-161 empty-account class up
+    /// front; the rest of the class (a touched account whose merged triple is empty) is
+    /// cleared in finalizeAccount after the merge.
     bool sawEthereumRow = false;
 };
 
@@ -238,10 +237,8 @@ bcos::task::Task<void> finalizeAccount(BuildContext<Storage>& context, bcos::Add
     // revert), so the run reaches us as "all three core rows deleted"; without this case
     // requireNotDeleted() would reject a perfectly legal transaction.
     //
-    // Removing a pre-existing leaf is the same one line, kept as compatibility headroom: there is
-    // no path to it today (6780 spares already-existing contracts; EIP-158/161 empty-account
-    // clearing is not implemented) — but if one appears, silently leaving a stale leaf behind
-    // would be a fork.
+    // Removing a pre-existing leaf is the same one line; EIP-6780 spares already-existing
+    // contracts, so today the only other remover is the EIP-161 empty-account clearing below.
     if (rows.nonce.deleted && rows.balance.deleted && rows.codeHash.deleted)
     {
         // Record the prior storage root for future pathdb pruning — the full subtree walk
@@ -293,6 +290,40 @@ bcos::task::Task<void> finalizeAccount(BuildContext<Storage>& context, bcos::Add
         updated.codeHash = meta.codeHash;
     }
 
+    if (rows.nonce.value)
+    {
+        updated.nonce = *rows.nonce.value;
+    }
+    if (rows.balance.value)
+    {
+        updated.balance = *rows.balance.value;
+    }
+    if (rows.codeHash.value)
+    {
+        updated.codeHash = *rows.codeHash.value;
+    }
+
+    // EIP-158/161 empty-account clearing (issue #5373): a touched account whose post-block core
+    // triple is {nonce 0, balance 0, keccak256("")} is removed from the trie, never written.
+    // Decided on the MERGED triple because fields the block did not write keep their baseline /
+    // flat value, and only the merged triple is the account's real state. Storage is not
+    // consulted for emptiness, and the block's slot writes for such an account are DROPPED
+    // together with its prior storage trie — the same semantics as reth (revm
+    // touch_empty_eip161 sets storage_was_destroyed; HashedPostState maps the account to None).
+    // Checked before the storage commit so those dropped slot writes never produce nodes.
+    if (updated.nonce == 0 && updated.balance == 0 && updated.codeHash == emptyCodeHash())
+    {
+        if (priorStorageRoot != emptyRootHash())
+        {
+            output.obsoletedNodes.insert(priorStorageRoot);
+        }
+        if (baseline)
+        {
+            accountChanges[accountKeyHash(address)] = std::nullopt;
+        }
+        co_return;
+    }
+
     if (!rows.storageChanges.empty())
     {
         // First trie level: commit THIS account's storage trie; the new root is embedded in
@@ -307,19 +338,6 @@ bcos::task::Task<void> finalizeAccount(BuildContext<Storage>& context, bcos::Add
     else
     {
         updated.storageRoot = priorStorageRoot;
-    }
-
-    if (rows.nonce.value)
-    {
-        updated.nonce = *rows.nonce.value;
-    }
-    if (rows.balance.value)
-    {
-        updated.balance = *rows.balance.value;
-    }
-    if (rows.codeHash.value)
-    {
-        updated.codeHash = *rows.codeHash.value;
     }
     accountChanges[accountKeyHash(address)] = updated.encode();
 }

--- a/bcos-ledger/test/unittests/mpt/MPTBuilderEmptyAccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTBuilderEmptyAccountTest.cpp
@@ -1,0 +1,183 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5373: EIP-158/161 empty-account clearing. An account whose
+ *        post-block state is {nonce 0, balance 0, keccak256(""), *} must not be written as a
+ *        leaf; if it had a leaf it is removed and its storage trie obsoleted (reth: touched &&
+ *        empty -> destroyed; storage is not consulted for emptiness but is dropped).
+ */
+#include "TestHelpers.h"
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/MPTBuilder.h>
+#include <bcos-ledger/mpt/MPTReadView.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <map>
+
+namespace bcos::ledger::mpt::test
+{
+BOOST_AUTO_TEST_SUITE(MPTBuilderEmptyAccountSuite)
+
+namespace
+{
+using NodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+
+bcos::h256 buildStorageTrie(NodeStorage& storage, std::map<bcos::h256, bcos::bytes> const& slots)
+{
+    std::map<bcos::h256, bcos::bytes> entries;
+    for (auto const& [slot, value] : slots)
+    {
+        entries[slotKeyHash(slot)] = encodeStorageValue(bcos::ref(value));
+    }
+    return seedTrieFlushed(storage, emptyRootHash(), entries).root;
+}
+
+bcos::storage::Entry codeHashEntry(bcos::h256 const& hash)
+{
+    return makeEntry(
+        std::string_view{reinterpret_cast<char const*>(hash.data()), bcos::h256::SIZE});
+}
+}  // namespace
+
+// A zero-value touch of a never-seen address writes nothing (EIP-161 c: an absent account must
+// not become "present but empty").
+BOOST_AUTO_TEST_CASE(EmptyFirstTouchWritesNoLeaf)
+{
+    NodeStorage storage;
+    auto const addr = makeAddress(0xE1);
+    FlatBackendStorage flatBackend;
+    auto view = makeFlatView(flatBackend);
+    writeFlatRow(view, accountFieldKey(addr, ROW_BALANCE), makeEntry("0"));
+
+    auto output =
+        bcos::task::syncWait(buildAndCollect(storage, emptyRootHash(), view, /*l2Mode=*/false));
+
+    BOOST_CHECK(output.stateRoot == emptyRootHash());
+    MPTReadView<NodeStorage> readView(storage, output.stateRoot);
+    BOOST_CHECK(!bcos::task::syncWait(readView.readAccount(addr)).has_value());
+}
+
+// A live account drained to {0, 0, keccak256("")} loses its leaf; its storage trie (not part of
+// the emptiness test) is dropped with it.
+BOOST_AUTO_TEST_CASE(DrainedAccountLeafIsRemovedAndStorageObsoleted)
+{
+    NodeStorage storage;
+    auto const drained = makeAddress(0xE2);
+    auto const other = makeAddress(0xE3);
+
+    Account before;  // nonce 0, codeHash defaults to emptyCodeHash()
+    before.balance = 5;
+    before.storageRoot = buildStorageTrie(storage, {{makeHash(0x01), bcos::bytes{0x10}}});
+    Account otherAccount;
+    otherAccount.balance = 99;
+    auto const parentRoot =
+        seedStateTrieFlushed(storage, {{drained, before}, {other, otherAccount}});
+
+    FlatBackendStorage flatBackend;
+    auto view = makeFlatView(flatBackend);
+    writeFlatRow(view, accountFieldKey(drained, ROW_BALANCE), makeEntry("0"));
+
+    auto output =
+        bcos::task::syncWait(buildAndCollect(storage, parentRoot, view, /*l2Mode=*/false));
+
+    MPTReadView<NodeStorage> readView(storage, output.stateRoot);
+    BOOST_CHECK(!bcos::task::syncWait(readView.readAccount(drained)).has_value());
+    auto alive = bcos::task::syncWait(readView.readAccount(other));
+    BOOST_REQUIRE(alive.has_value());
+    BOOST_CHECK_EQUAL(alive->balance, bcos::u256(99));
+    BOOST_CHECK(output.obsoletedNodes.contains(before.storageRoot));
+    // state root equals a trie holding only the surviving account
+    BOOST_CHECK(
+        output.stateRoot == referenceRoot({{accountKeyHash(other), otherAccount.encode()}}));
+}
+
+// A contract that dies in this block (codeHash written back to keccak256(""), balance drained)
+// and also writes slots in the same block: the slot writes are dropped with the account, so the
+// build produces exactly the same nodes as the same death without the slot writes.
+BOOST_AUTO_TEST_CASE(DyingAccountSlotWritesAreDroppedWithoutOrphanNodes)
+{
+    NodeStorage storage;
+    auto const addr = makeAddress(0xE6);
+    Account before;
+    before.balance = 5;
+    before.codeHash = makeHash(0xC6);
+    before.storageRoot = buildStorageTrie(storage, {{makeHash(0x01), bcos::bytes{0x10}}});
+    auto const parentRoot = seedStateTrieFlushed(storage, {{addr, before}});
+
+    auto death = [&](bool withSlotWrite) {
+        FlatBackendStorage flatBackend;
+        auto view = makeFlatView(flatBackend);
+        writeFlatRow(view, accountFieldKey(addr, ROW_BALANCE), makeEntry("0"));
+        writeFlatRow(view, accountFieldKey(addr, ROW_CODE_HASH), codeHashEntry(emptyCodeHash()));
+        if (withSlotWrite)
+        {
+            writeFlatRow(
+                view, accountSlotKey(addr, makeHash(0x02)), makeEntry(std::string_view{"\x77", 1}));
+        }
+        return bcos::task::syncWait(buildAndCollect(storage, parentRoot, view, /*l2Mode=*/false));
+    };
+    auto plain = death(false);
+    auto withSlots = death(true);
+
+    MPTReadView<NodeStorage> readView(storage, withSlots.stateRoot);
+    BOOST_CHECK(!bcos::task::syncWait(readView.readAccount(addr)).has_value());
+    BOOST_CHECK(withSlots.obsoletedNodes.contains(before.storageRoot));
+    BOOST_CHECK(withSlots.stateRoot == plain.stateRoot);
+    // no storage-trie node was produced for the dropped slot write
+    BOOST_CHECK_EQUAL(withSlots.newNodes.size(), plain.newNodes.size());
+    for (auto const& [hash, rlp] : plain.newNodes)
+    {
+        BOOST_CHECK(withSlots.newNodes.contains(hash));
+    }
+}
+
+// nonce 0 + balance 0 but real code is NOT empty: the leaf stays.
+BOOST_AUTO_TEST_CASE(ZeroBalanceContractStays)
+{
+    NodeStorage storage;
+    auto const addr = makeAddress(0xE4);
+    Account contract;
+    contract.codeHash = makeHash(0xC4);
+    auto const parentRoot = seedStateTrieFlushed(storage, {{addr, contract}});
+
+    FlatBackendStorage flatBackend;
+    auto view = makeFlatView(flatBackend);
+    writeFlatRow(view, accountFieldKey(addr, ROW_BALANCE), makeEntry("0"));
+
+    auto output =
+        bcos::task::syncWait(buildAndCollect(storage, parentRoot, view, /*l2Mode=*/false));
+
+    MPTReadView<NodeStorage> readView(storage, output.stateRoot);
+    auto account = bcos::task::syncWait(readView.readAccount(addr));
+    BOOST_REQUIRE(account.has_value());
+    BOOST_CHECK(account->codeHash == makeHash(0xC4));
+}
+
+// A brand-new account that receives a nonce (CREATE sets nonce 1) is not empty.
+BOOST_AUTO_TEST_CASE(NoncedFirstTouchIsKept)
+{
+    NodeStorage storage;
+    auto const addr = makeAddress(0xE5);
+    FlatBackendStorage flatBackend;
+    auto view = makeFlatView(flatBackend);
+    writeFlatRow(view, accountFieldKey(addr, ROW_NONCE), makeEntry("1"));
+    writeFlatRow(view, accountFieldKey(addr, ROW_BALANCE), makeEntry("0"));
+    writeFlatRow(view, accountFieldKey(addr, ROW_CODE_HASH), codeHashEntry(emptyCodeHash()));
+
+    auto output =
+        bcos::task::syncWait(buildAndCollect(storage, emptyRootHash(), view, /*l2Mode=*/false));
+    MPTReadView<NodeStorage> readView(storage, output.stateRoot);
+    BOOST_CHECK(bcos::task::syncWait(readView.readAccount(addr)).has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/MPTBuilderSubsequentTouchTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTBuilderSubsequentTouchTest.cpp
@@ -177,6 +177,9 @@ BOOST_AUTO_TEST_CASE(ZeroValueWriteLeavesTheTrieLikeADelete)
     std::map<bcos::h256, bcos::bytes> const priorSlots{
         {slotKey(0x00), bcos::bytes{0x10}}, {slotKey(0x01), bcos::bytes{0x11}}};
     Account prior;
+    // A real contract: with the default {0, 0, keccak256("")} triple the account would be
+    // EIP-161 empty and cleared by the #5373 rule, which is not what this case is about.
+    prior.codeHash = makeHash(0xCD);
     prior.storageRoot = buildStorageTrie(storage, priorSlots);
     auto const parentRoot = buildStateTrie(storage, {{addr, prior}});
 

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -444,13 +444,10 @@ void EthBlockHeader::rlpEncode(bcos::bytes& out) const
 
 bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
 {
-    // The shared scalar codec now fails closed on over-wide uint payloads (> target width),
-    // so a malformed header is rejected here at decode time instead of being accepted and
-    // later normalised when hashing the canonical re-encoding. Leading zeros are still
-    // accepted by the codec (the shared UnsignedIntegral walker in RLPDecode.h has no
-    // CanonInt check — geth rejects ErrCanonInt); the canonical re-encode below is what
-    // guards the hash against them. FOLLOW-UP: reject leading-zero integers in the shared
-    // decoder (ywy F4; shared codec, outside this PR's file set).
+    // The shared scalar codec fails closed on over-wide uint payloads (> target width) and,
+    // since #5353, on non-canonical integers (leading zero byte, lone 0x00; geth ErrCanonInt),
+    // so a malformed header is rejected here at decode time. The canonical re-encode below
+    // then only guarantees the header's overall spelling for hashing.
     //
     // The codec's decode only advances a view cursor and never writes the buffer, so
     // take the view directly; the const_cast is confined to this read-only entry point.

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxEnvelope.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxEnvelope.h
@@ -36,45 +36,15 @@ namespace bcos::rlp::protocol
     return !payload.empty() && payload[0] > 0 && payload[0] < bcos::codec::rlp::BYTES_HEAD_BASE;
 }
 
-/// Decode an RLP unsigned integer; reject non-minimal encodings (leading zeros, bare 0x00,
-/// oversized prefixes). Re-encode must match the source bytes.
+/// Decode an RLP unsigned integer, rejecting non-minimal encodings (leading zeros, bare 0x00,
+/// oversized prefixes) with NonCanonicalSize. Since #5353 the shared decoder enforces all of
+/// that itself (RLPDecode.h: width gate, header canonicality, leading-zero payload), so this is
+/// a plain forward kept for its name at the ~60 Web3TxHandler call sites.
 template <typename T>
 [[nodiscard]] inline bcos::Error::UniquePtr decodeCanonicalRlpUint(
     bcos::bytesRef& from, T& to) noexcept
 {
-    auto const* const start = from.data();
-    if (auto error = bcos::codec::rlp::decode(from, to); error != nullptr)
-    {
-        return error;
-    }
-    // Canonicality checked in place (finding BA: the decode-then-re-encode roundtrip cost
-    // 1-2 heap allocations per scalar on the shared decode funnel). The consumed item
-    // [start, from.data()) must be the minimal RLP spelling of an unsigned integer:
-    //   0        -> exactly {0x80} (empty payload)
-    //   1..0x7f  -> single inline byte ({0x00} would be the non-canonical spelling of 0)
-    //   >=0x80   -> prefix 0x80+len + minimal big-endian payload: no leading zero, and a
-    //              one-byte payload must be >= 0x80 or it should have been inline.
-    // Payload width beyond T is already rejected by decode above.
-    auto const consumed = static_cast<std::size_t>(from.data() - start);
-    if (consumed == 1)
-    {
-        if (*start == 0x00) [[unlikely]]
-        {
-            return BCOS_ERROR_UNIQUE_PTR(
-                bcos::codec::rlp::DecodingError::NonCanonicalSize, "non-canonical RLP integer");
-        }
-        return nullptr;
-    }
-    auto const headerByte = *start;
-    auto const payloadLength = consumed - 1;
-    if (headerByte < 0x80 || headerByte != static_cast<bcos::byte>(0x80 + payloadLength) ||
-        start[1] == 0x00 || (payloadLength == 1 && start[1] < 0x80)) [[unlikely]]
-    {
-        // In-range but non-minimal spelling.
-        return BCOS_ERROR_UNIQUE_PTR(
-            bcos::codec::rlp::DecodingError::NonCanonicalSize, "non-canonical RLP integer");
-    }
-    return nullptr;
+    return bcos::codec::rlp::decode(from, to);
 }
 
 /// Typed yParity: whole item must be 0x80 (0) or 0x01 (1). Bare 0x00 is rejected.

--- a/bcos-rpc/bcos-rpc/filter/LogMatcher.cpp
+++ b/bcos-rpc/bcos-rpc/filter/LogMatcher.cpp
@@ -41,7 +41,8 @@ uint32_t LogMatcher::matches(FilterRequest::ConstPtr _params, bcos::crypto::Hash
             count++;
             Json::Value log;
             log["data"] = toHexStringWithPrefix(logEntry.data());
-            log["logIndex"] = toQuantity(i);
+            // block-wide index, same base as ReceiptResponse.cpp (issue #5553)
+            log["logIndex"] = toQuantity(_receipt.logIndex() + i);
             log["blockNumber"] = toQuantity(blockNumber);
             log["blockHash"] = _blockHash.hexPrefixed();
             log["transactionIndex"] = toQuantity(_txIndex);

--- a/bcos-rpc/test/unittests/rpc/LogIndexParityTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/LogIndexParityTest.cpp
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5553: eth_getLogs (LogMatcher) must report the same
+ *        block-wide logIndex as eth_getTransactionReceipt (ReceiptResponse: receipt.logIndex() + i)
+ *        once the receipt carries a non-zero logIndex.
+ */
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-rpc/filter/LogMatcher.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3FilterRequest.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(LogIndexParityTest)
+
+BOOST_AUTO_TEST_CASE(logMatcherUsesReceiptLogIndexBase)
+{
+    auto suite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    bcostars::protocol::TransactionReceiptFactoryImpl factory(suite);
+
+    bytes address(20, 0xab);
+    std::vector<protocol::LogEntry> logs;
+    logs.emplace_back(address, h256s{h256(1U)}, bytes{});
+    logs.emplace_back(address, h256s{h256(2U)}, bytes{});
+    bytes out;
+    auto receipt = factory.createReceipt(u256(21000), "", logs, 0, ref(out), 7);
+    receipt->setLogIndex(5);  // second tx in the block, first tx emitted 5 logs
+
+    LogMatcher matcher;
+    auto params = std::make_shared<Web3FilterRequest>();  // no address/topic filter: match all
+    Json::Value result(Json::arrayValue);
+    auto count = matcher.matches(params, h256(9U), *receipt, h256(8U), 1, result);
+    BOOST_REQUIRE_EQUAL(count, 2U);
+    BOOST_REQUIRE_EQUAL(result.size(), 2U);
+    // same formula as ReceiptResponse.cpp: toQuantity(receipt.logIndex() + i)
+    BOOST_CHECK_EQUAL(result[0]["logIndex"].asString(), "0x5");
+    BOOST_CHECK_EQUAL(result[1]["logIndex"].asString(), "0x6");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -918,24 +918,26 @@ BOOST_AUTO_TEST_CASE(testRejectOverwideInteger)
         auto e = rlp::decode(ref, v);
         BOOST_CHECK(e != nullptr);
     }
-    // A canonical 8-byte uint64 still decodes fine (no regression).
+    // A canonical 8-byte uint64 still decodes fine (no regression). The leading byte must be
+    // non-zero: leading zeros are a non-canonical integer and are rejected since #5353.
     {
-        bcos::bytes raw{0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a};  // 42
+        bcos::bytes raw{0x88, 0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
         auto ref = bcos::ref(raw);
         uint64_t v = 0;
         BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
-        BOOST_CHECK_EQUAL(v, 42);
+        BOOST_CHECK_EQUAL(v, 0x2a00000000000001ULL);
     }
     // A canonical 32-byte u256 still decodes fine (guards the maxBytes formula against a
     // sizeof(T)-based regression: sizeof(u256) == 48, which would reject legal 32-byte values).
     {
         bcos::bytes raw(33, 0x00);
         raw[0] = 0xa0;   // long-string header, 32-byte payload
-        raw[32] = 0x01;  // least-significant payload byte -> value 1
+        raw[1] = 0x01;   // most-significant payload byte non-zero (canonical)
+        raw[32] = 0x01;  // least-significant payload byte
         auto ref = bcos::ref(raw);
         bcos::u256 v = 0;
         BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
-        BOOST_CHECK(v == 1);
+        BOOST_CHECK(v == (bcos::u256(1) << 248) + 1);
     }
     // Narrow integers: 5-byte uint32 rejected, canonical 4-byte accepted.
     {
@@ -945,11 +947,11 @@ BOOST_AUTO_TEST_CASE(testRejectOverwideInteger)
         BOOST_CHECK(rlp::decode(ref, v) != nullptr);
     }
     {
-        bcos::bytes raw{0x84, 0x00, 0x00, 0x00, 0x2a};  // 42
+        bcos::bytes raw{0x84, 0x2a, 0x00, 0x00, 0x01};
         auto ref = bcos::ref(raw);
         uint32_t v = 0;
         BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
-        BOOST_CHECK_EQUAL(v, 42);
+        BOOST_CHECK_EQUAL(v, 0x2a000001U);
     }
     // 3-byte uint16 rejected, canonical 2-byte accepted.
     {
@@ -959,11 +961,11 @@ BOOST_AUTO_TEST_CASE(testRejectOverwideInteger)
         BOOST_CHECK(rlp::decode(ref, v) != nullptr);
     }
     {
-        bcos::bytes raw{0x82, 0x00, 0x2a};  // 42
+        bcos::bytes raw{0x82, 0x2a, 0x01};
         auto ref = bcos::ref(raw);
         uint16_t v = 0;
         BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
-        BOOST_CHECK_EQUAL(v, 42);
+        BOOST_CHECK_EQUAL(v, 0x2a01U);
     }
 }
 

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.h
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.h
@@ -22,12 +22,14 @@
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/hash/SM3.h"
 #include <bcos-utilities/Common.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/throw_exception.hpp>
 #include <cassert>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
 namespace bcos
 {
@@ -266,6 +268,7 @@ public:
 
     bcos::bytes getMethodID(bcos::crypto::Hash::Ptr _hashImpl) const
     {
+        requireHashImpl(_hashImpl);
         auto methodSig = getMethodSignatureAsString();
         auto hashBytes =
             _hashImpl->hash(bcos::bytesConstRef((bcos::byte*)methodSig.data(), methodSig.size()))
@@ -276,6 +279,7 @@ public:
 
     std::string getMethodIDAsString(bcos::crypto::Hash::Ptr _hashImpl) const
     {
+        requireHashImpl(_hashImpl);
         auto methodSig = getMethodSignatureAsString();
         return _hashImpl->hash(bcos::bytesConstRef((bcos::byte*)methodSig.data(), methodSig.size()))
             .hex()
@@ -284,10 +288,21 @@ public:
 
     std::string getEventTopicAsString(bcos::crypto::Hash::Ptr _hashImpl) const
     {
+        requireHashImpl(_hashImpl);
         auto eventSig = getMethodSignatureAsString();
         return _hashImpl->hash(bcos::bytesConstRef((bcos::byte*)eventSig.data(), eventSig.size()))
             .hex()
             .substr(0, 8);
+    }
+
+private:
+    // issue #5047: every selector/topic computation dereferences the caller's hash impl
+    static void requireHashImpl(const bcos::crypto::Hash::Ptr& _hashImpl)
+    {
+        if (!_hashImpl)
+        {
+            BOOST_THROW_EXCEPTION(std::invalid_argument("hash implementation must not be null"));
+        }
     }
 };
 

--- a/bcos-sdk/tests/unittests/abi/ContractABIDefinitionNullHashTest.cpp
+++ b/bcos-sdk/tests/unittests/abi/ContractABIDefinitionNullHashTest.cpp
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5047: ContractABIDefinition lookups given a null Hash
+ *        implementation must throw instead of dereferencing the null pointer.
+ */
+#include "bcos-cpp-sdk/utilities/abi/ContractABIDefinition.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <stdexcept>
+
+using namespace bcos::cppsdk::abi;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(ContractABIDefinitionNullHashTest)
+
+namespace
+{
+ContractABIDefinition makeAbiWithOneMethodAndEvent()
+{
+    ContractABIDefinition abi;
+    auto method = std::make_shared<ContractABIMethodDefinition>();
+    method->setName("transfer");
+    method->setType(ContractABIMethodDefinition::FUNCTION_TYPE);
+    method->setInputs({std::make_shared<NamedType>("to", "address"),
+        std::make_shared<NamedType>("amount", "uint256")});
+    abi.addMethod("transfer", method);
+
+    auto event = std::make_shared<ContractABIMethodDefinition>();
+    event->setName("Transfer");
+    event->setType(ContractABIMethodDefinition::EVENT_TYPE);
+    event->setInputs({std::make_shared<NamedType>("to", "address")});
+    abi.addEvent(event);
+    return abi;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(nullHashImplThrowsInsteadOfCrashing)
+{
+    auto abi = makeAbiWithOneMethodAndEvent();
+    bcos::crypto::Hash::Ptr nullHash;
+
+    BOOST_CHECK_THROW((void)abi.methodIDs("transfer", nullHash), std::invalid_argument);
+    BOOST_CHECK_THROW((void)abi.getMethodByMethodID("a9059cbb", nullHash), std::invalid_argument);
+    BOOST_CHECK_THROW((void)abi.getEventByTopic("0x00", nullHash), std::invalid_argument);
+}
+
+// The dereference lives in ContractABIMethodDefinition's leaf methods, which are public too.
+BOOST_AUTO_TEST_CASE(nullHashImplThrowsAtLeafMethods)
+{
+    ContractABIMethodDefinition method;
+    method.setName("transfer");
+    method.setType(ContractABIMethodDefinition::FUNCTION_TYPE);
+    bcos::crypto::Hash::Ptr nullHash;
+
+    BOOST_CHECK_THROW((void)method.getMethodID(nullHash), std::invalid_argument);
+    BOOST_CHECK_THROW((void)method.getMethodIDAsString(nullHash), std::invalid_argument);
+    BOOST_CHECK_THROW((void)method.getEventTopicAsString(nullHash), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(validHashImplStillWorks)
+{
+    auto abi = makeAbiWithOneMethodAndEvent();
+    auto keccak = std::make_shared<bcos::crypto::Keccak256>();
+
+    auto ids = abi.methodIDs("transfer", keccak);
+    BOOST_REQUIRE_EQUAL(ids.size(), 1U);
+    BOOST_CHECK_EQUAL(ids[0], "a9059cbb");  // keccak256("transfer(address,uint256)")[:4]
+    BOOST_CHECK(abi.getMethodByMethodID("a9059cbb", keccak) != nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -35,7 +35,9 @@
 #include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
 #include "bcos-tars-protocol/tars/TransactionReceipt.h"
 #include "bcos-utilities/AnyHolder.h"
+#include <algorithm>
 #include <range/v3/view/transform.hpp>
+#include <stdexcept>
 
 bcostars::protocol::BlockImpl::BlockImpl(bcostars::Block _block) : BlockImpl()
 {
@@ -87,6 +89,11 @@ void bcostars::protocol::BlockImpl::setBlockHeader(bcos::protocol::BlockHeader::
 void bcostars::protocol::BlockImpl::setReceipt(
     uint64_t _index, bcos::protocol::TransactionReceipt::Ptr _receipt)
 {
+    // issue #5355: reject before the lazy resize so the error path has no side effect
+    if (_index >= std::max(m_inner.receipts.size(), m_inner.transactions.size()))
+    {
+        throw std::out_of_range("BlockImpl::setReceipt index out of range");
+    }
     if (_index >= m_inner.receipts.size())
     {
         m_inner.receipts.resize(m_inner.transactions.size());
@@ -119,7 +126,7 @@ void bcostars::protocol::BlockImpl::setNonceList(::ranges::any_view<std::string>
 
 bcos::crypto::HashType bcostars::protocol::BlockImpl::transactionHash(uint64_t _index) const
 {
-    const auto& hashBytes = m_inner.transactionsMetaData[_index].hash;
+    const auto& hashBytes = m_inner.transactionsMetaData.at(_index).hash;
     return bcos::crypto::HashType{
         bcos::bytesConstRef((const bcos::byte*)hashBytes.data(), hashBytes.size())};
 }
@@ -147,7 +154,7 @@ void bcostars::protocol::BlockImpl::setBlockType(bcos::protocol::BlockType _bloc
 void bcostars::protocol::BlockImpl::setTransaction(
     uint64_t _index, bcos::protocol::Transaction::Ptr _transaction)
 {
-    m_inner.transactions[_index] =
+    m_inner.transactions.at(_index) =
         std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(_transaction)->inner();
 }
 void bcostars::protocol::BlockImpl::appendTransaction(bcos::protocol::Transaction::Ptr _transaction)

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp
@@ -410,6 +410,9 @@ void bcostars::protocol::TransactionReceiptImpl::setLogsBloom(bcos::bytesConstRe
 }
 size_t bcostars::protocol::TransactionReceiptImpl::logIndex() const
 {
-    return 0;
+    return m_inner()->logIndex;
 }
-void bcostars::protocol::TransactionReceiptImpl::setLogIndex(size_t index) {}
+void bcostars::protocol::TransactionReceiptImpl::setLogIndex(size_t index)
+{
+    m_inner()->logIndex = static_cast<tars::UInt32>(index);
+}

--- a/bcos-tars-protocol/test/BlockImplIndexBoundsTest.cpp
+++ b/bcos-tars-protocol/test/BlockImplIndexBoundsTest.cpp
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5355: BlockImpl setTransaction / setReceipt /
+ *        transactionHash must reject out-of-range indices instead of writing past the vector.
+ */
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionMetaDataImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+
+using namespace bcostars::protocol;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(BlockImplIndexBoundsTest)
+
+namespace
+{
+bcos::crypto::CryptoSuite::Ptr makeSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+        std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+}
+
+bcos::protocol::Transaction::Ptr makeTx(TransactionFactoryImpl& factory, bcos::byte tag)
+{
+    return factory.createTransaction(0, "0xa", bcos::bytes{tag}, "0x1", 1, "c", "g", 0);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(setTransactionPastSizeThrows)
+{
+    auto suite = makeSuite();
+    TransactionFactoryImpl txFactory(suite);
+    auto block = std::make_shared<BlockImpl>();
+    block->appendTransaction(makeTx(txFactory, 0x01));
+
+    BOOST_CHECK_THROW(block->setTransaction(1, makeTx(txFactory, 0x02)), std::out_of_range);
+    BOOST_CHECK_THROW(block->setTransaction(100, makeTx(txFactory, 0x02)), std::out_of_range);
+    BOOST_CHECK_EQUAL(block->transactionsSize(), 1U);  // unchanged
+
+    // in-range still works
+    BOOST_CHECK_NO_THROW(block->setTransaction(0, makeTx(txFactory, 0x03)));
+}
+
+BOOST_AUTO_TEST_CASE(setReceiptPastTransactionCountThrows)
+{
+    auto suite = makeSuite();
+    TransactionFactoryImpl txFactory(suite);
+    TransactionReceiptFactoryImpl rFactory(suite);
+    std::vector<bcos::protocol::LogEntry> logs;
+    bcos::bytes out;
+    auto receipt = rFactory.createReceipt(bcos::u256(1), "", logs, 0, bcos::ref(out), 1);
+
+    // No transactions at all: the lazy resize sizes receipts to 0, so index 0 is out of range.
+    auto empty = std::make_shared<BlockImpl>();
+    BOOST_CHECK_THROW(empty->setReceipt(0, receipt), std::out_of_range);
+    BOOST_CHECK_EQUAL(empty->receiptsSize(), 0U);
+
+    // Two transactions: indices 0/1 valid, 2 is past the transaction count.
+    auto block = std::make_shared<BlockImpl>();
+    block->appendTransaction(makeTx(txFactory, 0x01));
+    block->appendTransaction(makeTx(txFactory, 0x02));
+    BOOST_CHECK_NO_THROW(block->setReceipt(1, receipt));
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 2U);
+    BOOST_CHECK_THROW(block->setReceipt(2, receipt), std::out_of_range);
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 2U);
+
+    // More receipts than transactions (appendReceipt): an out-of-range setReceipt must throw
+    // without first truncating the receipts vector back to the transaction count.
+    block->appendReceipt(receipt);
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 3U);
+    BOOST_CHECK_THROW(block->setReceipt(3, receipt), std::out_of_range);
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 3U);
+}
+
+BOOST_AUTO_TEST_CASE(transactionHashPastMetaDataSizeThrows)
+{
+    auto block = std::make_shared<BlockImpl>();
+    BOOST_CHECK_THROW((void)block->transactionHash(0), std::out_of_range);
+
+    const bcos::crypto::HashType hash(1U);
+    block->appendTransactionMetaData(std::make_shared<TransactionMetaDataImpl>(hash, "0xto"));
+    BOOST_CHECK(block->transactionHash(0) == hash);
+    BOOST_CHECK_THROW((void)block->transactionHash(1), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-tars-protocol/test/BlockImplTest.cpp
+++ b/bcos-tars-protocol/test/BlockImplTest.cpp
@@ -81,11 +81,8 @@ BOOST_AUTO_TEST_CASE(transactionAndReceiptByIndex)
     block->appendReceipt(receipt);
     BOOST_CHECK_EQUAL(block->receiptsSize(), 3U);
 
-    // Out-of-range indices (setReceipt/setTransaction/transactionHash past the
-    // vector size) are currently *unchecked* and hit undefined behavior rather
-    // than throwing — see bug #5355. A regression test asserting std::out_of_range
-    // must land together with the bounds-check fix; triggering the OOB here would
-    // corrupt or crash the test process, so it is intentionally not exercised.
+    // Out-of-range indices throw std::out_of_range since the #5355 fix; see
+    // BlockImplIndexBoundsTest.cpp.
 }
 
 // nonceList round-trips through the any_view setter/getter.

--- a/bcos-tars-protocol/test/TransactionReceiptImplTest.cpp
+++ b/bcos-tars-protocol/test/TransactionReceiptImplTest.cpp
@@ -180,9 +180,9 @@ BOOST_AUTO_TEST_CASE(sizeGasUsedAndLogIndex)
     TransactionReceiptImpl empty;
     BOOST_CHECK_EQUAL(empty.gasUsed(), bcos::u256(0));
     BOOST_CHECK_EQUAL(empty.size(), 0U);
-    // logIndex is a stub: always zero, setter is a no-op.
+    // logIndex round-trips through the tars field (issue #5553).
     empty.setLogIndex(9);
-    BOOST_CHECK_EQUAL(empty.logIndex(), 0U);
+    BOOST_CHECK_EQUAL(empty.logIndex(), 9U);
 
     // size() accumulates output + log payload + message; check it tracks the
     // message delta rather than an exact byte total (robust to encoding).

--- a/bcos-tars-protocol/test/TransactionReceiptLogIndexTest.cpp
+++ b/bcos-tars-protocol/test/TransactionReceiptLogIndexTest.cpp
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5553: TransactionReceiptImpl must persist logIndex through
+ *        the tars field, survive encode/decode, and NOT change the receipt hash (the hash covers
+ *        only the fields listed in TarsHashable.h, and logIndex is stamped after hashing like
+ *        transactionIndex / cumulativeGasUsed / logsBloom).
+ */
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcostars::protocol;
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(TransactionReceiptLogIndexTest)
+
+namespace
+{
+bcos::crypto::CryptoSuite::Ptr makeSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+        std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(logIndexRoundTripsAndDoesNotAffectHash)
+{
+    auto suite = makeSuite();
+    TransactionReceiptFactoryImpl factory(suite);
+    std::vector<bcos::protocol::LogEntry> logs;
+    logs.emplace_back(bcos::bytes{0x01}, std::vector<bcos::h256>{bcos::h256(1U)}, bcos::bytes{});
+    bcos::bytes out;
+    auto receipt = factory.createReceipt(bcos::u256(21000), "", logs, 0, bcos::ref(out), 5);
+    auto hashBefore = receipt->hash();
+    BOOST_CHECK_EQUAL(receipt->logIndex(), 0U);
+
+    receipt->setLogIndex(17);
+    BOOST_CHECK_EQUAL(receipt->logIndex(), 17U);
+
+    // encode -> decode keeps it
+    bcos::bytes encoded;
+    receipt->encode(encoded);
+    auto decoded = factory.createReceipt(bcos::ref(encoded));
+    BOOST_CHECK_EQUAL(decoded->logIndex(), 17U);
+
+    // the receipt hash is untouched by the stamp (legacy receiptsRoot unchanged)
+    BOOST_CHECK(receipt->hash() == hashBefore);
+    BOOST_CHECK(decoded->hash() == hashBefore);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -1377,12 +1377,15 @@ void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
             "use thread_pool.io_thread_count instead");
     }
 
-    m_txpoolLimit = checkAndGetValue(_pt, "txpool.limit", "15000");
-    if (m_txpoolLimit <= 0)
+    // validate on the signed value: m_txpoolLimit is size_t, so a negative would wrap to
+    // UINT64_MAX and pass a `<= 0` check on the member (issue #5354)
+    auto txpoolLimit = checkAndGetValue(_pt, "txpool.limit", "15000");
+    if (txpoolLimit <= 0)
     {
         BOOST_THROW_EXCEPTION(
             InvalidConfig() << errinfo_comment("Please set txpool.limit to positive !"));
     }
+    m_txpoolLimit = static_cast<size_t>(txpoolLimit);
     // the txs expiration time, in second
     auto txsExpirationTime = checkAndGetValue(_pt, "txpool.txs_expiration_time", "600");
     if (txsExpirationTime * 1000 <= DEFAULT_MIN_CONSENSUS_TIME_MS) [[unlikely]]
@@ -1795,14 +1798,15 @@ void NodeConfig::loadFailOverConfig(boost::property_tree::ptree const& _pt, bool
         BOOST_THROW_EXCEPTION(
             InvalidConfig() << errinfo_comment("Please set failover.member_id must be non-empty "));
     }
-    m_leaseTTL =
+    auto leaseTTL =
         checkAndGetValue(_pt, "failover.lease_ttl", std::to_string(DEFAULT_MIN_LEASE_TTL_SECONDS));
-    if (m_leaseTTL < DEFAULT_MIN_LEASE_TTL_SECONDS)
+    if (leaseTTL < static_cast<int64_t>(DEFAULT_MIN_LEASE_TTL_SECONDS))
     {
         BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
                                   "Please set failover.lease_ttl to no less than " +
                                   std::to_string(DEFAULT_MIN_LEASE_TTL_SECONDS) + " seconds!"));
     }
+    m_leaseTTL = static_cast<unsigned>(leaseTTL);
 
     NodeConfig_LOG(INFO) << LOG_DESC("loadFailOverConfig")
                          << LOG_KV("failOverClusterUrl", m_failOverClusterUrl)
@@ -1834,9 +1838,22 @@ void NodeConfig::loadOthersConfig(boost::property_tree::ptree const& _pt)
             "use thread_pool.io_thread_count instead");
     }
 
-    m_ioThreadCount = checkAndGetValue(_pt, "thread_pool.io_thread_count",
+    auto ioThreadCount = checkAndGetValue(_pt, "thread_pool.io_thread_count",
         std::to_string(std::thread::hardware_concurrency() + 1));
-    m_tbbThreadCount = checkAndGetValue(_pt, "thread_pool.tbb_thread_count", "0");
+    if (ioThreadCount <= 0)
+    {
+        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
+                                  "Please set thread_pool.io_thread_count to positive !"));
+    }
+    m_ioThreadCount = static_cast<size_t>(ioThreadCount);
+    // 0 means "let TBB decide"; only negatives are invalid
+    auto tbbThreadCount = checkAndGetValue(_pt, "thread_pool.tbb_thread_count", "0");
+    if (tbbThreadCount < 0)
+    {
+        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
+                                  "Please set thread_pool.tbb_thread_count to non-negative !"));
+    }
+    m_tbbThreadCount = static_cast<size_t>(tbbThreadCount);
 
     m_tarsRPCConfig.host = _pt.get<std::string>("rpc.tars_rpc_host", "127.0.0.1");
     m_tarsRPCConfig.port = _pt.get<int>("rpc.tars_rpc_port", 0);
@@ -1862,32 +1879,40 @@ void NodeConfig::loadOthersConfig(boost::property_tree::ptree const& _pt)
 
 void NodeConfig::loadConsensusConfig(boost::property_tree::ptree const& _pt)
 {
-    m_checkPointTimeoutInterval = checkAndGetValue(
+    // All of these are size_t members: compare the signed value first so a negative cannot wrap
+    // past the lower bound (issue #5354).
+    auto checkPointTimeoutInterval = checkAndGetValue(
         _pt, "consensus.checkpoint_timeout", std::to_string(DEFAULT_MIN_CONSENSUS_TIME_MS));
-    m_pipelineSize =
+    auto pipelineSize =
         checkAndGetValue(_pt, "consensus.pipeline_size", std::to_string(DEFAULT_PIPELINE_SIZE));
-    if (m_checkPointTimeoutInterval < DEFAULT_MIN_CONSENSUS_TIME_MS)
+    if (checkPointTimeoutInterval < static_cast<int64_t>(DEFAULT_MIN_CONSENSUS_TIME_MS))
     {
         BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
                                   "Please set consensus.checkpoint_timeout to no less than " +
                                   std::to_string(DEFAULT_MIN_CONSENSUS_TIME_MS) + "ms!"));
     }
-    if (m_pipelineSize < DEFAULT_PIPELINE_SIZE)
+    if (pipelineSize < static_cast<int64_t>(DEFAULT_PIPELINE_SIZE))
     {
         BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
                                   "Please set consensus.pipeline_size to no less than " +
                                   std::to_string(DEFAULT_PIPELINE_SIZE)));
     }
+    m_checkPointTimeoutInterval = static_cast<size_t>(checkPointTimeoutInterval);
+    m_pipelineSize = static_cast<size_t>(pipelineSize);
     m_pipelineAdmissionEnabled = _pt.get<bool>("consensus.pipeline_admission_enabled", true);
-    m_pipelinePerPeerCapacity = checkAndGetValue(_pt, "consensus.pipeline_per_peer_capacity", "64");
-    m_pipelineLruCapacity = checkAndGetValue(_pt, "consensus.pipeline_lru_capacity", "256");
-    m_pipelineMaxPeers = checkAndGetValue(_pt, "consensus.pipeline_max_peers", "1024");
-    if (m_pipelinePerPeerCapacity == 0 || m_pipelineLruCapacity == 0 || m_pipelineMaxPeers == 0)
+    auto pipelinePerPeerCapacity =
+        checkAndGetValue(_pt, "consensus.pipeline_per_peer_capacity", "64");
+    auto pipelineLruCapacity = checkAndGetValue(_pt, "consensus.pipeline_lru_capacity", "256");
+    auto pipelineMaxPeers = checkAndGetValue(_pt, "consensus.pipeline_max_peers", "1024");
+    if (pipelinePerPeerCapacity <= 0 || pipelineLruCapacity <= 0 || pipelineMaxPeers <= 0)
     {
         BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
                                   "pipeline_per_peer_capacity / pipeline_lru_capacity / "
                                   "pipeline_max_peers must all be > 0"));
     }
+    m_pipelinePerPeerCapacity = static_cast<size_t>(pipelinePerPeerCapacity);
+    m_pipelineLruCapacity = static_cast<size_t>(pipelineLruCapacity);
+    m_pipelineMaxPeers = static_cast<size_t>(pipelineMaxPeers);
     NodeConfig_LOG(INFO) << LOG_DESC("loadConsensusConfig")
                          << LOG_KV("checkPointTimeoutInterval", m_checkPointTimeoutInterval)
                          << LOG_KV("pipeline_size", m_pipelineSize)

--- a/bcos-tool/test/unittests/libtool/NodeConfigNegativeValuesTest.cpp
+++ b/bcos-tool/test/unittests/libtool/NodeConfigNegativeValuesTest.cpp
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression test for issue #5354: negative numeric config values must be rejected
+ *        instead of wrapping to a huge size_t and passing the `<= 0` guard.
+ */
+#include "ExceptionCheck.h"
+#include "NodeConfigLoaderProbe.h"
+#include <bcos-tool/Exceptions.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(NodeConfigNegativeValuesTest)
+
+BOOST_AUTO_TEST_CASE(txpoolLimitNegativeRejected)
+{
+    LoaderProbe a;
+    BOOST_CHECK_EXCEPTION(a.loadTxPoolConfig(fromIni("[txpool]\nlimit=-1\n")),
+        bcos::tool::InvalidConfig,
+        [](auto const& e) { return errinfoContains(e, "txpool.limit"); });
+
+    LoaderProbe b;  // positive still accepted
+    b.loadTxPoolConfig(fromIni("[txpool]\nlimit=7\n"));
+    BOOST_CHECK_EQUAL(b.txpoolLimit(), 7U);
+}
+
+BOOST_AUTO_TEST_CASE(threadPoolCountsNegativeRejected)
+{
+    LoaderProbe a;
+    BOOST_CHECK_EXCEPTION(a.loadOthersConfig(fromIni("[thread_pool]\nio_thread_count=-1\n")),
+        bcos::tool::InvalidConfig,
+        [](auto const& e) { return errinfoContains(e, "io_thread_count"); });
+
+    LoaderProbe b;
+    BOOST_CHECK_EXCEPTION(b.loadOthersConfig(fromIni("[thread_pool]\nio_thread_count=0\n")),
+        bcos::tool::InvalidConfig,
+        [](auto const& e) { return errinfoContains(e, "io_thread_count"); });
+
+    LoaderProbe c;
+    BOOST_CHECK_EXCEPTION(c.loadOthersConfig(fromIni("[thread_pool]\ntbb_thread_count=-1\n")),
+        bcos::tool::InvalidConfig,
+        [](auto const& e) { return errinfoContains(e, "tbb_thread_count"); });
+
+    LoaderProbe d;  // 0 means "auto" for tbb_thread_count and stays accepted
+    d.loadOthersConfig(fromIni("[thread_pool]\nio_thread_count=3\ntbb_thread_count=0\n"));
+    BOOST_CHECK_EQUAL(d.ioThreadCount(), 3U);
+    BOOST_CHECK_EQUAL(d.tbbThreadCount(), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(consensusCountsNegativeRejected)
+{
+    struct Case
+    {
+        const char* key;
+        const char* needle;
+    };
+    for (auto const& c :
+        {Case{"checkpoint_timeout", "checkpoint_timeout"}, Case{"pipeline_size", "pipeline_size"},
+            Case{"pipeline_per_peer_capacity", "pipeline_per_peer_capacity"},
+            Case{"pipeline_lru_capacity", "pipeline_lru_capacity"},
+            Case{"pipeline_max_peers", "pipeline_max_peers"}})
+    {
+        LoaderProbe probe;
+        auto ini = std::string("[consensus]\n") + c.key + "=-1\n";
+        BOOST_CHECK_EXCEPTION(probe.loadConsensusConfig(fromIni(ini)), bcos::tool::InvalidConfig,
+            [&](auto const& e) { return errinfoContains(e, c.needle); });
+    }
+
+    LoaderProbe ok;  // defaults still load
+    BOOST_CHECK_NO_THROW(ok.loadConsensusConfig(fromIni("[consensus]\npipeline_size=50\n")));
+    BOOST_CHECK_EQUAL(ok.pipelineSize(), 50U);
+}
+
+BOOST_AUTO_TEST_CASE(failoverLeaseTtlNegativeRejected)
+{
+    LoaderProbe a;
+    BOOST_CHECK_EXCEPTION(
+        a.loadFailOverConfig(
+            fromIni("[failover]\nenable=true\nmember_id=m\nlease_ttl=-1\n"), false),
+        bcos::tool::InvalidConfig, [](auto const& e) { return errinfoContains(e, "lease_ttl"); });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -398,13 +398,42 @@ public:
     {
         Account<Storage> account(m_rollbackableStorage.get(), address,
             m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
-        co_return co_await account.codeHash();
+        if (!m_ledgerConfig.get().features().get(
+                ledger::Features::Flag::bugfix_eip161_1052_account_semantics))
+        {
+            co_return co_await account.codeHash();  // pre-fix: zero for any code-less account
+        }
+        // EIP-1052: 0 for an absent or EIP-161-empty account, hash("") for a live code-less
+        // one, the code hash otherwise (issue #5372). Read CODE_HASH first so a contract costs
+        // the same single read as before; nonce/balance are consulted only for code-less rows.
+        // hash("") rather than Hash::emptyHash(): the latter is non-const and memoises without
+        // synchronisation, and m_hashImpl is a const reference shared across executor threads.
+        auto const emptyCodeHash = m_hashImpl.get().hash(bytesConstRef{});
+        auto codeHash = co_await account.codeHash();
+        if (codeHash != h256{} && codeHash != emptyCodeHash)
+        {
+            co_return codeHash;
+        }
+        if (!co_await account.existsEthereum(emptyCodeHash, codeHash))
+        {
+            co_return {};
+        }
+        co_return emptyCodeHash;
     }
 
-    task::Task<bool> exists([[maybe_unused]] const evmc_address& address, auto&&... /*unused*/)
+    task::Task<bool> exists(const evmc_address& address, auto&&... /*unused*/)
     {
-        // TODO: impl the full support for solidity
-        co_return true;
+        if (!m_ledgerConfig.get().features().get(
+                ledger::Features::Flag::bugfix_eip161_1052_account_semantics))
+        {
+            co_return true;  // pre-fix: every address "exists"
+        }
+        // EIP-161: empty == absent; feeds evmone's new-account gas and SELFDESTRUCT beneficiary
+        // handling through account_exists (issue #5371).
+        Account<Storage> account(m_rollbackableStorage.get(), address,
+            m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
+        auto const emptyCodeHash = m_hashImpl.get().hash(bytesConstRef{});
+        co_return co_await account.existsEthereum(emptyCodeHash);
     }
 
     /// Hash of a block if within the last 256 blocks, or h256() otherwise.

--- a/transaction-executor/tests/Issue5371_5372_AccountExistsTest.cpp
+++ b/transaction-executor/tests/Issue5371_5372_AccountExistsTest.cpp
@@ -1,0 +1,289 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @brief Regression tests for issues #5371 (HostContext::exists() always true) and #5372
+ *        (EXTCODEHASH 0 for a live code-less account), behind bugfix_eip161_1052_account_semantics.
+ */
+#include "../bcos-transaction-executor/EVMCResult.h"
+#include "../bcos-transaction-executor/precompiled/PrecompiledManager.h"
+#include "../bcos-transaction-executor/vm/HostContext.h"
+#include "TestMemoryStorage.h"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-transaction-executor/RollbackableStorage.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::task;
+using namespace bcos::executor_v1;
+using namespace bcos::executor_v1::hostcontext;
+
+namespace bcos::test
+{
+struct AccountExistsFixture
+{
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+    MutableStorage storage;
+    Rollbackable<decltype(storage)> rollbackableStorage{storage};
+    using TransientStorageType = storage2::memory_storage::MemoryStorage<StateKey, StateValue,
+        storage2::memory_storage::Attribute(
+            storage2::memory_storage::ORDERED | storage2::memory_storage::LOGICAL_DELETION)>;
+    TransientStorageType transientStorage;
+    Rollbackable<TransientStorageType> rollbackableTransientStorage{transientStorage};
+    int64_t seq = 0;
+    PrecompiledManager precompiledManager{hashImpl};
+    ledger::LedgerConfig ledgerConfig;
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    evmc_message message{};
+    evmc_address origin{};
+
+    AccountExistsFixture()
+    {
+        blockHeader.setVersion(static_cast<uint32_t>(protocol::BlockVersion::MAX_VERSION));
+        blockHeader.calculateHash(*hashImpl);
+        message.kind = EVMC_CALL;
+        message.gas = 100000;
+    }
+
+    void enableFix(bool on)
+    {
+        ledger::Features features;
+        if (on)
+        {
+            features.set(ledger::Features::Flag::bugfix_eip161_1052_account_semantics);
+        }
+        ledgerConfig.setFeatures(features);
+    }
+
+    static evmc_address addr(uint8_t last)
+    {
+        evmc_address a{};
+        a.bytes[19] = last;
+        return a;
+    }
+
+    /// Runner (code-bearing) addresses get a suite-specific prefix: the executable cache is
+    /// process-wide and keyed by address alone, and the EIP-2929 helpers in this binary already
+    /// put other code at 0x..71 / 0x..72.
+    static evmc_address runnerAddr(uint8_t tag)
+    {
+        evmc_address a{};
+        a.bytes[0] = 0x53;
+        a.bytes[1] = 0x71;
+        a.bytes[19] = tag;
+        return a;
+    }
+
+    auto makeHost()
+    {
+        return HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>(
+            rollbackableStorage, rollbackableTransientStorage, blockHeader, message, origin, "", 0,
+            seq, precompiledManager, ledgerConfig, *hashImpl, false, 0, bcos::task::syncWait);
+    }
+
+    ledger::account::EVMAccount<decltype(rollbackableStorage)> account(const evmc_address& a)
+    {
+        return {rollbackableStorage, a, false};
+    }
+
+    h256 emptyCodeHash() const { return hashImpl->hash(bytesConstRef{}); }
+
+    /// Run @p code as the body of a funded runner contract at @p runnerTag under @p features;
+    /// returns the raw EVMC result (gas_left, output). Same shape as
+    /// eip2929::detail::measureProbeGasTask, without that helper's fixture contract.
+    task::Task<EVMCResult> runBytecode(
+        ledger::Features features, bytes const& code, uint8_t runnerTag, int64_t startGas)
+    {
+        ledgerConfig.setFeatures(features);
+        auto originAddr = addr(0x70);
+        auto runner = runnerAddr(runnerTag);
+        auto originAcc = account(originAddr);
+        if (!co_await originAcc.exists())
+        {
+            co_await originAcc.create();
+        }
+        co_await originAcc.setBalance(u256(1) << 96);
+        auto runnerAcc = account(runner);
+        if (!co_await runnerAcc.exists())
+        {
+            co_await runnerAcc.create();
+        }
+        co_await runnerAcc.setBalance(u256(1) << 96);
+        co_await runnerAcc.setCode(code, "", hashImpl->hash(ref(code)));
+
+        evmc_message msg{};
+        msg.kind = EVMC_CALL;
+        msg.gas = startGas;
+        msg.recipient = runner;
+        msg.code_address = runner;
+        msg.sender = originAddr;
+        HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)> host(
+            rollbackableStorage, rollbackableTransientStorage, blockHeader, msg, originAddr, "", 0,
+            seq, precompiledManager, ledgerConfig, *hashImpl, false, 0, bcos::task::syncWait);
+        co_await host.prepare();
+        co_return co_await host.execute();
+    }
+
+    static ledger::Features featuresWithFix(bool on)
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_evm_cancun);  // explicit; HostContext floors
+                                                                   // m_revision at CANCUN anyway
+        if (on)
+        {
+            features.set(ledger::Features::Flag::bugfix_eip161_1052_account_semantics);
+        }
+        return features;
+    }
+
+    /// PUSH1 0 x4 (retSize retOffset argsSize argsOffset) PUSH1 1 (value) PUSH20 <to>
+    /// PUSH2 gas CALL STOP
+    static bytes callWithOneWeiBytecode(const evmc_address& to)
+    {
+        bytes code;
+        for (int i = 0; i < 4; ++i)
+        {
+            code.insert(code.end(), {0x60, 0x00});
+        }
+        code.insert(code.end(), {0x60, 0x01});
+        code.push_back(0x73);
+        code.insert(code.end(), to.bytes, to.bytes + 20);
+        code.insert(code.end(), {0x61, 0xff, 0xff});
+        code.push_back(0xf1);
+        code.push_back(0x00);
+        return code;
+    }
+
+    /// PUSH20 <a> EXTCODEHASH PUSH1 0 MSTORE PUSH1 32 PUSH1 0 RETURN
+    static bytes extCodeHashBytecode(const evmc_address& a)
+    {
+        bytes code{0x73};
+        code.insert(code.end(), a.bytes, a.bytes + 20);
+        code.insert(code.end(), {0x3f, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3});
+        return code;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(Issue5371_5372_AccountExists, AccountExistsFixture)
+
+BOOST_AUTO_TEST_CASE(absentAccountDoesNotExistAndHashesToZero)
+{
+    enableFix(true);
+    auto host = makeHost();
+    BOOST_CHECK(!syncWait(host.exists(addr(0x01))));
+    BOOST_CHECK(syncWait(host.codeHashAt(addr(0x01))) == h256{});
+}
+
+BOOST_AUTO_TEST_CASE(fundedEoaExistsAndHashesToEmptyCode)
+{
+    enableFix(true);
+    auto eoa = account(addr(0x02));
+    syncWait(eoa.create());
+    syncWait(eoa.setBalance(u256(1)));
+
+    auto host = makeHost();
+    BOOST_CHECK(syncWait(host.exists(addr(0x02))));
+    BOOST_CHECK(syncWait(host.codeHashAt(addr(0x02))) == emptyCodeHash());
+}
+
+BOOST_AUTO_TEST_CASE(emptyAccountIsAbsentPerEip161)
+{
+    enableFix(true);
+    auto empty = account(addr(0x03));
+    syncWait(empty.create());  // table exists, nonce 0, balance 0, no code
+
+    auto host = makeHost();
+    BOOST_CHECK(!syncWait(host.exists(addr(0x03))));
+    BOOST_CHECK(syncWait(host.codeHashAt(addr(0x03))) == h256{});
+}
+
+BOOST_AUTO_TEST_CASE(contractHashesToItsCode)
+{
+    enableFix(true);
+    auto contract = account(addr(0x04));
+    syncWait(contract.create());
+    bytes code{0x60, 0x00, 0x60, 0x00, 0xf3};
+    auto codeHash = hashImpl->hash(ref(code));
+    syncWait(contract.setCode(code, "", codeHash));
+
+    auto host = makeHost();
+    BOOST_CHECK(syncWait(host.exists(addr(0x04))));
+    BOOST_CHECK(syncWait(host.codeHashAt(addr(0x04))) == codeHash);
+}
+
+BOOST_AUTO_TEST_CASE(legacyBehaviourWithoutFlag)
+{
+    enableFix(false);
+    auto eoa = account(addr(0x05));
+    syncWait(eoa.create());
+    syncWait(eoa.setBalance(u256(1)));
+
+    auto host = makeHost();
+    BOOST_CHECK(syncWait(host.exists(addr(0x05))));
+    BOOST_CHECK(syncWait(host.exists(addr(0x06))));                // absent, still true pre-fix
+    BOOST_CHECK(syncWait(host.codeHashAt(addr(0x05))) == h256{});  // pre-fix zero
+}
+
+// The consensus-visible effect of #5371: evmone charges EIP-161's 25000 new-account gas for a
+// value-carrying CALL to an address that does not exist. It never did before, because exists()
+// answered true. (The charge does not depend on feature_balance: evmone looks at msg.value only.)
+BOOST_AUTO_TEST_CASE(valueCallToFreshAddressChargesNewAccountGasOnlyWithFix)
+{
+    constexpr int64_t startGas = 1'000'000;
+    auto used = [&](bool fix, uint8_t target, uint8_t runnerTag) {
+        auto r = syncWait(runBytecode(
+            featuresWithFix(fix), callWithOneWeiBytecode(addr(target)), runnerTag, startGas));
+        BOOST_REQUIRE_EQUAL(r.status_code, EVMC_SUCCESS);
+        return startGas - r.gas_left;
+    };
+    // Warm-up: the first top-level frame in a fixture also pays BALANCE_TRANSFER_GAS
+    // (consumeTransferGas at m_level == 0); the level counter is shared across HostContext
+    // instances, so every later run in this fixture is a like-for-like comparison.
+    (void)used(false, 0x90, 0x70);
+
+    auto eoa = account(addr(0x97));
+    syncWait(eoa.create());
+    syncWait(eoa.setBalance(u256(1)));
+
+    auto offAbsent = used(false, 0x98, 0x71);
+    auto onAbsent = used(true, 0x99, 0x72);
+    auto onExisting = used(true, 0x97, 0x73);
+    BOOST_CHECK_EQUAL(onAbsent - offAbsent, 25000);
+    BOOST_CHECK_EQUAL(onExisting, offAbsent);  // an existing callee is never charged for
+}
+
+// The consensus-visible effect of #5372: the EXTCODEHASH opcode's stack value.
+BOOST_AUTO_TEST_CASE(extCodeHashOpcodeFollowsEip1052WithFix)
+{
+    auto eoa = account(addr(0x0a));
+    syncWait(eoa.create());
+    syncWait(eoa.setBalance(u256(1)));
+
+    // Runner tags are unique across this suite: a runner address must never carry two codes.
+    auto readHash = [](EVMCResult const& r) {
+        BOOST_REQUIRE_EQUAL(r.status_code, EVMC_SUCCESS);
+        BOOST_REQUIRE_EQUAL(r.output_size, 32U);
+        return h256(bytesConstRef(r.output_data, r.output_size));
+    };
+    // flag off: funded EOA hashes to zero (the pre-fix answer)
+    BOOST_CHECK(readHash(syncWait(runBytecode(featuresWithFix(false),
+                    extCodeHashBytecode(addr(0x0a)), 0x80, 500'000))) == h256{});
+    // flag on: funded EOA -> hash(""), absent -> 0
+    BOOST_CHECK(readHash(syncWait(runBytecode(featuresWithFix(true),
+                    extCodeHashBytecode(addr(0x0a)), 0x81, 500'000))) == emptyCodeHash());
+    BOOST_CHECK(readHash(syncWait(runBytecode(featuresWithFix(true),
+                    extCodeHashBytecode(addr(0x0b)), 0x82, 500'000))) == h256{});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
Ten fixes, one per open issue, batched because each is a handful of production lines with its own regression test. Every fix was done red-green: the test was written first and watched fail, then the minimal production change went in.

## Not in this PR

- `AirNodeInitializer.cpp:140` still has `nodeConfig->ioThreadCount() > 0`, which is now always true because the loader rejects 0. Left as is; a follow-up can drop it.
- `NodeConfig.cpp` now has nine copies of the "validate the signed value, then cast" pattern. A `checkAndGetPositiveValue` helper would collapse them; not done here to keep the diff reviewable against the issue text.
- `chain.block_limit` and `consensus.min_seal_time` are also `size_t` fed from `checkAndGetValue`, but their upper-bound checks already reject the wrapped value, so they are untouched.

## #5356 `Sha256::hasher()` returned a SHA3-256 hasher

`bcos-crypto/bcos-crypto/hash/HashImpl.cpp`: `Sha256::hash()` computes SHA2-256 but `Sha256::hasher()` returned `OpenSSL_SHA3_256_Hasher`, and the ctor labelled the impl `HashImplType::Sha3` (copy-paste from `Sha3`). `hasher()` now returns `OpenSSL_SHA2_256_Hasher`; a new `HashImplType::Sha256Hash` value lets `getHashImplType()` tell the two apart. The value carries the `Hash` suffix like `Keccak256Hash` / `Sm3Hash` because the enum is unscoped and a bare `Sha256` would shadow the class (`HashTest.cpp` does `make_shared<Sha256>`; the existing `Sha3` value already forces `class Sha3` in tests). `HashImplType` has no `switch` or serialization anywhere in the repo, only three `== Sm3Hash` compares in the executor, so appending a value is safe. The `Sha256` class is only instantiated by `bcos-crypto/demo/perf_demo.cpp`, so no consensus path changes. `HashImplHasherTest.cpp`, which pinned the mismatch, now asserts equality and the SHA2-256("abcdef") reference vector.

## #5355 `BlockImpl` unchecked indices

`bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp`: `setReceipt`, `setTransaction` and `transactionHash` indexed the tars vectors with `[]`; `setReceipt` resized to `transactions.size()` and then wrote at `_index`, so any index past the transaction count was an out-of-bounds write. All three now throw `std::out_of_range`. `setReceipt` checks the index before its lazy resize so a rejected call cannot truncate a receipts vector that `appendReceipt` had grown past the transaction count. All five production callers of `transactionHash` loop up to `transactionsHashSize()` / `transactionsMetaDataSize()` / `receiptsSize()`, and the only `setReceipt` caller (`BlockExecutive`) indexes by its own result vector, so no existing path hits the new throw. New `BlockImplIndexBoundsTest.cpp`; the old pinning comment in `BlockImplTest.cpp` now points to it.

## #5433 `FrontService::stop()` leaves the dispatcher cycle alive

`bcos-front/bcos-front/FrontService.cpp`: both lambdas registered by `libinitializer/FrontServiceInitializer.cpp` (`registerModuleMessageDispatcher` and `registerGroupNodeInfoNotification`) capture TxPool / BlockSync / PBFT by value, and those modules hold the FrontService back through their configs. `stop()` cleared `m_callback` but neither table, so the graph outlived `stop()` and the modules' destructors (thread joins, io_context teardown) never ran. `stop()` now clears both after flushing the send strand.

`m_module2GroupNodeInfoNotifier` already had `x_notifierLock`. `m_moduleID2MessageDispatcher` was read without a lock on every received message, which was fine while it was write-once at init; clearing it in `stop()` needs synchronisation in AIR because gateway and front share one `IOServicePool` and `Gateway::stop()` does not drain a pool thread that is already inside `onReceiveMessage`. It now has a `SharedMutex`: the receive path copies the `std::function` out under a `ReadGuard` and invokes it outside, registration and the clear take a `WriteGuard`. In MAX the tars server joins its handle threads before `destroyApp`, so no concurrent reader exists there. New `Issue5433_StopReleasesDispatchersTest.cpp` registers a sentinel `shared_ptr` through each of the two registration paths and asserts both `weak_ptr`s expire after `stop()`.

## #5354 negative config values wrap into `size_t`

`bcos-tool/bcos-tool/NodeConfig.cpp`: `checkAndGetValue` returns `int64_t` but the target members are `size_t` / `unsigned`, so `txpool.limit=-1` became `18446744073709551615` and passed the `<= 0` guard on the member; `thread_pool.io_thread_count` and `tbb_thread_count` had no guard at all. Nine keys are now validated on the signed value before the cast: `txpool.limit`, `thread_pool.io_thread_count`, `thread_pool.tbb_thread_count`, `consensus.checkpoint_timeout`, `consensus.pipeline_size`, `consensus.pipeline_per_peer_capacity`, `consensus.pipeline_lru_capacity`, `consensus.pipeline_max_peers`, `failover.lease_ttl`. Two behaviour notes: `io_thread_count=0` is now rejected where it used to be accepted, because `IOServicePool::getIOService` does `% m_contexts.size()` and a zero-sized pool dies with SIGFPE on the first call; `tbb_thread_count=0` stays accepted because `Initializer.cpp` only sets `global_control` when it is `> 0`. `notify_worker_num` / `verify_worker_num` named in the issue are already deprecated keys on this base. New `NodeConfigNegativeValuesTest.cpp` covers all nine keys plus the accepted zero for tbb.

## #5047 cpp-sdk null `Hash::Ptr` dereference

The dereference lives in `ContractABIMethodDefinition.h`'s `getMethodID` / `getMethodIDAsString` / `getEventTopicAsString`, which are public and are what `ContractABIDefinition::methodIDs` / `getMethodByMethodID` / `getEventByTopic` call. A private `requireHashImpl()` in the leaf class now throws `std::invalid_argument` on a null pointer, so every entry point is covered by one check. New `ContractABIDefinitionNullHashTest.cpp` covers the three `ContractABIDefinition` lookups, the three leaf methods, and a positive Keccak256 case (`transfer(address,uint256)` selector `a9059cbb`).

## #5353 RLP integer decoder accepts leading zeros

`bcos-codec/bcos-codec/rlp/RLPDecode.h` `decode(bytesRef&, UnsignedIntegral auto&)` checked that an integer payload is not wider than the target type but not that it is canonical, so `82 00 01` decoded to 1 and the lone byte `00` decoded to 0. go-ethereum rejects both (`ErrCanonInt`): integers carry no leading zero and zero is the empty string `80`. The decoder now rejects a payload whose first byte is zero with `NonCanonicalSize`, the same code the header path already uses for non-minimal length prefixes. Every integer field of a Web3 transaction goes through this function, so two distinct byte encodings of the same value can no longer both be accepted. `Web3TypeTest.cpp`'s `testRejectOverwideInteger` labelled `88 00 00 00 00 00 00 00 2a` a canonical 8-byte integer; its four accept vectors now start with a non-zero byte and still pin the 8/32/4/2-byte width boundary. New `RLPNonCanonicalIntegerTest.cpp`.

## #5553 receipt `logIndex` hardcoded to 0

`bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp`: `logIndex()` returned 0 and `setLogIndex()` was empty, so every log served by `eth_getTransactionReceipt` reported `logIndex: 0`. The tars schema already has field 7 (`optional unsigned int logIndex`), `BaselineScheduler-tpp.h` already stamps it per receipt in the same loop that stamps `transactionIndex`, `cumulativeGasUsed` and `logsBloom`, and `ReceiptResponse.cpp` already emits `logIndex + i` per log; only the implementation was stubbed. It now reads and writes the field. The issue text worried that the receipt hash serializes the whole struct; it does not: `TarsHashable.h` hashes version, gasUsed, contractAddress, status, output, effectiveGasPrice and the log entries only, so receipt hashes and `receiptsRoot` are byte-identical before and after, which the new `TransactionReceiptLogIndexTest.cpp` pins (round-trip, encode/decode, hash unchanged). The field is `optional` in tars and serialized only when non-zero, so older binaries skip it.

## #5371 `HostContext::exists()` always true and #5372 EXTCODEHASH 0 for code-less accounts

**This is a gas-schedule change.** From the block where `compatibility_version` reaches 3.18.0, a value-carrying `CALL` to an address that does not exist in the EIP-161 sense costs 25000 more, and so does `SELFDESTRUCT` to a non-existent beneficiary when the balance is non-zero. evmone decides this on `msg.value` alone, so it applies whether or not `feature_balance` is on. Contracts that hard-code call gas may run out where they did not before. A binary rollback below 3.18.0 is not supported once the flag has activated, as for every `bugfix_` flag. The v0 executor is untouched, so executor versions 0 and 1 answer EXTCODEHASH differently on 3.18.0; that divergence predates this change.

Both are older than 3.18.0 (the `exists()` TODO dates from the v1 executor's first commit in 2022, `EVMAccount::codeHash()` from #4082 in 2023) and the v0 executor carries the same `exists()` stub, so they are fixed on the v1 executor behind a new flag, `bugfix_eip161_1052_account_semantics` (value 61), bound to 3.18.0 in the upgrade roadmap. With the flag on, `transaction-executor/.../HostContext.h` answers `exists()` with `EVMAccount::existsEthereum()` (table exists and nonce, balance or code is non-empty; a `CODE_HASH` row equal to hash("") counts as no code), which feeds evmone's new-account gas and SELFDESTRUCT beneficiary handling through `account_exists`. `codeHashAt()` returns 0 for an absent or EIP-161-empty account, hash("") for a live code-less account, and the stored hash otherwise (EIP-1052). The empty-code hash is the chain hasher's hash of "", i.e. keccak256("") on standard chains and sm3("") on SM chains, matching what `setCode` stores. With the flag off both keep their old answers. New `Issue5371_5372_AccountExistsTest.cpp` covers absent, funded EOA, empty-but-present, contract, and the flag-off legacy path at the host-function level, and at the bytecode level pins the 25000 gas delta for a value CALL to a fresh address (flag on vs off, and no delta for an existing callee) and the EXTCODEHASH opcode's stack value.

## #5373 MPT keeps EIP-161 empty accounts

`bcos-ledger/bcos-ledger/mpt/MPTBuilder.h` `finalizeAccount` wrote a touched account whose merged {nonce, balance, codeHash} is {0, 0, keccak256("")} as a leaf. Ethereum clients delete it: in revm a touched, non-created, non-selfdestructed account that `is_empty()` (storage not consulted) becomes `Destroyed` with its storage wiped (`crates/database/src/states/cache.rs` `CacheState::apply_account_state`, `crates/database/src/states/cache_account.rs` `CacheAccount::touch_empty_eip161`, `crates/state/src/account_info.rs` `AccountInfo::is_empty`), and reth maps that to `HashedPostState` `None` (`crates/trie/common/src/hashed_state.rs` `HashedPostState::from_bundle_state`) and removes the leaf and its storage trie (`crates/trie/trie/src/trie.rs` `StateRoot::calculate`, `destroyed_accounts` / `removed_keys`). The builder now checks the merged triple before the storage commit: an existing leaf is removed and its prior storage root recorded in `obsoletedNodes`, a first touch writes nothing, and an absent account touched with zero value stays absent. No flag: `feature_mpt_state_root` (flag 58), the only thing that routes a chain's stateRoot through `MPTBuilder`, has never been enabled on a released version. `buildAndCollect` is wired in `BaselineScheduler` and `OpScheduler`, so the argument is "never activated", not "not wired". One fixture in `MPTBuilderSubsequentTouchTest.cpp` used a default (empty) account with storage and now carries a code hash so it still tests slot deletion. New `MPTBuilderEmptyAccountTest.cpp`, including a case where the dying account also writes slots in the same block: those writes are dropped with it and the build emits exactly the same nodes as the same death without them.

## Verification

Run locally on macOS arm64 (AppleClang, Debug, `WITH_CPPSDK=ON`):

- Red step for every assertion: each new test failed before its production change (OOB segfault and later `2 != 3` truncation for #5355, both `weak_ptr`s still alive for #5433, `ioThreadCount=18446744073709551615` logged for #5354, SIGSEGV at the leaf for #5047, digest mismatch for #5356).
- `test-transaction-executor` is green except `TestHostContext/nestConstructor`, which fails only when run after the `TransactionExecutorImpl` suite and does so with HEAD's production code as well (pre-existing order dependence, not touched here); green with `--run_test='!TransactionExecutorImpl'`.
- Full binaries green after the change: `test-bcos-crypto`, `test-bcos-tars-protocol`, `test-bcos-front`, `test-bcos-tool`, `test-bcos-cpp-sdk`, and for the RLP / receipt changes additionally `test-bcos-codec`, `test-bcos-protocol`, `test-bcos-rpc`, `test-bcos-ledger`, `test-bcos-tx-validator`, `test-bcos-txpool`, `test-bcos-rlp-protocol`, `test-bcos-engine`, `test-transaction-scheduler`, and for the EIP-161 changes `test-bcos-framework`, `test-bcos-ledger`.
- Each new test `.cpp` compiled standalone with the target's real `flags.make` (`-fsyntax-only`) to rule out unity-build include leaks.
- Every changed `.cpp` scanned with `g++-16 -Wall -Wextra -pedantic` using the target's real defines/includes: no warnings.
- `git clang-format --diff` empty on the changed hunks. `FrontService.cpp` and `NodeConfig.cpp` carry pre-existing whole-file format violations on the base; those lines are untouched.

Closes #5356, closes #5355, closes #5433, closes #5354, closes #5047, closes #5353, closes #5553, closes #5371, closes #5372, closes #5373

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJVRsxJ6getz5B3bjriPPw
