### PR TITLE
feat(tx-validator): reject FISCO-native transactions on an L2 chain

### DIFF
--- a/bcos-executor/test/unittest/libprecompiled/SystemConfigPrecompileTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/SystemConfigPrecompileTest.cpp
@@ -220,4 +220,32 @@ BOOST_AUTO_TEST_CASE(web3ChainIdSharesParseWeb3ChainId)
     BOOST_CHECK_THROW(trySet("4294967296"), PrecompiledError);
 }
 
+// feature_l2_ethereum_compat is genesis-only. Features::validate refuses it, and this pins the
+// refusal where an operator meets it: the governance setValueByKey transaction, which must fail
+// rather than turn L2 mode on for a chain that was not born one. The message matters too --
+// SystemConfigPrecompiled re-throws the errinfo_comment verbatim (SystemConfigPrecompiled.cpp:334)
+// so what is asserted here is the revert reason the caller sees.
+BOOST_AUTO_TEST_CASE(genesisOnlyFeatureIsRefusedByGovernance)
+{
+    SystemConfigPrecompiled systemConfigPrecompiled(hashImpl);
+    auto setParameters = std::make_shared<PrecompiledExecResult>();
+    CodecWrapper codec(hashImpl);
+
+    auto setInput = codec.encodeWithSig("setValueByKey(string,string)",
+        std::string("feature_l2_ethereum_compat"), std::string("1"));
+    setParameters->m_input = bcos::ref(setInput);
+    BOOST_CHECK_EXCEPTION(systemConfigPrecompiled.call(executive, setParameters), PrecompiledError,
+        [](PrecompiledError const& e) {
+            auto const* msg = boost::get_error_info<bcos::errinfo_comment>(e);
+            return msg != nullptr && msg->find("genesis-only") != std::string::npos;
+        });
+
+    // The refusal is the feature rule, not the unknown-key rule: the key IS recognised, so a
+    // neighbouring genesis-era feature on the same channel is still settable by governance.
+    setInput = codec.encodeWithSig(
+        "setValueByKey(string,string)", std::string("feature_op_jovian"), std::string("1"));
+    setParameters->m_input = bcos::ref(setInput);
+    BOOST_CHECK_NO_THROW(systemConfigPrecompiled.call(executive, setParameters));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-framework/bcos-framework/ledger/Features.cpp
+++ b/bcos-framework/bcos-framework/ledger/Features.cpp
@@ -44,6 +44,25 @@ void Features::validate(Flag flag) const
         BOOST_THROW_EXCEPTION(bcos::tool::InvalidSetFeature{}
                               << errinfo_comment("must set feature_balance_precompiled first"));
     }
+    // Genesis-only. validate() has exactly one production caller --
+    // SystemConfigPrecompiled::validate (SystemConfigPrecompiled.cpp:309), the governance
+    // setSystemConfig path, which reaches this overload through the string overload above --
+    // while genesis loading calls set() directly, so rejecting here bars post-genesis activation
+    // without touching how a chain is born. Every reader of this flag treats it as a property the
+    // chain was created with, not one it can acquire: NodeConfig::validateL2Invariants ties it to
+    // the genesis [alloc.*] and [eth_genesis_header] sections that only exist at genesis;
+    // scheduler_v1::validateMPTFlagMatrix refuses to boot a node whose activation block is not 0,
+    // because switching the state-root scheme mid-chain forks every replaying node; and the L2
+    // admission gate (Check::BcosTxAllowedOnChain) judges a transaction once, at admission, so a
+    // mid-chain flip would leave already-admitted native transactions eligible for a proposal.
+    if (flag == Flag::feature_l2_ethereum_compat)
+    {
+        BOOST_THROW_EXCEPTION(
+            bcos::tool::InvalidSetFeature{} << errinfo_comment(
+                "feature_l2_ethereum_compat is a genesis-only feature: set it in config.genesis "
+                "[features] when the chain is created. It cannot be enabled by governance on a "
+                "running chain -- start a new chain instead."));
+    }
 }
 
 bool Features::get(Flag flag) const

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -115,7 +115,8 @@ public:
         feature_rpbft_vrf_type_secp256k1 = 55,
         feature_balance_policy2 = 56,     // 转账白名单 Transfer whitelist
         feature_l2_ethereum_compat = 57,  // OP-Stack L2 mode: Ethereum-compatible
-                                          // genesis/predeploys
+                                          // genesis/predeploys. Genesis-only: validate()
+                                          // rejects it on the governance setSystemConfig path.
         feature_mpt_state_root = 58,      // MPT lazy-build: block stateRoot switches to the
                                           // Ethereum MPT root from this flag's activation
                                           // block on (spec 2026-04-24 design3 4.3)
@@ -168,6 +169,9 @@ public:
 
     void validate(std::string_view flag) const;
 
+    /// Rejects a feature the governance setSystemConfig path must not turn on: one whose
+    /// dependencies are unmet, and one that is genesis-only. Not called by genesis loading,
+    /// which uses set() directly.
     void validate(Flag flag) const;
 
     bool get(Flag flag) const;

--- a/bcos-framework/test/CMakeLists.txt
+++ b/bcos-framework/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES unittests/storage2/TestMemoryStorage.cpp
     unittests/main/main.cpp
     unittests/interfaces/ExecutorTest.cpp
     unittests/interfaces/FeaturesActivationBlockTest.cpp
+    unittests/interfaces/FeaturesGenesisOnlyTest.cpp
     unittests/interfaces/FeaturesTest.cpp
     unittests/interfaces/TestTransactionExecutor.cpp
     unittests/mempool/TestAnyMemPool.cpp

--- a/bcos-framework/test/unittests/interfaces/FeaturesGenesisOnlyTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesGenesisOnlyTest.cpp
@@ -1,0 +1,86 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FeaturesGenesisOnlyTest.cpp
+ * @brief feature_l2_ethereum_compat is genesis-only: Features::validate rejects it, so the
+ *        governance setSystemConfig path cannot turn L2 mode on for a running chain, while
+ *        genesis loading -- which calls set() directly -- is untouched.
+ */
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-tool/Exceptions.h"
+#include <bcos-utilities/Exceptions.h>
+#include <boost/exception/get_error_info.hpp>
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace bcos::ledger;
+
+BOOST_AUTO_TEST_SUITE(FeaturesGenesisOnlyTest)
+
+/// SystemConfigPrecompiled::validate reaches Features::validate through the string overload
+/// (it holds the raw SYS_CONFIG key), so both overloads must refuse.
+BOOST_AUTO_TEST_CASE(governanceCannotEnableL2Mode)
+{
+    Features features;
+    BOOST_CHECK_THROW(features.validate(Features::Flag::feature_l2_ethereum_compat),
+        bcos::tool::InvalidSetFeature);
+    BOOST_CHECK_THROW(
+        features.validate("feature_l2_ethereum_compat"), bcos::tool::InvalidSetFeature);
+
+    // The refusal is unconditional: already being on does not make it settable again.
+    Features alreadyL2;
+    alreadyL2.set(Features::Flag::feature_l2_ethereum_compat);
+    BOOST_CHECK_THROW(alreadyL2.validate(Features::Flag::feature_l2_ethereum_compat),
+        bcos::tool::InvalidSetFeature);
+}
+
+/// BOOST_CHECK_THROW above pins only the type; a wrong-field throw of the same type would pass.
+/// The message has to tell an operator where the flag does belong, since SystemConfigPrecompiled
+/// surfaces the errinfo_comment as the failing transaction's reason.
+BOOST_AUTO_TEST_CASE(refusalNamesTheGenesisSection)
+{
+    auto namesGenesis = [](bcos::tool::InvalidSetFeature const& e) {
+        auto const* msg = boost::get_error_info<bcos::errinfo_comment>(e);
+        return msg != nullptr && msg->find("genesis-only") != std::string::npos &&
+               msg->find("config.genesis") != std::string::npos;
+    };
+    Features features;
+    BOOST_CHECK_EXCEPTION(features.validate(Features::Flag::feature_l2_ethereum_compat),
+        bcos::tool::InvalidSetFeature, namesGenesis);
+}
+
+/// Genesis loading does not go through validate(): set() still works, and the flag reads back.
+BOOST_AUTO_TEST_CASE(genesisSetIsUnaffected)
+{
+    Features features;
+    BOOST_CHECK(!features.get(Features::Flag::feature_l2_ethereum_compat));
+    BOOST_CHECK_NO_THROW(features.set(Features::Flag::feature_l2_ethereum_compat));
+    BOOST_CHECK(features.get(Features::Flag::feature_l2_ethereum_compat));
+
+    Features byName;
+    BOOST_CHECK_NO_THROW(byName.set("feature_l2_ethereum_compat"));
+    BOOST_CHECK(byName.get(Features::Flag::feature_l2_ethereum_compat));
+}
+
+/// Negative control: the rule is about this one flag, not about validate() rejecting whatever
+/// it is handed. A neighbouring L2-adjacent flag with no dependency still validates.
+BOOST_AUTO_TEST_CASE(otherFeaturesStillValidate)
+{
+    Features features;
+    BOOST_CHECK_NO_THROW(features.validate(Features::Flag::feature_op_jovian));
+    BOOST_CHECK_NO_THROW(features.validate(Features::Flag::feature_balance));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-protocol/bcos-protocol/TransactionStatus.h
+++ b/bcos-protocol/bcos-protocol/TransactionStatus.h
@@ -86,6 +86,10 @@ enum class TransactionStatus : int32_t
     FeeCapLessThanBaseFee = 10022,
     /// gasLimit exceeds the per-transaction cap (tx_gas_limit, or the Osaka constant cap).
     MaxGasLimitExceeded = 10023,
+    /// A FISCO-native (tars BCOSTransaction) transaction on a chain that carries EIP-2718
+    /// envelopes only (feature_l2_ethereum_compat). It has no envelope an OP verifier can
+    /// re-derive, so one inside a block makes that verifier reject the whole block.
+    BcosTxNotAllowed = 10024,
 };
 
 inline std::ostream& operator<<(std::ostream& _out, bcos::protocol::TransactionStatus const& _er)
