### PR TITLE
feat(rpc): OP Web3 RPC surface — eth_feeHistory, call/block/receipt responses, Engine API errors

### DIFF
--- a/bcos-framework/bcos-framework/engine/OpBaseFee.h
+++ b/bcos-framework/bcos-framework/engine/OpBaseFee.h
@@ -23,14 +23,19 @@
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
+#include <boost/throw_exception.hpp>
 #include <cstdint>
 #include <optional>
 #include <span>
-#include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace bcos::engine
 {
+[[noreturn]] inline void throwOpBaseFeeError(std::string message)
+{
+    BOOST_THROW_EXCEPTION(InvalidEngineEncoding{} << bcos::errinfo_comment{std::move(message)});
+}
 
 /// Canyon EIP-1559 parameters (op-geth params/config.go).
 inline constexpr std::uint32_t c_eip1559DenominatorCanyon = 250;
@@ -92,8 +97,8 @@ inline std::optional<std::string> validateOpExtraDataShape(
 /// Next-block baseFee (op-geth CalcBaseFee). Holocene-active and later only:
 /// a pre-Holocene parent has empty extraData and must use the prior 1559 constants
 /// in the caller, not this helper. extraData layout (version byte first):
-///   9 bytes  = Holocene: 0x00 || denominator(u32 BE) || elasticity(u32 BE)
-///   17 bytes = Jovian:   0x01 || denominator || elasticity || minBaseFee(u64 BE)
+/// 9 bytes = Holocene: 0x00 || denominator(u32 BE) || elasticity(u32 BE)
+/// 17 bytes = Jovian: 0x01 || denominator || elasticity || minBaseFee(u64 BE)
 /// Fail-closed everywhere (no 8/2 default): empty, short, wrong-version, or zero
 /// denom/elasticity extraData throws; a Holocene+/Jovian parent missing baseFee
 /// (or a Jovian parent missing blobGasUsed) throws — op-geth dereferences those
@@ -107,7 +112,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
     std::span<const bcos::byte> extra{extraView.data(), extraView.size()};
     if (auto shapeError = validateOpExtraDataShape(extra, /*allowEmpty=*/false))
     {
-        throw std::invalid_argument("OP parent extraData " + *shapeError);
+        throwOpBaseFeeError("OP parent extraData " + *shapeError);
     }
     auto [denominator32, elasticity32] =
         decodeEip1559Params(extra.subspan(1, c_eip1559ParamsBytes));
@@ -126,7 +131,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
     bcos::u256 const gasTarget = parent.gasLimit() / elasticity;
     if (gasTarget == 0) [[unlikely]]
     {
-        throw std::invalid_argument("invalid OP base-fee parameters: zero gas target");
+        throwOpBaseFeeError("invalid OP base-fee parameters: zero gas target");
     }
 
     // Jovian meters max(gasUsed, blobGasUsed DA footprint). op-geth dereferences
@@ -137,7 +142,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
     {
         if (!parent.blobGasUsed().has_value())
         {
-            throw std::invalid_argument("Jovian OP parent header is missing blobGasUsed");
+            throwOpBaseFeeError("Jovian OP parent header is missing blobGasUsed");
         }
         if (*parent.blobGasUsed() > gasMetered)
         {
@@ -150,7 +155,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
     // next block at 0.
     if (!parent.baseFee().has_value())
     {
-        throw std::invalid_argument("OP parent header is missing baseFee");
+        throwOpBaseFeeError("OP parent header is missing baseFee");
     }
     bcos::u256 const parentBaseFee = *parent.baseFee();
     // op-geth computes with unbounded big.Int; guard the fixed-width u256 multiply
@@ -170,7 +175,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
         bcos::u256 const delta = gasMetered - gasTarget;
         if (parentBaseFee > u256Max / delta) [[unlikely]]
         {
-            throw std::invalid_argument("OP base-fee delta computation overflows u256");
+            throwOpBaseFeeError("OP base-fee delta computation overflows u256");
         }
         bcos::u256 deltaFee = parentBaseFee * delta;
         deltaFee /= gasTarget;
@@ -180,7 +185,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
         // would wrap exactly here, where big.Int would keep going.
         if (result < parentBaseFee) [[unlikely]]
         {
-            throw std::invalid_argument("OP base-fee increase overflows u256");
+            throwOpBaseFeeError("OP base-fee increase overflows u256");
         }
     }
     else
@@ -189,7 +194,7 @@ inline bcos::u256 calcOpBaseFee(bcos::protocol::BlockHeader const& parent, bool 
         bcos::u256 const delta = gasTarget - gasMetered;
         if (parentBaseFee > u256Max / delta) [[unlikely]]
         {
-            throw std::invalid_argument("OP base-fee delta computation overflows u256");
+            throwOpBaseFeeError("OP base-fee delta computation overflows u256");
         }
         bcos::u256 deltaFee = parentBaseFee * delta;
         deltaFee /= gasTarget;

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -24,6 +24,7 @@
 #include <bcos-framework/consensus/ConsensusInterface.h>
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
 #include <bcos-framework/engine/AnyEngineService.h>
+#include <bcos-framework/engine/DACaps.h>
 #include <bcos-framework/ledger/LedgerInterface.h>
 #include <bcos-framework/multigroup/ChainNodeInfo.h>
 #include <bcos-framework/multigroup/GroupInfo.h>
@@ -171,6 +172,15 @@ public:
     }
     protocol::BlockNumber finalizedBlockDepth() const noexcept { return m_finalizedBlockDepth; }
 
+    /// OP DA size caps, read by OpEngineService during payload assembly. Null on Ethereum-only
+    /// nodes. Inert at this revision: the miner_setMaxDASize producer is not registered until
+    /// the OpEngineService cutover wires a reader for it (see DACaps.h).
+    void setDaCaps(std::shared_ptr<bcos::engine::DACaps> caps) noexcept
+    {
+        m_daCaps = std::move(caps);
+    }
+    std::shared_ptr<bcos::engine::DACaps> daCaps() const noexcept { return m_daCaps; }
+
     void setLedgerPrx(bcostars::LedgerServicePrx const& _ledgerPrx) { m_ledgerPrx = _ledgerPrx; }
 
     bool unreachable()
@@ -209,6 +219,9 @@ private:
     /// else keeps it alive. Null until set, which is every mode that has no mempool.
     std::shared_ptr<txvalidator::TxValidator> m_admissionValidator;
     txvalidator::AdmissionContext m_admissionContext = txvalidator::AdmissionContext::PoolAdmission;
+
+    /// Shared OP DA caps (see setDaCaps); nullptr on Ethereum-only nodes.
+    std::shared_ptr<bcos::engine::DACaps> m_daCaps;
 
     bcostars::LedgerServicePrx m_ledgerPrx;
 };

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
@@ -70,6 +70,11 @@ void EndpointsMapping::addEngineHandlers()
     m_handlers[methodString(EthMethod::engine_newPayloadV2)] = &Endpoints::newPayloadV2;
     m_handlers[methodString(EthMethod::engine_newPayloadV3)] = &Endpoints::newPayloadV3;
     m_handlers[methodString(EthMethod::engine_newPayloadV4)] = &Endpoints::newPayloadV4;
+    // miner_setMaxDASize is deliberately NOT registered: no production consumer reads DACaps
+    // yet (OpEngineService has no production construction site), so answering `true` would
+    // make the batcher size its channel frames against a limit the sequencer never applies.
+    // The producer, the reader and the Pro/Max (tars) setDaCaps bootstrap land together in
+    // the OpEngineService cutover.
     // clang-format on
 }
 
@@ -116,6 +121,7 @@ void EndpointsMapping::addEthHandlers()
     m_handlers[methodString(EthMethod::eth_getLogs)] = &Endpoints::getLogs;
     m_handlers[methodString(EthMethod::eth_maxPriorityFeePerGas)] = &Endpoints::maxPriorityFeePerGas;
     m_handlers[methodString(EthMethod::eth_getProof)] = &Endpoints::getProof;
+    m_handlers[methodString(EthMethod::eth_feeHistory)] = &Endpoints::feeHistory;
     // clang-format on
 }
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -24,6 +24,7 @@
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <exception>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -48,6 +49,21 @@ struct OpPayloadBusyReset
         }
     }
 };
+
+/// Map unexpected service errors to a SHORT -32603: the reason is echoed so the operator can
+/// diagnose it, but boost's file/line diagnostics are not. EngineRpcTest pins both halves
+/// (isShortInternalError), so this is a deliberate contract, not an accident.
+[[noreturn]] void rethrowAsEngineInternalError(std::exception const& e)
+{
+    auto const* what = e.what();
+    std::string message = "Internal error";
+    if (what != nullptr && what[0] != '\0')
+    {
+        message += ": ";
+        message += what;
+    }
+    BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, std::move(message)));
+}
 }  // namespace
 
 EngineEndpoint::EngineEndpoint(NodeService::Ptr nodeService) : m_nodeService(std::move(nodeService))
@@ -162,6 +178,13 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
     }
     catch (engine::UnsupportedFork const& e)
     {
+        // Keep -38005 and preserve the service error text.
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
+    }
+    catch (engine::UnsupportedEngineApiVersion const& e)
+    {
+        // Method-version mismatch maps to -38005.
         BOOST_THROW_EXCEPTION(JsonRpcException(
             EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
     }
@@ -169,6 +192,14 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::InvalidForkchoiceState,
             std::string("Invalid forkchoice state: ") + e.what()));
+    }
+    catch (engine::OpExecutionInternalError const& e)
+    {
+        rethrowAsEngineInternalError(e);
+    }
+    catch (std::exception const& e)
+    {
+        rethrowAsEngineInternalError(e);
     }
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);
@@ -228,9 +259,22 @@ task::Task<void> EngineEndpoint::handleGetPayload(
     }
     catch (engine::IncompatiblePayloadVersion const&)
     {
-        // Payload was built under a different method version.
+        // Payload was built by a different Engine API method version.
         BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
             "Unsupported fork: payload was built by a different method version"));
+    }
+    catch (engine::UnsupportedEngineApiVersion const& e)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
+    }
+    catch (engine::OpExecutionInternalError const& e)
+    {
+        rethrowAsEngineInternalError(e);
+    }
+    catch (std::exception const& e)
+    {
+        rethrowAsEngineInternalError(e);
     }
     if (!engineResult)
     {
@@ -304,10 +348,23 @@ task::Task<void> EngineEndpoint::handleNewPayload(
         BOOST_THROW_EXCEPTION(JsonRpcException(
             EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
     }
+    catch (engine::UnsupportedEngineApiVersion const& e)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            EngineError::UnsupportedFork, std::string("Unsupported fork: ") + e.what()));
+    }
     catch (engine::InvalidPayloadAttributes const& e)
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::InvalidPayloadAttributes,
             std::string("Invalid payload attributes: ") + e.what()));
+    }
+    catch (engine::OpExecutionInternalError const& e)
+    {
+        rethrowAsEngineInternalError(e);
+    }
+    catch (std::exception const& e)
+    {
+        rethrowAsEngineInternalError(e);
     }
     auto result = serializePayloadStatus(engineResult, version);
     buildJsonContent(result, response);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -29,6 +29,7 @@
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-executor/src/Common.h>
+#include <bcos-executor/src/precompiled/common/Utilities.h>  // trimHexPrefix
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-framework/storage/LegacyStorageMethods.h>
 #include <bcos-framework/storage2/Storage.h>
@@ -44,9 +45,11 @@
 #include <bcos-rpc/web3jsonrpc/model/CallRequest.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
+#include <bcos-rpc/web3jsonrpc/utils/FeeHistory.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-tx-validator/TxValidator.h>
+#include <bcos-utilities/DataConvertUtility.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
@@ -239,6 +242,27 @@ task::Task<void> EthEndpoint::getBalance(const Json::Value& request, Json::Value
     u256 balance = 0;
     if (isLatest)
     {
+        // OP / scenario-B chains commit account state in MPT only; the flat ACCOUNT_BALANCE
+        // row is absent, so "latest" must read the tip block's committed state root (same as
+        // an explicit block tag) instead of ledger::getStorageAt on the empty flat plane.
+        auto const mptReader = m_nodeService->mptNodeReader();
+        if (mptReader)
+        {
+            auto const ctx = co_await resolveHistoricalMptContext(*ledger, blockNumber, mptReader);
+            if (ctx.fullTrie)
+            {
+                bcos::ledger::mpt::MPTReadView view{*mptReader, ctx.stateRoot};
+                auto const account = co_await view.readAccount(
+                    bcos::Address{addressStr, bcos::Address::FromHex, bcos::Address::AlignRight});
+                if (account)
+                {
+                    balance = account->balance;
+                }
+                Json::Value result = toQuantity(std::move(balance));
+                buildJsonContent(result, response);
+                co_return;
+            }
+        }
         if (auto const entry = co_await ledger::getStorageAt(
                 *ledger, addressStr, bcos::executor::ACCOUNT_BALANCE, /*blockNumber*/ 0);
             entry.has_value())
@@ -403,17 +427,17 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
 
     // Query the slot through the MPT at that root: account leaf -> storageRoot -> slot leaf
     // (slotKeyHash(slot)). Absence semantics are scenario-driven, exactly like getProof:
-    //  - scenario B (ctx.fullTrie): the trie is complete, so absent account / empty storage
-    //    trie / absent slot all read zero — Ethereum semantics at a committed root;
-    //  - scenario A (mid-chain activation): a dormant account absent from the trie is
-    //    indistinguishable from a non-existent one → explicit error; a slot absent from the
-    //    (incomplete) storage trie — whether the account has no storage in the trie yet
-    //    (storageRoot == emptyRootHash(), first touch wrote only nonce/balance/code) or the
-    //    storage trie has no leaf for this slot — → fall back to the flat KV. The flat value
-    //    is authoritative when the slot was never written after activation; if it was written
-    //    *after* the requested block the fallback returns that later value, since
-    //    ledger::getStorageAt ignores blockNumber today (the same limitation as getProof's
-    //    SlotNotInMPT fallback). Still strictly better than reporting zero.
+    // - scenario B (ctx.fullTrie): the trie is complete, so absent account / empty storage
+    // trie / absent slot all read zero — Ethereum semantics at a committed root;
+    // - scenario A (mid-chain activation): a dormant account absent from the trie is
+    // indistinguishable from a non-existent one → explicit error; a slot absent from the
+    // (incomplete) storage trie — whether the account has no storage in the trie yet
+    // (storageRoot == emptyRootHash(), first touch wrote only nonce/balance/code) or the
+    // storage trie has no leaf for this slot — → fall back to the flat KV. The flat value
+    // is authoritative when the slot was never written after activation; if it was written
+    // *after* the requested block the fallback returns that later value, since
+    // ledger::getStorageAt ignores blockNumber today (the same limitation as getProof's
+    // SlotNotInMPT fallback). Still strictly better than reporting zero.
     std::optional<std::string> flatFallback;  // scenario-A dormant-slot fallback rendering
     bcos::u256 value = 0;
     {
@@ -507,6 +531,24 @@ task::Task<void> EthEndpoint::getTransactionCount(const Json::Value& request, Js
     u256 nonce = 0;
     if (isLatest)
     {
+        auto const mptReader = m_nodeService->mptNodeReader();
+        if (mptReader)
+        {
+            auto const ctx = co_await resolveHistoricalMptContext(*ledger, blockNumber, mptReader);
+            if (ctx.fullTrie)
+            {
+                bcos::ledger::mpt::MPTReadView view{*mptReader, ctx.stateRoot};
+                auto const account = co_await view.readAccount(
+                    bcos::Address{addressStr, bcos::Address::FromHex, bcos::Address::AlignRight});
+                if (account)
+                {
+                    nonce = account->nonce;
+                }
+                Json::Value result = toQuantity(nonce);
+                buildJsonContent(result, response);
+                co_return;
+            }
+        }
         if (auto const entry = co_await ledger::getStorageAt(
                 *ledger, addressStr, bcos::ledger::ACCOUNT_TABLE_FIELDS::NONCE, /*blockNumber*/ 0);
             entry.has_value())
@@ -866,6 +908,15 @@ task::Task<void> EthEndpoint::call(
         BOOST_THROW_EXCEPTION(
             JsonRpcException(JsonRpcError::InternalError, "Scheduler not available!"));
     }
+    // eth_estimateGas sizes its gas cap from the target block's header, so it cannot run
+    // without the ledger. Fail closed here rather than later substituting a constant cap that
+    // has nothing to do with this chain's configuration.
+    auto ledger = m_nodeService->ledger();
+    if (isEstimate && !ledger)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            JsonRpcError::InternalError, "Ledger not available for eth_estimateGas"));
+    }
     auto [valid, call] = decodeCallRequest(request[0U]);
     if (!valid)
     {
@@ -878,8 +929,51 @@ task::Task<void> EthEndpoint::call(
         WEB3_LOG(TRACE) << LOG_DESC("eth_call") << LOG_KV("call", call)
                         << LOG_KV("blockTag", blockTag) << LOG_KV("blockNumber", blockNumber);
     }
-    auto tx = call.takeToTransaction(
-        m_nodeService->blockFactory()->transactionFactory(), isEstimate ? scheduler : nullptr);
+    std::optional<uint64_t> chainBlockGasLimit;
+    if (isEstimate)
+    {
+        if (auto block = co_await ledger::getBlockData(*ledger, blockNumber, bcos::ledger::HEADER))
+        {
+            // Bounds-checked narrowing: an over-wide gasLimit leaves the optional unset and
+            // the guard below refuses the request instead of using a truncated cap.
+            auto const limit = block->blockHeader()->gasLimit();
+            if (bcos::u256FitsUint64(limit))
+            {
+                chainBlockGasLimit = static_cast<uint64_t>(limit);
+            }
+        }
+        // No default cap: an unreadable header or an over-wide gasLimit must fail the request
+        // with a diagnosable message, not silently size the estimate against a constant.
+        bool const needsGasDefault = !call.gas.has_value() || call.gas.value() == 0;
+        if (needsGasDefault && !chainBlockGasLimit.has_value())
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(JsonRpcError::InternalError,
+                "Unable to read parent block gas limit for eth_estimateGas"));
+        }
+    }
+    // Await the sender's committed nonce HERE (a coroutine suspension) instead of blocking
+    // the handler thread with task::syncWait inside takeToTransaction. Needed so validation
+    // does not reject with NONCE_TOO_LOW; on OP chains this read itself costs several storage
+    // round-trips, so it stays off the synchronous path.
+    std::optional<std::string> pendingNonce;
+    if (scheduler && call.from.has_value())
+    {
+        // Validate the sender here, at the RPC boundary: a malformed `from` must be
+        // InvalidParams, not a silently empty pending nonce. Downstream the value becomes a
+        // storage table name (EVMAccount) and the scheduler swallows its decode error, so the
+        // request would otherwise proceed with the sender's stale state nonce and a WARNING
+        // log line per call.
+        auto const fromBytes = bcos::safeFromHexWithPrefix(call.from.value());
+        if (!fromBytes.has_value() || fromBytes->size() != bcos::Address::SIZE)
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "invalid `from` address in call request"));
+        }
+        pendingNonce = CallRequest::nonceFromPendingEntry(co_await scheduler->getPendingStorageAt(
+            bcos::precompiled::trimHexPrefix(call.from.value()), "nonce", 0));
+    }
+    auto tx = call.takeToTransaction(m_nodeService->blockFactory()->transactionFactory(),
+        std::move(pendingNonce), chainBlockGasLimit);
     struct Awaitable
     {
         bcos::scheduler::SchedulerInterface& m_scheduler;
@@ -954,6 +1048,13 @@ task::Task<void> EthEndpoint::estimateGas(const Json::Value& request, Json::Valu
 {
     // params: transaction(TX), blockNumber(QTY|TAG)
     // result: gas(QTY)
+    // Resolving the block tag and sizing the gas cap both need the ledger: refuse up front
+    // instead of dereferencing a null ledger, or silently substituting a constant gas cap.
+    if (!m_nodeService->ledger())
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            JsonRpcError::InternalError, "Ledger not available for eth_estimateGas"));
+    }
     auto const& tx = request[0U];
     auto const blockTag = toView(request[1U]);
     auto [blockNumber, _] = co_await getBlockNumberByTag(blockTag);
@@ -1254,13 +1355,84 @@ task::Task<void> EthEndpoint::maxPriorityFeePerGas(
     co_return;
 }
 
+task::Task<void> EthEndpoint::feeHistory(const Json::Value& request, Json::Value& response)
+{
+    // params: blockCount(QTY), newestBlock(QTY|TAG), rewardPercentiles(FLOAT[] optional)
+    if (request.empty() || !request[0U].isString())
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "eth_feeHistory expects [blockCount, newestBlock, ...]"));
+    }
+    auto const blockCountParsed = bcos::safeFromQuantity(request[0U].asString());
+    if (!blockCountParsed.has_value())
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "invalid blockCount"));
+    }
+    if (request.size() < 2 || !request[1U].isString())
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "eth_feeHistory expects [blockCount, newestBlock, ...]"));
+    }
+
+    auto const newestTag = toView(request[1U]);
+    auto [newestBlock, _] = co_await getBlockNumberByTag(newestTag);
+
+    std::vector<double> rewardPercentiles;
+    if (request.size() >= 3)
+    {
+        // geth rejects a non-array third parameter rather than ignoring it.
+        if (!request[2U].isArray())
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "rewardPercentiles must be an array"));
+        }
+        // Same query limit as geth (eth/gasprice/feehistory.go maxQueryLimit).
+        constexpr std::size_t c_maxRewardPercentiles = 100;
+        if (request[2U].size() > c_maxRewardPercentiles)
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "rewardPercentiles over the query limit 100"));
+        }
+        for (auto const& entry : request[2U])
+        {
+            if (!entry.isNumeric())
+            {
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException(InvalidParams, "rewardPercentiles must be numbers"));
+            }
+            auto const percentile = entry.asDouble();
+            if (percentile < 0.0 || percentile > 100.0)
+            {
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException(InvalidParams, "rewardPercentiles must be in [0, 100]"));
+            }
+            // geth rejects a non-increasing array (errInvalidPercentile).
+            if (!rewardPercentiles.empty() && percentile <= rewardPercentiles.back())
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(
+                    InvalidParams, "rewardPercentiles must be monotonically increasing"));
+            }
+            rewardPercentiles.push_back(percentile);
+        }
+    }
+
+    // The OP base-fee rule is keyed on the chain's L2 flag (feature_l2_ethereum_compat) —
+    // the same canonical source the MPT paths above use — not on the DA-cap object, which
+    // is a DA-throttling handshake that only coincides with OP mode today.
+    auto const opStackMode = co_await ledger::getFeature(
+        *m_nodeService->ledger(), ledger::Features::Flag::feature_l2_ethereum_compat, newestBlock);
+    auto result = co_await buildFeeHistory(*m_nodeService->ledger(), newestBlock,
+        static_cast<std::size_t>(*blockCountParsed), rewardPercentiles, opStackMode);
+    buildJsonContent(result, response);
+}
+
 /// eth_getProof custom error code (spec §5.9): both request-level proof failures — dormant
 /// account and unknown/uncommitted state root — map to -32004; the message distinguishes them.
 constexpr int32_t EthGetProofUnavailable = -32004;
 
 task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& response)
 {
-    // params: address(DATA 20B), storageKeys(DATA[] of 32B), blockNumber(QTY|TAG)  (EIP-1186)
+    // params: address(DATA 20B), storageKeys(DATA[] of 32B), blockNumber(QTY|TAG) (EIP-1186)
     // result: {address, balance, nonce, codeHash, storageHash, accountProof[], storageProof[]}
     Address address;
     try

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
@@ -79,6 +79,7 @@ public:
         std::string_view blockTag);
     task::Task<void> maxPriorityFeePerGas(const Json::Value&, Json::Value&);
     task::Task<void> getProof(const Json::Value&, Json::Value&);
+    task::Task<void> feeHistory(const Json::Value&, Json::Value&);
 
 private:
     NodeService::Ptr m_nodeService;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
@@ -84,7 +84,8 @@ enum class EthMethod
     eth_getFilterLogs,
     eth_getLogs,
     eth_maxPriorityFeePerGas,
-    eth_getProof
+    eth_getProof,
+    eth_feeHistory
 };
 
 [[maybe_unused]] static std::string methodString(EthMethod _method)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -3,18 +3,36 @@
 
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-ledger/mpt/Constants.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-utilities/Bloom.h>
 
 #include <range/v3/view/enumerate.hpp>