@@ -226,6 +230,9 @@ inline std::ostream& operator<<(std::ostream& _out, bcos::protocol::TransactionS
         break;
     case TransactionStatus::MaxGasLimitExceeded:
         _out << "MaxGasLimitExceeded";
+        break;
+    case TransactionStatus::BcosTxNotAllowed:
+        _out << "BcosTxNotAllowed";
         break;
     case TransactionStatus::AlreadyInTxPoolAndAccept:
         _out << "AlreadyInTxPoolAndAccept";

--- a/bcos-protocol/test/unittests/TransactionStatusTest.cpp
+++ b/bcos-protocol/test/unittests/TransactionStatusTest.cpp
@@ -70,6 +70,7 @@ constexpr Expectation kExpectations[] = {
     {TransactionStatus::NonceHasMaxValue, "NonceHasMaxValue"},
     {TransactionStatus::FeeCapLessThanBaseFee, "FeeCapLessThanBaseFee"},
     {TransactionStatus::MaxGasLimitExceeded, "MaxGasLimitExceeded"},
+    {TransactionStatus::BcosTxNotAllowed, "BcosTxNotAllowed"},
 };
 }  // namespace
 

--- a/bcos-tx-validator/bcos-tx-validator/CheckSet.h
+++ b/bcos-tx-validator/bcos-tx-validator/CheckSet.h
@@ -112,6 +112,12 @@ enum class Check : uint32_t
     /// pool (Web3NonceChecker::existsMemoryNonce). The Web3 counterpart of BcosPoolNonce, and
     /// node-local in the same way -- but keyed on the SENDER, which BcosPoolNonce is not.
     Web3PoolNonce = 1U << 19,
+    /// Whether this chain carries FISCO-native (tars) transactions at all. An OP-Stack L2
+    /// (feature_l2_ethereum_compat) carries EIP-2718 envelopes only: a BCOSTransaction has no
+    /// envelope for an op-reth verifier to re-derive, so one inside a block makes that verifier
+    /// reject the WHOLE block. Reads the configuration snapshot alone -- no account, no
+    /// envelope -- which is why it sits in the state stage.
+    BcosTxAllowedOnChain = 1U << 20,
 };
 
 constexpr Check operator|(Check lhs, Check rhs) noexcept
@@ -151,9 +157,10 @@ constexpr bool contains(Check set, Check item) noexcept
 ///   pool  -- the BCOS nonce checkers, pool set before ledger, as the pool-side validator ran
 ///            them. Reads the pool, not the chain.
 ///