+
+namespace
+{
+/// isOpEthereumBlock lives in web3jsonrpc/utils/util.h — the fee-history base-fee read
+/// needs the same predicate, and two copies drifted once already.
+bcos::crypto::HashType blockIdentityHash(const bcos::protocol::BlockHeader& header)
+{
+    if (bcos::rpc::isOpEthereumBlock(header))
+    {
+        return bcos::protocol::EthBlockHeader::computeHash(header);
+    }
+    return header.hash();
+}
+}  // namespace
 
 void bcos::rpc::combineBlockResponse(
     Json::Value& result, const bcos::protocol::Block& block, bool fullTxs)
 {
     auto blockHeader = block.blockHeader();
-    auto blockHash = blockHeader->hash();
     auto blockNumber = blockHeader->number();
     auto const ethVersion = blockHeader->ethBlockVersion();
     auto const isEth = ethVersion != bcos::protocol::EthBlockVersion::NON_ETH;
+    auto const isOp = isOpEthereumBlock(*blockHeader);
+    auto const isEthLike = isEth || isOp;
+    auto blockHash = blockIdentityHash(*blockHeader);
 
     result["number"] = toQuantity(blockNumber);
     result["hash"] = blockHash.hexPrefixed();
@@ -25,10 +43,10 @@ void bcos::rpc::combineBlockResponse(
     // non-zero parent would surface here as a changed RPC value.
     result["parentHash"] = blockHeader->parentInfo().blockHash.hexPrefixed();
 
-    if (isEth)
+    if (isEthLike)
     {
-        // Ethereum header: header-carried fields are taken from the header. The block-body
-        // fields (withdrawals list, totalDifficulty) remain placeholders below.
+        // Ethereum / OP-Stack header: header-carried fields are taken from the header. The
+        // block-body fields (withdrawals list, totalDifficulty) remain placeholders below.
         result["nonce"] = blockHeader->nonce().hexPrefixed();
         result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
         // EIP-55 checksummed address, matching geth's eth_getBlock* output.
@@ -45,8 +63,7 @@ void bcos::rpc::combineBlockResponse(
         // the sealer list (FISCO headers carry no coinbase).
         result["nonce"] = "0x0000000000000000";
         // empty uncle hash: keccak256(RLP([]))
-        result["sha3Uncles"] =
-            "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
+        result["sha3Uncles"] = "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
         result["difficulty"] = "0x0";
         result["mixHash"] = crypto::HashType().hexPrefixed();
         if (blockNumber == 0)
@@ -69,7 +86,7 @@ void bcos::rpc::combineBlockResponse(
     // NON_ETH branch the block's own bloom. A per-log copy was previously built here and
     // never read; removed.
     result["logsBloom"] = toPaddingHexStringWithPrefix(
-        BloomBytesSize, isEth ? blockHeader->logsBloom() : block.logsBloom());
+        BloomBytesSize, isEthLike ? blockHeader->logsBloom() : block.logsBloom());
     result["transactionsRoot"] = blockHeader->txsRoot().hexPrefixed();
     result["stateRoot"] = blockHeader->stateRoot().hexPrefixed();
     result["receiptsRoot"] = blockHeader->receiptsRoot().hexPrefixed();
@@ -79,8 +96,7 @@ void bcos::rpc::combineBlockResponse(
     // Native FISCO-BCOS blocks never call setGasLimit, so the header field reads back as 0;
     // keep the historical fixed value for NON_ETH blocks (the Ethereum-compatible gas limit),
     // and the real header value for Eth blocks (where buildPayload always sets it).
-    result["gasLimit"] = toQuantity(
-        isEth ? blockHeader->gasLimit() : bcos::u256(30000000));
+    result["gasLimit"] = toQuantity(isEthLike ? blockHeader->gasLimit() : bcos::u256(30000000));
     result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
     // BlockHeader stores the timestamp in milliseconds; the eth_* RPC emits seconds.
     result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);
@@ -105,9 +121,9 @@ void bcos::rpc::combineBlockResponse(
         // build path always sets it (finalizeEthBlockHeader uses the empty-trie root), so
         // the absent case only arises for non-engine producers — emit the canonical
         // empty-trie root to keep the response shape unconditional for the fork.
-        result["withdrawalsRoot"] =
-            blockHeader->withdrawalsRoot().value_or(bcos::ledger::mpt::emptyRootHash())
-                .hexPrefixed();
+        result["withdrawalsRoot"] = blockHeader->withdrawalsRoot()
+                                        .value_or(bcos::ledger::mpt::emptyRootHash())
+                                        .hexPrefixed();
     }
     if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
     {
@@ -131,7 +147,33 @@ void bcos::rpc::combineBlockResponse(
             result["requestsHash"] = requestsHash->hexPrefixed();
         }
     }
-    if (!isEth)
+    if (isOp)
+    {
+        // OP blocks are always post-Shanghai/Prague-shaped; emit fork fields from the header
+        // (op-node PayloadByHash / derivation read these via eth_getBlockByHash).
+        result["baseFeePerGas"] = toQuantity(blockHeader->baseFee().value_or(bcos::u256(0)));
+        result["withdrawals"] = Json::Value(Json::arrayValue);
+        result["withdrawalsRoot"] = blockHeader->withdrawalsRoot()
+                                        .value_or(bcos::ledger::mpt::emptyRootHash())
+                                        .hexPrefixed();
+        if (auto blobGasUsed = blockHeader->blobGasUsed())
+        {
+            result["blobGasUsed"] = toQuantity(*blobGasUsed);
+        }
+        if (auto excessBlobGas = blockHeader->excessBlobGas())
+        {
+            result["excessBlobGas"] = toQuantity(*excessBlobGas);
+        }
+        if (auto beaconRoot = blockHeader->parentBeaconBlockRoot())
+        {
+            result["parentBeaconBlockRoot"] = beaconRoot->hexPrefixed();
+        }
+        if (auto requestsHash = blockHeader->requestsHash())
+        {
+            result["requestsHash"] = requestsHash->hexPrefixed();
+        }
+    }
+    else if (!isEth)
     {
         // Native FISCO-BCOS blocks keep their pre-existing Ethereum-compatible mock shape.
         result["baseFeePerGas"] = "0x0";

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
@@ -26,44 +26,55 @@
 using namespace bcos;
 using namespace bcos::rpc;
 
-bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
-    bcos::protocol::TransactionFactory::Ptr const& factory,
-    bcos::scheduler::SchedulerInterface::Ptr const& scheduler) noexcept
+std::optional<std::string> CallRequest::nonceFromPendingEntry(
+    std::optional<bcos::storage::Entry> const& entry)
 {
-    std::string nonce;
-    if (to.empty() && scheduler) [[unlikely]]
+    if (!entry)
     {
-        // estimate gas deploy contract
-        if (from.has_value())
-        {
-            if (const auto entry = task::syncWait(scheduler->getPendingStorageAt(
-                    bcos::precompiled::trimHexPrefix(from.value()), "nonce", 0)))
-            {
-                // FISCO stores account nonces as DECIMAL strings (EVMAccount writes
-                // convert_to<std::string>(); StorageStateView reads them unprefixed),
-                // and the transaction nonce is parsed as HEX downstream — both
-                // bcosTransactionToEvmone (safeFromQuantity) and TransactionExecutorImpl
-                // (hex2u) treat it as hex. So the stored decimal must be converted to a
-                // hex quantity here, otherwise a deployment eth_estimateGas at nonce >= 10
-                // gets its decimal "12" misread as hex 0x12 = 18 (NONCE_TOO_HIGH). 0-9
-                // coincide in both bases, which is why only the 11th+ deployment would break.
-                //
-                // The all-digits guard keeps this noexcept-safe: bcos::u256 throws on an
-                // unparseable string (std::terminate out of noexcept), and an empty or
-                // non-numeric stored nonce is left unset (empty nonce string) — a corrupt
-                // row falls back to the executor reading the sender's state nonce rather
-                // than aborting the RPC.
-                if (auto const raw = entry->get();
-                    !raw.empty() && std::all_of(raw.begin(), raw.end(),
-                                        [](char c) { return c >= '0' && c <= '9'; }))
-                {
-                    nonce = toQuantity(bcos::u256(raw));
-                }
-            }
-        }
+        return std::nullopt;
     }
-    auto tx = factory->createTransaction(1, std::move(this->to), this->data, nonce, 0, {}, {}, 0,
-        "", value.value_or(""), gasPrice.value_or(""), gas.value_or(0), maxFeePerGas.value_or(""),
+    // FISCO stores account nonces as DECIMAL strings (EVMAccount writes
+    // convert_to<std::string>(); StorageStateView reads them unprefixed), and the transaction
+    // nonce is parsed as HEX downstream — both bcosTransactionToEvmone (safeFromQuantity) and
+    // TransactionExecutorImpl (hex2u) treat it as hex. So the stored decimal must be converted
+    // to a hex quantity here, otherwise an eth_estimateGas at nonce >= 10 gets its decimal
+    // "12" misread as hex 0x12 = 18 (NONCE_TOO_HIGH). 0-9 coincide in both bases, which is why
+    // only the 11th+ transaction would break.
+    //
+    // The all-digits guard keeps the caller's noexcept contract: bcos::u256 throws on an
+    // unparseable string, and an empty or non-numeric stored nonce is left unset (empty nonce
+    // string) — a corrupt row falls back to the executor reading the sender's state nonce
+    // rather than aborting the RPC.
+    auto const raw = entry->get();
+    if (raw.empty() ||
+        !std::all_of(raw.begin(), raw.end(), [](char c) { return c >= '0' && c <= '9'; }))
+    {
+        return std::nullopt;
+    }
+    return toQuantity(bcos::u256(raw));
+}
+
+bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
+    bcos::protocol::TransactionFactory::Ptr const& factory, std::optional<std::string> pendingNonce,
+    std::optional<uint64_t> chainBlockGasLimit) noexcept
+{
+    uint64_t gasLimit = gas.value_or(0);
+    // eth_estimateGas omits gas; validation rejects gasLimit==0 ("intrinsic gas too low").
+    // Cap at the parent block's gas limit when the request did not pin one: absent gas AND an
+    // explicit zero both mean "size it for me" — op-geth's estimator does `hi = Header.GasLimit`
+    // unless `GasLimit >= params.TxGas`, and EthEndpoint::call's guard reads the header for
+    // exactly these two cases. Keeping them on one predicate is what removes the old asymmetry
+    // (the guard demanded the header read for gas:"0x0", then the conversion left it at zero).
+    // A failed header read leaves the limit at 0 so validation fails instead of being silently
+    // sized against a constant that has nothing to do with this chain's configuration. The
+    // endpoint passes the limit only on the estimate arm, so eth_call keeps its zero.
+    if ((!gas.has_value() || *gas == 0) && chainBlockGasLimit.has_value())
+    {
+        gasLimit = *chainBlockGasLimit;
+    }
+    auto tx = factory->createTransaction(1, std::move(this->to), this->data,
+        pendingNonce.value_or(std::string{}), 0, {}, {}, 0, "", value.value_or(""),
+        gasPrice.value_or(""), gasLimit, maxFeePerGas.value_or(""),
         maxPriorityFeePerGas.value_or(""));
     if (from.has_value())
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.h
@@ -26,6 +26,7 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <json/json.h>
+#include <optional>
 
 namespace bcos::rpc
 {
@@ -58,9 +59,18 @@ struct CallRequest
         _out << "maxFeePerGas: " << _in.maxFeePerGas.value_or("") << ", ";
         return _out;
     }
+    /// Convert a pending-nonce storage row (FISCO stores DECIMAL strings) to the hex quantity
+    /// the executor parses; nullopt when the row is absent or non-numeric, so the executor
+    /// falls back to the sender's state nonce instead of aborting the RPC.
+    [[nodiscard]] static std::optional<std::string> nonceFromPendingEntry(
+        std::optional<bcos::storage::Entry> const& entry);
+
+    /// @param pendingNonce the sender's committed nonce, already awaited by the caller
+    ///        (EthEndpoint::call). Passing it in keeps this function synchronous and noexcept:
+    ///        the scheduler read must not block the RPC handler thread.
     bcos::protocol::Transaction::Ptr takeToTransaction(
-        bcos::protocol::TransactionFactory::Ptr const&,
-        bcos::scheduler::SchedulerInterface::Ptr const&) noexcept;
+        bcos::protocol::TransactionFactory::Ptr const&, std::optional<std::string> pendingNonce,
+        std::optional<uint64_t> chainBlockGasLimit = std::nullopt) noexcept;
 };
 [[maybe_unused]] std::tuple<bool, CallRequest> decodeCallRequest(Json::Value const& _root);
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -7,6 +7,23 @@
 #include <bcos-crypto/hash/Keccak256.h>
 #include <cstdint>
 
+namespace
+{
+std::string checksummedHexAddress(std::string hexNoPrefix)
+{
+    bcos::toAddress(hexNoPrefix);
+    bcos::toChecksumAddress(
+        hexNoPrefix, bcos::crypto::keccak256Hash(bcos::bytesConstRef(hexNoPrefix)).hex());
+    return hexNoPrefix;
+}
+
+std::string checksummedHexAddressFromHex(std::string_view hexAddress)
+{
+    auto const hexNoPrefix = hexAddress.starts_with("0x") ? hexAddress.substr(2) : hexAddress;
+    return checksummedHexAddress(std::string(hexNoPrefix));
+}
+}  // namespace
+
 void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::TransactionReceipt& receipt,
     const bcos::protocol::Transaction& tx, const crypto::HashType& blockHash)
 {
@@ -26,22 +43,14 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     result["blockHash"] = blockHashHex;
     auto blockNumber = receipt.blockNumber();
     result["blockNumber"] = toQuantity(blockNumber);
-    auto from = toHex(tx.sender());
-    // EIP-55 checksum needs keccak256(address) per recipient; RPC read path (not consensus),
-    // so the 3-4 hashes per receipt are acceptable — caching here would need shared-state
-    // synchronization for a marginal win (see review Finding J).
-    toChecksumAddress(from, bcos::crypto::keccak256Hash(bcos::bytesConstRef(from)).hex());
-    result["from"] = "0x" + std::move(from);
+    result["from"] = "0x" + checksummedHexAddress(bcos::toHex(tx.sender()));
     if (tx.to().empty())
     {
         result["to"] = Json::nullValue;
     }
     else
     {
-        auto toView = tx.to();
-        auto to = std::string(toView.starts_with("0x") ? toView.substr(2) : toView);
-        toChecksumAddress(to, bcos::crypto::keccak256Hash(bcos::bytesConstRef(to)).hex());
-        result["to"] = "0x" + std::move(to);
+        result["to"] = "0x" + checksummedHexAddressFromHex(tx.to());
     }
     result["cumulativeGasUsed"] = toQuantity(cumulativeGasUsed);
     result["effectiveGasPrice"] =
@@ -53,10 +62,7 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     }
     else
     {
-        auto contractAddress = std::string(receipt.contractAddress());
-        toChecksumAddress(contractAddress,
-            bcos::crypto::keccak256Hash(bcos::bytesConstRef(contractAddress)).hex());
-        result["contractAddress"] = "0x" + std::move(contractAddress);
+        result["contractAddress"] = "0x" + checksummedHexAddressFromHex(receipt.contractAddress());
     }
     result["logs"] = Json::arrayValue;
     auto* mutableReceipt = std::addressof(receipt);
@@ -64,9 +70,7 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     for (size_t i = 0; i < receiptLog.size(); i++)
     {
         Json::Value log;
-        auto address = std::string(receiptLog[i].address());
-        toChecksumAddress(address, bcos::crypto::keccak256Hash(bcos::bytesConstRef(address)).hex());
-        log["address"] = "0x" + std::move(address);
+        log["address"] = "0x" + checksummedHexAddress(bcos::toHex(receiptLog[i].address()));
         log["topics"] = Json::arrayValue;
         for (const auto& topic : receiptLog[i].topics())
         {
@@ -76,7 +80,7 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
         log["logIndex"] = toQuantity(logIndex + i);
         log["blockNumber"] = toQuantity(blockNumber);
         log["blockHash"] = blockHashHex;
-        log["transactionIndex"] = toQuantity(transactionIndex);
+        log["transactionIndex"] = transactionIndex;
         log["transactionHash"] = txHashHex;
         log["removed"] = false;
         result["logs"].append(std::move(log));

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/FeeHistory.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/FeeHistory.cpp
@@ -1,0 +1,350 @@
+/**
+ * Copyright (C) 2026 FISCO BCOS.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file FeeHistory.cpp
+ * @brief eth_feeHistory: EIP-1559 history on Ethereum-mode chains, OP base-fee rules on OP Stack.
+ */
+
+#include "FeeHistory.h"
+
+#include <bcos-framework/engine/OpBaseFee.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/protocol/Protocol.h>
+#include <bcos-ledger/LedgerMethods.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Exceptions.h>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace
+{
+constexpr std::size_t c_maxFeeHistoryBlocks = 1024;
+// Reward requests load full block bodies per block; see buildFeeHistory for why this is
+// tighter than the header-only cap.
+constexpr std::size_t c_maxRewardHistoryBlocks = 128;
+constexpr std::uint32_t c_eth1559Elasticity = 2;
+constexpr std::uint32_t c_eth1559Denominator = 8;
+
+bool versionAtLeast(bcos::protocol::EthBlockVersion version, bcos::protocol::EthBlockVersion fork)
+{
+    return static_cast<std::uint8_t>(version) >= static_cast<std::uint8_t>(fork);
+}
+
+bool isJovianOpParent(bcos::protocol::BlockHeader const& parent)
+{
+    auto const& extra = parent.extraData();
+    return extra.size() == bcos::engine::c_jovianExtraDataBytes && !extra.empty() &&
+           extra[0] == bcos::engine::c_jovianExtraDataVersion;
+}
+
+double gasUsedRatio(bcos::protocol::BlockHeader const& header)
+{
+    auto const limit = header.gasLimit();
+    if (limit == 0)
+    {
+        return 0.0;
+    }
+    // Saturate rather than truncate: a value beyond u64_t is not producible by the engine,
+    // and if gasUsed exceeds it the ratio is >= 1 (clamped) anyway.
+    if (!bcos::u256FitsUint64(limit) || !bcos::u256FitsUint64(header.gasUsed()))
+    {
+        return 1.0;
+    }
+    auto const used = static_cast<double>(static_cast<std::uint64_t>(header.gasUsed()));
+    auto const cap = static_cast<double>(static_cast<std::uint64_t>(limit));
+    auto const ratio = used / cap;
+    return std::clamp(ratio, 0.0, 1.0);
+}
+
+std::vector<GasWeightedPriorityFee> collectPriorityFeeSamples(
+    bcos::protocol::Block const& block, bcos::u256 baseFee)
+{
+    // geth weights each sample by the receipt's gasUsed over EVERY transaction in the block,
+    // zero-tip included (eth/gasprice/feehistory.go: sorter[i] = {gasUsed: receipts[i].GasUsed,
+    // reward: reward}). Weighting by the gas limit, or dropping zero-tip txs, shifts every
+    // percentile boundary away from the reference. Receipts are fetched alongside the
+    // transactions (see the getBlockData flags in buildFeeHistory).
+    std::vector<GasWeightedPriorityFee> samples;
+    auto receipts = block.receipts();  // any_view: size()/operator[] need a non-const view
+    std::size_t index = 0;
+    for (auto const& tx : block.transactions())
+    {
+        std::uint64_t gasUsed = 0;
+        if (index < receipts.size())
+        {
+            auto const used = receipts[index]->gasUsed();
+            // A gasUsed beyond uint64 is not producible by the engine; clamp rather than fold to
+            // zero so the sample keeps its weight. gasUsedRatio saturates the same malformed
+            // condition to 1.0, so the two helpers must not disagree inside one response.
+            gasUsed = bcos::u256FitsUint64(used) ? static_cast<std::uint64_t>(used) :
+                                                   std::numeric_limits<std::uint64_t>::max();
+        }
+        ++index;
+        samples.push_back(
+            GasWeightedPriorityFee{effectivePriorityFeePerGas(*tx, baseFee), gasUsed});
+    }
+    std::sort(samples.begin(), samples.end(),
+        [](GasWeightedPriorityFee const& left, GasWeightedPriorityFee const& right) {
+            return left.tip < right.tip;
+        });
+    return samples;
+}
+}  // namespace
+
+bcos::u256 bcos::rpc::blockBaseFee(bcos::protocol::BlockHeader const& header)
+{
+    // OP-Stack headers are NON_ETH yet carry a real base fee (rebuildOpEthHeader
+    // deliberately leaves ethBlockVersion NON_ETH). Check that case before the NON_ETH
+    // short-circuit, which is for native FISCO headers that have no base fee at all.
+    if (isOpEthereumBlock(header))
+    {
+        return header.baseFee().value_or(0);
+    }
+    if (!versionAtLeast(header.ethBlockVersion(), bcos::protocol::EthBlockVersion::LONDON))
+    {
+        return 0;
+    }
+    return header.baseFee().value_or(0);
+}
+
+bcos::u256 bcos::rpc::calcEthNextBaseFee(bcos::protocol::BlockHeader const& parent)
+{
+    if (!versionAtLeast(parent.ethBlockVersion(), bcos::protocol::EthBlockVersion::LONDON))
+    {
+        return 0;
+    }
+    auto const parentBase = parent.baseFee().value_or(0);
+    // Refuse to compute on an over-wide header rather than truncating the gas fields.
+    if (!bcos::u256FitsUint64(parent.gasLimit()) || !bcos::u256FitsUint64(parent.gasUsed()))
+    {
+        return parentBase;
+    }
+    auto const gasLimit = static_cast<std::uint64_t>(parent.gasLimit());
+    auto const gasUsed = static_cast<std::uint64_t>(parent.gasUsed());
+    if (gasLimit == 0)
+    {
+        return parentBase;
+    }
+    auto const gasTarget = gasLimit / c_eth1559Elasticity;
+    if (gasTarget == 0)
+    {
+        return parentBase;
+    }
+    if (gasUsed == gasTarget)
+    {
+        return parentBase;
+    }
+    if (gasUsed > gasTarget)
+    {
+        auto const delta = gasUsed - gasTarget;
+        bcos::u256 deltaFee = parentBase * bcos::u256(delta);
+        deltaFee /= gasTarget;
+        deltaFee /= c_eth1559Denominator;
+        if (deltaFee == 0)
+        {
+            deltaFee = 1;
+        }
+        return parentBase + deltaFee;
+    }
+    auto const delta = gasTarget - gasUsed;
+    bcos::u256 deltaFee = parentBase * bcos::u256(delta);
+    deltaFee /= gasTarget;
+    deltaFee /= c_eth1559Denominator;
+    return deltaFee < parentBase ? parentBase - deltaFee : bcos::u256(0);
+}
+
+bcos::u256 bcos::rpc::calcOpNextBaseFee(bcos::protocol::BlockHeader const& parent)
+{
+    // Pre-check the parent's shape instead of catching everything: a genesis-adjacent OP
+    // parent (empty or not-yet-Holocene extraData) has no EIP-1559 parameters to decode, so
+    // keep its base fee. calcOpBaseFee's own fail-closed errors (missing baseFee, a Jovian
+    // parent missing blobGasUsed, u256 overflow) must surface rather than silently degrading
+    // to the parent fee — a bare catch (...) hid them all.
+    auto const& extra = parent.extraData();
+    auto const extraSpan = std::span<const bcos::byte>(
+        reinterpret_cast<const bcos::byte*>(extra.data()), extra.size());
+    if (extra.empty() ||
+        bcos::engine::validateOpExtraDataShape(extraSpan, /*allowEmpty=*/true).has_value())
+    {
+        return blockBaseFee(parent);
+    }
+    // parentIsJovian is derived from the parent's extraData shape (17-byte Jovian form):
+    // this RPC path has no fork schedule, and the header shape is the only signal available
+    // here. It agrees with m_scheduler.isJovianActive() for headers this node produced.
+    return bcos::engine::calcOpBaseFee(parent, isJovianOpParent(parent));
+}
+
+bcos::u256 bcos::rpc::effectivePriorityFeePerGas(
+    bcos::protocol::Transaction const& tx, bcos::u256 const& baseFee)
+{
+    bcos::u256 tip = 0;
+    if (auto const priority = tx.maxPriorityFeePerGas(); priority.has_value())
+    {
+        tip = *priority;
+    }
+    else if (auto const gasPrice = tx.gasPrice(); gasPrice.has_value() && *gasPrice > baseFee)
+    {
+        tip = *gasPrice - baseFee;
+    }
+    bcos::u256 maxFee = tx.maxFeePerGas().value_or(tx.gasPrice().value_or(0));
+    bcos::u256 cap = maxFee > baseFee ? maxFee - baseFee : bcos::u256(0);
+    return tip < cap ? tip : cap;
+}
+
+std::vector<bcos::u256> bcos::rpc::pickRewardPercentiles(
+    std::vector<GasWeightedPriorityFee> const& samples, std::span<double const> percentiles)
+{
+    std::vector<bcos::u256> rewards;
+    rewards.reserve(percentiles.size());
+    if (samples.empty())
+    {
+        rewards.assign(percentiles.size(), 0);
+        return rewards;
+    }
+    // One prefix sum over cumulative gas, then a binary search per percentile: the boundary is
+    // the tip of the first sample whose cumulative gas reaches the threshold. The previous
+    // version restarted the scan inside the percentile loop (O(percentiles x samples)); with up
+    // to 100 percentiles and 1024 blocks per request that dominated the response cost.
+    std::vector<std::uint64_t> cumulativeGas;
+    cumulativeGas.reserve(samples.size());
+    std::uint64_t totalGas = 0;
+    for (auto const& sample : samples)
+    {
+        totalGas += sample.gas;
+        cumulativeGas.push_back(totalGas);
+    }
+    for (double percentile : percentiles)
+    {
+        // The RPC boundary rejects values outside [0, 100], so no clamp is needed here; a
+        // clamp would only mask a caller that skipped that validation.
+        if (totalGas == 0)
+        {
+            rewards.push_back(0);
+            continue;
+        }
+        // op-geth truncates the threshold to uint64 before comparing
+        // (eth/gasprice/feehistory.go: thresholdGasUsed := uint64(float64(block.GasUsed()) * p /
+        // 100)); comparing the raw double would advance one sample further whenever a prefix sum
+        // lands exactly on the truncated value.
+        auto const threshold =
+            static_cast<std::uint64_t>(static_cast<double>(totalGas) * percentile / 100.0);
+        auto const boundary =
+            std::lower_bound(cumulativeGas.begin(), cumulativeGas.end(), threshold);
+        auto const index = boundary == cumulativeGas.end() ?
+                               samples.size() - 1 :
+                               static_cast<std::size_t>(boundary - cumulativeGas.begin());
+        rewards.push_back(samples[index].tip);
+    }
+    return rewards;
+}
+
+bcos::task::Task<Json::Value> bcos::rpc::buildFeeHistory(bcos::ledger::LedgerInterface& ledger,
+    bcos::protocol::BlockNumber newestBlock, std::size_t blockCount,
+    std::vector<double> const& rewardPercentiles, bool opStackMode)
+{
+    // The reward path loads each block's full body (transactions + receipts) and is reachable
+    // unauthenticated on the public listener; the header-only path is cheap. geth's 1024 cap
+    // assumes its fee-history cache, which this implementation does not have, so the
+    // body-loading path gets a tighter bound on what one request can deserialise.
+    //
+    // An out-of-range request is rejected rather than silently shortened (op-geth's
+    // resolveBlockRange errors on blocks < 1 or > maxQueryLimit), and a zero blockCount must not
+    // answer a shape-violating empty object.
+    bool const wantRewards = !rewardPercentiles.empty();
+    if (blockCount == 0)
+    {
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "eth_feeHistory: blockCount must be at least 1"));
+    }
+    if (wantRewards && blockCount > c_maxRewardHistoryBlocks)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
+            "eth_feeHistory: blockCount over the 128-block rewardPercentiles limit"));
+    }
+    if (blockCount > c_maxFeeHistoryBlocks)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "eth_feeHistory: blockCount over the query limit 1024"));
+    }
+
+    auto const oldestBlock = static_cast<bcos::protocol::BlockNumber>(
+        (std::max)(static_cast<bcos::protocol::BlockNumber>(newestBlock + 1 - blockCount),
+            bcos::protocol::BlockNumber{0}));
+
+    Json::Value result(Json::objectValue);
+    result["oldestBlock"] = toQuantity(oldestBlock);
+
+    Json::Value baseFees(Json::arrayValue);
+    Json::Value gasRatios(Json::arrayValue);
+    Json::Value rewards(Json::arrayValue);
+
+    std::shared_ptr<bcos::protocol::BlockHeader> lastHeader;
+    for (auto number = oldestBlock; number <= newestBlock; ++number)
+    {
+        auto const block = co_await ledger::getBlockData(ledger, number,
+            bcos::ledger::HEADER |
+                (wantRewards ? (bcos::ledger::TRANSACTIONS | bcos::ledger::RECEIPTS) : 0));
+        if (!block || !block->blockHeader())
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Block not found"));
+        }
+        auto const& header = *block->blockHeader();
+        lastHeader = block->blockHeader();
+
+        baseFees.append(toQuantity(blockBaseFee(header)));
+        gasRatios.append(gasUsedRatio(header));
+
+        if (wantRewards)
+        {
+            auto const samples = collectPriorityFeeSamples(*block, blockBaseFee(header));
+            auto const row = pickRewardPercentiles(samples, rewardPercentiles);
+            Json::Value rewardRow(Json::arrayValue);
+            for (auto const& tip : row)
+            {
+                rewardRow.append(toQuantity(tip));
+            }
+            rewards.append(std::move(rewardRow));
+        }
+    }
+
+    bcos::u256 trailingBaseFee = 0;
+    if (lastHeader)
+    {
+        if (opStackMode)
+        {
+            trailingBaseFee = calcOpNextBaseFee(*lastHeader);
+        }
+        else if (versionAtLeast(
+                     lastHeader->ethBlockVersion(), bcos::protocol::EthBlockVersion::LONDON))
+        {
+            trailingBaseFee = calcEthNextBaseFee(*lastHeader);
+        }
+    }
+    baseFees.append(toQuantity(trailingBaseFee));
+
+    result["baseFeePerGas"] = std::move(baseFees);
+    result["gasUsedRatio"] = std::move(gasRatios);
+    if (wantRewards)
+    {
+        result["reward"] = std::move(rewards);
+    }
+    co_return result;
+}

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/FeeHistory.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/FeeHistory.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2026 FISCO BCOS.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file FeeHistory.h
+ * @brief eth_feeHistory: EIP-1559 history on Ethereum-mode chains, OP base-fee rules on OP Stack.
+ */
+
+#pragma once
+
+#include <bcos-framework/ledger/LedgerInterface.h>
+#include <bcos-framework/protocol/BlockHeader.h>
+#include <bcos-framework/protocol/Transaction.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <json/json.h>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace bcos::rpc
+{
+
+/// Base fee a block header carries, as the eth_feeHistory history array reports it.
+/// 0 for native FISCO NON_ETH headers and for pre-London Eth headers. OP-Stack headers
+/// are NON_ETH yet carry a real base fee (see isOpEthereumBlock), so they must NOT take
+/// the NON_ETH short-circuit — that reported 0x0 for every OP block.
+bcos::u256 blockBaseFee(bcos::protocol::BlockHeader const& header);
+
+/// Ethereum L1 next-block base fee (EIP-1559, elasticity 2, denominator 8).
+bcos::u256 calcEthNextBaseFee(bcos::protocol::BlockHeader const& parent);
+
+/// OP Stack next-block base fee (op-geth CalcBaseFee). Returns parent base fee when the parent
+/// header is not yet Holocene-shaped (genesis-adjacent OP chains).
+bcos::u256 calcOpNextBaseFee(bcos::protocol::BlockHeader const& parent);
+
+/// Effective priority fee per gas for one transaction at a given block base fee.
+bcos::u256 effectivePriorityFeePerGas(
+    bcos::protocol::Transaction const& tx, bcos::u256 const& baseFee);
+
+/// One transaction's effective priority fee and gas limit for eth_feeHistory rewards.
+struct GasWeightedPriorityFee
+{
+    bcos::u256 tip;
+    std::uint64_t gas;
+};
+
+/// Pick reward percentiles using geth's gas-weighted indexing over ascending tips.
+std::vector<bcos::u256> pickRewardPercentiles(
+    std::vector<GasWeightedPriorityFee> const& samples, std::span<double const> percentiles);
+
+/// Build the eth_feeHistory result object. `opStackMode` selects OP vs Ethereum base-fee
+/// prediction for the trailing entry (and OP parent metering on Jovian parents).
+bcos::task::Task<Json::Value> buildFeeHistory(bcos::ledger::LedgerInterface& ledger,
+    bcos::protocol::BlockNumber newestBlock, std::size_t blockCount,
+    std::vector<double> const& rewardPercentiles, bool opStackMode);
+
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/util.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/util.h
@@ -19,12 +19,29 @@
  */
 
 #pragma once
+#include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-rpc/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <json/json.h>
 
 namespace bcos::rpc
 {
+/// OP-Stack blocks are stored as NON_ETH BlockHeaders (EthBlockVersion::NON_ETH) but their
+/// identity hash and RPC shape follow the Ethereum RLP header (op-geth / op-node). Ledger
+/// indexes them by EthBlockHeader::computeHash via blockHashOverride; native FISCO NON_ETH
+/// headers lack the Shanghai+ fork fields OP always stamps.
+///
+/// One definition: the block response and the fee-history base-fee read both need it, and
+/// a second copy is how one of them ends up treating an OP block as a plain NON_ETH header.
+[[nodiscard]] inline bool isOpEthereumBlock(bcos::protocol::BlockHeader const& header)
+{
+    if (header.ethBlockVersion() != bcos::protocol::EthBlockVersion::NON_ETH)
+    {
+        return false;
+    }
+    return header.withdrawalsRoot().has_value() && header.baseFee().has_value();
+}
+
 void buildJsonContent(Json::Value& result, Json::Value& response);
 void buildJsonError(
     Json::Value const& request, int32_t code, std::string message, Json::Value& response);

--- a/bcos-rpc/test/unittests/rpc/CallRequestTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/CallRequestTest.cpp
@@ -8,29 +8,11 @@
 #include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
 #include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
 #include "bcos-utilities/DataConvertUtility.h"
-#include <bcos-framework/testutils/faker/FakeScheduler.h>
 
 #include <boost/test/unit_test.hpp>
 using namespace bcos;
 using namespace bcos::rpc;
 
-namespace
-{
-/// Scheduler stub that answers getPendingStorageAt("nonce", ...) with a fixed raw
-/// value, simulating the FISCO account-table row (a DECIMAL nonce string).
-class NonceStubScheduler : public bcos::test::FakeScheduler
-{
-public:
-    using bcos::test::FakeScheduler::FakeScheduler;
-    std::string nonceValue;
-
-    task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(
-        std::string_view, std::string_view, bcos::protocol::BlockNumber) override
-    {
-        co_return bcos::storage::Entry(nonceValue);
-    }
-};
-}  // namespace
 
 BOOST_AUTO_TEST_SUITE(testCallRequest)
 
@@ -199,14 +181,13 @@ BOOST_AUTO_TEST_CASE(deployEstimateGasParsesDecimalNonce)
             std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
     auto txFactory = std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
 
-    auto nonceScheduler = std::make_shared<NonceStubScheduler>(nullptr, nullptr);
-    nonceScheduler->nonceValue = "12";
-
     CallRequest req;
     req.from = "0x1234567890abcdef1234567890abcdef12345678";
     req.to = "";  // deployment (no `to`)
 
-    auto tx = req.takeToTransaction(txFactory, nonceScheduler);
+    // The endpoint awaits the row and hands the converted nonce in.
+    auto tx = req.takeToTransaction(
+        txFactory, CallRequest::nonceFromPendingEntry(bcos::storage::Entry("12")));
     // Decimal 12, not hex 0x12 = 18.
     BOOST_CHECK_EQUAL(tx->nonce(), "0xc");
 }
@@ -223,16 +204,47 @@ BOOST_AUTO_TEST_CASE(deployEstimateGasLeavesCorruptNonceUnset)
 
     for (auto const& corrupt : {std::string{}, std::string{"12a"}, std::string{"abc"}})
     {
-        auto nonceScheduler = std::make_shared<NonceStubScheduler>(nullptr, nullptr);
-        nonceScheduler->nonceValue = corrupt;
-
         CallRequest req;
         req.from = "0x1234567890abcdef1234567890abcdef12345678";
         req.to = "";
 
-        auto tx = req.takeToTransaction(txFactory, nonceScheduler);
+        auto tx = req.takeToTransaction(
+            txFactory, CallRequest::nonceFromPendingEntry(bcos::storage::Entry(corrupt)));
         BOOST_CHECK(tx->nonce().empty());
     }
+}
+
+BOOST_AUTO_TEST_CASE(estimateGasGasCapComesOnlyFromTheParentHeader)
+{
+    // eth_estimateGas with no explicit `gas` takes its cap from the target block's header and
+    // nowhere else: an unreadable header leaves the limit unset, and the endpoint refuses the
+    // request (EthEndpoint::call) instead of substituting a hardcoded constant — which is what
+    // the removed 30'000'000 fallback did. An explicit non-zero gas always wins; an explicit
+    // zero means "size it for me" and takes the same cap, matching op-geth's estimator.
+    auto cryptoSuite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    auto txFactory = std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+
+    CallRequest req;
+    req.to = "0x1234567890abcdef1234567890abcdef12345678";
+
+    auto const noLimit = req.takeToTransaction(txFactory, std::nullopt, std::nullopt);
+    BOOST_CHECK_EQUAL(noLimit->gasLimit(), 0);
+
+    auto const capped = req.takeToTransaction(txFactory, std::nullopt, uint64_t{30'000'000});
+    BOOST_CHECK_EQUAL(capped->gasLimit(), 30'000'000);
+
+    req.gas = 21000;
+    auto const explicitGas = req.takeToTransaction(txFactory, std::nullopt, uint64_t{30'000'000});
+    BOOST_CHECK_EQUAL(explicitGas->gasLimit(), 21000);
+
+    // gas:"0x0" is present-but-zero: op-geth's estimator keeps the header cap for anything
+    // below params.TxGas, and the endpoint's guard reads the header for it, so the conversion
+    // must apply the same cap (the old code left it at zero and always failed validation).
+    req.gas = 0;
+    auto const explicitZero = req.takeToTransaction(txFactory, std::nullopt, uint64_t{30'000'000});
+    BOOST_CHECK_EQUAL(explicitZero->gasLimit(), 30'000'000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <thread>
 
 using namespace bcos;
@@ -62,7 +63,10 @@ public:
         bool throwUnknownPayload = false;
         bool throwInvalidPayloadAttributes = false;
         bool throwUnsupportedFork = false;
+        bool throwUnsupportedEngineApiVersion = false;
         bool throwInvalidForkchoiceState = false;
+        bool throwOpExecutionInternalError = false;
+        bool throwStdRuntimeError = false;
         std::atomic<bool> hangNewPayload{false};
         std::atomic<bool> enteredNewPayload{false};
     };
@@ -90,9 +94,22 @@ public:
         {
             BOOST_THROW_EXCEPTION(engine::UnsupportedFork{});
         }
+        if (m_state->throwUnsupportedEngineApiVersion)
+        {
+            BOOST_THROW_EXCEPTION(engine::UnsupportedEngineApiVersion{});
+        }
         if (m_state->throwInvalidForkchoiceState)
         {
             BOOST_THROW_EXCEPTION(engine::InvalidForkchoiceState{});
+        }
+        if (m_state->throwOpExecutionInternalError)
+        {
+            BOOST_THROW_EXCEPTION(engine::OpExecutionInternalError{}
+                                  << bcos::errinfo_comment{"Null receipt returned by scheduler"});
+        }
+        if (m_state->throwStdRuntimeError)
+        {
+            throw std::runtime_error{"untreated scheduler fault"};
         }
         co_return m_state->forkchoiceUpdatedResult;
     }
@@ -105,6 +122,19 @@ public:
         if (m_state->throwUnknownPayload)
         {
             BOOST_THROW_EXCEPTION(engine::UnknownPayload{});
+        }
+        if (m_state->throwUnsupportedEngineApiVersion)
+        {
+            BOOST_THROW_EXCEPTION(engine::UnsupportedEngineApiVersion{});
+        }
+        if (m_state->throwOpExecutionInternalError)
+        {
+            BOOST_THROW_EXCEPTION(engine::OpExecutionInternalError{}
+                                  << bcos::errinfo_comment{"Null receipt returned by scheduler"});
+        }
+        if (m_state->throwStdRuntimeError)
+        {
+            throw std::runtime_error{"untreated scheduler fault"};
         }
         co_return std::make_unique<engine::GetPayloadData>(*m_state->getPayloadResult);
     }
@@ -126,6 +156,19 @@ public:
         if (m_state->throwUnsupportedFork)
         {
             BOOST_THROW_EXCEPTION(engine::UnsupportedFork{});
+        }
+        if (m_state->throwUnsupportedEngineApiVersion)
+        {
+            BOOST_THROW_EXCEPTION(engine::UnsupportedEngineApiVersion{});
+        }
+        if (m_state->throwOpExecutionInternalError)
+        {
+            BOOST_THROW_EXCEPTION(engine::OpExecutionInternalError{}
+                                  << bcos::errinfo_comment{"Null receipt returned by scheduler"});
+        }
+        if (m_state->throwStdRuntimeError)
+        {
+            throw std::runtime_error{"untreated scheduler fault"};
         }
         co_return m_state->forkchoiceUpdatedResult.payloadStatus;
     }