-/// Per (kind, context) this yields exactly the reads the table implies: a BCOS transaction
-/// reads nothing, a Web3 proposal reads the chain view, a Web3 admission reads the chain view
-/// and the account.
+/// Per (kind, context) this yields exactly the reads the table implies: a BCOS transaction takes
+/// the configuration snapshot and reads one flag out of it, a Web3 proposal derives the whole
+/// chain view, a Web3 admission derives it and reads the account. Which FIELDS of the view are
+/// derived is itself keyed on the set -- see c_revisionDependent.
 inline constexpr std::array c_gateOrder{
     Check::TypeGate,
     Check::ToFieldFormat,
@@ -161,6 +168,12 @@ inline constexpr std::array c_gateOrder{
     Check::BcosGroupChainId,
 };
 inline constexpr std::array c_stateOrder{
+    /// First, though the position is not observable today: BcosTxAllowedOnChain appears only in
+    /// TxKind::Bcos's set, whose sole state-stage member it is, so no transaction can violate it
+    /// and one of evmone's rules at once. The place is chosen for the case where that stops being
+    /// true -- a whole kind the chain refuses says more than any rule about the transaction's
+    /// contents -- not because anything reports a different code because of it.
+    Check::BcosTxAllowedOnChain,
     Check::TypeByRevision,
     Check::SetCodeHasTo,
     Check::AuthListNonEmpty,
@@ -252,6 +265,23 @@ inline constexpr Check c_poolStage = detail::unionOf(c_poolOrder);
 inline constexpr Check c_accountStateDependent =
     Check::SenderIsEOA | Check::NonceNotMax | Check::Web3NonceWindow | Check::Balance;
 
+/// What the chain view has to DERIVE, per field. The state stage always holds the configuration
+/// snapshot itself -- a pointer copy -- but the three values read out of it are not free, and one
+/// of them can fail: tx_gas_price reaches the snapshot as whatever string genesis put there
+/// (NodeConfig.cpp reads tx.gas_price with no validation, and SystemConfigPrecompiled's hex rule
+/// only governs later governance writes), so parsing it throws on a malformed value. Deriving a
+/// field no check in the set will read would turn that into a rejection of every transaction on a
+/// chain whose checks never look at the gas price -- which is exactly a BCOS transaction's set.
+///
+/// Same rule as c_accountStateDependent one level down: verify() reads what the table says is
+/// needed, nothing else. A check missing from its field's set here reads a disengaged optional
+/// (or a zero base fee), which every reader treats as "stand down" -- so adding a check without
+/// listing it weakens the check rather than crashing, and the state-stage cases in the admission
+/// tests are what catch it.
+inline constexpr Check c_revisionDependent =
+    Check::TypeByRevision | Check::MaxGasLimit | Check::InitCodeSize | Check::IntrinsicGas;
+inline constexpr Check c_baseFeeDependent = Check::FeeCapVsBaseFee | Check::Balance;
+
 /// Web3PoolNonce IS sender-dependent, and that is the difference between the two pool rules: its
 /// key is the PAIR (sender, nonce), where BcosPoolNonce's is a nonce value alone. Run with an
 /// unrecovered sender it would file every pending Web3 transaction under the empty string, and
@@ -277,8 +307,15 @@ constexpr Check poolAdmissionCheckSet(TxKind kind) noexcept
     case TxKind::Bcos:
         // A BCOS transaction's dataHash covers its whole TransactionData, so none of the
         // envelope-derived Web3 rules apply to it.
+        //
+        // BcosTxAllowedOnChain survives into all three contexts (neither derived column strips
+        // it): its answer is a function of the transaction kind and the chain configuration, so
+        // every honest node computes the same one and enforcing it under ProposalVerification
+        // cannot split a block -- while a native transaction sealed by a leader is exactly as
+        // unverifiable to an OP verifier as one submitted over RPC. EESTReplay keeps it too;
+        // fixtures are Web3 only, so it never fires there.
         return Check::TypeGate | Check::ToFieldFormat | Check::Signature | Check::BcosGroupChainId |
-               Check::BcosPoolNonce | Check::BcosLedgerNonce;
+               Check::BcosTxAllowedOnChain | Check::BcosPoolNonce | Check::BcosLedgerNonce;
     case TxKind::Web3Legacy:
         return c_web3Common;
     case TxKind::Web3AccessList:

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.cpp
@@ -19,6 +19,7 @@
 
 #include "bcos-tx-validator/TxValidator.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
+#include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-framework/protocol/Protocol.h"
@@ -192,6 +193,10 @@ struct ChainView
 {
     /// const: LedgerConfigState hands out a snapshot nobody may mutate.
     std::shared_ptr<const ledger::LedgerConfig> config;
+    /// The three fields below are derived only when the check set contains a reader of them
+    /// (c_revisionDependent, c_baseFeeDependent, Check::ChainId); otherwise each keeps the value
+    /// that already means "nothing to say".
+    ///
     /// nullopt = the chain declares no EVM revision; revision-dependent checks stand down rather
     /// than guess, because admission must never be STRICTER than execution.
     std::optional<evmc_revision> revision;
@@ -338,6 +343,30 @@ TransactionStatus checkBcosGroupChainId(Envelope const& in)
     if (in.tx.chainId() != in.chainId) [[unlikely]]
     {
         return TransactionStatus::InvalidChainId;
+    }
+    return TransactionStatus::None;
+}
+
+TransactionStatus checkBcosTxAllowedOnChain(StateInputs const& in)
+{
+    // An OP-Stack L2 carries EIP-2718 envelopes only. A BCOSTransaction has none, so op-reth
+    // cannot re-derive it and rejects the whole block that carries it -- one native transaction
+    // in one block stalls the whole L2. Refuse it here instead of sealing a block the verifier
+    // throws away.
+    //
+    // The flag comes from the same snapshot every other state check reads, so this follows
+    // whatever the chain last published. It cannot change under a running pool: the flag is
+    // genesis-only, and Features::validate rejects it on the governance setSystemConfig path
+    // (bcos-framework/ledger/Features.cpp). That closes what would otherwise be a hole here --
+    // transactions already admitted are not re-judged at seal time (MemoryStorage re-checks the
+    // ledger nonce alone), so a mid-chain flip would leave native transactions in the pool
+    // eligible for a proposal. The rest of the tree makes the same genesis-time assumption
+    // (OpScheduler.h; NodeConfig::validateL2Invariants, which validates the flag against the
+    // genesis alloc; scheduler_v1::validateMPTFlagMatrix, which refuses to boot when its
+    // activation block is not 0).
+    if (in.chain.config->features().get(ledger::Features::Flag::feature_l2_ethereum_compat))
+    {
+        return TransactionStatus::BcosTxNotAllowed;
     }
     return TransactionStatus::None;
 }
@@ -636,6 +665,7 @@ constexpr std::array<CheckEntry<Envelope>, c_gateOrder.size()> c_gateRegistry{{
 }};
 
 constexpr std::array<CheckEntry<StateInputs>, c_stateOrder.size()> c_stateRegistry{{
+    {Check::BcosTxAllowedOnChain, &checkBcosTxAllowedOnChain},
     {Check::TypeByRevision, &checkTypeByRevision},
     {Check::SetCodeHasTo, &checkSetCodeHasTo},
     {Check::AuthListNonEmpty, &checkAuthListNonEmpty},
@@ -716,11 +746,16 @@ u256 parseBalance(std::string_view raw)
     }
 }
 
-/// The state stage's inputs, taken once: a pointer copy and two field conversions. Whoever
-/// commits a block republishes the configuration, and nothing here goes to storage. Throws
-/// (never returns a status) on a snapshot that cannot be used -- infrastructure, not a defect in
-/// the transaction, and reported so that it cannot masquerade as a rejected transaction.
-ChainView readChainView(ledger::LedgerConfigState const& configState)
+/// The state stage's inputs, taken once: a pointer copy and the fields @p checks actually reads.
+/// Whoever commits a block republishes the configuration, and nothing here goes to storage.
+/// Throws (never returns a status) on a snapshot that cannot be used -- infrastructure, not a
+/// defect in the transaction, and reported so that it cannot masquerade as a rejected
+/// transaction.
+///
+/// Per-field, keyed on @p checks, for the same reason verify() reads the account only for
+/// c_accountStateDependent: deriving a value nothing in the set will read is work at best and a
+/// failure at worst. tx_gas_price is the "at worst" -- see c_baseFeeDependent.
+ChainView readChainView(ledger::LedgerConfigState const& configState, Check checks)
 {
     ChainView view;
     view.config = configState.get();
@@ -730,14 +765,23 @@ ChainView readChainView(ledger::LedgerConfigState const& configState)
         // corrupted.
         BOOST_THROW_EXCEPTION(std::runtime_error("admission: ledger config state returned null"));
     }
-    // Judged against the block it would execute in, which is the next one.
-    view.revision = view.config->evmcRevisionForBlock(view.config->blockNumber() + 1);
-    // The raw SYS_CONFIG string: "0x0" by default, hex as SystemConfigPrecompiled enforces. A
-    // value u256 cannot parse throws here, as it did when the checks parsed it themselves.
-    view.baseFee = u256(std::get<0>(view.config->gasPrice()));
-    if (auto const& chainId = view.config->chainId())
+    if ((checks & c_revisionDependent) != Check::None)
     {
-        view.web3ChainId = fromBigEndian<u256>(chainId->bytes);
+        // Judged against the block it would execute in, which is the next one.
+        view.revision = view.config->evmcRevisionForBlock(view.config->blockNumber() + 1);
+    }
+    if ((checks & c_baseFeeDependent) != Check::None)
+    {
+        // The raw SYS_CONFIG string: "0x0" by default, hex as SystemConfigPrecompiled enforces. A
+        // value u256 cannot parse throws here, as it did when the checks parsed it themselves.
+        view.baseFee = u256(std::get<0>(view.config->gasPrice()));
+    }
+    if (contains(checks, Check::ChainId))
+    {
+        if (auto const& chainId = view.config->chainId())
+        {
+            view.web3ChainId = fromBigEndian<u256>(chainId->bytes);
+        }
     }
     return view;
 }
@@ -861,7 +905,7 @@ task::Task<TransactionStatus> TxValidator::verify(
     // extra member keys on the sender address without reading anything.
     if ((checks & c_stateStage) != Check::None)
     {
-        auto const chain = readChainView(*m_ledgerConfigState);
+        auto const chain = readChainView(*m_ledgerConfigState, checks);
         std::optional<AccountState> sender;
         if ((checks & c_accountStateDependent) != Check::None)
         {

--- a/bcos-tx-validator/bcos-tx-validator/TxValidator.h
+++ b/bcos-tx-validator/bcos-tx-validator/TxValidator.h
@@ -74,6 +74,22 @@ using SystemTxPredicate = std::function<bool(protocol::Transaction const&)>;
 /// consensus or the OP engine RPC) has one, EthEndpoint::sendRawTransaction, which calls it and
 /// then reserves the (sender, nonce) with MemPoolImpl::tryAdd.
 ///
+/// NOT every way a transaction reaches a block. Two paths do not pass through here, and both
+/// matter to whoever reads the L2 rule below (Check::BcosTxAllowedOnChain):
+///
+///   - transactions an external CL hands the engine in newPayload. Nothing under engine/ calls
+///     verify(); that block arrives already built, and rejecting it is a payload-validation
+///     answer, not an admission one.
+///   - block production's own filter. Every engine service's payload builder -- buildPayload in
+///     EngineServiceImpl.h and EthEngineService.inl, buildOpPayload in OpEngineService.inl --
+///     drops a sealed transaction whose type is not TransactionType::Web3Transaction, logging
+///     and continuing. That is NOT this rule seen from the other end, and the two are not
+///     copies to merge: the builder enforces a payload-encoding invariant that holds on any
+///     chain -- a transaction with no EIP-2718 wire form cannot be written into an engine
+///     payload at all, whatever feature_l2_ethereum_compat says -- while the check below is a
+///     ruling about what THIS chain's configuration admits, and reports a status a caller can
+///     read. Different predicate, different domain, different consequence.
+///
 /// It holds pointers to the shared nonce checkers rather than owning them: the txpool reserves
 /// and clears nonces through the same instances without going near admission, and the admission
 /// question is asked here. Nonce admission is the same question at every ingress, and routing it

--- a/bcos-tx-validator/test/unittests/AdmissionHarness.h
+++ b/bcos-tx-validator/test/unittests/AdmissionHarness.h
@@ -1,0 +1,314 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AdmissionHarness.h
+ * @brief One TxValidator harness for every admission test file.
+ *
+ * The module is stateless and every dependency is injected, so these run against fakes: no
+ * transaction pool, no block sequence, no scheduler unless a case wants one. A test file adds
+ * cases, never a second copy of this -- two harnesses drift the moment one of them changes its
+ * default revision or its funding, and both files stay green while they disagree.
+ *
+ * `ledgerConfig` is the SETUP config, not the served one: a case edits it freely (gas price,
+ * revision, chain id, features) between construction and run(), and run() then publishes a fresh
+ * copy through LedgerConfigState::set() -- the same call a committing node makes. So what the
+ * validator reads is an immutable snapshot, as in production, and no case can mutate a
+ * configuration that has already been published. A case wanting the never-published state (the
+ * gap between a node's construction and its first commit) clears `ledgerConfig`.
+ */
+
+#pragma once
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
+#include "bcos-framework/ledger/LedgerConfigState.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/testutils/faker/FakeLedger.h"
+#include "bcos-framework/testutils/faker/FakeScheduler.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include "bcos-tx-validator/LedgerNonceChecker.h"
+#include "bcos-tx-validator/TxValidator.h"
+#include "bcos-tx-validator/Web3NonceChecker.h"
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace bcos::test
+{
+/// Scoped to this namespace, not global: everything below names protocol and validator types
+/// unqualified, and every file that includes this puts its cases in bcos::test too.
+using namespace bcos::protocol;
+using namespace bcos::txvalidator;
+
+inline constexpr uint64_t kChainId = 5;
+
+/// One key pair for the whole suite, so `sender` is stable across cases.
+inline crypto::Secp256k1Crypto& signer()
+{
+    static crypto::Secp256k1Crypto instance;
+    return instance;
+}
+inline crypto::KeyPairInterface& senderKey()
+{
+    static auto keyPair = signer().generateKeyPair();
+    return *keyPair;
+}
+
+/// Build and genuinely SIGN a Web3 transaction, then project it to tars the way the RPC ingress
+/// does.
+///
+/// Signing here rather than using a static raw-transaction vector is deliberate: the RLP suite's
+/// vectors exist to round-trip the codec, so several carry arbitrary r/s that do not recover to
+/// any address -- and admit() runs signature recovery. Signing also makes gasLimit, chainId and
+/// the fee fields free variables, which several cases below need; a fixed vector cannot be
+/// edited without invalidating its own signature.
+struct TxSpec
+{
+    rpc::TransactionType type = rpc::TransactionType::EIP1559;
+    std::optional<uint64_t> chainId = kChainId;
+    uint64_t nonce = 7;
+    uint64_t gasLimit = 100000;
+    u256 maxFeePerGas = 30000000000ULL;
+    u256 maxPriorityFeePerGas = 1000000000ULL;
+    std::optional<Address> to = Address{"0x811a752c8cd697e3cb27279c330ed1ada745a8d7"};
+    bcos::bytes data{};
+    u256 value = 1;
+    bool withAuthorization = false;
+    /// Zero out r after signing: the envelope stays self-consistent (the hash commits to the
+    /// signature bytes as sent) but recovery is impossible, so the rejection is the signature
+    /// check's own and not normalization's.
+    bool unrecoverableSignature = false;
+    /// Replace s by n - s after signing: the same envelope under the other of the two signatures
+    /// every ECDSA message has. Recovery succeeds on it (to a different address), and only the
+    /// EIP-2 low-s rule tells the twins apart.
+    bool highS = false;
+};
+
+inline std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec = {})
+{
+    rpc::Web3Transaction web3;
+    web3.type = spec.type;
+    web3.chainId = spec.chainId;
+    web3.nonce = spec.nonce;
+    web3.gasLimit = spec.gasLimit;
+    web3.maxFeePerGas = spec.maxFeePerGas;
+    web3.maxPriorityFeePerGas = spec.maxPriorityFeePerGas;
+    web3.to = spec.to;
+    web3.data = spec.data;
+    web3.value = spec.value;
+    if (spec.withAuthorization)
+    {
+        rpc::AuthorizationListEntry entry;
+        entry.chainId = kChainId;
+        entry.address = Address{"0x00000000000000000000000000000000000000aa"};
+        web3.authorizationList.push_back(entry);
+    }
+
+    crypto::Keccak256 hasher;
+    auto const signHash = web3.hashForSign();
+    auto signature = signer().sign(senderKey(), signHash, true);
+    BOOST_REQUIRE_EQUAL(signature->size(), 65U);
+    web3.signatureR.assign(signature->begin(), signature->begin() + 32);
+    web3.signatureS.assign(signature->begin() + 32, signature->begin() + 64);
+    web3.signatureV = static_cast<uint64_t>((*signature)[64]);
+    if (spec.highS)
+    {
+        auto const s = fromBigEndian<u256>(web3.signatureS);
+        BOOST_REQUIRE_LT(s, crypto::c_secp256k1nOver2);  // the signer emits low-s; the twin is high
+        bcos::bytes twin(32, 0);
+        toBigEndian(crypto::c_secp256k1n - s, twin);
+        web3.signatureS = std::move(twin);
+    }
+    if (spec.unrecoverableSignature)
+    {
+        web3.signatureR.assign(32, 0);
+    }
+
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [inner = web3.takeToTarsTransaction()]() mutable { return &inner; });
+    tx->calculateHash(hasher);
+    return tx;
+}
+
+/// Counts committedNonce() calls, so a test can state which plane a context consulted rather
+/// than inferring it from a status code.
+struct CountingWeb3NonceChecker : Web3NonceChecker
+{
+    using Web3NonceChecker::Web3NonceChecker;
+    int reads = 0;
+    task::Task<std::optional<u256>> committedNonce(std::string_view sender) override
+    {
+        ++reads;
+        co_return co_await Web3NonceChecker::committedNonce(sender);
+    }
+};
+
+/// The pending plane. Counting its reads is how the tests below say "this context did NOT do a
+/// full account-state read": the balance is the half of that read the nonce path never touches.
+struct CountingScheduler : FakeScheduler
+{
+    CountingScheduler() : FakeScheduler(nullptr, nullptr) {}
+    int reads = 0;
+    u256 balance;
+    task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(
+        std::string_view, std::string_view, bcos::protocol::BlockNumber) override
+    {
+        ++reads;
+        bcos::storage::Entry entry;
+        entry.set(balance.convert_to<std::string>());
+        co_return entry;
+    }
+};
+
+/// A ledger nonce checker whose verdict the test dictates. checkNonce is virtual on
+/// NonceCheckerInterface, so this needs no seam in the validator.
+struct StubLedgerNonceChecker : LedgerNonceChecker
+{
+    explicit StubLedgerNonceChecker(TransactionStatus verdict)
+      : LedgerNonceChecker({}, /*blockNumber=*/0, /*blockLimit=*/600,
+            /*checkBlockLimit=*/false),
+        m_verdict(verdict)
+    {}
+    TransactionStatus checkNonce(const Transaction&) override { return m_verdict; }
+    TransactionStatus m_verdict;
+};
+
+/// Supplies the one field readAccountState leaves empty on every real path. Nothing populates
+/// contract code at admission today (see readAccountState), so without this seam the EIP-3607
+/// rule would be untestable and would silently rot until code becomes readable.
+struct CodeInjectingValidator : TxValidator
+{
+    using TxValidator::TxValidator;
+    bytes code;
+
+protected:
+    task::Task<std::optional<AccountState>> readAccountState(std::string_view sender) override
+    {
+        auto state = co_await TxValidator::readAccountState(sender);
+        if (state)
+        {
+            state->code = code;
+        }
+        co_return state;
+    }
+};
+
+/// Everything the validator needs, with knobs for the cases below.
+///
+/// Unlike the callback-injected version this replaces, the account state is SEEDED into the
+/// fake ledger and read back through the validator's own path -- so the test exercises
+/// readAccountState and Web3NonceChecker rather than a stand-in for them.
+struct AdmitHarness
+{
+    std::shared_ptr<FakeLedger> ledger = std::make_shared<FakeLedger>();
+    /// Edited by the case, never served directly. Null = publish nothing, leaving the holder in
+    /// its construction-time empty state.
+    ledger::LedgerConfig::Ptr ledgerConfig = std::make_shared<ledger::LedgerConfig>();
+    ledger::LedgerConfigState::Ptr ledgerConfigState =
+        std::make_shared<ledger::LedgerConfigState>();
+    std::shared_ptr<CountingWeb3NonceChecker> web3NonceChecker;
+    std::shared_ptr<CountingScheduler> scheduler = std::make_shared<CountingScheduler>();
+    std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
+    /// Null by default: the mempool-side validator has no pool set, and most cases here are
+    /// Web3, which never consult it.
+    std::shared_ptr<NonceCheckerInterface> txPoolNonceChecker;
+    /// Nothing is a system transaction unless a case says so.
+    SystemTxPredicate isSystemTx = [](Transaction const&) { return false; };
+    AccountState account{};
+    bool accountExists = true;
+
+    AdmitHarness()
+    {
+        // The snapshot is the only chain configuration admission reads. The fake ledger's
+        // SYS_CONFIG map stays empty on purpose (see admissionReadsNoSystemConfig).
+        ledgerConfig->setChainId(evmc::bytes32{kChainId});
+        ledgerConfig->setGasPrice({"0", 0});  // free gas by default
+        ledgerConfig->setBlockNumber(100);
+        ledgerConfig->setGasLimit({3000000000ULL, 0});
+        ledgerConfig->setEVMCRevision(EVMC_PRAGUE);
+        web3NonceChecker = std::make_shared<CountingWeb3NonceChecker>(ledger);
+        // Comfortably funded, nonce 7 (matches the fixture), plain EOA.
+        account.balance = u256("0xffffffffffffffffffffffffffff");
+        account.nonce = u256(7);
+    }
+
+    int accountStateReads() const { return scheduler->reads; }
+    int accountNonceReads() const { return web3NonceChecker->reads; }
+
+    /// The address the fixture key signs as. Committed state is keyed by it.
+    static std::string senderHex()
+    {
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        return toHex(senderKey().address(hashImpl));
+    }
+
+    /// Publish the account into the committed plane the validator actually reads.
+    void publishAccount()
+    {
+        scheduler->balance = account.balance;
+        if (!accountExists)
+        {
+            return;
+        }
+        ledger::StorageState state;
+        state.nonce = account.nonce ? account.nonce->convert_to<std::string>() : "0";
+        state.balance = account.balance.convert_to<std::string>();
+        ledger->setStorageState(senderHex(), std::move(state));
+    }
+
+    /// Publish the case's chain configuration the way a committing node does: a copy, handed to
+    /// the holder as const, so the object the validator reads is not the object the case edited.
+    void publishChainConfig()
+    {
+        if (!ledgerConfig)
+        {
+            return;
+        }
+        ledgerConfigState->set(std::make_shared<ledger::LedgerConfig const>(*ledgerConfig));
+    }
+
+    std::unique_ptr<CodeInjectingValidator> make()
+    {
+        auto cryptoSuite =
+            std::make_shared<crypto::CryptoSuite>(std::make_shared<crypto::Keccak256>(),
+                std::make_shared<crypto::Secp256k1Crypto>(), nullptr);
+        auto validator =
+            std::make_unique<CodeInjectingValidator>(cryptoSuite, ledger, ledgerConfigState,
+                txPoolNonceChecker, web3NonceChecker, isSystemTx, "group0", "chain0");
+        validator->code = account.code;
+        validator->setScheduler(scheduler);
+        if (ledgerNonceChecker)
+        {
+            validator->setLedgerNonceChecker(ledgerNonceChecker);
+        }
+        return validator;
+    }
+
+    TransactionStatus run(Transaction& tx,
+        AdmissionContext context = AdmissionContext::PoolAdmission,
+        SignaturePolicy policy = SignaturePolicy::Required)
+    {
+        publishAccount();
+        publishChainConfig();
+        auto validator = make();
+        return task::syncWait(validator->verify(tx, context, policy));
+    }
+};
+
+}  // namespace bcos::test

--- a/bcos-tx-validator/test/unittests/AdmitTest.cpp
+++ b/bcos-tx-validator/test/unittests/AdmitTest.cpp
@@ -16,28 +16,16 @@
  * @file AdmitTest.cpp
  * @brief TxValidator::verify -- the checks that have no counterpart in the tree today.
  *
- * The module is stateless and every dependency is injected, so these run against fakes: no
- * transaction pool, no block sequence, no scheduler.
+ * The harness these cases run on lives in AdmissionHarness.h, shared with every other admission
+ * test file.
  */
 
-#include "bcos-crypto/hash/Keccak256.h"
-#include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
-#include "bcos-framework/ledger/LedgerConfigState.h"
-#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "AdmissionHarness.h"
 #include "bcos-framework/protocol/TxGasModel.h"
-#include "bcos-framework/testutils/faker/FakeLedger.h"
-#include "bcos-framework/testutils/faker/FakeScheduler.h"
 #include "bcos-framework/txpool/Constant.h"
-#include "bcos-rlp-protocol/Web3Transaction.h"
 #include "bcos-rlp-protocol/Web3TxEnvelope.h"
-#include "bcos-tars-protocol/protocol/TransactionImpl.h"
-#include "bcos-tx-validator/LedgerNonceChecker.h"
 #include "bcos-tx-validator/Normalize.h"
 #include "bcos-tx-validator/TxPoolNonceChecker.h"
-#include "bcos-tx-validator/TxValidator.h"
-#include "bcos-tx-validator/Web3NonceChecker.h"
-#include <bcos-task/Wait.h>
-#include <bcos-utilities/DataConvertUtility.h>
 #include <boost/test/unit_test.hpp>
 #include <memory>
 
@@ -47,250 +35,6 @@ using namespace bcos::txvalidator;
 
 namespace bcos::test
 {
-namespace
-{
-constexpr uint64_t kChainId = 5;
-
-/// One key pair for the whole suite, so `sender` is stable across cases.
-crypto::Secp256k1Crypto& signer()
-{
-    static crypto::Secp256k1Crypto instance;
-    return instance;
-}
-crypto::KeyPairInterface& senderKey()
-{
-    static auto keyPair = signer().generateKeyPair();
-    return *keyPair;
-}
-
-/// Build and genuinely SIGN a Web3 transaction, then project it to tars the way the RPC ingress
-/// does.
-///
-/// Signing here rather than using a static raw-transaction vector is deliberate: the RLP suite's
-/// vectors exist to round-trip the codec, so several carry arbitrary r/s that do not recover to
-/// any address -- and admit() runs signature recovery. Signing also makes gasLimit, chainId and
-/// the fee fields free variables, which several cases below need; a fixed vector cannot be
-/// edited without invalidating its own signature.
-struct TxSpec
-{
-    rpc::TransactionType type = rpc::TransactionType::EIP1559;
-    std::optional<uint64_t> chainId = kChainId;
-    uint64_t nonce = 7;
-    uint64_t gasLimit = 100000;
-    u256 maxFeePerGas = 30000000000ULL;
-    u256 maxPriorityFeePerGas = 1000000000ULL;
-    std::optional<Address> to = Address{"0x811a752c8cd697e3cb27279c330ed1ada745a8d7"};
-    bcos::bytes data{};
-    u256 value = 1;
-    bool withAuthorization = false;
-    /// Zero out r after signing: the envelope stays self-consistent (the hash commits to the
-    /// signature bytes as sent) but recovery is impossible, so the rejection is the signature
-    /// check's own and not normalization's.
-    bool unrecoverableSignature = false;
-    /// Replace s by n - s after signing: the same envelope under the other of the two signatures
-    /// every ECDSA message has. Recovery succeeds on it (to a different address), and only the
-    /// EIP-2 low-s rule tells the twins apart.
-    bool highS = false;
-};
-
-std::shared_ptr<bcostars::protocol::TransactionImpl> admitTx(TxSpec const& spec = {})
-{
-    rpc::Web3Transaction web3;
-    web3.type = spec.type;
-    web3.chainId = spec.chainId;
-    web3.nonce = spec.nonce;
-    web3.gasLimit = spec.gasLimit;
-    web3.maxFeePerGas = spec.maxFeePerGas;
-    web3.maxPriorityFeePerGas = spec.maxPriorityFeePerGas;
-    web3.to = spec.to;
-    web3.data = spec.data;
-    web3.value = spec.value;
-    if (spec.withAuthorization)
-    {
-        rpc::AuthorizationListEntry entry;
-        entry.chainId = kChainId;
-        entry.address = Address{"0x00000000000000000000000000000000000000aa"};
-        web3.authorizationList.push_back(entry);
-    }
-
-    crypto::Keccak256 hasher;
-    auto const signHash = web3.hashForSign();
-    auto signature = signer().sign(senderKey(), signHash, true);
-    BOOST_REQUIRE_EQUAL(signature->size(), 65U);
-    web3.signatureR.assign(signature->begin(), signature->begin() + 32);
-    web3.signatureS.assign(signature->begin() + 32, signature->begin() + 64);
-    web3.signatureV = static_cast<uint64_t>((*signature)[64]);
-    if (spec.highS)
-    {
-        auto const s = fromBigEndian<u256>(web3.signatureS);
-        BOOST_REQUIRE_LT(s, crypto::c_secp256k1nOver2);  // the signer emits low-s; the twin is high
-        bcos::bytes twin(32, 0);
-        toBigEndian(crypto::c_secp256k1n - s, twin);
-        web3.signatureS = std::move(twin);
-    }
-    if (spec.unrecoverableSignature)
-    {
-        web3.signatureR.assign(32, 0);
-    }
-
-    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
-        [inner = web3.takeToTarsTransaction()]() mutable { return &inner; });
-    tx->calculateHash(hasher);
-    return tx;
-}
-
-/// Counts committedNonce() calls, so a test can state which plane a context consulted rather
-/// than inferring it from a status code.
-struct CountingWeb3NonceChecker : Web3NonceChecker
-{
-    using Web3NonceChecker::Web3NonceChecker;
-    int reads = 0;
-    task::Task<std::optional<u256>> committedNonce(std::string_view sender) override
-    {
-        ++reads;
-        co_return co_await Web3NonceChecker::committedNonce(sender);
-    }
-};
-
-/// The pending plane. Counting its reads is how the tests below say "this context did NOT do a
-/// full account-state read": the balance is the half of that read the nonce path never touches.
-struct CountingScheduler : FakeScheduler
-{
-    CountingScheduler() : FakeScheduler(nullptr, nullptr) {}
-    int reads = 0;
-    u256 balance;
-    task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(
-        std::string_view, std::string_view, bcos::protocol::BlockNumber) override
-    {
-        ++reads;
-        bcos::storage::Entry entry;
-        entry.set(balance.convert_to<std::string>());
-        co_return entry;
-    }
-};
-
-/// A ledger nonce checker whose verdict the test dictates. checkNonce is virtual on
-/// NonceCheckerInterface, so this needs no seam in the validator.
-struct StubLedgerNonceChecker : LedgerNonceChecker
-{
-    explicit StubLedgerNonceChecker(TransactionStatus verdict)
-      : LedgerNonceChecker({}, /*blockNumber=*/0, /*blockLimit=*/600,
-            /*checkBlockLimit=*/false),
-        m_verdict(verdict)
-    {}
-    TransactionStatus checkNonce(const Transaction&) override { return m_verdict; }
-    TransactionStatus m_verdict;
-};
-
-/// Supplies the one field readAccountState leaves empty on every real path. Nothing populates
-/// contract code at admission today (see readAccountState), so without this seam the EIP-3607
-/// rule would be untestable and would silently rot until code becomes readable.
-struct CodeInjectingValidator : TxValidator
-{
-    using TxValidator::TxValidator;
-    bytes code;
-
-protected:
-    task::Task<std::optional<AccountState>> readAccountState(std::string_view sender) override
-    {
-        auto state = co_await TxValidator::readAccountState(sender);
-        if (state)
-        {
-            state->code = code;
-        }
-        co_return state;
-    }
-};
-
-/// Everything the validator needs, with knobs for the cases below.
-///
-/// Unlike the callback-injected version this replaces, the account state is SEEDED into the
-/// fake ledger and read back through the validator's own path -- so the test exercises
-/// readAccountState and Web3NonceChecker rather than a stand-in for them.
-struct AdmitHarness
-{
-    std::shared_ptr<FakeLedger> ledger = std::make_shared<FakeLedger>();
-    ledger::LedgerConfig::Ptr ledgerConfig = std::make_shared<ledger::LedgerConfig>();
-    ledger::LedgerConfigState::Ptr ledgerConfigState;
-    std::shared_ptr<CountingWeb3NonceChecker> web3NonceChecker;
-    std::shared_ptr<CountingScheduler> scheduler = std::make_shared<CountingScheduler>();
-    std::shared_ptr<LedgerNonceChecker> ledgerNonceChecker;
-    /// Null by default: the mempool-side validator has no pool set, and most cases here are
-    /// Web3, which never consult it.
-    std::shared_ptr<NonceCheckerInterface> txPoolNonceChecker;
-    /// Nothing is a system transaction unless a case says so.
-    SystemTxPredicate isSystemTx = [](Transaction const&) { return false; };
-    AccountState account{};
-    bool accountExists = true;
-
-    AdmitHarness()
-    {
-        // The snapshot is the only chain configuration admission reads. The fake ledger's
-        // SYS_CONFIG map stays empty on purpose (see admissionReadsNoSystemConfig).
-        ledgerConfig->setChainId(evmc::bytes32{kChainId});
-        ledgerConfig->setGasPrice({"0", 0});  // free gas by default
-        ledgerConfig->setBlockNumber(100);
-        ledgerConfig->setGasLimit({3000000000ULL, 0});
-        ledgerConfig->setEVMCRevision(EVMC_PRAGUE);
-        ledgerConfigState = std::make_shared<ledger::LedgerConfigState>(ledgerConfig);
-        web3NonceChecker = std::make_shared<CountingWeb3NonceChecker>(ledger);
-        // Comfortably funded, nonce 7 (matches the fixture), plain EOA.
-        account.balance = u256("0xffffffffffffffffffffffffffff");
-        account.nonce = u256(7);
-    }
-
-    int accountStateReads() const { return scheduler->reads; }
-    int accountNonceReads() const { return web3NonceChecker->reads; }
-
-    /// The address the fixture key signs as. Committed state is keyed by it.
-    static std::string senderHex()
-    {
-        auto hashImpl = std::make_shared<crypto::Keccak256>();
-        return toHex(senderKey().address(hashImpl));
-    }
-
-    /// Publish the account into the committed plane the validator actually reads.
-    void publishAccount()
-    {
-        scheduler->balance = account.balance;
-        if (!accountExists)
-        {
-            return;
-        }
-        ledger::StorageState state;
-        state.nonce = account.nonce ? account.nonce->convert_to<std::string>() : "0";
-        state.balance = account.balance.convert_to<std::string>();
-        ledger->setStorageState(senderHex(), std::move(state));
-    }
-
-    std::unique_ptr<CodeInjectingValidator> make()
-    {
-        auto cryptoSuite =
-            std::make_shared<crypto::CryptoSuite>(std::make_shared<crypto::Keccak256>(),
-                std::make_shared<crypto::Secp256k1Crypto>(), nullptr);
-        auto validator =
-            std::make_unique<CodeInjectingValidator>(cryptoSuite, ledger, ledgerConfigState,
-                txPoolNonceChecker, web3NonceChecker, isSystemTx, "group0", "chain0");
-        validator->code = account.code;
-        validator->setScheduler(scheduler);
-        if (ledgerNonceChecker)
-        {
-            validator->setLedgerNonceChecker(ledgerNonceChecker);
-        }
-        return validator;
-    }
-
-    TransactionStatus run(Transaction& tx,
-        AdmissionContext context = AdmissionContext::PoolAdmission,
-        SignaturePolicy policy = SignaturePolicy::Required)
-    {
-        publishAccount();
-        auto validator = make();
-        return task::syncWait(validator->verify(tx, context, policy));
-    }
-};
-}  // namespace
-
 BOOST_AUTO_TEST_SUITE(AdmitTest)
 
 BOOST_AUTO_TEST_CASE(wellFormedTransactionIsAdmitted)
@@ -510,7 +254,7 @@ BOOST_AUTO_TEST_CASE(wrongChainIdIsRejected)
 BOOST_AUTO_TEST_CASE(missingChainIdConfigRejectsRatherThanSkips)
 {
     AdmitHarness harness;
-    harness.ledgerConfigState = std::make_shared<ledger::LedgerConfigState>();
+    harness.ledgerConfig.reset();  // publish nothing: the holder stays in its empty state
     auto tx = admitTx();
     BOOST_CHECK(harness.run(*tx) == TransactionStatus::InvalidChainId);
 }

--- a/bcos-tx-validator/test/unittests/CheckSetTest.cpp
+++ b/bcos-tx-validator/test/unittests/CheckSetTest.cpp
@@ -42,9 +42,10 @@ BOOST_AUTO_TEST_SUITE(CheckSetTest)
 // says so.
 BOOST_AUTO_TEST_CASE(poolAdmissionColumnIsExact)
 {
-    BOOST_CHECK(checkSet(TxKind::Bcos, AdmissionContext::PoolAdmission) ==
-                (Check::TypeGate | Check::ToFieldFormat | Check::Signature |
-                    Check::BcosGroupChainId | Check::BcosPoolNonce | Check::BcosLedgerNonce));
+    BOOST_CHECK(
+        checkSet(TxKind::Bcos, AdmissionContext::PoolAdmission) ==
+        (Check::TypeGate | Check::ToFieldFormat | Check::Signature | Check::BcosGroupChainId |
+            Check::BcosTxAllowedOnChain | Check::BcosPoolNonce | Check::BcosLedgerNonce));
 
     constexpr auto legacy = Check::TypeGate | Check::ToFieldFormat | Check::Signature |
                             Check::MaxGasLimit | Check::FeeCapVsBaseFee | Check::ChainId |
@@ -210,12 +211,14 @@ BOOST_AUTO_TEST_CASE(stagesPartitionTheEvaluationOrder)
     BOOST_CHECK(contains(c_senderDependent, Check::Web3PoolNonce));
     BOOST_CHECK(!contains(c_accountStateDependent, Check::Web3PoolNonce));
     BOOST_CHECK((c_senderDependent & ~(c_stateStage | c_poolStage)) == Check::None);
-    // A BCOS transaction has no state-stage check in any context, so it never reads the chain;
-    // a Web3 proposal has state-stage checks but no sender-dependent one, so it reads the chain
-    // view and not the account.
+    // A BCOS transaction's only state-stage check is BcosTxAllowedOnChain, so it reads the chain
+    // view and never the account; a Web3 proposal has state-stage checks but no sender-dependent
+    // one, so it too reads the chain view and not the account.
     for (auto context : kContexts)
     {
-        BOOST_CHECK((checkSet(TxKind::Bcos, context) & c_stateStage) == Check::None);
+        BOOST_CHECK(
+            (checkSet(TxKind::Bcos, context) & c_stateStage) == Check::BcosTxAllowedOnChain);
+        BOOST_CHECK((checkSet(TxKind::Bcos, context) & c_senderDependent) == Check::None);
     }
     const auto proposal = checkSet(TxKind::Web3DynamicFee, AdmissionContext::ProposalVerification);
     BOOST_CHECK((proposal & c_stateStage) != Check::None);
@@ -276,8 +279,9 @@ BOOST_AUTO_TEST_CASE(proposalVerificationKeepsProtocolInvariants)
         return checkSet(kind, AdmissionContext::ProposalVerification);
     };
     BOOST_CHECK(
-        proposal(TxKind::Bcos) == (Check::TypeGate | Check::ToFieldFormat | Check::Signature |
-                                      Check::BcosGroupChainId | Check::BcosLedgerNonce));
+        proposal(TxKind::Bcos) ==
+        (Check::TypeGate | Check::ToFieldFormat | Check::Signature | Check::BcosGroupChainId |
+            Check::BcosTxAllowedOnChain | Check::BcosLedgerNonce));
 
     constexpr auto legacy = Check::TypeGate | Check::ToFieldFormat | Check::Signature |
                             Check::MaxGasLimit | Check::FeeCapVsBaseFee | Check::ChainId |

--- a/bcos-tx-validator/test/unittests/L2NativeTxGateTest.cpp
+++ b/bcos-tx-validator/test/unittests/L2NativeTxGateTest.cpp
@@ -1,0 +1,246 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file L2NativeTxGateTest.cpp
+ * @brief Check::BcosTxAllowedOnChain -- a FISCO-native transaction on an OP-Stack L2 chain.
+ *
+ * An L2 block is verified by op-reth, which rebuilds every transaction from its EIP-2718
+ * envelope. A tars BCOSTransaction has no envelope, so one inside a block makes the verifier
+ * reject the whole block. feature_l2_ethereum_compat is what says a chain is such an L2.
+ *
+ * Runs on the shared AdmissionHarness, with one line turning the flag on.
+ */
+
+#include "AdmissionHarness.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-tx-validator/CheckSet.h"
+#include "bcos-tx-validator/TxPoolNonceChecker.h"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+
+using namespace bcos;
+using namespace bcos::protocol;
+using namespace bcos::txvalidator;
+
+namespace bcos::test
+{
+namespace
+{
+/// A FISCO-native transaction: outer tars type BCOSTransaction, no EIP-2718 envelope at all.
+///
+/// Every case below runs it under SignaturePolicy::Disabled, the convention AdmitTest.cpp already
+/// uses for BCOS transactions: production is SignaturePolicy::Required, but a tars signature
+/// needs a real BCOS key pair and a matching hash, and what this file measures sits AFTER the
+/// signature check. That the gate does not skip ahead of the signature check is pinned
+/// structurally instead, by theSignatureCheckStillRunsFirst reading the order array -- a stronger
+/// statement than one signed fixture reaching a status code.
+std::shared_ptr<bcostars::protocol::TransactionImpl> nativeTx(std::string nonce = "native-nonce")
+{
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x1234567890123456789012345678901234567890";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.chainID = "chain0";
+    tx->mutableInner().data.nonce = std::move(nonce);
+    return tx;
+}
+
+/// Turn this chain into an OP-Stack L2. This edits the harness's setup config; run() publishes it
+/// through LedgerConfigState::set(), so a case may call this any time before run().
+void makeL2(AdmitHarness& harness)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    harness.ledgerConfig->setFeatures(features);
+}
+
+std::ptrdiff_t orderIndexOf(Check target)
+{
+    return std::distance(c_checkOrder.begin(), std::ranges::find(c_checkOrder, target));
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(L2NativeTxGateTest)
+
+// The baseline. On an ordinary FISCO chain the flag is off and a native transaction is what the
+// chain is for.
+BOOST_AUTO_TEST_CASE(nativeTransactionIsAdmittedWhenTheChainIsNotAnL2)
+{
+    AdmitHarness harness;
+    auto tx = nativeTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(nativeTransactionIsRefusedOnAnL2Chain)
+{
+    AdmitHarness harness;
+    makeL2(harness);
+    auto tx = nativeTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::BcosTxNotAllowed);
+}
+
+// All three contexts carry the bit. A native transaction a leader sealed is exactly as
+// unverifiable to op-reth as one submitted over RPC, and the verdict is a function of the chain
+// configuration alone, so enforcing it during proposal verification cannot split a block.
+BOOST_AUTO_TEST_CASE(everyContextRefusesANativeTransactionOnAnL2Chain)
+{
+    constexpr std::array contexts{AdmissionContext::PoolAdmission,
+        AdmissionContext::ProposalVerification, AdmissionContext::EESTReplay};
+    for (auto context : contexts)
+    {
+        AdmitHarness harness;
+        makeL2(harness);
+        auto tx = nativeTx();
+        BOOST_CHECK_MESSAGE(harness.run(*tx, context, SignaturePolicy::Disabled) ==
+                                TransactionStatus::BcosTxNotAllowed,
+            "context " << static_cast<int>(context) << " admitted a native transaction on an L2");
+    }
+    // The table says the same thing, so an edit to a derived column fails here too.
+    for (auto context : contexts)
+    {
+        BOOST_CHECK(contains(checkSet(TxKind::Bcos, context), Check::BcosTxAllowedOnChain));
+    }
+}
+
+// The bit belongs to TxKind::Bcos only: an L2 chain exists to carry Web3 transactions, so turning
+// the flag on must leave them exactly as they were.
+BOOST_AUTO_TEST_CASE(web3TransactionIsUnaffectedByTheL2Gate)
+{
+    AdmitHarness harness;
+    makeL2(harness);
+    auto tx = admitTx();
+    BOOST_CHECK(harness.run(*tx) == TransactionStatus::None);
+
+    for (auto kind : {TxKind::Web3Legacy, TxKind::Web3AccessList, TxKind::Web3DynamicFee,
+             TxKind::Web3SetCode, TxKind::Rejected})
+    {
+        for (auto context : {AdmissionContext::PoolAdmission,
+                 AdmissionContext::ProposalVerification, AdmissionContext::EESTReplay})
+        {
+            BOOST_CHECK_MESSAGE(!contains(checkSet(kind, context), Check::BcosTxAllowedOnChain),
+                "the L2 gate leaked into kind " << static_cast<int>(kind));
+        }
+    }
+}
+
+// The verdict must not depend on the account. Stated by counting the two account planes rather
+// than inferred from the status code: a status assertion would pass just as well with the reads
+// still happening.
+BOOST_AUTO_TEST_CASE(theGateDecidesWithoutReadingTheAccount)
+{
+    AdmitHarness harness;
+    makeL2(harness);
+    auto tx = nativeTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::BcosTxNotAllowed);
+    BOOST_CHECK_EQUAL(harness.accountStateReads(), 0);
+    BOOST_CHECK_EQUAL(harness.accountNonceReads(), 0);
+
+    // The table is why: no check in a BCOS transaction's set needs the sender or the account, so
+    // verify() performs no account read on that path however this rule is written.
+    BOOST_CHECK(!contains(c_senderDependent, Check::BcosTxAllowedOnChain));
+    BOOST_CHECK(!contains(c_accountStateDependent, Check::BcosTxAllowedOnChain));
+    BOOST_CHECK(contains(c_stateStage, Check::BcosTxAllowedOnChain));
+    BOOST_CHECK(!contains(c_poolStage, Check::BcosTxAllowedOnChain));
+}
+
+// ... and not on the rest of the chain view either. readChainView derives the EVM revision, the
+// base fee and the Web3 chain id only for the checks that read them, and a BCOS transaction's set
+// contains none of those -- so tx_gas_price, whose genesis value nothing validates, is not parsed
+// on this path. An unparseable one would make readChainView throw, so this is observable end to
+// end and not only as a table fact.
+BOOST_AUTO_TEST_CASE(theGateDecidesWithoutTheRestOfTheChainView)
+{
+    for (auto context : {AdmissionContext::PoolAdmission, AdmissionContext::ProposalVerification,
+             AdmissionContext::EESTReplay})
+    {
+        const auto set = checkSet(TxKind::Bcos, context);
+        BOOST_CHECK((set & c_revisionDependent) == Check::None);
+        BOOST_CHECK((set & c_baseFeeDependent) == Check::None);
+        BOOST_CHECK(!contains(set, Check::ChainId));
+    }
+
+    AdmitHarness harness;
+    makeL2(harness);
+    harness.ledgerConfig->setGasPrice({"not a number", 0});
+    auto tx = nativeTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::BcosTxNotAllowed);
+
+    // The negative control: the same value DOES stop a Web3 transaction, whose set contains a
+    // base-fee reader -- so the case above passes because the field was not derived, not because
+    // the value is harmless.
+    AdmitHarness web3Harness;
+    web3Harness.ledgerConfig->setGasPrice({"not a number", 0});
+    auto web3 = admitTx();
+    BOOST_CHECK_THROW(web3Harness.run(*web3, AdmissionContext::PoolAdmission), std::exception);
+}
+
+// Ordering, end to end: with both nonce checks primed to fail, the reported status is still the
+// gate's. A native transaction on an L2 is refused for what it IS, not for the state of a pool it
+// was never going to enter.
+BOOST_AUTO_TEST_CASE(theGateIsReportedAheadOfTheNonceChecks)
+{
+    AdmitHarness harness;
+    makeL2(harness);
+    auto pool = std::make_shared<TxPoolNonceChecker>();
+    pool->insert("native-nonce");
+    harness.txPoolNonceChecker = pool;
+    harness.ledgerNonceChecker =
+        std::make_shared<StubLedgerNonceChecker>(TransactionStatus::BlockLimitCheckFail);
+
+    auto tx = nativeTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Disabled) ==
+                TransactionStatus::BcosTxNotAllowed);
+
+    // Pinned on the order array as well, so a reordering this case happens not to reach still
+    // fails.
+    for (auto later : {Check::BcosPoolNonce, Check::BcosLedgerNonce, Check::Balance,
+             Check::Web3NonceWindow, Check::SenderIsEOA})
+    {
+        BOOST_CHECK_MESSAGE(orderIndexOf(Check::BcosTxAllowedOnChain) < orderIndexOf(later),
+            "the L2 gate is ordered after check " << static_cast<uint32_t>(later));
+    }
+}
+
+// The gate sits in the state stage, so the gate stage still runs first. Stated rather than left
+// implicit: a native transaction that is ALSO unsigned reports InvalidSignature, and moving the
+// L2 rule ahead of signature recovery would be a deliberate change, not an accident.
+BOOST_AUTO_TEST_CASE(theSignatureCheckStillRunsFirst)
+{
+    AdmitHarness harness;
+    makeL2(harness);
+    auto tx = nativeTx();
+    BOOST_CHECK(harness.run(*tx, AdmissionContext::PoolAdmission, SignaturePolicy::Required) ==
+                TransactionStatus::InvalidSignature);
+    BOOST_CHECK(orderIndexOf(Check::Signature) < orderIndexOf(Check::BcosTxAllowedOnChain));
+}
+
+// The status has to travel: MemoryStorage turns it into a bcos::Error carrying the code and
+// toString(), and that string is what the JSON-RPC caller reads.
+BOOST_AUTO_TEST_CASE(theStatusHasItsOwnLabel)
+{
+    BOOST_CHECK_EQUAL(toString(TransactionStatus::BcosTxNotAllowed), "BcosTxNotAllowed");
+    BOOST_CHECK_EQUAL(static_cast<int32_t>(TransactionStatus::BcosTxNotAllowed), 10024);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test


### PR DESCRIPTION
## Summary

An OP-Stack L2 chain built on FISCO must only carry Ethereum EIP-2718 transactions: types 0x00/0x01/0x02/0x04 from users and 0x7e deposits injected by the engine. A FISCO-native tars `BCOSTransaction` has no Ethereum envelope; if one ever reaches a block, the OP verifier (op-reth) rejects the whole block. Nothing stopped a native transaction from entering the pool on an L2 node. L2 mode is signalled on-chain by `feature_l2_ethereum_compat`; there is no separate chain mode.

Admission is the routing table in `bcos-tx-validator` (`(TxKind × AdmissionContext) → Check` bitset, `CheckSet.h`). This PR adds one bit to that table and nothing beside it: `Check::BcosTxAllowedOnChain`, in `TxKind::Bcos`'s set for all three contexts, implemented as a synchronous check in `TxValidator.cpp` that reads `feature_l2_ethereum_compat` from the same per-verify `LedgerConfig` snapshot every other check uses. The verdict is a function of `(kind, chain config)` and identical on every honest node, so keeping it under `ProposalVerification` cannot split a proposal, and a native transaction a leader sealed is exactly as unverifiable to op-reth as one arriving over RPC. `EESTReplay` keeps it because fixtures are Web3-only, so it never fires there.

The rejection is a new status, `TransactionStatus::BcosTxNotAllowed = 10024`, named after its nearest sibling `BlobTxNotAllowed`. `TxTypeNotSupported` is documented as being about the envelope type and a native transaction has no envelope, so it was not reused. Both status→string sites in the tree (`TransactionStatus.h` `operator<<` and the `TransactionStatusTest` expectation table) are updated; downstream consumers pass the status through as `bcos::Error` code + `toString`, they do not whitelist.

The bit sits first in the state stage (`c_stateOrder`), after the gate stage. It therefore runs after `Signature` but before every nonce and account check; a BCOS set contains nothing from `c_accountStateDependent`, so `verify()` performs no account read on that path. Moving it into the gate stage would require the gate to take the chain config, which breaks the "gate refuses unauthenticated input without a single read" property the file is built around.

## Not in this PR

- **`newPayload` is not gated.** Nothing under `engine/` calls `verify()` — a block an external CL hands the engine arrives already built, and refusing it is a payload-validation answer, not an admission one. Stated in `TxValidator.h` next to the new rule.
- **Transactions already in a pool at an in-place binary upgrade are not re-judged.** `MemoryStorage::batchFetchTxs` consults only `committedNonceStatus` when sealing, so on an L2 node upgraded in place, a native transaction the old binary admitted can still be sealed. Draining or restarting the pool across that upgrade is an operational step, not a code change here; every chain born on this binary is unaffected because admission refuses the transaction on the way in.
- **Two ride-along changes carry most of the diff and are not about the title.** `readChainView` now derives its fields per check set — forced by this PR, see the regression section below — and `AdmitTest.cpp`'s fixtures move into `AdmissionHarness.h` so the new test file shares them instead of forking a second harness.

## Regression found and closed while adding the bit

Placing the bit in the state stage means a BCOS transaction now enters that stage, which it never did before. `readChainView` unconditionally parsed `tx_gas_price` as a `u256`, and that string reaches the snapshot straight from genesis with no validation (`NodeConfig.cpp` reads `tx.gas_price` raw; the hex rule in `SystemConfigPrecompiled` only governs later governance writes). An unparseable value would have started throwing on every BCOS transaction on an ordinary non-L2 chain: `Unknown` for every submission, and a view-change loop on the proposal path. `readChainView` now takes the check set and derives `revision` / `baseFee` / `web3ChainId` only when the set contains a reader (new `c_revisionDependent` / `c_baseFeeDependent` masks), the same conditional-input rule `verify()` already applies to the account state. `theGateDecidesWithoutTheRestOfTheChainView` pins it with a real negative control: an unparseable gas price passes for a native transaction and throws for a Web3 transaction.

## Ingress coverage (no new dispatch)

- BCOS JSON-RPC `sendTransaction` (`JsonRpcImpl_2_0.cpp`): on an engine-driven node the legacy txpool object still exists (`TxPoolInitializer` constructs it unconditionally; only `init()`/`start()` are skipped), so `txpool->submitTransaction` reaches `MemoryStorage::verifyAndSubmitTransaction` → `verify()` → `BcosTxNotAllowed`, returned to the client as a `bcos::Error` with code 10024. Previously such a transaction entered a pool that never seals and hung silently. No RPC change.
- P2P transaction sync (`MemoryStorage::batchImportTxs` → `verifyAndSubmitTransaction`) and proposal verification (`enforceSubmitTransaction`) both go through `verify()` and are covered by the table.
- Engine-driven mempool ingress (`EthEndpoint::sendRawTransaction`) decodes RLP into a `Web3Transaction`, so `kindOf()` can never produce `TxKind::Bcos` there.

Two paths that do not reach `verify()` are now disclosed in `TxValidator.h` instead of left implicit: transactions an external CL hands the engine in `newPayload` (nothing under `engine/` calls `verify()`), and each engine service's build-time drop of non-Web3 sealed transactions from an OP payload — `EngineServiceImpl.h`, `EthEngineService.inl` and `OpEngineService.inl` all carry that filter.

## Governance cannot flip the flag under a running pool

Round 1 (Copilot, and ywy2090 F1) pointed out the hole this gate would otherwise leave: `Features::featureKeys()` enumerates every `Flag`, so `setSystemConfig("feature_l2_ethereum_compat", "1")` was accepted by `SystemConfigPrecompiled::validate` and effective at the next block. Transactions already admitted are not re-judged at seal time — `MemoryStorage` re-checks the ledger nonce alone — so a mid-chain flip would leave native transactions in the pool eligible for a proposal, which is exactly the block op-reth rejects.

That is now closed rather than disclosed. `Features::validate(Flag)` throws `bcos::tool::InvalidSetFeature` for `feature_l2_ethereum_compat`, naming `config.genesis` `[features]` in the message the precompiled surfaces as the revert reason. The overload is reached from exactly one place — `SystemConfigPrecompiled.cpp:309`, the governance path — while genesis loading calls `set()` directly, so being born an L2 is unaffected. The rest of the tree already assumed this: `NodeConfig::validateL2Invariants` ties the flag to the genesis `[alloc.*]` and `[eth_genesis_header]` sections, and `scheduler_v1::validateMPTFlagMatrix` refuses to boot a node whose activation block is not 0. New `bcos-framework/test/unittests/interfaces/FeaturesGenesisOnlyTest.cpp` pins it: both `validate` overloads throw, the message names the genesis section, `set()` still works, and a negative control (`feature_op_jovian`, `feature_balance`) shows the rule is about this one flag rather than `validate()` refusing whatever it is handed. Nothing in the repo sets the flag through governance — the `tools/.ci/*.sh` and `tests/eest_rpc_runner.py` hits all write it into `config.genesis`.

`Features::validate` runs inside `SystemConfigPrecompiled::call`, i.e. inside transaction execution, so tightening it is a consensus-visible change: a transaction that once succeeded would now revert, with a different receipt and state root on replay. It carries no `compatibility_version` or `bugfix_*` gate, and does not need one — `feature_l2_ethereum_compat = 57` first exists in 3.18.0, which is unreleased, so no committed block on any chain can contain a successful flip of it.

Nor can the refusal break a real workflow: `kL2DisabledSet` (`bcos-executor/src/precompiled/L2DisabledSet.h:45`) already hides `SYS_CONFIG_ADDRESS`, `CONSENSUS_ADDRESS`, `AUTH_MANAGER_ADDRESS` and the rest of the private precompiled set whenever the flag is on, so an L2 chain has no legitimate native governance transaction to lose.

The comment block at `TxValidator.cpp` that used to call post-genesis activation "a separate question this does not answer" now says how it is answered.

## Other changes

- `TxValidator.h`'s header comment claimed the engine-driven mempool was "NOT yet" routed through `verify()` and that "#5555 wires that ingress"; #5555 is merged on this base and `EthEndpoint.cpp` does call `verify()`. Rewritten.
- The admission fixtures that lived in `AdmitTest.cpp`'s anonymous namespace are extracted to `AdmissionHarness.h` and shared with the new `L2NativeTxGateTest.cpp`; `AdmitTest.cpp` loses 259 lines and gains an include, no test case in it changes. Two copies of the harness would have drifted silently.
- Round 1 (ywy2090 F2, and a suppressed Copilot comment) flagged that the harness mutated the `LedgerConfig` already published into `LedgerConfigState`, so the tests never exercised the publication path and could not have caught a snapshot-contract violation. `ledgerConfig` is now the setup config only: `run()` publishes a fresh `const` copy through `LedgerConfigState::set()`, the same call a committing node makes, so what the validator reads is immutable. `missingChainIdConfigRejectsRatherThanSkips` — the one case that wants the never-published state — says so by clearing `ledgerConfig` instead of swapping the holder.

## Test plan

Configured `RelWithDebInfo` with `TESTS=ON`, reusing the existing vcpkg install dir.

- `cmake --build . --target test-bcos-tx-validator test-bcos-framework test-bcos-protocol test-bcos-executor test-bcos-txpool` — 0 errors.
- `test-bcos-tx-validator`, `test-bcos-framework`, `test-bcos-protocol`, `test-bcos-txpool` — each "No errors detected" over its full suite set. `test-bcos-executor --run_test=SystemConfigPrecompiledTest` (the governance `validate` path: the existing `feature_balance` dependency cases plus the new `genesisOnlyFeatureIsRefusedByGovernance`, which drives a real `setValueByKey("feature_l2_ethereum_compat","1")` through `SystemConfigPrecompiled::call` and asserts both the `PrecompiledError` and that its reason still says "genesis-only") and `--run_test='*FeatureL2*'` — both clean.
- Negative control on the genesis-only rule, at both layers: with the new arm in `Features::validate` disabled, `FeaturesGenesisOnlyTest` reports 4 failures and `SystemConfigPrecompiledTest/genesisOnlyFeatureIsRefusedByGovernance` 1; restored, 0 in both.
- `test-bcos-executor` full run: 2 pre-existing failures in `precompiledCryptoTest/testSM3AndKeccak256` (hard-coded SM3/Keccak expectations, zero occurrences of "feature" in that file), unrelated to this diff and not rebuilt at the base to prove it.
- New `L2NativeTxGateTest.cpp`, 8 cases: native tx with the flag off passes the new check; flag on yields exactly `BcosTxNotAllowed` under all three contexts; a Web3 (0x02) tx with the flag on is unaffected; the gate decides without reading the account; `Signature` still runs first; the chain-view negative control above; status→string mapping.
- `CheckSetTest.cpp` column and stage-membership expectations updated for the new bit.
- Every changed/new `.cpp` compiled standalone with `-fsyntax-only` outside the unity build, using each target's own `flags.make`: `Features.cpp`, `FeaturesGenesisOnlyTest.cpp`, `TxValidator.cpp`, `AdmitTest.cpp`, `CheckSetTest.cpp`, `L2NativeTxGateTest.cpp`, `TransactionStatusTest.cpp` — all clean.
- `clang-format --dry-run -Werror` silent on all touched files.

Not run: full-tree build, `bcos-rpc` tests (rpc untouched), live-chain run.

## Follow-ups

- `TransactionStatusTest.cpp` is a hand-written list; a `magic_enum` sweep would catch a future enumerator that skips the `operator<<` case.
- A `MemoryStorageTest` case symmetrical to the existing `BlobTxNotAllowed` one would pin the status shape coming out of `verifyAndSubmitTransaction`.
- `getFeatures` (`bcos-ledger/bcos-ledger/LedgerMethods.cpp:404-413`) swallows a fetch failure and returns an empty `Features`, which makes this gate — and `OpScheduler`'s reads of the same flag — fail open. Pre-existing and shared; worth an issue rather than a defensive layer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYvTrK1SwMfmsxmeYf816i