@@ -275,6 +318,60 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedTypedFailuresMapToSpecErrorCodes)
     Json::Value stateOnly(Json::arrayValue);
     stateOnly.append(fc);
     expectCode(stateOnly, EngineError::InvalidForkchoiceState);
+
+    mockService.m_state->throwInvalidForkchoiceState = false;
+    mockService.m_state->throwUnsupportedEngineApiVersion = true;
+    expectCode(params, EngineError::UnsupportedFork);
+}
+
+namespace
+{
+bool isShortInternalError(JsonRpcException const& e, char const* needle)
+{
+    auto const& msg = e.msg();
+    return e.code() == InternalError && msg.find("Internal error") != std::string::npos &&
+           msg.find(needle) != std::string::npos && msg.find("boost") == std::string::npos &&
+           msg.find("Diagnostic") == std::string::npos;
+}
+
+Json::Value makeForkchoiceParams()
+{
+    Json::Value params(Json::arrayValue);
+    Json::Value fc;
+    fc["headBlockHash"] = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    fc["safeBlockHash"] = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    fc["finalizedBlockHash"] = "0x3333333333333333333333333333333333333333333333333333333333333333";
+    params.append(fc);
+    return params;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(engineRpcInternalFaultsMapToShort32603)
+{
+    auto const params = makeForkchoiceParams();
+
+    mockService.m_state->throwOpExecutionInternalError = true;
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(forkchoiceUpdatedV3, params, response), JsonRpcException,
+        [](JsonRpcException const& e) {
+            return isShortInternalError(e, "Null receipt returned by scheduler");
+        });
+
+    mockService.m_state->throwOpExecutionInternalError = false;
+    mockService.m_state->throwStdRuntimeError = true;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(forkchoiceUpdatedV3, params, response), JsonRpcException,
+        [](JsonRpcException const& e) {
+            return isShortInternalError(e, "untreated scheduler fault");
+        });
+
+    mockService.m_state->throwStdRuntimeError = false;
+    mockService.m_state->throwOpExecutionInternalError = true;
+    Json::Value getParams(Json::arrayValue);
+    getParams.append("0x00000000deadbeef");
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(getPayloadV3, getParams, response), JsonRpcException,
+        [](JsonRpcException const& e) {
+            return isShortInternalError(e, "Null receipt returned by scheduler");
+        });
 }
 
 
@@ -467,6 +564,17 @@ BOOST_AUTO_TEST_CASE(getPayloadV5UnknownPayload)
         [](JsonRpcException const& e) { return e.code() == EngineError::UnknownPayload; });
 }
 
+BOOST_AUTO_TEST_CASE(getPayloadUnsupportedEngineApiVersionMapsTo38005)
+{
+    mockService.m_state->throwUnsupportedEngineApiVersion = true;
+
+    Json::Value params(Json::arrayValue);
+    params.append("0x00000000deadbeef");
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(getPayloadV3, params, response), JsonRpcException,
+        [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
+}
+
 BOOST_AUTO_TEST_CASE(getPayloadV5MissingParams)
 {
     Json::Value params(Json::arrayValue);
@@ -518,9 +626,41 @@ Json::Value makeV1ExecutionPayloadJson()
 }
 }  // namespace
 
+BOOST_AUTO_TEST_CASE(newPayloadInternalFaultsMapToShort32603)
+{
+    mockService.m_state->throwOpExecutionInternalError = true;
+
+    Json::Value params(Json::arrayValue);
+    params.append(makeV1ExecutionPayloadJson());
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV1, params, response), JsonRpcException,
+        [](JsonRpcException const& e) {
+            return isShortInternalError(e, "Null receipt returned by scheduler");
+        });
+
+    mockService.m_state->throwOpExecutionInternalError = false;
+    mockService.m_state->throwStdRuntimeError = true;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV1, params, response), JsonRpcException,
+        [](JsonRpcException const& e) {
+            return isShortInternalError(e, "untreated scheduler fault");
+        });
+}
+
 BOOST_AUTO_TEST_CASE(newPayloadUnsupportedForkMapsTo38005)
 {
     mockService.m_state->throwUnsupportedFork = true;
+
+    Json::Value params(Json::arrayValue);
+    params.append(makeV1ExecutionPayloadJson());
+
+    Json::Value response;
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(newPayloadV1, params, response), JsonRpcException,
+        [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
+}
+
+BOOST_AUTO_TEST_CASE(newPayloadUnsupportedEngineApiVersionMapsTo38005)
+{
+    mockService.m_state->throwUnsupportedEngineApiVersion = true;
 
     Json::Value params(Json::arrayValue);
     params.append(makeV1ExecutionPayloadJson());

--- a/bcos-rpc/test/unittests/rpc/EthGetStorageAtTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetStorageAtTest.cpp
@@ -149,8 +149,8 @@ public:
         storage::Entry entry;
         entry.set(bcos::bytes(value32));
         task::syncWait(storage2::writeOne(m_latestState,
-            executor_v1::StateKey{std::string(bcos::ledger::SYS_DIRECTORY::USER_APPS) +
-                                      address.hex(),
+            executor_v1::StateKey{
+                std::string(bcos::ledger::SYS_DIRECTORY::USER_APPS) + address.hex(),
                 std::string{reinterpret_cast<char const*>(slot.ref().data()), h256::SIZE}},
             std::move(entry)));
     }
@@ -346,15 +346,16 @@ BOOST_AUTO_TEST_CASE(HistoricalDormantAccountScenarioAErrors)
     m_ledger->ledgerData()[1]->blockHeader()->setStateRoot(stateRoot);
 
     std::string const dormant = "0x00000000000000000000000000000000000000cc";
-    for (auto const& [method, resp] : {std::make_pair("eth_getStorageAt", getStorageAt(dormant, "0x1", "0x1")),
-             std::make_pair("eth_getBalance", getBalance(dormant, "0x1")),
-             std::make_pair("eth_getTransactionCount", getTransactionCount(dormant, "0x1")),
-             std::make_pair("eth_getCode", getCode(dormant, "0x1"))})
+    for (auto const& [method, resp] :
+        {std::make_pair("eth_getStorageAt", getStorageAt(dormant, "0x1", "0x1")),
+            std::make_pair("eth_getBalance", getBalance(dormant, "0x1")),
+            std::make_pair("eth_getTransactionCount", getTransactionCount(dormant, "0x1")),
+            std::make_pair("eth_getCode", getCode(dormant, "0x1"))})
     {
         BOOST_REQUIRE_MESSAGE(resp.isMember("error"), method);
         BOOST_CHECK_MESSAGE(resp["error"]["code"].asInt() == -32004, method);
-        BOOST_CHECK_MESSAGE(resp["error"]["message"].asString().find("Account not in trie") !=
-                                std::string::npos,
+        BOOST_CHECK_MESSAGE(
+            resp["error"]["message"].asString().find("Account not in trie") != std::string::npos,
             method);
     }
 }
@@ -444,11 +445,11 @@ BOOST_AUTO_TEST_CASE(HistoricalMissingRootReturns32004)
     auto resp = getStorageAt(address.hexPrefixed(), "0x1", "0x1");
     BOOST_REQUIRE(resp.isMember("error"));
     BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32004);
-    BOOST_CHECK(resp["error"]["message"].asString().find("not in MPT node storage") !=
-                std::string::npos);
+    BOOST_CHECK(
+        resp["error"]["message"].asString().find("not in MPT node storage") != std::string::npos);
 }
 
-// Historical state, empty root, scenario B (round-2 Finding K): the empty root is a legal
+// Historical state, empty root, scenario B: the empty root is a legal
 // "no accounts" root — the empty trie has no node rows, so it is NOT a "root not in MPT
 // storage" error. With complete tries the absent account provably reads zero, matching
 // Ethereum semantics.
@@ -485,8 +486,8 @@ BOOST_AUTO_TEST_CASE(HistoricalEmptyRootScenarioADormantAccountErrors)
     {
         BOOST_REQUIRE_MESSAGE(resp.isMember("error"), method);
         BOOST_CHECK_MESSAGE(resp["error"]["code"].asInt() == -32004, method);
-        BOOST_CHECK_MESSAGE(resp["error"]["message"].asString().find("Account not in trie") !=
-                                std::string::npos,
+        BOOST_CHECK_MESSAGE(
+            resp["error"]["message"].asString().find("Account not in trie") != std::string::npos,
             method);
     }
 }
@@ -514,8 +515,7 @@ BOOST_AUTO_TEST_CASE(OverwidePositionReturnsInvalidParams)
     auto resp = getStorageAt(address.hexPrefixed(), overwide, "latest");
     BOOST_REQUIRE(resp.isMember("error"));
     BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32602);
-    BOOST_CHECK(resp["error"]["message"].asString().find("storage position") !=
-                std::string::npos);
+    BOOST_CHECK(resp["error"]["message"].asString().find("storage position") != std::string::npos);
 }
 
 // blockTag semantics: the default depths are 0 — PBFT commits are final, so safe/finalized
@@ -591,6 +591,25 @@ BOOST_AUTO_TEST_CASE(HistoricalBalanceFromMPT)
     m_ledger->ledgerData()[1]->blockHeader()->setStateRoot(stateRoot);
 
     auto resp = getBalance(address.hexPrefixed(), "0x1");
+    BOOST_TEST(!resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    BOOST_TEST(resp["result"].asString() == toQuantity(1000));
+}
+
+// Latest getBalance on scenario B: OP chains store balances in MPT only, so "latest" must
+// read the tip block's committed root (not the empty flat ACCOUNT_BALANCE row).
+BOOST_AUTO_TEST_CASE(LatestBalanceFromMPTOnScenarioB)
+{
+    bcos::ledger::Features features;
+    features.set(bcos::ledger::Features::Flag::feature_l2_ethereum_compat);
+    m_ledger->setFeatures(std::move(features));
+
+    buildTrie();
+    wireReader();
+    // "latest" resolves to the tip block, not an arbitrary historical height.
+    m_ledger->ledgerData().back()->blockHeader()->setStateRoot(stateRoot);
+
+    auto resp = getBalance(address.hexPrefixed(), "latest");
     BOOST_TEST(!resp.isMember("error"));
     BOOST_REQUIRE(resp.isMember("result"));
     BOOST_TEST(resp["result"].asString() == toQuantity(1000));

--- a/bcos-rpc/test/unittests/rpc/FeeHistoryTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/FeeHistoryTest.cpp
@@ -1,0 +1,307 @@
+/**
+ * Copyright (C) 2026 FISCO BCOS.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file FeeHistoryTest.cpp
+ * @brief eth_feeHistory helpers: EIP-1559 / OP base-fee prediction and DA-cap wiring.
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-framework/testutils/faker/FakeLedger.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/FeeHistory.h>
+#include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+using namespace bcostars::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+BlockHeaderImpl makeLondonParent(bcos::u256 gasLimit, bcos::u256 gasUsed, bcos::u256 baseFee)
+{
+    BlockHeaderImpl header;
+    header.setEthBlockVersion(bcos::protocol::EthBlockVersion::LONDON);
+    header.setGasLimit(gasLimit);
+    header.setGasUsed(gasUsed);
+    header.setBaseFee(baseFee);
+    return header;
+}
+
+/// OP-Stack headers: ethBlockVersion stays NON_ETH (rebuildOpEthHeader deliberately
+/// skips setEthBlockVersion) but every Shanghai+ fork field is stamped.
+BlockHeaderImpl makeOpHeader(bcos::u256 baseFee)
+{
+    BlockHeaderImpl header;
+    header.setEthBlockVersion(bcos::protocol::EthBlockVersion::NON_ETH);
+    header.setWithdrawalsRoot(bcos::crypto::HashType(1));
+    header.setBaseFee(baseFee);
+    return header;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(FeeHistoryTest)
+
+BOOST_AUTO_TEST_CASE(opHeaderBaseFeeIsReportedNotZeroed)
+{
+    // Regression: a NON_ETH short-circuit in the base-fee read made eth_feeHistory report
+    // 0x0 for every OP block (and compute rewards against a zero base fee), because OP
+    // headers are NON_ETH yet carry a real base fee.
+    auto const opHeader = makeOpHeader(7);
+    BOOST_CHECK_EQUAL(blockBaseFee(opHeader), bcos::u256(7));
+
+    // A native FISCO NON_ETH header (no withdrawalsRoot / baseFee) still reads 0.
+    BlockHeaderImpl nativeHeader;
+    nativeHeader.setEthBlockVersion(bcos::protocol::EthBlockVersion::NON_ETH);
+    BOOST_CHECK_EQUAL(blockBaseFee(nativeHeader), bcos::u256(0));
+
+    // Pre-London Eth header: the field is not part of the shape, so 0 even if set.
+    BlockHeaderImpl preLondon;
+    preLondon.setEthBlockVersion(bcos::protocol::EthBlockVersion::PRE_LONDON);
+    preLondon.setBaseFee(bcos::u256(9));
+    BOOST_CHECK_EQUAL(blockBaseFee(preLondon), bcos::u256(0));
+
+    // London Eth header: the header's own value.
+    auto const london = makeLondonParent(30'000'000, 15'000'000, 11);
+    BOOST_CHECK_EQUAL(blockBaseFee(london), bcos::u256(11));
+}
+
+BOOST_AUTO_TEST_CASE(ethNextBaseFeeHoldsAtTarget)
+{
+    auto parent = makeLondonParent(30'000'000, 15'000'000, 1'000'000'000);
+    auto const next = calcEthNextBaseFee(parent);
+    BOOST_CHECK_EQUAL(next, bcos::u256(1'000'000'000));
+}
+
+BOOST_AUTO_TEST_CASE(opNextBaseFeeFallsBackWithoutHoloceneExtraData)
+{
+    auto parent = makeLondonParent(30'000'000, 0, 1'000'000'000);
+    auto const next = calcOpNextBaseFee(parent);
+    BOOST_CHECK_EQUAL(next, bcos::u256(1'000'000'000));
+}
+
+/// A Holocene-shaped parent is NOT genesis-adjacent: calcOpBaseFee's own fail-closed
+/// errors must surface instead of being swallowed into the fallback. The previous
+/// catch (...) returned the parent fee here, hiding a corrupt header.
+BOOST_AUTO_TEST_CASE(opNextBaseFeeThrowsOnHoloceneShapedParentMissingBaseFee)
+{
+    // Same shape as makeLondonParent but with baseFee left UNENGAGED (setBaseFee(0) would
+    // engage it): calcOpBaseFee must throw, not degrade to the parent fee.
+    BlockHeaderImpl parent;
+    parent.setEthBlockVersion(bcos::protocol::EthBlockVersion::LONDON);
+    parent.setGasLimit(30'000'000);
+    parent.setGasUsed(0);
+    // 9-byte Holocene extraData: version 0x00 || denominator(250) || elasticity(6).
+    bcos::bytes extra;
+    extra.push_back(0x00);
+    for (int shift : {24, 16, 8, 0})
+        extra.push_back(static_cast<bcos::byte>((250U >> shift) & 0xff));
+    for (int shift : {24, 16, 8, 0})
+        extra.push_back(static_cast<bcos::byte>((6U >> shift) & 0xff));
+    parent.setExtraData(extra);
+    // InvalidEngineEncoding carries several distinct fail-closed messages, so pin the reason:
+    // a wrong guard that throws the same type for another shape must not pass.
+    BOOST_CHECK_EXCEPTION((void)calcOpNextBaseFee(parent), bcos::engine::InvalidEngineEncoding,
+        [](bcos::engine::InvalidEngineEncoding const& e) {
+            return std::string(e.what()).find("missing baseFee") != std::string::npos;
+        });
+}
+
+BOOST_AUTO_TEST_CASE(effectivePriorityFeePerGasBranches)
+{
+    using bcostars::protocol::TransactionImpl;
+    auto feeTx = [](std::string priority, std::string gasPrice, std::string maxFee) {
+        TransactionImpl tx;
+        tx.mutableInner().data.maxPriorityFeePerGas = std::move(priority);
+        tx.mutableInner().data.gasPrice = std::move(gasPrice);
+        tx.mutableInner().data.maxFeePerGas = std::move(maxFee);
+        return tx;
+    };
+    // Explicit priority below the cap: the tip is the priority.
+    BOOST_CHECK_EQUAL(
+        effectivePriorityFeePerGas(feeTx("0x2", "", "0xa"), bcos::u256(1)), bcos::u256(2));
+    // Priority above maxFee - baseFee: capped by the fee cap.
+    BOOST_CHECK_EQUAL(
+        effectivePriorityFeePerGas(feeTx("0x9", "", "0x5"), bcos::u256(1)), bcos::u256(4));
+    // Legacy gasPrice above baseFee, no priority: tip = gasPrice - baseFee.
+    BOOST_CHECK_EQUAL(
+        effectivePriorityFeePerGas(feeTx("", "0x7", ""), bcos::u256(2)), bcos::u256(5));
+    // gasPrice at or below baseFee: no tip.
+    BOOST_CHECK_EQUAL(
+        effectivePriorityFeePerGas(feeTx("", "0x1", ""), bcos::u256(2)), bcos::u256(0));
+}
+
+BOOST_AUTO_TEST_CASE(pickRewardPercentilesKeepsZeroTipSamples)
+{
+    // geth keeps zero-tip transactions in the weighted sample set (it sorts every tx in the
+    // block); the percentile boundary can land on one, so the helper must not filter them.
+    std::vector<GasWeightedPriorityFee> samples{{0, 21'000}, {5, 21'000}};
+    auto rewards = pickRewardPercentiles(samples, std::vector<double>{10.0});
+    BOOST_REQUIRE_EQUAL(rewards.size(), 1);
+    BOOST_CHECK_EQUAL(rewards[0], 0);
+}
+
+BOOST_AUTO_TEST_CASE(pickRewardPercentilesGasWeighted)
+{
+    // Equal gas: geth walks cumulative gas, not tx-count index (75th -> highest tip).
+    std::vector<GasWeightedPriorityFee> equalGas{{1, 21'000}, {3, 21'000}, {9, 21'000}};
+    std::vector<double> percentiles{25.0, 50.0, 75.0};
+    auto rewards = pickRewardPercentiles(equalGas, percentiles);
+    BOOST_REQUIRE_EQUAL(rewards.size(), 3);
+    BOOST_CHECK_EQUAL(rewards[0], 1);
+    BOOST_CHECK_EQUAL(rewards[1], 3);
+    BOOST_CHECK_EQUAL(rewards[2], 9);
+
+    // Unequal gas: the 50th percentile lands on the high-gas low-tip tx.
+    std::vector<GasWeightedPriorityFee> skewed{{1, 10'000}, {3, 90'000}};
+    std::vector<double> halfPercentile{50.0};
+    auto skewedRewards = pickRewardPercentiles(skewed, halfPercentile);
+    BOOST_REQUIRE_EQUAL(skewedRewards.size(), 1);
+    BOOST_CHECK_EQUAL(skewedRewards[0], 3);
+}
+
+BOOST_AUTO_TEST_CASE(pickRewardPercentilesSingleSweepMatchesBoundaries)
+{
+    // Boundaries exactly on a cumulative sum, plus 0 / 100: the prefix-sum + binary-search
+    // rewrite must return the same samples the previous per-percentile rescan did.
+    // gas 10k / 20k / 70k (total 100k) -> cumulative 10k / 30k / 100k.
+    std::vector<GasWeightedPriorityFee> samples{{7, 10'000}, {5, 20'000}, {3, 70'000}};
+    std::vector<double> percentiles{0.0, 10.0, 30.0, 30.1, 99.0, 100.0};
+    auto rewards = pickRewardPercentiles(samples, percentiles);
+    BOOST_REQUIRE_EQUAL(rewards.size(), 6);
+    BOOST_CHECK_EQUAL(rewards[0], 7);  // 0% -> first sample
+    BOOST_CHECK_EQUAL(rewards[1], 7);  // threshold 10k == first cumulative sum
+    BOOST_CHECK_EQUAL(rewards[2], 5);  // threshold 30k == second cumulative sum
+    BOOST_CHECK_EQUAL(rewards[3], 3);  // just past the second boundary
+    BOOST_CHECK_EQUAL(rewards[4], 3);
+    BOOST_CHECK_EQUAL(rewards[5], 3);  // 100% -> last sample
+
+    // All-zero gas weights collapse to zero rewards instead of dividing by zero.
+    std::vector<GasWeightedPriorityFee> zeroGas{{1, 0}, {2, 0}};
+    auto zeroRewards = pickRewardPercentiles(zeroGas, std::vector<double>{25.0, 75.0});
+    BOOST_REQUIRE_EQUAL(zeroRewards.size(), 2);
+    BOOST_CHECK_EQUAL(zeroRewards[0], 0);
+    BOOST_CHECK_EQUAL(zeroRewards[1], 0);
+}
+
+/// End-to-end weighting pin: rewards must follow the receipt's gasUsed, not the tx's
+/// gasLimit. Two txs whose two weightings disagree: A has the low tip and a huge gasLimit
+/// but consumes almost nothing; B has the higher tip and consumes its full limit.
+/// gasUsed-weighting puts the 50th percentile on B; gasLimit-weighting would put it on A.
+BOOST_AUTO_TEST_CASE(buildFeeHistoryWeightsRewardsByReceiptGasUsed)
+{
+    auto suite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    auto blockFactory = std::make_shared<bcostars::protocol::BlockFactoryImpl>(suite,
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(suite),
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(suite),
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(suite));
+    auto ledger = std::make_shared<bcos::test::FakeLedger>(blockFactory, /*blocks=*/2, 0, 0);
+
+    auto block = ledger->ledgerData()[1];
+    BOOST_REQUIRE(block);
+    auto makeTx = [&](std::string priority, int64_t gasLimit) {
+        // version 1: the V0 branch of the factory zeroes every fee field.
+        return blockFactory->transactionFactory()->createTransaction(1,
+            "0x1234567890123456789012345678901234567890", bcos::bytes{}, "0x1", 100, "chain0",
+            "group0", 0, /*abi=*/"", /*value=*/"0x0", /*gasPrice=*/"", gasLimit,
+            /*maxFeePerGas=*/"0x4a817c800", std::move(priority));
+    };
+    auto makeReceipt = [&](bcos::u256 gasUsed) {
+        return blockFactory->receiptFactory()->createReceipt(gasUsed,
+            "0x1234567890123456789012345678901234567890", {}, /*status=*/0, bcos::bytesConstRef{},
+            /*blockNumber=*/1);
+    };
+    // A: tip 1, gasLimit 1'000'000, gasUsed 10'000.
+    block->appendTransaction(makeTx("0x1", 1'000'000));
+    block->appendReceipt(makeReceipt(bcos::u256(10'000)));
+    // B: tip 2, gasLimit 21'000, gasUsed 21'000.
+    block->appendTransaction(makeTx("0x2", 21'000));
+    block->appendReceipt(makeReceipt(bcos::u256(21'000)));
+
+    auto result = bcos::task::syncWait(buildFeeHistory(*ledger, /*newestBlock=*/1,
+        /*blockCount=*/1, std::vector<double>{50.0}, /*opStackMode=*/false));
+    BOOST_REQUIRE(result.isMember("reward"));
+    BOOST_REQUIRE_EQUAL(result["reward"].size(), 1U);
+    BOOST_REQUIRE_EQUAL(result["reward"][0U].size(), 1U);
+    // 50% of 31'000 gasUsed = 15'500: past A (10'000) and inside B -> B's tip (2).
+    BOOST_CHECK_EQUAL(result["reward"][0U][0U].asString(), toQuantity(bcos::u256(2)));
+}
+
+/// The reward path loads full block bodies (txs + receipts) per block, so it is capped tighter
+/// than the header-only path: geth's 1024 assumes a fee-history cache this implementation does
+/// not have. An out-of-range request is rejected (op-geth's resolveBlockRange errors on
+/// blocks < 1 or > maxQueryLimit) instead of being silently shortened, and blockCount 0 must
+/// never answer a shape-violating empty object.
+BOOST_AUTO_TEST_CASE(buildFeeHistoryRejectsOutOfRangeBlockCount)
+{
+    auto suite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    auto blockFactory = std::make_shared<bcostars::protocol::BlockFactoryImpl>(suite,
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(suite),
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(suite),
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(suite));
+    auto ledger = std::make_shared<bcos::test::FakeLedger>(blockFactory, /*blocks=*/201, 0, 0);
+
+    // Rewards: 1000 blocks is over the 128-block body-loading bound -> rejected, not shortened.
+    BOOST_CHECK_THROW(bcos::task::syncWait(buildFeeHistory(*ledger, /*newestBlock=*/200,
+                          /*blockCount=*/1000, std::vector<double>{50.0}, /*opStackMode=*/false)),
+        JsonRpcException);
+
+    // The 128-block bound itself is served: newest 200, 128 blocks -> oldest 200 - 127 = 73.
+    auto atBound = bcos::task::syncWait(buildFeeHistory(*ledger, /*newestBlock=*/200,
+        /*blockCount=*/128, std::vector<double>{50.0}, /*opStackMode=*/false));
+    BOOST_CHECK_EQUAL(atBound["oldestBlock"].asString(), toQuantity(bcos::u256(73)));
+    BOOST_CHECK_EQUAL(atBound["baseFeePerGas"].size(), 129U);  // 128 blocks + trailing fee
+
+    // Headers only: 1000 is under the 1024 query limit -> served.
+    auto headersOnly = bcos::task::syncWait(buildFeeHistory(*ledger, /*newestBlock=*/200,
+        /*blockCount=*/1000, /*rewardPercentiles=*/{}, /*opStackMode=*/false));
+    BOOST_CHECK_EQUAL(headersOnly["oldestBlock"].asString(), toQuantity(bcos::u256(0)));
+    BOOST_CHECK_EQUAL(headersOnly["baseFeePerGas"].size(), 202U);  // 201 blocks + trailing fee
+    BOOST_CHECK(!headersOnly.isMember("reward"));
+
+    // Over the geth query limit, and a zero count, are both InvalidParams.
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(buildFeeHistory(*ledger, /*newestBlock=*/200, /*blockCount=*/1025,
+            /*rewardPercentiles=*/{}, /*opStackMode=*/false)),
+        JsonRpcException);
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(buildFeeHistory(*ledger, /*newestBlock=*/200, /*blockCount=*/0,
+            /*rewardPercentiles=*/{}, /*opStackMode=*/false)),
+        JsonRpcException);
+}
+
+BOOST_AUTO_TEST_CASE(pickRewardPercentilesTruncatesThresholdLikeOpGeth)
+{
+    // op-geth truncates the threshold to uint64 before the comparison
+    // (uint64(float64(blockGasUsed) * p / 100)); with total = 101 and p = 50 that is 50, not
+    // 50.5, so the sample whose cumulative gas is exactly 50 is the boundary.
+    std::vector<GasWeightedPriorityFee> samples{{1, 50}, {2, 51}};
+    auto rewards = pickRewardPercentiles(samples, std::vector<double>{50.0});
+    BOOST_REQUIRE_EQUAL(rewards.size(), 1);
+    BOOST_CHECK_EQUAL(rewards[0], 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -10,6 +10,9 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h>
+#include <bcos-task/Wait.h>
 #include <boost/test/unit_test.hpp>
 #include <future>
 #include <string_view>
@@ -227,6 +230,82 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)
     auto resp = call(req("eth_sendRawTransaction", R"(["0xdeadbeef"])"));
     BOOST_CHECK(resp.isMember("error") || resp.isMember("result"));
     BOOST_CHECK(resp.isMember("id"));
+}
+
+BOOST_AUTO_TEST_CASE(feeHistoryRegisteredAndDACapRpcDeferred)
+{
+    // Check handler registration directly; a generic RPC error is not enough.
+    EndpointsMapping publicMapping(/*enableOPEngine=*/false);
+    BOOST_CHECK_MESSAGE(
+        publicMapping.findHandler("eth_feeHistory").has_value(), "eth_feeHistory not dispatched");
+    BOOST_CHECK_MESSAGE(!publicMapping.findHandler("miner_setMaxDASize").has_value(),
+        "miner_setMaxDASize must not be exposed on public web3_rpc");
+
+    EndpointsMapping engineMapping(/*enableOPEngine=*/true);
+    // Not registered on op_engine_rpc either: no production consumer reads DACaps yet, so the
+    // batcher must keep failing loudly (MethodNotFound) instead of being told `true` and
+    // sizing its channel frames against a cap nothing applies. The RPC lands with the
+    // OpEngineService cutover, together with its reader.
+    BOOST_CHECK_MESSAGE(!engineMapping.findHandler("miner_setMaxDASize").has_value(),
+        "miner_setMaxDASize must not be dispatched before a DA-cap consumer exists");
+
+    // And the endpoint stays reachable through the real dispatch path. Require an actual
+    // result: accepting any error other than -32601 would pass even if the handler always
+    // failed, which is exactly what this test is meant to rule out.
+    auto resp = call(req("eth_feeHistory", R"(["0x1","latest"])"));
+    BOOST_REQUIRE_MESSAGE(
+        resp.isMember("result"), "eth_feeHistory dispatch failed: " + resp.toStyledString());
+    BOOST_CHECK(resp["result"].isMember("oldestBlock"));
+    BOOST_CHECK(resp["result"].isMember("baseFeePerGas"));
+    BOOST_CHECK(resp["result"].isMember("gasUsedRatio"));
+}
+
+BOOST_AUTO_TEST_CASE(estimateGasWithoutLedgerFailsClosed)
+{
+    // eth_estimateGas sizes its gas cap from the target block's header, so a node with no
+    // ledger must refuse the request with InternalError. The chore(style) commit deleted that
+    // guard and let the cap fall back to a hardcoded 30'000'000 instead.
+    auto noLedgerService = std::make_shared<rpc::NodeService>(
+        nullptr, scheduler, nullptr, nullptr, nullptr, m_blockFactory, nullptr);
+    auto endpoint = std::make_shared<EthEndpoint>(noLedgerService, nullptr, false);
+
+    Json::Value params(Json::arrayValue);
+    Json::Value tx(Json::objectValue);
+    tx["to"] = "0x1234567890abcdef1234567890abcdef12345678";
+    tx["data"] = "0x";
+    params.append(tx);
+    params.append("0x1");
+
+    Json::Value response;
+    try
+    {
+        task::syncWait(endpoint->estimateGas(params, response));
+        BOOST_FAIL("eth_estimateGas must not succeed without a ledger");
+    }
+    catch (JsonRpcException const& error)
+    {
+        BOOST_CHECK_EQUAL(error.code(), static_cast<int32_t>(JsonRpcError::InternalError));
+        BOOST_CHECK_EQUAL(error.msg(), "Ledger not available for eth_estimateGas");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(callRejectsMalformedFromAddress)
+{
+    // A malformed `from` used to be passed straight to the scheduler as a storage table name:
+    // the read threw, SchedulerManager swallowed it into nullopt, and the request continued
+    // with the sender's stale state nonce plus a WARNING per call. It must be InvalidParams.
+    auto resp = call(req("eth_call",
+        R"([{"from":"not_an_address","to":"0x1234567890abcdef1234567890abcdef12345678","data":"0x"},"latest"])"));
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32602);
+
+    // A well-formed `from` still reaches execution (no InvalidParams).
+    auto ok = call(req("eth_call",
+        R"([{"from":"0x1234567890abcdef1234567890abcdef12345678","to":"0x1234567890abcdef1234567890abcdef12345678","data":"0x"},"latest"])"));
+    if (ok.isMember("error"))
+    {
+        BOOST_CHECK_NE(ok["error"]["code"].asInt(), -32602);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -10,6 +10,7 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-crypto/ChecksumAddress.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
@@ -223,12 +224,11 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     header->setNumber(7);
     header->setTimestamp(1700000000 * 1000LL);  // BlockHeader milliseconds == 1700000000 s
     header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
-    header->setParentInfo(
-        bcos::protocol::ParentInfo{.blockNumber = 6,
-            .blockHash = bcos::crypto::HashType(
-                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
-    header->setUncleHash(
-        bcos::crypto::HashType("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 6,
+        .blockHash = bcos::crypto::HashType(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
+    header->setUncleHash(bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
     header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
     header->setDifficulty(bcos::u256(0));
     header->setNonce(bcos::h64(0));
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
         bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
     header->setReceiptsRoot(
         bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
-    bcos::Bloom bloom;
+    bcos::Bloom bloom{};
     bloom[0] = 0xab;
     header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
     header->setBaseFee(bcos::u256(1000000000));
@@ -311,10 +311,9 @@ static std::shared_ptr<bcos::protocol::Block> makeEthHeaderBlock(
     header->setNumber(7);
     header->setTimestamp(1700000000 * 1000LL);  // BlockHeader milliseconds == 1700000000 s
     header->setEthBlockVersion(version);
-    header->setParentInfo(
-        bcos::protocol::ParentInfo{.blockNumber = 6,
-            .blockHash = bcos::crypto::HashType(
-                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
+    header->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 6,
+        .blockHash = bcos::crypto::HashType(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
     header->setUncleHash(bcos::crypto::HashType(
         "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
     header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
@@ -330,7 +329,7 @@ static std::shared_ptr<bcos::protocol::Block> makeEthHeaderBlock(
         bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
     header->setReceiptsRoot(
         bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
-    bcos::Bloom bloom;
+    bcos::Bloom bloom{};
     bloom[0] = 0xab;
     header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
     if (baseFee)
@@ -360,6 +359,69 @@ static std::shared_ptr<bcos::protocol::Block> makeEthHeaderBlock(
     header->calculateHash(*hashImpl);
     block->setBlockHeader(header);
     return block;
+}
+
+BOOST_AUTO_TEST_CASE(combineBlockResponseOpNonEthUsesRlpIdentityHashAndPrevRandao)
+{
+    auto block = m_blockFactory->createBlock();
+    auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(1);
+    header->setTimestamp(1700000000 * 1000LL);
+    header->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 0,
+        .blockHash = bcos::crypto::HashType(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
+    header->setCoinbase(bcos::Address("4200000000000000000000000000000000000011"));
+    header->setUncleHash(
+        bcos::h256("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setDifficulty(bcos::u256(0));
+    header->setNonce(bcos::h64(0));
+    header->setPrevRandao(
+        bcos::h256("62293916ac98bc02b90472638bd2beb1b531a914395c34239abe6fc011b9011a"));
+    header->setGasLimit(bcos::u256(30000000));
+    header->setGasUsed(bcos::u256(21000));
+    header->setStateRoot(
+        bcos::h256("4444444444444444444444444444444444444444444444444444444444444444"));
+    header->setTxsRoot(
+        bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
+    header->setReceiptsRoot(
+        bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
+    // Value-initialised: bcos::Bloom is a std::array with no default initialisation, so
+    // `Bloom bloom;` would leave 255 bytes indeterminate and make the header hash vary run
+    // to run (which is why this case could only ever compare the code to itself).
+    bcos::Bloom bloom{};
+    bloom[0] = 0xcd;
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    header->setExtraData(bcos::bytes{0x01, 0x00, 0x00, 0x00, 0xfa, 0x00, 0x00, 0x00, 0x06, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    header->setBaseFee(bcos::u256(1000000000));
+    header->setWithdrawalsRoot(
+        bcos::h256("2222222222222222222222222222222222222222222222222222222222222222"));
+    header->setBlobGasUsed(bcos::u256(0));
+    header->setExcessBlobGas(bcos::u256(0));
+    header->setParentBeaconBlockRoot(
+        bcos::h256("3333333333333333333333333333333333333333333333333333333333333333"));
+    header->setRequestsHash(
+        bcos::h256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    header->calculateHash(*hashImpl);
+    auto const tarsHash = header->hash();
+    auto const rlpHash = bcos::protocol::EthBlockHeader::computeHash(*header);
+    BOOST_CHECK(tarsHash != rlpHash);
+    block->setBlockHeader(header);
+
+    Json::Value result(Json::objectValue);
+    combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+    // Golden literal, independent of the code under test: the header is fully deterministic
+    // now that the bloom is value-initialised, so a change to the RLP identity hash or to
+    // any hashed field fails here instead of comparing the production function to itself.
+    BOOST_CHECK_EQUAL(result["hash"].asString(),
+        "0x2aa80e9130ed69be2160c354c483adf10e39d7ed2d899ba7dd22c39d4136f8b4");
+    BOOST_CHECK_NE(result["hash"].asString(), tarsHash.hexPrefixed());
+    BOOST_CHECK_EQUAL(result["mixHash"].asString(),
+        "0x62293916ac98bc02b90472638bd2beb1b531a914395c34239abe6fc011b9011a");
+    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x3b9aca00");
+    BOOST_CHECK(result.isMember("withdrawalsRoot"));
+    BOOST_CHECK(result.isMember("requestsHash"));
 }
 
 // The fork-gated key matrix must match geth's eth_getBlock* shape exactly: LONDON has only
@@ -396,20 +458,20 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthForkShapesGateKeys)
         std::optional<bcos::h256> requestsHash;
         if (c.expectWithdrawals)
         {
-            withdrawalsRoot = bcos::h256(
-                "2222222222222222222222222222222222222222222222222222222222222222");
+            withdrawalsRoot =
+                bcos::h256("2222222222222222222222222222222222222222222222222222222222222222");
         }
         if (c.expectBlobTrio)
         {
             blobGasUsed = bcos::u256(0);
             excessBlobGas = bcos::u256(0);
-            parentBeaconBlockRoot = bcos::h256(
-                "3333333333333333333333333333333333333333333333333333333333333333");
+            parentBeaconBlockRoot =
+                bcos::h256("3333333333333333333333333333333333333333333333333333333333333333");
         }
         if (c.expectRequestsHash)
         {
-            requestsHash = bcos::h256(
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+            requestsHash =
+                bcos::h256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
         }
         auto block = makeEthHeaderBlock(m_blockFactory, hashImpl, c.version, baseFee,
             withdrawalsRoot, blobGasUsed, excessBlobGas, parentBeaconBlockRoot, requestsHash);
@@ -476,6 +538,47 @@ BOOST_AUTO_TEST_CASE(combineReceiptResponseShapesReceipt)
     BOOST_CHECK(result.isMember("gasUsed"));
     BOOST_CHECK(result.isMember("logs"));
     BOOST_CHECK(result["logs"].isArray());
+}
+
+/// The per-log branch needs a NON-EMPTY logs vector: log.address must be the EIP-55
+/// checksum of the raw 20 bytes and log.transactionIndex a hex quantity. The base emitted
+/// toQuantity(transactionIndex) on an already-hex string ("0x307833") and the raw-byte
+/// address, so this case is the regression pin for both fixes.
+BOOST_AUTO_TEST_CASE(combineReceiptResponseEmitsLogAddressAndIndex)
+{
+    auto txFactory = m_blockFactory->transactionFactory();
+    auto tx = txFactory->createTransaction(0, "0x1234567890123456789012345678901234567890",
+        bcos::bytes{0x0a}, "0x2", 100, chainId, groupId, 0);
+    BOOST_REQUIRE(tx);
+
+    // EIP-55 test vector: 0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed must checksum to the
+    // mixed-case form below.
+    bcos::bytes const logAddress = bcos::fromHex("5aaeb6053f3e94c9b9a09f33669435e7ef1beaed");
+    bcos::h256s const topics{
+        bcos::h256("0000000000000000000000000000000000000000000000000000000000000001")};
+    std::vector<bcos::protocol::LogEntry> logs;
+    logs.emplace_back(logAddress, topics, bcos::bytes{0x01, 0x02});
+
+    auto receiptFactory = m_blockFactory->receiptFactory();
+    auto receipt = receiptFactory->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", logs, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    BOOST_REQUIRE(receipt);
+    receipt->setTransactionIndex(3);
+
+    bcos::crypto::HashType blockHash;
+    Json::Value result(Json::objectValue);
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    BOOST_REQUIRE_EQUAL(result["logs"].size(), 1U);
+    auto const& log = result["logs"][0U];
+    BOOST_CHECK_EQUAL(log["address"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+    BOOST_CHECK_EQUAL(log["transactionIndex"].asString(), "0x3");
+    BOOST_CHECK_EQUAL(log["logIndex"].asString(), "0x0");
+    BOOST_REQUIRE_EQUAL(log["topics"].size(), 1U);
+    BOOST_CHECK_EQUAL(log["topics"][0U].asString(), topics[0].hexPrefixed());
+    BOOST_CHECK_EQUAL(log["data"].asString(), "0x0102");
+    BOOST_CHECK_EQUAL(log["removed"].asBool(), false);
 }
 
 BOOST_AUTO_TEST_CASE(combineReceiptResponseEmitsOpExtensionFieldsFromMeta)

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/view/concat.hpp>
@@ -101,6 +102,13 @@ u256 safeCastToU256(const concepts::StringLike auto& value)
     {
         return {};
     }
+}
+
+/// True when @a value fits in uint64_t without truncation.
+[[nodiscard]] inline bool u256FitsUint64(u256 const& value)
+{
+    static u256 const c_maxU64(std::numeric_limits<std::uint64_t>::max());
+    return value <= c_maxU64;
 }
 
 template <class T>

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -122,6 +122,10 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
             nodeConfig->eestReplayMode() ? bcos::txvalidator::AdmissionContext::EESTReplay :
                                            bcos::txvalidator::AdmissionContext::PoolAdmission);
     }
+    if (auto daCaps = m_nodeInitializer->daCaps())
+    {
+        nodeService->setDaCaps(daCaps);
+    }
 
     // create rpc
     RpcFactory rpcFactory(nodeConfig->chainId(), m_gateway, keyFactory,

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -54,6 +54,7 @@
 #include <bcos-crypto/hasher/AnyHasher.h>
 #include <bcos-crypto/interfaces/crypto/CommonType.h>
 #include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-framework/engine/DACaps.h>
 #include <bcos-framework/executor/NativeExecutionMessage.h>
 #include <bcos-framework/executor/ParallelTransactionExecutorInterface.h>
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
@@ -401,6 +402,11 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     // any case requires an on-chain EVM revision (buildPayload fails closed without one),
     // so the escape hatch can no longer build payloads; production configs must never set
     // it.
+    if (m_nodeConfig->enableOpEngineRpc())
+    {
+        m_daCaps = std::make_shared<bcos::engine::DACaps>();
+    }
+
     if (m_nodeConfig->enableOpEngineRpc() && engineApiForV1Only)
     {
         if (!m_nodeConfig->opEngineAllowV1Executor())

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -61,7 +61,8 @@ class SchedulerInterface;
 namespace engine
 {
 class AnyEngineService;
-}
+struct DACaps;
+}  // namespace engine
 namespace single_consensus
 {
 class SingleNodeConsensus;
@@ -103,6 +104,7 @@ public:
         return m_engineServiceInitializer;
     }
     std::shared_ptr<bcos::engine::AnyEngineService> engineService();
+    std::shared_ptr<bcos::engine::DACaps> daCaps() const { return m_daCaps; }
 
     std::shared_ptr<bcos::single_consensus::SingleNodeConsensus> singleNodeConsensus()
     {
@@ -191,6 +193,7 @@ private:
 #endif
     std::shared_ptr<GlobalStateStorageInitializer> m_globalStateStorageInitializer;
     std::shared_ptr<EngineServiceInitializer> m_engineServiceInitializer;
+    std::shared_ptr<bcos::engine::DACaps> m_daCaps;
     std::shared_ptr<bcos::single_consensus::SingleNodeConsensus> m_singleNodeConsensus;
     std::shared_ptr<executor_v1::PrecompiledManager> m_precompiledManager;
     bcos::storage::TransactionalStorageInterface::Ptr m_storage = nullptr;


### PR DESCRIPTION
## Summary

The OP Web3 RPC surface, split out of #5566 so it can be built and tested on its own. Contains
only the RPC layer:

- **`eth_feeHistory`** (`FeeHistory.{h,cpp}` + the `EthEndpoint` handler): EIP-1559 base-fee
  history and OP base-fee prediction, reward percentiles weighted by receipt `gasUsed` the way
  op-geth does (`uint64(float64(blockGasUsed) * p / 100)`, first prefix sum `>=` the threshold,
  last sample when nothing reaches it), percentile range + monotonicity + the 100-entry cap, and
  `blockCount` rejected with `InvalidParams` when 0 / over 1024 / over the 128-block reward bound.
- **`EthEndpoint`**: `eth_estimateGas` fail-closed gas-cap guards (no hardcoded fallback), `from`
  validated at the RPC boundary, and the awaited pending-nonce read.
- **`CallRequest` / `BlockResponse` / `ReceiptResponse`**: nonce and gas defaults, the
  `transactionIndex` quantity fix, and OP header base-fee reporting.
- **`EngineEndpoint`**: the short `-32603` catch ladder (reason echoed, boost diagnostics not —
  `EngineRpcTest` pins both halves).
- **`NodeService` / `Initializer` / `AirNodeInitializer`**: the `DACaps` handshake seam. It stays
  inert here too — no `miner_setMaxDASize` writer is registered, so a batcher still fails loudly
  instead of being told `true` for a cap nothing applies.

Two small prerequisites are carried here as well because the engine PR keeps its own copies and
uses them too: `OpBaseFee.h`'s `throwOpBaseFeeError` (domain-typed guards) and
`DataConvertUtility.h`'s `u256FitsUint64`. The two PRs will therefore show a trivial conflict on
those files when the second one lands.

## Test plan

- [x] `cmake --build build --target test-bcos-rpc init`
- [x] `test-bcos-rpc` (all suites green)
- [x] `FeeHistoryTest` (threshold truncation, reward weighting, out-of-range rejection),
      `CallRequestTest` (gas cap incl. explicit zero), `Web3EthMethodsTest` (feeHistory reachable
      and `miner_setMaxDASize` not registered on either listener), `Web3ResponseTest`,
      `EngineRpcTest` (short -32603)

Refs #5566, #5550


